### PR TITLE
fix: resolve plugin registration and cross-tenant auth issues (#59)

### DIFF
--- a/schemas/plugin-registration.schema.json
+++ b/schemas/plugin-registration.schema.json
@@ -193,7 +193,7 @@
           "description": "Comma-separated list of attributes to include. Null means all attributes (not recommended for performance)."
         }
       },
-      "required": ["name", "entityAlias", "imageType"],
+      "required": ["name", "imageType"],
       "additionalProperties": true
     }
   }

--- a/schemas/plugin-registration.schema.json
+++ b/schemas/plugin-registration.schema.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/joshsmithxrm/ppds-sdk/main/schemas/plugin-registration.schema.json",
+  "title": "PPDS Plugin Registration Configuration",
+  "description": "Schema for plugin registration configuration files used by the PPDS CLI.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON schema reference for validation."
+    },
+    "version": {
+      "type": "string",
+      "description": "Schema version for forward compatibility.",
+      "default": "1.0"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the configuration was generated (Zulu time format)."
+    },
+    "assemblies": {
+      "type": "array",
+      "description": "List of plugin assemblies in this configuration.",
+      "items": {
+        "$ref": "#/$defs/assembly"
+      }
+    }
+  },
+  "required": ["assemblies"],
+  "additionalProperties": true,
+  "$defs": {
+    "assembly": {
+      "type": "object",
+      "description": "Configuration for a single plugin assembly.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Assembly name (without extension)."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["Assembly", "Nuget"],
+          "description": "Assembly type: 'Assembly' for classic DLL, 'Nuget' for NuGet package.",
+          "default": "Assembly"
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path to the assembly DLL (from the config file location). Use forward slashes for cross-platform compatibility."
+        },
+        "packagePath": {
+          "type": "string",
+          "description": "Relative path to the NuGet package (for Nuget type only)."
+        },
+        "solution": {
+          "type": "string",
+          "description": "Solution unique name to add components to."
+        },
+        "allTypeNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "All plugin type names in this assembly (for orphan detection)."
+        },
+        "types": {
+          "type": "array",
+          "description": "Plugin types with their step registrations.",
+          "items": {
+            "$ref": "#/$defs/pluginType"
+          }
+        }
+      },
+      "required": ["name", "types"],
+      "additionalProperties": true
+    },
+    "pluginType": {
+      "type": "object",
+      "description": "Configuration for a single plugin type (class).",
+      "properties": {
+        "typeName": {
+          "type": "string",
+          "description": "Fully qualified type name (namespace.classname)."
+        },
+        "steps": {
+          "type": "array",
+          "description": "Step registrations for this plugin type.",
+          "items": {
+            "$ref": "#/$defs/step"
+          }
+        }
+      },
+      "required": ["typeName", "steps"],
+      "additionalProperties": true
+    },
+    "step": {
+      "type": "object",
+      "description": "Configuration for a single plugin step registration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name for the step. Auto-generated if not specified: '{TypeName}: {Message} of {Entity}'."
+        },
+        "message": {
+          "type": "string",
+          "description": "SDK message name (Create, Update, Delete, Retrieve, etc.)."
+        },
+        "entity": {
+          "type": "string",
+          "description": "Primary entity logical name. Use 'none' for global messages."
+        },
+        "secondaryEntity": {
+          "type": "string",
+          "description": "Secondary entity logical name for relationship messages (Associate, etc.)."
+        },
+        "stage": {
+          "type": "string",
+          "enum": ["PreValidation", "PreOperation", "MainOperation", "PostOperation"],
+          "description": "Pipeline stage. MainOperation is for Custom API plugins."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["Synchronous", "Asynchronous"],
+          "description": "Execution mode.",
+          "default": "Synchronous"
+        },
+        "executionOrder": {
+          "type": "integer",
+          "description": "Execution order when multiple plugins handle the same event.",
+          "default": 1
+        },
+        "filteringAttributes": {
+          "type": "string",
+          "description": "Comma-separated list of attributes that trigger this step (Update message only)."
+        },
+        "unsecureConfiguration": {
+          "type": "string",
+          "description": "Unsecure configuration string passed to plugin constructor. Safe for source control."
+        },
+        "deployment": {
+          "type": "string",
+          "enum": ["ServerOnly", "Offline", "Both"],
+          "description": "Deployment target.",
+          "default": "ServerOnly"
+        },
+        "runAsUser": {
+          "type": "string",
+          "description": "User context to run the plugin as. Use 'CallingUser' (default), 'System', or a systemuser GUID."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this step does."
+        },
+        "asyncAutoDelete": {
+          "type": "boolean",
+          "description": "For async steps, whether to delete the async job on successful completion.",
+          "default": false
+        },
+        "stepId": {
+          "type": "string",
+          "description": "Step identifier for associating images with specific steps on multi-step plugins."
+        },
+        "images": {
+          "type": "array",
+          "description": "Entity images registered for this step.",
+          "items": {
+            "$ref": "#/$defs/image"
+          }
+        }
+      },
+      "required": ["message", "entity", "stage"],
+      "additionalProperties": true
+    },
+    "image": {
+      "type": "object",
+      "description": "Configuration for a plugin step image (pre-image or post-image).",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name used to access the image in plugin context."
+        },
+        "entityAlias": {
+          "type": "string",
+          "description": "Entity alias for the image. Defaults to 'name' if not specified."
+        },
+        "imageType": {
+          "type": "string",
+          "enum": ["PreImage", "PostImage", "Both"],
+          "description": "Image type."
+        },
+        "attributes": {
+          "type": "string",
+          "description": "Comma-separated list of attributes to include. Null means all attributes (not recommended for performance)."
+        }
+      },
+      "required": ["name", "entityAlias", "imageType"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cross-tenant token cache issue** - Fixed bug where `ppds env list` would return environments from wrong tenant when user had profiles for multiple tenants. Root cause was MSAL account lookup using `FirstOrDefault()` instead of filtering by tenant. Now uses `HomeAccountId` for precise account lookup with tenant filtering fallback. ([#59](https://github.com/joshsmithxrm/ppds-sdk/issues/59))
+
+### Added
+
+- `HomeAccountId` property on `AuthProfile` and `ICredentialProvider` to track MSAL account identity across sessions
+
 ## [1.0.0-beta.1] - 2025-12-29
 
 ### Added

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-01-01
+
 ### Fixed
 
 - **Cross-tenant token cache issue** - Fixed bug where `ppds env list` would return environments from wrong tenant when user had profiles for multiple tenants. Root cause was MSAL account lookup using `FirstOrDefault()` instead of filtering by tenant. Now uses `HomeAccountId` for precise account lookup with tenant filtering fallback. ([#59](https://github.com/joshsmithxrm/ppds-sdk/issues/59))
@@ -39,5 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JWT claims parsing for identity information
 - Targets: `net8.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.1...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.2...HEAD
+[1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.1...Auth-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Auth-v1.0.0-beta.1

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -39,6 +39,9 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Not available for federated auth without additional calls
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Federated auth doesn't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => _cachedToken?.Token;
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
@@ -40,6 +40,9 @@ public sealed class CertificateFileCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Service principals don't have a user OID
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Service principals don't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => null; // Connection string auth doesn't expose the token
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
@@ -44,6 +44,9 @@ public sealed class CertificateStoreCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Service principals don't have a user OID
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Service principals don't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => null; // Connection string auth doesn't expose the token
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/ClientSecretCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ClientSecretCredentialProvider.cs
@@ -36,6 +36,9 @@ public sealed class ClientSecretCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Service principals don't have a user OID
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Service principals don't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => null; // Connection string auth doesn't expose the token
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -39,6 +39,9 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Not available for federated auth without additional calls
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Federated auth doesn't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => _cachedToken?.Token;
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/ICredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ICredentialProvider.cs
@@ -54,6 +54,13 @@ public interface ICredentialProvider : IDisposable
     string? ObjectId { get; }
 
     /// <summary>
+    /// Gets the MSAL home account identifier.
+    /// Format: {objectId}.{tenantId} - uniquely identifies the account+tenant for token cache lookup.
+    /// Available after successful authentication.
+    /// </summary>
+    string? HomeAccountId { get; }
+
+    /// <summary>
     /// Gets the access token from the last authentication.
     /// Available after successful authentication. Used for extracting JWT claims.
     /// </summary>

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -28,6 +28,7 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
     private readonly CloudEnvironment _cloud;
     private readonly string? _tenantId;
     private readonly string? _username;
+    private readonly string? _homeAccountId;
 
     private IPublicClientApplication? _msalClient;
     private MsalCacheHelper? _cacheHelper;
@@ -50,6 +51,9 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
     public string? ObjectId => _cachedResult?.UniqueId;
 
     /// <inheritdoc />
+    public string? HomeAccountId => _cachedResult?.Account?.HomeAccountId?.Identifier;
+
+    /// <inheritdoc />
     public string? AccessToken => _cachedResult?.AccessToken;
 
     /// <inheritdoc />
@@ -61,14 +65,17 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
     /// <param name="cloud">The cloud environment.</param>
     /// <param name="tenantId">Optional tenant ID (defaults to "organizations" for multi-tenant).</param>
     /// <param name="username">Optional username for silent auth lookup.</param>
+    /// <param name="homeAccountId">Optional MSAL home account identifier for precise account lookup.</param>
     public InteractiveBrowserCredentialProvider(
         CloudEnvironment cloud = CloudEnvironment.Public,
         string? tenantId = null,
-        string? username = null)
+        string? username = null,
+        string? homeAccountId = null)
     {
         _cloud = cloud;
         _tenantId = tenantId;
         _username = username;
+        _homeAccountId = homeAccountId;
     }
 
     /// <summary>
@@ -81,7 +88,8 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         return new InteractiveBrowserCredentialProvider(
             profile.Cloud,
             profile.TenantId,
-            profile.Username);
+            profile.Username,
+            profile.HomeAccountId);
     }
 
     /// <summary>
@@ -176,19 +184,14 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
                 return _cachedResult.AccessToken;
             }
 
-            // Try silent acquisition from MSAL cache
-            var accounts = await _msalClient!.GetAccountsAsync().ConfigureAwait(false);
-
-            // Look up by username if we have one, otherwise fall back to first account
-            var account = !string.IsNullOrEmpty(_username)
-                ? accounts.FirstOrDefault(a => string.Equals(a.Username, _username, StringComparison.OrdinalIgnoreCase))
-                : accounts.FirstOrDefault();
+            // Try to find the correct account for silent acquisition
+            var account = await FindAccountAsync().ConfigureAwait(false);
 
             if (account != null)
             {
                 try
                 {
-                    _cachedResult = await _msalClient
+                    _cachedResult = await _msalClient!
                         .AcquireTokenSilent(scopes, account)
                         .ExecuteAsync(cancellationToken)
                         .ConfigureAwait(false);
@@ -223,6 +226,50 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         Console.WriteLine();
 
         return _cachedResult.AccessToken;
+    }
+
+    /// <summary>
+    /// Finds the correct cached account for this profile.
+    /// Uses HomeAccountId for precise lookup, falls back to tenant filtering, then username.
+    /// </summary>
+    private async Task<IAccount?> FindAccountAsync()
+    {
+        // Best case: we have the exact account identifier stored
+        if (!string.IsNullOrEmpty(_homeAccountId))
+        {
+            var account = await _msalClient!.GetAccountAsync(_homeAccountId).ConfigureAwait(false);
+            if (account != null)
+                return account;
+        }
+
+        // Fall back to filtering accounts
+        var accounts = await _msalClient!.GetAccountsAsync().ConfigureAwait(false);
+        var accountList = accounts.ToList();
+
+        if (accountList.Count == 0)
+            return null;
+
+        // If we have a tenant ID, filter by it to avoid cross-tenant token usage
+        if (!string.IsNullOrEmpty(_tenantId))
+        {
+            var tenantAccount = accountList.FirstOrDefault(a =>
+                string.Equals(a.HomeAccountId?.TenantId, _tenantId, StringComparison.OrdinalIgnoreCase));
+            if (tenantAccount != null)
+                return tenantAccount;
+        }
+
+        // Fall back to username match
+        if (!string.IsNullOrEmpty(_username))
+        {
+            var usernameAccount = accountList.FirstOrDefault(a =>
+                string.Equals(a.Username, _username, StringComparison.OrdinalIgnoreCase));
+            if (usernameAccount != null)
+                return usernameAccount;
+        }
+
+        // If we can't find the right account, return null to force re-authentication.
+        // Never silently use a random cached account - that causes cross-tenant issues.
+        return null;
     }
 
     /// <summary>

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -230,47 +230,9 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
 
     /// <summary>
     /// Finds the correct cached account for this profile.
-    /// Uses HomeAccountId for precise lookup, falls back to tenant filtering, then username.
     /// </summary>
-    private async Task<IAccount?> FindAccountAsync()
-    {
-        // Best case: we have the exact account identifier stored
-        if (!string.IsNullOrEmpty(_homeAccountId))
-        {
-            var account = await _msalClient!.GetAccountAsync(_homeAccountId).ConfigureAwait(false);
-            if (account != null)
-                return account;
-        }
-
-        // Fall back to filtering accounts
-        var accounts = await _msalClient!.GetAccountsAsync().ConfigureAwait(false);
-        var accountList = accounts.ToList();
-
-        if (accountList.Count == 0)
-            return null;
-
-        // If we have a tenant ID, filter by it to avoid cross-tenant token usage
-        if (!string.IsNullOrEmpty(_tenantId))
-        {
-            var tenantAccount = accountList.FirstOrDefault(a =>
-                string.Equals(a.HomeAccountId?.TenantId, _tenantId, StringComparison.OrdinalIgnoreCase));
-            if (tenantAccount != null)
-                return tenantAccount;
-        }
-
-        // Fall back to username match
-        if (!string.IsNullOrEmpty(_username))
-        {
-            var usernameAccount = accountList.FirstOrDefault(a =>
-                string.Equals(a.Username, _username, StringComparison.OrdinalIgnoreCase));
-            if (usernameAccount != null)
-                return usernameAccount;
-        }
-
-        // If we can't find the right account, return null to force re-authentication.
-        // Never silently use a random cached account - that causes cross-tenant issues.
-        return null;
-    }
+    private Task<IAccount?> FindAccountAsync()
+        => MsalAccountHelper.FindAccountAsync(_msalClient!, _homeAccountId, _tenantId, _username);
 
     /// <summary>
     /// Ensures the MSAL client is initialized with token cache.

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -41,6 +41,9 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
     public string? ObjectId => null; // Managed identity doesn't expose OID
 
     /// <inheritdoc />
+    public string? HomeAccountId => null; // Managed identity doesn't use MSAL user cache
+
+    /// <inheritdoc />
     public string? AccessToken => _cachedToken?.Token;
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Credentials/MsalAccountHelper.cs
+++ b/src/PPDS.Auth/Credentials/MsalAccountHelper.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Identity.Client;
+
+namespace PPDS.Auth.Credentials;
+
+/// <summary>
+/// Helper class for MSAL account lookup operations.
+/// Provides consistent account selection logic across credential providers.
+/// </summary>
+internal static class MsalAccountHelper
+{
+    /// <summary>
+    /// Finds the correct cached account for a profile.
+    /// Uses HomeAccountId for precise lookup, falls back to tenant filtering, then username.
+    /// </summary>
+    /// <param name="msalClient">The MSAL public client application.</param>
+    /// <param name="homeAccountId">Optional MSAL home account identifier for precise lookup.</param>
+    /// <param name="tenantId">Optional tenant ID for filtering.</param>
+    /// <param name="username">Optional username for filtering.</param>
+    /// <returns>The matching account, or null if no match found (forces re-authentication).</returns>
+    internal static async Task<IAccount?> FindAccountAsync(
+        IPublicClientApplication msalClient,
+        string? homeAccountId,
+        string? tenantId,
+        string? username = null)
+    {
+        // Best case: we have the exact account identifier stored
+        if (!string.IsNullOrEmpty(homeAccountId))
+        {
+            var account = await msalClient.GetAccountAsync(homeAccountId).ConfigureAwait(false);
+            if (account != null)
+                return account;
+        }
+
+        // Fall back to filtering accounts
+        var accounts = await msalClient.GetAccountsAsync().ConfigureAwait(false);
+        var accountList = accounts.ToList();
+
+        if (accountList.Count == 0)
+            return null;
+
+        // If we have a tenant ID, filter by it to avoid cross-tenant token usage
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            var tenantAccount = accountList.FirstOrDefault(a =>
+                string.Equals(a.HomeAccountId?.TenantId, tenantId, StringComparison.OrdinalIgnoreCase));
+            if (tenantAccount != null)
+                return tenantAccount;
+        }
+
+        // Fall back to username match
+        if (!string.IsNullOrEmpty(username))
+        {
+            var usernameAccount = accountList.FirstOrDefault(a =>
+                string.Equals(a.Username, username, StringComparison.OrdinalIgnoreCase));
+            if (usernameAccount != null)
+                return usernameAccount;
+        }
+
+        // If we can't find the right account, return null to force re-authentication.
+        // Never silently use a random cached account - that causes cross-tenant issues.
+        return null;
+    }
+}

--- a/src/PPDS.Auth/Credentials/UsernamePasswordCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/UsernamePasswordCredentialProvider.cs
@@ -45,6 +45,9 @@ public sealed class UsernamePasswordCredentialProvider : ICredentialProvider
     public string? ObjectId => _cachedResult?.UniqueId;
 
     /// <inheritdoc />
+    public string? HomeAccountId => _cachedResult?.Account?.HomeAccountId?.Identifier;
+
+    /// <inheritdoc />
     public string? AccessToken => _cachedResult?.AccessToken;
 
     /// <inheritdoc />

--- a/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
+++ b/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
@@ -229,38 +229,9 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
 
     /// <summary>
     /// Finds the correct cached account for this profile.
-    /// Uses HomeAccountId for precise lookup, falls back to tenant filtering.
     /// </summary>
-    private async Task<IAccount?> FindAccountAsync()
-    {
-        // Best case: we have the exact account identifier stored
-        if (!string.IsNullOrEmpty(_homeAccountId))
-        {
-            var account = await _msalClient!.GetAccountAsync(_homeAccountId).ConfigureAwait(false);
-            if (account != null)
-                return account;
-        }
-
-        // Fall back to filtering accounts
-        var accounts = await _msalClient!.GetAccountsAsync().ConfigureAwait(false);
-        var accountList = accounts.ToList();
-
-        if (accountList.Count == 0)
-            return null;
-
-        // If we have a tenant ID, filter by it to avoid cross-tenant token usage
-        if (!string.IsNullOrEmpty(_tenantId))
-        {
-            var tenantAccount = accountList.FirstOrDefault(a =>
-                string.Equals(a.HomeAccountId?.TenantId, _tenantId, StringComparison.OrdinalIgnoreCase));
-            if (tenantAccount != null)
-                return tenantAccount;
-        }
-
-        // If we can't find the right account, return null to force re-authentication.
-        // Never silently use a random cached account - that causes cross-tenant issues.
-        return null;
-    }
+    private Task<IAccount?> FindAccountAsync()
+        => MsalAccountHelper.FindAccountAsync(_msalClient!, _homeAccountId, _tenantId);
 
     /// <summary>
     /// Ensures the MSAL client is initialized with token cache.

--- a/src/PPDS.Auth/Profiles/AuthProfile.cs
+++ b/src/PPDS.Auth/Profiles/AuthProfile.cs
@@ -165,6 +165,13 @@ public sealed class AuthProfile
     [JsonPropertyName("puid")]
     public string? Puid { get; set; }
 
+    /// <summary>
+    /// Gets or sets the MSAL home account identifier.
+    /// Format: {objectId}.{tenantId} - uniquely identifies the account+tenant for token cache lookup.
+    /// </summary>
+    [JsonPropertyName("homeAccountId")]
+    public string? HomeAccountId { get; set; }
+
     #endregion
 
     /// <summary>

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `entityAlias` field in plugin image configuration (defaults to `name` if not specified)
+- `unsecureConfiguration` field for plugin step configuration (renamed from `configuration` for clarity)
+- `MainOperation` stage (30) support for Custom API plugin steps
+- JSON schema for `plugin-registration.json` at `schemas/plugin-registration.schema.json`
+- Zulu time format (`Z` suffix) for `generatedAt` timestamps in extracted config
+
+### Fixed
+
+- Solution component addition now works on UPDATE path (was only adding on CREATE) ([#59](https://github.com/joshsmithxrm/ppds-sdk/issues/59))
+- Cross-platform path normalization uses forward slashes consistently
+- Runtime ETC lookup for `pluginpackage` entity type code
+
 ## [1.0.0-beta.2] - 2025-12-30
 
 ### Added

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.3] - 2026-01-01
+
 ### Added
 
 - `entityAlias` field in plugin image configuration (defaults to `name` if not specified)
@@ -78,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaged as .NET global tool (`ppds`)
 - Targets: `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.2...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.3...HEAD
+[1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.2...Cli-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.1...Cli-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Cli-v1.0.0-beta.1

--- a/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
@@ -286,6 +286,7 @@ public static class AuthCommandGroup
                 profile.Username = provider.Identity;
                 profile.ObjectId = provider.ObjectId;
                 profile.TokenExpiresOn = provider.TokenExpiresAt;
+                profile.HomeAccountId = provider.HomeAccountId;
 
                 // Store tenant ID from auth result if not already set
                 if (string.IsNullOrEmpty(profile.TenantId) && !string.IsNullOrEmpty(provider.TenantId))

--- a/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
@@ -104,7 +104,8 @@ public static class ExtractCommand
             var outputDir = Path.GetDirectoryName(outputPath) ?? ".";
 
             // Calculate relative path from output to input
-            var relativePath = Path.GetRelativePath(outputDir, input.FullName);
+            // Normalize to forward slashes for cross-platform compatibility
+            var relativePath = Path.GetRelativePath(outputDir, input.FullName).Replace('\\', '/');
             if (assemblyConfig.Type == "Assembly")
             {
                 assemblyConfig.Path = relativePath;

--- a/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
@@ -250,6 +250,7 @@ public static class ListCommand
                     Deployment = step.Deployment,
                     RunAsUser = step.ImpersonatingUserName,
                     AsyncAutoDelete = step.AsyncAutoDelete,
+                    UnsecureConfiguration = step.Configuration,
                     Images = []
                 };
 
@@ -260,6 +261,7 @@ public static class ListCommand
                     stepOutput.Images.Add(new ImageOutput
                     {
                         Name = image.Name,
+                        EntityAlias = image.EntityAlias ?? image.Name,
                         ImageType = image.ImageType,
                         Attributes = image.Attributes
                     });
@@ -422,6 +424,9 @@ public static class ListCommand
         [JsonPropertyName("asyncAutoDelete")]
         public bool AsyncAutoDelete { get; set; }
 
+        [JsonPropertyName("unsecureConfiguration")]
+        public string? UnsecureConfiguration { get; set; }
+
         [JsonPropertyName("images")]
         public List<ImageOutput> Images { get; set; } = [];
     }
@@ -430,6 +435,9 @@ public static class ListCommand
     {
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("entityAlias")]
+        public string EntityAlias { get; set; } = string.Empty;
 
         [JsonPropertyName("imageType")]
         public string ImageType { get; set; } = string.Empty;

--- a/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
@@ -179,7 +179,7 @@ public sealed class AssemblyExtractor : IDisposable
                     step.Name = value?.ToString();
                     break;
                 case "UnsecureConfiguration":
-                    step.Configuration = value?.ToString();
+                    step.UnsecureConfiguration = value?.ToString();
                     break;
                 case "Description":
                     step.Description = value?.ToString();
@@ -249,6 +249,9 @@ public sealed class AssemblyExtractor : IDisposable
             }
         }
 
+        // Default entityAlias to name if not explicitly specified
+        image.EntityAlias ??= image.Name;
+
         return image;
     }
 
@@ -280,6 +283,7 @@ public sealed class AssemblyExtractor : IDisposable
             {
                 10 => "PreValidation",
                 20 => "PreOperation",
+                30 => "MainOperation",
                 40 => "PostOperation",
                 _ => intValue.ToString()
             };

--- a/src/PPDS.Cli/Plugins/Models/PluginRegistrationConfig.cs
+++ b/src/PPDS.Cli/Plugins/Models/PluginRegistrationConfig.cs
@@ -4,6 +4,30 @@ using System.Text.Json.Serialization;
 namespace PPDS.Cli.Plugins.Models;
 
 /// <summary>
+/// Converts DateTimeOffset to/from Zulu time format (yyyy-MM-ddTHH:mm:ssZ).
+/// </summary>
+public sealed class ZuluTimeConverter : JsonConverter<DateTimeOffset?>
+{
+    public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return string.IsNullOrEmpty(value) ? null : DateTimeOffset.Parse(value);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+        {
+            writer.WriteStringValue(value.Value.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}
+
+/// <summary>
 /// Root configuration for plugin registrations.
 /// Serialized to/from registrations.json.
 /// </summary>
@@ -25,6 +49,7 @@ public sealed class PluginRegistrationConfig
     /// Timestamp when the configuration was generated.
     /// </summary>
     [JsonPropertyName("generatedAt")]
+    [JsonConverter(typeof(ZuluTimeConverter))]
     public DateTimeOffset? GeneratedAt { get; set; }
 
     /// <summary>
@@ -175,9 +200,10 @@ public sealed class PluginStepConfig
 
     /// <summary>
     /// Unsecure configuration string passed to plugin constructor.
+    /// Safe for source control (never contains secrets).
     /// </summary>
-    [JsonPropertyName("configuration")]
-    public string? Configuration { get; set; }
+    [JsonPropertyName("unsecureConfiguration")]
+    public string? UnsecureConfiguration { get; set; }
 
     /// <summary>
     /// Deployment target: ServerOnly (default), Offline, or Both.

--- a/src/PPDS.Cli/Plugins/Models/PluginRegistrationConfig.cs
+++ b/src/PPDS.Cli/Plugins/Models/PluginRegistrationConfig.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,7 +12,7 @@ public sealed class ZuluTimeConverter : JsonConverter<DateTimeOffset?>
     public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var value = reader.GetString();
-        return string.IsNullOrEmpty(value) ? null : DateTimeOffset.Parse(value);
+        return string.IsNullOrEmpty(value) ? null : DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
     }
 
     public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)

--- a/tests/PPDS.Cli.Tests/Plugins/Models/PluginRegistrationConfigTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Models/PluginRegistrationConfigTests.cs
@@ -262,7 +262,7 @@ public class PluginRegistrationConfigTests
                                     Mode = "Synchronous",
                                     ExecutionOrder = 10,
                                     FilteringAttributes = null,
-                                    Configuration = "some config",
+                                    UnsecureConfiguration = "some config",
                                     StepId = "step1",
                                     Images = []
                                 }
@@ -293,7 +293,7 @@ public class PluginRegistrationConfigTests
         Assert.Equal(origStep.Name, deserStep.Name);
         Assert.Equal(origStep.Message, deserStep.Message);
         Assert.Equal(origStep.ExecutionOrder, deserStep.ExecutionOrder);
-        Assert.Equal(origStep.Configuration, deserStep.Configuration);
+        Assert.Equal(origStep.UnsecureConfiguration, deserStep.UnsecureConfiguration);
         Assert.Equal(origStep.StepId, deserStep.StepId);
     }
 


