### PR TITLE
fix: use per-package versions instead of tag override

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -18,23 +18,36 @@ jobs:
           8.0.x
           10.0.x
 
-    - name: Get version from tag
-      id: version
+    - name: Show release tag
       shell: bash
       run: |
-        # Extract version from tag (v1.0.0-alpha.1 -> 1.0.0-alpha.1)
+        # Extract version from tag for logging
         VERSION=${GITHUB_REF#refs/tags/v}
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        echo "Publishing version: $VERSION"
+        echo "Release triggered by tag: v$VERSION"
+
+    - name: Show package versions
+      shell: pwsh
+      run: |
+        Write-Host "Package versions from csproj files:" -ForegroundColor Cyan
+        Get-ChildItem -Path src -Filter "*.csproj" -Recurse | ForEach-Object {
+          $content = Get-Content $_.FullName -Raw
+          if ($content -match '<PackageId>([^<]+)</PackageId>') {
+            $packageId = $Matches[1]
+            if ($content -match '<Version>([^<]+)</Version>') {
+              $version = $Matches[1]
+              Write-Host "  $packageId : $version"
+            }
+          }
+        }
 
     - name: Restore dependencies
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.version.outputs.VERSION }}
+      run: dotnet build --configuration Release --no-restore
 
     - name: Pack
-      run: dotnet pack --configuration Release --no-build --output ./nupkgs -p:Version=${{ steps.version.outputs.VERSION }}
+      run: dotnet pack --configuration Release --no-build --output ./nupkgs
 
     - name: List packages
       shell: bash


### PR DESCRIPTION
## Summary

Fixes an issue where the publish workflow would override all package versions with the git tag version. This caused problems when packages have different versions.

### Problem

The workflow used `-p:Version=${{ steps.version.outputs.VERSION }}` which would apply the tag version to ALL packages:

| Package | csproj Version | With tag v1.0.0-alpha.1 |
|---------|----------------|-------------------------|
| PPDS.Plugins | 1.1.0 | ❌ Would publish as 1.0.0-alpha.1 (DOWNGRADE) |
| PPDS.Dataverse | 1.0.0-alpha.1 | ✅ Correct |
| PPDS.Migration | 1.0.0-alpha.1 | ✅ Correct |
| PPDS.Migration.Cli | 1.0.0-alpha.1 | ✅ Correct |

### Solution

- Remove `-p:Version=` override from build and pack commands
- Each package now uses its version from its csproj file
- Add step to display package versions before publishing for visibility

### Changes

- `publish-nuget.yml`: Removed version override, added package version display step

## Test Plan

- [ ] Verify workflow syntax is valid
- [ ] Create a test release to confirm packages publish with correct versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)