### PR TITLE
fix: NuGet plugin package deployment (#62)

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2026-01-01
+
+### Fixed
+
+- NuGet plugin package deployment now works correctly ([#62](https://github.com/joshsmithxrm/ppds-sdk/issues/62))
+  - Package name is parsed from .nupkg filename (matches nuspec `<id>`)
+  - Dataverse extracts `uniquename` from package content automatically - CLI no longer sets it
+  - Solution association works on both create and update via `SolutionUniqueName` request parameter
+  - Removed unnecessary publisher prefix querying logic
+
 ## [1.0.0-beta.3] - 2026-01-01
 
 ### Added
@@ -80,7 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaged as .NET global tool (`ppds`)
 - Targets: `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.4...HEAD
+[1.0.0-beta.4]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.3...Cli-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.2...Cli-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.1...Cli-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Cli-v1.0.0-beta.1

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - NuGet plugin package deployment now works correctly ([#62](https://github.com/joshsmithxrm/ppds-sdk/issues/62))
-  - Package name is parsed from .nupkg filename (matches nuspec `<id>`)
+  - Package ID is read directly from `.nuspec` inside the nupkg (authoritative source)
   - Dataverse extracts `uniquename` from package content automatically - CLI no longer sets it
   - Solution association works on both create and update via `SolutionUniqueName` request parameter
   - Removed unnecessary publisher prefix querying logic

--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -221,11 +221,12 @@ public static class DeployCommand
                 // Get the assembly ID from the package (Dataverse creates it automatically)
                 // Use assemblyConfig.Name here since that's the assembly name inside the package
                 var pkgAssemblyId = await service.GetAssemblyIdForPackageAsync(packageId, assemblyConfig.Name);
-                if (pkgAssemblyId == null)
+                if (pkgAssemblyId == null && !whatIf)
                 {
                     throw new InvalidOperationException($"Could not find assembly '{assemblyConfig.Name}' in package after deployment");
                 }
-                assemblyId = pkgAssemblyId.Value;
+                // In what-if mode for new packages, the assembly won't exist yet - use a placeholder ID
+                assemblyId = pkgAssemblyId ?? Guid.NewGuid();
             }
             else
             {

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -409,22 +409,18 @@ public sealed class PluginRegistrationService
 
         if (existing != null)
         {
-            // UPDATE: Only update content
+            // UPDATE: Only update content, use solution header for solution association
             var updateEntity = new Entity("pluginpackage", existing.Id)
             {
                 ["content"] = Convert.ToBase64String(nupkgContent)
             };
-            await UpdateAsync(updateEntity);
 
-            // Add to solution if specified (handles case where package exists but isn't in solution)
+            var request = new UpdateRequest { Target = updateEntity };
             if (!string.IsNullOrEmpty(solutionName))
             {
-                var componentType = await GetComponentTypeAsync("pluginpackage");
-                if (componentType > 0)
-                {
-                    await AddToSolutionAsync(existing.Id, componentType, solutionName);
-                }
+                request.Parameters["SolutionUniqueName"] = solutionName;
             }
+            await ExecuteAsync(request);
 
             return existing.Id;
         }

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -403,7 +403,7 @@ public sealed class PluginRegistrationService
     /// <returns>The package ID.</returns>
     public async Task<Guid> UpsertPackageAsync(string packageName, byte[] nupkgContent, string? solutionName = null)
     {
-        // packageName comes from .nuspec <id> (parsed from filename)
+        // packageName comes from .nuspec <id> (parsed from .nuspec)
         // Dataverse extracts uniquename from the nupkg content, so we use packageName for lookup
         var existing = await GetPackageByNameAsync(packageName);
 

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -415,6 +415,17 @@ public sealed class PluginRegistrationService
                 ["content"] = Convert.ToBase64String(nupkgContent)
             };
             await UpdateAsync(updateEntity);
+
+            // Add to solution if specified (handles case where package exists but isn't in solution)
+            if (!string.IsNullOrEmpty(solutionName))
+            {
+                var componentType = await GetComponentTypeAsync("pluginpackage");
+                if (componentType > 0)
+                {
+                    await AddToSolutionAsync(existing.Id, componentType, solutionName);
+                }
+            }
+
             return existing.Id;
         }
 


### PR DESCRIPTION
## Summary

Fixes NuGet plugin package deployment which was completely broken for updates.

- Read package ID directly from `.nuspec` inside the nupkg (authoritative source)
- Let Dataverse extract `uniquename` from package content - CLI no longer sets it
- Use `SolutionUniqueName` request parameter for solution association on create/update
- Remove unnecessary publisher prefix querying logic

## Key Discovery

The Plugin Registration Tool and Dataverse work together:
1. PRT sends `name` + `content` (base64 nupkg bytes)
2. Dataverse parses the nupkg, extracts `.nuspec`, reads `<id>` element
3. Dataverse sets `uniquename` = nuspec `<id>`

We were incorrectly trying to set `uniquename` ourselves and querying publisher prefixes unnecessarily.

## Test Plan

- [x] Deploy new NuGet plugin package to environment
- [x] Verify package appears in target solution
- [x] Update existing package (change code, rebuild, redeploy)
- [x] Verify steps/images are registered correctly
- [x] Verify `ppds plugins list --package` shows the package

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)