### PR DESCRIPTION
## Summary

Resolves all items in #59:

### Plugin Registration Fixes
- Add `entityAlias` field to image definitions (defaults to `name` if not specified)
- Add `unsecureConfiguration` field for step configuration
- Add `MainOperation` stage (30) support for Custom API plugin steps
- Add JSON schema for `plugin-registration.json`
- Use Zulu time format for `generatedAt` timestamps
- Fix solution component addition on UPDATE path (was only on CREATE)
- Fix cross-platform path normalization (use forward slashes)
- Fix runtime ETC lookup for `pluginpackage` entity

### Cross-Tenant Auth Fix
**Root cause:** MSAL token cache shared by all profiles, but account lookup used `accounts.FirstOrDefault()` which picked an arbitrary cached account regardless of which tenant the profile belonged to.

**Fix:**
- Add `HomeAccountId` property to `AuthProfile` and `ICredentialProvider`
- Store account identifier (format: `{objectId}.{tenantId}`) after authentication
- Use `GetAccountAsync(homeAccountId)` for precise account lookup
- Fall back to filtering by `HomeAccountId.TenantId` if no identifier stored
- Never silently use random cached account - force re-auth if no match found

Applied to: `InteractiveBrowserCredentialProvider`, `DeviceCodeCredentialProvider`, `GlobalDiscoveryService`

## Test plan
- [x] Build succeeds with no errors
- [x] All 1,897 tests pass across all target frameworks
- [x] Manual test: verified cross-tenant auth now works correctly

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)