### PR TITLE
chore: update target frameworks to net8.0 and net10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated target frameworks: dropped `net6.0` (out of support), added `net10.0` (current LTS)
+  - Now targets: `net462`, `net8.0`, `net10.0`
+
 ## [1.1.0] - 2025-12-16
 
 ### Added

--- a/src/PPDS.Plugins/PPDS.Plugins.csproj
+++ b/src/PPDS.Plugins/PPDS.Plugins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>PPDS.Plugins</RootNamespace>
     <AssemblyName>PPDS.Plugins</AssemblyName>
     <LangVersion>latest</LangVersion>

--- a/tests/PPDS.Plugins.Tests/PPDS.Plugins.Tests.csproj
+++ b/tests/PPDS.Plugins.Tests/PPDS.Plugins.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <RootNamespace>PPDS.Plugins.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary

- Drop `net6.0` (end of support November 2024)
- Add `net10.0` (current LTS, released November 2025)
- Package now targets: `net462`, `net8.0`, `net10.0`

## Test plan

- [ ] Build succeeds for all target frameworks
- [ ] Tests pass on net8.0 and net10.0
- [ ] NuGet package includes all framework targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)