### PR TITLE
fix: align pre-release version format with ppds-tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ namespace PPDS.Plugins.Enums;        // Enums
 |------|---------|
 | Major versions | Sync with ppds-tools when attributes have breaking changes |
 | Minor/patch | Independent |
-| Pre-release format | `-alpha.N`, `-beta.N`, `-rc.N` suffix in git tag |
+| Pre-release format | `-alphaN`, `-betaN`, `-rcN` suffix in git tag |
 
 ### Breaking Changes Requiring Coordination
 

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>PPDS.Dataverse</PackageId>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.0.0-alpha1</Version>
     <Authors>Josh Smith</Authors>
     <Company>Power Platform Developer Suite</Company>
     <Description>High-performance Dataverse connectivity layer with connection pooling, bulk operations, and resilience. Provides multi-connection support for load distribution, throttle-aware connection selection, and modern bulk API wrappers (CreateMultiple, UpsertMultiple).</Description>

--- a/src/PPDS.Migration.Cli/PPDS.Migration.Cli.csproj
+++ b/src/PPDS.Migration.Cli/PPDS.Migration.Cli.csproj
@@ -14,7 +14,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ppds-migrate</ToolCommandName>
     <PackageId>PPDS.Migration.Cli</PackageId>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.0.0-alpha1</Version>
     <Authors>Josh Smith</Authors>
     <Company>Power Platform Developer Suite</Company>
     <Description>High-performance Dataverse data migration CLI tool. Export, import, and migrate

--- a/src/PPDS.Migration/PPDS.Migration.csproj
+++ b/src/PPDS.Migration/PPDS.Migration.csproj
@@ -16,7 +16,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>PPDS.Migration</PackageId>
-    <Version>1.0.0-alpha.1</Version>
+    <Version>1.0.0-alpha1</Version>
     <Authors>Josh Smith</Authors>
     <Company>Power Platform Developer Suite</Company>
     <Description>High-performance Dataverse data migration engine. Provides parallel export,


### PR DESCRIPTION
## Summary

Aligns pre-release version format with ppds-tools convention to ensure ecosystem consistency and avoid potential compatibility issues.

### Changes

| Package | Before | After |
|---------|--------|-------|
| PPDS.Dataverse | `1.0.0-alpha.1` | `1.0.0-alpha1` |
| PPDS.Migration | `1.0.0-alpha.1` | `1.0.0-alpha1` |
| PPDS.Migration.Cli | `1.0.0-alpha.1` | `1.0.0-alpha1` |

### Documentation Updated

- `CLAUDE.md`: Updated pre-release format from `-alpha.N` to `-alphaN`

### Why

- ppds-tools had issues with the dotted format (`alpha.1`)
- Ecosystem consistency - all PPDS projects should use the same version format
- NuGet treats `1.0.0-alpha1` as a newer version than `1.0.0-alpha.1`, so this is a forward-compatible change

## Test Plan

- [ ] Verify build succeeds
- [ ] Create new release with `v1.0.0-alpha1` tag after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)