### PR TITLE
fix: address code review findings from #71 and #80

### DIFF
--- a/src/PPDS.Auth/AuthenticationOutput.cs
+++ b/src/PPDS.Auth/AuthenticationOutput.cs
@@ -12,7 +12,7 @@ namespace PPDS.Auth;
 /// </remarks>
 public static class AuthenticationOutput
 {
-    private static Action<string>? _writer = Console.WriteLine;
+    private static volatile Action<string>? _writer = Console.WriteLine;
 
     /// <summary>
     /// Gets or sets the action used to write authentication status messages.

--- a/src/PPDS.Auth/AuthenticationOutput.cs
+++ b/src/PPDS.Auth/AuthenticationOutput.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace PPDS.Auth;
+
+/// <summary>
+/// Controls authentication status output for the auth library.
+/// </summary>
+/// <remarks>
+/// By default, authentication status messages are written to the console.
+/// Library consumers who don't want console output can set <see cref="Writer"/> to null
+/// or provide a custom action to redirect output.
+/// </remarks>
+public static class AuthenticationOutput
+{
+    private static Action<string>? _writer = Console.WriteLine;
+
+    /// <summary>
+    /// Gets or sets the action used to write authentication status messages.
+    /// Set to null to suppress all output, or provide a custom action to redirect.
+    /// Default: Console.WriteLine
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Suppress all auth output
+    /// AuthenticationOutput.Writer = null;
+    ///
+    /// // Redirect to a logger
+    /// AuthenticationOutput.Writer = message => logger.LogInformation(message);
+    /// </code>
+    /// </example>
+    public static Action<string>? Writer
+    {
+        get => _writer;
+        set => _writer = value;
+    }
+
+    /// <summary>
+    /// Writes a status message using the configured writer.
+    /// Does nothing if Writer is null.
+    /// </summary>
+    /// <param name="message">The message to write.</param>
+    internal static void WriteLine(string message = "")
+    {
+        _writer?.Invoke(message);
+    }
+
+    /// <summary>
+    /// Resets the writer to the default (Console.WriteLine).
+    /// </summary>
+    public static void Reset()
+    {
+        _writer = Console.WriteLine;
+    }
+}

--- a/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
@@ -156,9 +156,17 @@ public sealed class CertificateFileCredentialProvider : ICredentialProvider
         {
             var flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
 
+#if NET9_0_OR_GREATER
+            // Use X509CertificateLoader for .NET 9+ (X509Certificate2 constructors are obsolete)
+            _certificate = X509CertificateLoader.LoadPkcs12FromFile(
+                _certificatePath,
+                _certificatePassword,
+                flags);
+#else
             _certificate = string.IsNullOrEmpty(_certificatePassword)
                 ? new X509Certificate2(_certificatePath, (string?)null, flags)
                 : new X509Certificate2(_certificatePath, _certificatePassword, flags);
+#endif
 
             if (!_certificate.HasPrivateKey)
             {

--- a/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
@@ -225,7 +225,7 @@ public sealed class CertificateStoreCredentialProvider : ICredentialProvider
         // Add store location if not default
         if (_storeLocation != StoreLocation.CurrentUser)
         {
-            builder.Append($"StoreName={_storeLocation};");
+            builder.Append($"StoreLocation={_storeLocation};");
         }
 
         // Add authority for non-public clouds

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -262,6 +262,12 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         if (_disposed)
             return;
 
+        // Unregister cache before disposal to release file locks
+        if (_cacheHelper != null && _msalClient != null)
+        {
+            _cacheHelper.UnregisterCache(_msalClient.UserTokenCache);
+        }
+
         _disposed = true;
     }
 }

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -184,19 +184,15 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
                 }
                 else
                 {
-                    // Default console output
-                    Console.WriteLine();
-                    Console.WriteLine("To sign in, use a web browser to open the page:");
-                    Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.WriteLine($"  {deviceCodeResult.VerificationUrl}");
-                    Console.ResetColor();
-                    Console.WriteLine();
-                    Console.WriteLine("Enter the code:");
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine($"  {deviceCodeResult.UserCode}");
-                    Console.ResetColor();
-                    Console.WriteLine();
-                    Console.WriteLine("Waiting for authentication...");
+                    // Default output via AuthenticationOutput (can be redirected or suppressed)
+                    AuthenticationOutput.WriteLine();
+                    AuthenticationOutput.WriteLine("To sign in, use a web browser to open the page:");
+                    AuthenticationOutput.WriteLine($"  {deviceCodeResult.VerificationUrl}");
+                    AuthenticationOutput.WriteLine();
+                    AuthenticationOutput.WriteLine("Enter the code:");
+                    AuthenticationOutput.WriteLine($"  {deviceCodeResult.UserCode}");
+                    AuthenticationOutput.WriteLine();
+                    AuthenticationOutput.WriteLine("Waiting for authentication...");
                 }
                 return Task.CompletedTask;
             })
@@ -205,8 +201,8 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
 
         if (_deviceCodeCallback == null)
         {
-            Console.WriteLine($"Authenticated as: {_cachedResult.Account.Username}");
-            Console.WriteLine();
+            AuthenticationOutput.WriteLine($"Authenticated as: {_cachedResult.Account.Username}");
+            AuthenticationOutput.WriteLine();
         }
 
         return _cachedResult.AccessToken;

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -205,8 +205,8 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         }
 
         // Interactive browser authentication
-        Console.WriteLine();
-        Console.WriteLine("Opening browser for authentication...");
+        AuthenticationOutput.WriteLine();
+        AuthenticationOutput.WriteLine("Opening browser for authentication...");
 
         try
         {
@@ -222,8 +222,8 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
             throw new OperationCanceledException("Authentication was canceled by the user.", ex);
         }
 
-        Console.WriteLine($"Authenticated as: {_cachedResult.Account.Username}");
-        Console.WriteLine();
+        AuthenticationOutput.WriteLine($"Authenticated as: {_cachedResult.Account.Username}");
+        AuthenticationOutput.WriteLine();
 
         return _cachedResult.AccessToken;
     }

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -278,6 +278,12 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         if (_disposed)
             return;
 
+        // Unregister cache helper to release file locks on token cache
+        if (_cacheHelper != null && _msalClient != null)
+        {
+            _cacheHelper.UnregisterCache(_msalClient.UserTokenCache);
+        }
+
         _disposed = true;
     }
 }

--- a/src/PPDS.Auth/Credentials/UsernamePasswordCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/UsernamePasswordCredentialProvider.cs
@@ -164,6 +164,12 @@ public sealed class UsernamePasswordCredentialProvider : ICredentialProvider
         if (_disposed)
             return;
 
+        // Unregister cache before disposal to release file locks
+        if (_cacheHelper != null && _msalClient != null)
+        {
+            _cacheHelper.UnregisterCache(_msalClient.UserTokenCache);
+        }
+
         _disposed = true;
     }
 }

--- a/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
+++ b/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
@@ -94,18 +94,12 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
         var environments = new List<DiscoveredEnvironment>();
         foreach (var org in organizations)
         {
-            // Get the web API endpoint from the Endpoints dictionary
-            string apiUrl = string.Empty;
+            // Get the web application URL - used for both API connections and web interface
+            // In Dataverse, the WebApplication endpoint is the base URL (e.g., https://org.crm.dynamics.com)
+            string? baseUrl = null;
             if (org.Endpoints.TryGetValue(Microsoft.Xrm.Sdk.Discovery.EndpointType.WebApplication, out var webAppUrl))
             {
-                apiUrl = webAppUrl;
-            }
-
-            // Get the application URL
-            string? appUrl = null;
-            if (org.Endpoints.TryGetValue(Microsoft.Xrm.Sdk.Discovery.EndpointType.WebApplication, out var webUrl))
-            {
-                appUrl = webUrl;
+                baseUrl = webAppUrl;
             }
 
             // Parse TenantId if present (it may be a string or Guid depending on version)
@@ -122,8 +116,8 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
                 FriendlyName = org.FriendlyName,
                 UniqueName = org.UniqueName,
                 UrlName = org.UrlName,
-                ApiUrl = apiUrl,
-                Url = appUrl,
+                ApiUrl = baseUrl ?? string.Empty,
+                Url = baseUrl,
                 State = (int)org.State,
                 Version = org.OrganizationVersion,
                 Region = org.Geo,

--- a/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
+++ b/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
@@ -168,7 +168,7 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
             {
                 if (_deviceCodeCallback == null)
                 {
-                    Console.WriteLine("Opening browser for authentication...");
+                    AuthenticationOutput.WriteLine("Opening browser for authentication...");
                 }
 
                 result = await _msalClient!
@@ -192,18 +192,14 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
                         }
                         else
                         {
-                            Console.WriteLine();
-                            Console.WriteLine("To sign in, use a web browser to open the page:");
-                            Console.ForegroundColor = ConsoleColor.Cyan;
-                            Console.WriteLine($"  {deviceCodeResult.VerificationUrl}");
-                            Console.ResetColor();
-                            Console.WriteLine();
-                            Console.WriteLine("Enter the code:");
-                            Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine($"  {deviceCodeResult.UserCode}");
-                            Console.ResetColor();
-                            Console.WriteLine();
-                            Console.WriteLine("Waiting for authentication...");
+                            AuthenticationOutput.WriteLine();
+                            AuthenticationOutput.WriteLine("To sign in, use a web browser to open the page:");
+                            AuthenticationOutput.WriteLine($"  {deviceCodeResult.VerificationUrl}");
+                            AuthenticationOutput.WriteLine();
+                            AuthenticationOutput.WriteLine("Enter the code:");
+                            AuthenticationOutput.WriteLine($"  {deviceCodeResult.UserCode}");
+                            AuthenticationOutput.WriteLine();
+                            AuthenticationOutput.WriteLine("Waiting for authentication...");
                         }
                         return Task.CompletedTask;
                     })
@@ -213,8 +209,8 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
 
             if (_deviceCodeCallback == null)
             {
-                Console.WriteLine($"Authenticated as: {result.Account.Username}");
-                Console.WriteLine();
+                AuthenticationOutput.WriteLine($"Authenticated as: {result.Account.Username}");
+                AuthenticationOutput.WriteLine();
             }
 
             return result.AccessToken;

--- a/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
+++ b/src/PPDS.Auth/Discovery/GlobalDiscoveryService.cs
@@ -278,6 +278,12 @@ public sealed class GlobalDiscoveryService : IGlobalDiscoveryService, IDisposabl
         if (_disposed)
             return;
 
+        // Unregister cache helper to release file locks on token cache
+        if (_cacheHelper != null && _msalClient != null)
+        {
+            _cacheHelper.UnregisterCache(_msalClient.UserTokenCache);
+        }
+
         _disposed = true;
     }
 }

--- a/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
+++ b/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
@@ -128,9 +128,11 @@ public sealed class ProfileConnectionSource : IDisposable
 
             try
             {
-                // Create ServiceClient synchronously (pool expects sync method)
-                _seedClient = _provider
-                    .CreateServiceClientAsync(_environmentUrl, CancellationToken.None)
+                // Create ServiceClient synchronously (pool expects sync method).
+                // Wrap in Task.Run to avoid deadlock in sync contexts (UI/ASP.NET)
+                // by running async code on threadpool which has no sync context.
+                _seedClient = System.Threading.Tasks.Task.Run(() =>
+                    _provider.CreateServiceClientAsync(_environmentUrl, CancellationToken.None))
                     .GetAwaiter()
                     .GetResult();
 

--- a/src/PPDS.Auth/ServiceClientFactory.cs
+++ b/src/PPDS.Auth/ServiceClientFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -17,7 +18,7 @@ public sealed class ServiceClientFactory : IDisposable
 {
     private readonly ProfileStore _profileStore;
     private readonly Action<DeviceCodeInfo>? _deviceCodeCallback;
-    private readonly List<ICredentialProvider> _activeProviders = new();
+    private readonly ConcurrentBag<ICredentialProvider> _activeProviders = new();
     private bool _disposed;
 
     /// <summary>
@@ -258,12 +259,11 @@ public sealed class ServiceClientFactory : IDisposable
         if (_disposed)
             return;
 
-        foreach (var provider in _activeProviders)
+        while (_activeProviders.TryTake(out var provider))
         {
             provider.Dispose();
         }
 
-        _activeProviders.Clear();
         _profileStore.Dispose();
         _disposed = true;
     }

--- a/src/PPDS.Auth/ServiceClientFactory.cs
+++ b/src/PPDS.Auth/ServiceClientFactory.cs
@@ -243,6 +243,11 @@ public sealed class ServiceClientFactory : IDisposable
             ThreadPool.SetMinThreads(100, completionPortThreads);
         }
 
+        // SYSLIB0014: ServicePointManager is obsolete, but these settings are required for
+        // optimal Dataverse throughput. The Dataverse SDK uses HttpWebRequest internally,
+        // so these settings still apply. No alternative exists until Microsoft updates
+        // their SDK to use HttpClient.
+#pragma warning disable SYSLIB0014
         // Increase connection limit (default is 2)
         ServicePointManager.DefaultConnectionLimit = 65000;
 
@@ -251,6 +256,7 @@ public sealed class ServiceClientFactory : IDisposable
 
         // Disable Nagle algorithm for better latency
         ServicePointManager.UseNagleAlgorithm = false;
+#pragma warning restore SYSLIB0014
     }
 
     /// <inheritdoc />

--- a/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
@@ -1287,24 +1287,12 @@ public static class AuthCommandGroup
 
     private static string ExtractEnvironmentName(string url)
     {
-        try
-        {
-            var uri = new Uri(url);
-            var host = uri.Host;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return url;
 
-            // Extract org name from host (e.g., "myorg" from "myorg.crm.dynamics.com")
-            var parts = host.Split('.');
-            if (parts.Length > 0)
-            {
-                return parts[0];
-            }
-        }
-        catch
-        {
-            // Ignore parse errors
-        }
-
-        return url;
+        // Extract org name from host (e.g., "myorg" from "myorg.crm.dynamics.com")
+        var parts = uri.Host.Split('.');
+        return parts.Length > 0 ? parts[0] : url;
     }
 
     #endregion

--- a/src/PPDS.Cli/Commands/Data/CopyCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/CopyCommand.cs
@@ -176,7 +176,7 @@ public static class CopyCommand
             var verbose = parseResult.GetValue(verboseOption);
             var debug = parseResult.GetValue(debugOption);
 
-            var bypassPlugins = ParseBypassPlugins(bypassPluginsValue);
+            var bypassPlugins = DataCommandGroup.ParseBypassPlugins(bypassPluginsValue);
 
             return await ExecuteAsync(
                 sourceProfile, targetProfile,
@@ -188,17 +188,6 @@ public static class CopyCommand
         });
 
         return command;
-    }
-
-    private static CustomLogicBypass ParseBypassPlugins(string? value)
-    {
-        return value?.ToLowerInvariant() switch
-        {
-            "sync" => CustomLogicBypass.Synchronous,
-            "async" => CustomLogicBypass.Asynchronous,
-            "all" => CustomLogicBypass.All,
-            _ => CustomLogicBypass.None
-        };
     }
 
     private static async Task<int> ExecuteAsync(

--- a/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using PPDS.Dataverse.BulkOperations;
 
 namespace PPDS.Cli.Commands.Data;
 
@@ -37,5 +38,21 @@ public static class DataCommandGroup
         command.Subcommands.Add(AnalyzeCommand.Create());
 
         return command;
+    }
+
+    /// <summary>
+    /// Parses the --bypass-plugins option value to CustomLogicBypass enum.
+    /// </summary>
+    /// <param name="value">The option value: "sync", "async", "all", or null.</param>
+    /// <returns>The corresponding CustomLogicBypass value.</returns>
+    internal static CustomLogicBypass ParseBypassPlugins(string? value)
+    {
+        return value?.ToLowerInvariant() switch
+        {
+            "sync" => CustomLogicBypass.Synchronous,
+            "async" => CustomLogicBypass.Asynchronous,
+            "all" => CustomLogicBypass.All,
+            _ => CustomLogicBypass.None
+        };
     }
 }

--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -120,7 +120,7 @@ public static class ImportCommand
             var verbose = parseResult.GetValue(verboseOption);
             var debug = parseResult.GetValue(debugOption);
 
-            var bypassPlugins = ParseBypassPlugins(bypassPluginsValue);
+            var bypassPlugins = DataCommandGroup.ParseBypassPlugins(bypassPluginsValue);
 
             return await ExecuteAsync(
                 profile, environment, data, bypassPlugins, bypassFlows,
@@ -129,17 +129,6 @@ public static class ImportCommand
         });
 
         return command;
-    }
-
-    private static CustomLogicBypass ParseBypassPlugins(string? value)
-    {
-        return value?.ToLowerInvariant() switch
-        {
-            "sync" => CustomLogicBypass.Synchronous,
-            "async" => CustomLogicBypass.Asynchronous,
-            "all" => CustomLogicBypass.All,
-            _ => CustomLogicBypass.None
-        };
     }
 
     private static async Task<int> ExecuteAsync(

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -7,11 +7,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Suppress known vulnerability in transitive dependency until upstream fix -->
     <!-- NU1702: PPDS.Plugins targets net462 (required for Dataverse plugin sandbox) but is
          referenced from net8.0+. The package contains only attributes/enums with no
          framework-specific APIs, so cross-framework reference is safe. -->
-    <NoWarn>$(NoWarn);NU1903;NU1702</NoWarn>
+    <NoWarn>$(NoWarn);NU1702</NoWarn>
 
     <!-- MinVer Configuration -->
     <MinVerTagPrefix>Cli-v</MinVerTagPrefix>

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -8,7 +8,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Suppress known vulnerability in transitive dependency until upstream fix -->
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
+    <!-- NU1702: PPDS.Plugins targets net462 (required for Dataverse plugin sandbox) but is
+         referenced from net8.0+. The package contains only attributes/enums with no
+         framework-specific APIs, so cross-framework reference is safe. -->
+    <NoWarn>$(NoWarn);NU1903;NU1702</NoWarn>
 
     <!-- MinVer Configuration -->
     <MinVerTagPrefix>Cli-v</MinVerTagPrefix>

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
@@ -17,7 +18,7 @@ public sealed class PluginRegistrationService
     private readonly IOrganizationServiceAsync2? _asyncService;
 
     // Cache for entity type codes (ETCs) - some like pluginpackage vary by environment
-    private readonly Dictionary<string, int> _entityTypeCodeCache = new();
+    private readonly ConcurrentDictionary<string, int> _entityTypeCodeCache = new();
 
     // Well-known component type codes that are consistent across all environments
     private static readonly Dictionary<string, int> WellKnownComponentTypes = new()

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -29,14 +29,9 @@ public static class Program
         // Prepend [Required] to required option descriptions for scannability
         HelpCustomization.ApplyRequiredOptionStyle(rootCommand);
 
-        // Handle cancellation
-        using var cts = new CancellationTokenSource();
-        Console.CancelKeyPress += (_, e) =>
-        {
-            e.Cancel = true;
-            cts.Cancel();
-            Console.Error.WriteLine("\nCancellation requested. Waiting for current operation to complete...");
-        };
+        // Note: System.CommandLine handles Ctrl+C automatically and passes the
+        // CancellationToken to command handlers via SetAction's cancellationToken parameter.
+        // No manual CancelKeyPress handler is needed.
 
         var parseResult = rootCommand.Parse(args);
         return await parseResult.InvokeAsync();

--- a/src/PPDS.Dataverse/Pooling/ConnectionStringSource.cs
+++ b/src/PPDS.Dataverse/Pooling/ConnectionStringSource.cs
@@ -17,7 +17,7 @@ public sealed class ConnectionStringSource : IConnectionSource
 {
     private readonly DataverseConnection _config;
     private readonly object _lock = new();
-    private ServiceClient? _client;
+    private volatile ServiceClient? _client;
     private bool _disposed;
 
     /// <summary>

--- a/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
@@ -57,7 +57,12 @@ namespace PPDS.Migration.DependencyInjection
             // Export
             services.AddTransient<IExporter, ParallelExporter>();
 
-            // Import
+            // Import - Phase processors
+            services.AddTransient<ISchemaValidator, SchemaValidator>();
+            services.AddTransient<DeferredFieldProcessor>();
+            services.AddTransient<RelationshipProcessor>();
+
+            // Import - Orchestration
             services.AddTransient<IPluginStepManager, PluginStepManager>();
             services.AddTransient<IImporter, TieredImporter>();
 

--- a/src/PPDS.Migration/Formats/CmtSchemaReader.cs
+++ b/src/PPDS.Migration/Formats/CmtSchemaReader.cs
@@ -105,7 +105,11 @@ namespace PPDS.Migration.Formats
 
         private EntitySchema ParseEntity(XElement element)
         {
-            var logicalName = element.Attribute("name")?.Value ?? string.Empty;
+            var logicalName = element.Attribute("name")?.Value;
+            if (string.IsNullOrWhiteSpace(logicalName))
+            {
+                throw new InvalidOperationException("Entity element is missing required 'name' attribute.");
+            }
             var displayName = element.Attribute("displayname")?.Value ?? logicalName;
             var objectTypeCode = ParseInt(element.Attribute("etc")?.Value);
             var primaryIdField = element.Attribute("primaryidfield")?.Value ?? $"{logicalName}id";
@@ -154,7 +158,11 @@ namespace PPDS.Migration.Formats
 
         private FieldSchema ParseField(XElement element)
         {
-            var logicalName = element.Attribute("name")?.Value ?? string.Empty;
+            var logicalName = element.Attribute("name")?.Value;
+            if (string.IsNullOrWhiteSpace(logicalName))
+            {
+                throw new InvalidOperationException("Field element is missing required 'name' attribute.");
+            }
             var displayName = element.Attribute("displayname")?.Value ?? logicalName;
             var type = element.Attribute("type")?.Value ?? "string";
             var lookupEntity = element.Attribute("lookupType")?.Value;

--- a/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
+++ b/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Processes deferred fields after the initial entity import.
+    /// Deferred fields are self-referential lookups that couldn't be set during initial import
+    /// because the target records didn't exist yet.
+    /// </summary>
+    public class DeferredFieldProcessor : IImportPhaseProcessor
+    {
+        private readonly IDataverseConnectionPool _connectionPool;
+        private readonly ILogger<DeferredFieldProcessor>? _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeferredFieldProcessor"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The connection pool.</param>
+        /// <param name="logger">Optional logger.</param>
+        public DeferredFieldProcessor(
+            IDataverseConnectionPool connectionPool,
+            ILogger<DeferredFieldProcessor>? logger = null)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public string PhaseName => "Deferred Fields";
+
+        /// <inheritdoc />
+        public async Task<PhaseResult> ProcessAsync(
+            ImportContext context,
+            CancellationToken cancellationToken)
+        {
+            if (context.Plan.DeferredFieldCount == 0)
+            {
+                _logger?.LogDebug("No deferred fields to process");
+                return PhaseResult.Skipped();
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var totalUpdated = 0;
+
+            foreach (var (entityName, fields) in context.Plan.DeferredFields)
+            {
+                if (!context.Data.EntityData.TryGetValue(entityName, out var records))
+                {
+                    continue;
+                }
+
+                var fieldList = string.Join(", ", fields);
+                var processed = 0;
+                var updated = 0;
+
+                foreach (var record in records)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (!context.IdMappings.TryGetNewId(entityName, record.Id, out var newId))
+                    {
+                        processed++;
+                        continue;
+                    }
+
+                    var update = new Entity(entityName, newId);
+                    var hasUpdates = false;
+
+                    foreach (var fieldName in fields)
+                    {
+                        if (record.Contains(fieldName) && record[fieldName] is EntityReference er)
+                        {
+                            if (context.IdMappings.TryGetNewId(er.LogicalName, er.Id, out var mappedId))
+                            {
+                                update[fieldName] = new EntityReference(er.LogicalName, mappedId);
+                                hasUpdates = true;
+                            }
+                        }
+                    }
+
+                    if (hasUpdates)
+                    {
+                        await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        await client.UpdateAsync(update).ConfigureAwait(false);
+                        totalUpdated++;
+                        updated++;
+                    }
+
+                    processed++;
+
+                    // Report progress periodically (every 100 records or at completion)
+                    if (processed % 100 == 0 || processed == records.Count)
+                    {
+                        context.Progress?.Report(new ProgressEventArgs
+                        {
+                            Phase = MigrationPhase.ProcessingDeferredFields,
+                            Entity = entityName,
+                            Field = fieldList,
+                            Current = processed,
+                            Total = records.Count,
+                            SuccessCount = updated,
+                            Message = $"Updating deferred fields: {fieldList}"
+                        });
+                    }
+                }
+            }
+
+            stopwatch.Stop();
+            _logger?.LogInformation("Updated {Count} deferred field records in {Duration}ms",
+                totalUpdated, stopwatch.ElapsedMilliseconds);
+
+            return new PhaseResult
+            {
+                Success = true,
+                RecordsProcessed = totalUpdated,
+                SuccessCount = totalUpdated,
+                FailureCount = 0,
+                Duration = stopwatch.Elapsed
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/FieldMetadataCollection.cs
+++ b/src/PPDS.Migration/Import/FieldMetadataCollection.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Collection of field metadata for multiple entities.
+    /// Provides lookup methods for field validity during import.
+    /// </summary>
+    public class FieldMetadataCollection
+    {
+        private readonly IReadOnlyDictionary<string, Dictionary<string, FieldValidity>> _metadata;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldMetadataCollection"/> class.
+        /// </summary>
+        /// <param name="metadata">The metadata dictionary indexed by entity name.</param>
+        public FieldMetadataCollection(IReadOnlyDictionary<string, Dictionary<string, FieldValidity>> metadata)
+        {
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+        }
+
+        /// <summary>
+        /// Gets the number of entities with metadata.
+        /// </summary>
+        public int EntityCount => _metadata.Count;
+
+        /// <summary>
+        /// Gets field metadata for a specific entity.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <returns>Dictionary of field name to validity, or empty dictionary if entity not found.</returns>
+        public IReadOnlyDictionary<string, FieldValidity> GetFieldsForEntity(string entityName)
+        {
+            if (_metadata.TryGetValue(entityName, out var fields))
+            {
+                return fields;
+            }
+            return new Dictionary<string, FieldValidity>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Tries to get field validity for a specific field.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <param name="fieldName">The field logical name.</param>
+        /// <param name="validity">The field validity if found.</param>
+        /// <returns>True if the field was found, false otherwise.</returns>
+        public bool TryGetFieldValidity(string entityName, string fieldName, out FieldValidity validity)
+        {
+            validity = default;
+            if (_metadata.TryGetValue(entityName, out var fields) &&
+                fields.TryGetValue(fieldName, out validity))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if metadata exists for an entity.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <returns>True if metadata exists for the entity.</returns>
+        public bool HasEntity(string entityName) => _metadata.ContainsKey(entityName);
+
+        /// <summary>
+        /// Gets all entity names with metadata.
+        /// </summary>
+        public IEnumerable<string> EntityNames => _metadata.Keys;
+    }
+}

--- a/src/PPDS.Migration/Import/FieldValidity.cs
+++ b/src/PPDS.Migration/Import/FieldValidity.cs
@@ -1,0 +1,9 @@
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Represents the create/update validity of a field in the target environment.
+    /// </summary>
+    /// <param name="IsValidForCreate">Whether the field can be set during create operations.</param>
+    /// <param name="IsValidForUpdate">Whether the field can be set during update operations.</param>
+    public readonly record struct FieldValidity(bool IsValidForCreate, bool IsValidForUpdate);
+}

--- a/src/PPDS.Migration/Import/IImportPhaseProcessor.cs
+++ b/src/PPDS.Migration/Import/IImportPhaseProcessor.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Processes a phase of the import pipeline.
+    /// Each phase operates on the shared <see cref="ImportContext"/> and returns a <see cref="PhaseResult"/>.
+    /// </summary>
+    public interface IImportPhaseProcessor
+    {
+        /// <summary>
+        /// Gets the name of this phase for logging and progress reporting.
+        /// </summary>
+        string PhaseName { get; }
+
+        /// <summary>
+        /// Executes this phase of the import.
+        /// </summary>
+        /// <param name="context">The shared import context containing data, options, and state.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of this phase.</returns>
+        Task<PhaseResult> ProcessAsync(
+            ImportContext context,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/PPDS.Migration/Import/ISchemaValidator.cs
+++ b/src/PPDS.Migration/Import/ISchemaValidator.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Validates schema compatibility between exported data and target environment.
+    /// </summary>
+    public interface ISchemaValidator
+    {
+        /// <summary>
+        /// Loads field validity metadata from the target environment for all entities.
+        /// </summary>
+        /// <param name="entityNames">The entity names to load metadata for.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of field metadata indexed by entity name.</returns>
+        Task<FieldMetadataCollection> LoadTargetFieldMetadataAsync(
+            IEnumerable<string> entityNames,
+            IProgressReporter? progress,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Detects columns in exported data that don't exist in target environment.
+        /// </summary>
+        /// <param name="data">The migration data containing exported records.</param>
+        /// <param name="targetFieldMetadata">The target environment field metadata.</param>
+        /// <returns>Result containing missing columns by entity.</returns>
+        SchemaMismatchResult DetectMissingColumns(
+            MigrationData data,
+            FieldMetadataCollection targetFieldMetadata);
+
+        /// <summary>
+        /// Determines if a field should be included in the import based on operation mode and metadata.
+        /// </summary>
+        /// <param name="fieldName">The field name to check.</param>
+        /// <param name="mode">The import mode.</param>
+        /// <param name="fieldMetadata">Target environment field metadata for the entity.</param>
+        /// <param name="reason">Output: reason field was excluded, if any.</param>
+        /// <returns>True if field should be included, false otherwise.</returns>
+        bool ShouldIncludeField(
+            string fieldName,
+            ImportMode mode,
+            IReadOnlyDictionary<string, FieldValidity>? fieldMetadata,
+            out string? reason);
+    }
+}

--- a/src/PPDS.Migration/Import/ImportContext.cs
+++ b/src/PPDS.Migration/Import/ImportContext.cs
@@ -1,0 +1,71 @@
+using System;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Shared context passed to all import phases.
+    /// Contains the data, plan, options, and shared state needed for import operations.
+    /// </summary>
+    public class ImportContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImportContext"/> class.
+        /// </summary>
+        /// <param name="data">The migration data containing records to import.</param>
+        /// <param name="plan">The execution plan defining tier order and deferred fields.</param>
+        /// <param name="options">The import options.</param>
+        /// <param name="idMappings">The shared ID mapping collection.</param>
+        /// <param name="targetFieldMetadata">The target environment field metadata.</param>
+        /// <param name="progress">Optional progress reporter.</param>
+        public ImportContext(
+            MigrationData data,
+            ExecutionPlan plan,
+            ImportOptions options,
+            IdMappingCollection idMappings,
+            FieldMetadataCollection targetFieldMetadata,
+            IProgressReporter? progress = null)
+        {
+            Data = data ?? throw new ArgumentNullException(nameof(data));
+            Plan = plan ?? throw new ArgumentNullException(nameof(plan));
+            Options = options ?? throw new ArgumentNullException(nameof(options));
+            IdMappings = idMappings ?? throw new ArgumentNullException(nameof(idMappings));
+            TargetFieldMetadata = targetFieldMetadata ?? throw new ArgumentNullException(nameof(targetFieldMetadata));
+            Progress = progress;
+        }
+
+        /// <summary>
+        /// Gets the migration data containing records to import.
+        /// </summary>
+        public MigrationData Data { get; }
+
+        /// <summary>
+        /// Gets the execution plan defining tier order and deferred fields.
+        /// </summary>
+        public ExecutionPlan Plan { get; }
+
+        /// <summary>
+        /// Gets the import options.
+        /// </summary>
+        public ImportOptions Options { get; }
+
+        /// <summary>
+        /// Gets the shared ID mapping collection.
+        /// This is populated during entity import and read during deferred field and relationship processing.
+        /// Thread-safe for concurrent access.
+        /// </summary>
+        public IdMappingCollection IdMappings { get; }
+
+        /// <summary>
+        /// Gets the target environment field metadata.
+        /// Used to validate which fields are valid for create/update operations.
+        /// </summary>
+        public FieldMetadataCollection TargetFieldMetadata { get; }
+
+        /// <summary>
+        /// Gets the optional progress reporter.
+        /// </summary>
+        public IProgressReporter? Progress { get; }
+    }
+}

--- a/src/PPDS.Migration/Import/ImportOptions.cs
+++ b/src/PPDS.Migration/Import/ImportOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using PPDS.Dataverse.BulkOperations;
 using PPDS.Migration.Models;
 
@@ -8,6 +9,7 @@ namespace PPDS.Migration.Import
     /// </summary>
     public class ImportOptions
     {
+        private int _maxParallelEntities = 4;
         /// <summary>
         /// Gets or sets whether to use modern bulk APIs (CreateMultiple, etc.).
         /// Default: true
@@ -46,9 +48,20 @@ namespace PPDS.Migration.Import
 
         /// <summary>
         /// Gets or sets the maximum parallel entities within a tier.
+        /// Must be at least 1.
         /// Default: 4
         /// </summary>
-        public int MaxParallelEntities { get; set; } = 4;
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when value is less than 1.</exception>
+        public int MaxParallelEntities
+        {
+            get => _maxParallelEntities;
+            set
+            {
+                if (value < 1)
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "MaxParallelEntities must be at least 1.");
+                _maxParallelEntities = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the import mode.

--- a/src/PPDS.Migration/Import/PhaseResult.cs
+++ b/src/PPDS.Migration/Import/PhaseResult.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Result from a single import phase.
+    /// </summary>
+    public class PhaseResult
+    {
+        /// <summary>
+        /// Gets or sets whether the phase completed successfully (no errors).
+        /// </summary>
+        public bool Success { get; init; }
+
+        /// <summary>
+        /// Gets or sets the total number of records processed in this phase.
+        /// </summary>
+        public int RecordsProcessed { get; init; }
+
+        /// <summary>
+        /// Gets or sets the number of successfully processed records.
+        /// </summary>
+        public int SuccessCount { get; init; }
+
+        /// <summary>
+        /// Gets or sets the number of failed records.
+        /// </summary>
+        public int FailureCount { get; init; }
+
+        /// <summary>
+        /// Gets or sets the duration of this phase.
+        /// </summary>
+        public TimeSpan Duration { get; init; }
+
+        /// <summary>
+        /// Gets or sets the errors encountered during this phase.
+        /// </summary>
+        public IReadOnlyList<MigrationError> Errors { get; init; } = Array.Empty<MigrationError>();
+
+        /// <summary>
+        /// Creates a successful result with no records processed (phase skipped).
+        /// </summary>
+        public static PhaseResult Skipped() => new()
+        {
+            Success = true,
+            RecordsProcessed = 0,
+            SuccessCount = 0,
+            FailureCount = 0,
+            Duration = TimeSpan.Zero
+        };
+
+        /// <summary>
+        /// Creates a successful result with the specified counts.
+        /// </summary>
+        /// <param name="processed">Number of records processed.</param>
+        /// <param name="duration">Duration of the phase.</param>
+        public static PhaseResult Succeeded(int processed, TimeSpan duration) => new()
+        {
+            Success = true,
+            RecordsProcessed = processed,
+            SuccessCount = processed,
+            FailureCount = 0,
+            Duration = duration
+        };
+    }
+}

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Processes many-to-many relationships after entity import.
+    /// Creates associations between records using the mapped IDs.
+    /// </summary>
+    public class RelationshipProcessor : IImportPhaseProcessor
+    {
+        private readonly IDataverseConnectionPool _connectionPool;
+        private readonly ILogger<RelationshipProcessor>? _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RelationshipProcessor"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The connection pool.</param>
+        /// <param name="logger">Optional logger.</param>
+        public RelationshipProcessor(
+            IDataverseConnectionPool connectionPool,
+            ILogger<RelationshipProcessor>? logger = null)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public string PhaseName => "Relationships";
+
+        /// <inheritdoc />
+        public async Task<PhaseResult> ProcessAsync(
+            ImportContext context,
+            CancellationToken cancellationToken)
+        {
+            if (context.Data.RelationshipData.Count == 0)
+            {
+                _logger?.LogDebug("No relationships to process");
+                return PhaseResult.Skipped();
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            var totalProcessed = 0;
+            var failureCount = 0;
+
+            // Build role name-to-ID cache for role lookup (lazy initialized)
+            Dictionary<string, Guid>? roleNameCache = null;
+
+            foreach (var (entityName, m2mDataList) in context.Data.RelationshipData)
+            {
+                foreach (var m2mData in m2mDataList)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    context.Progress?.Report(new ProgressEventArgs
+                    {
+                        Phase = MigrationPhase.ProcessingRelationships,
+                        Entity = entityName,
+                        Relationship = m2mData.RelationshipName,
+                        Message = $"Processing {m2mData.RelationshipName}..."
+                    });
+
+                    // Get mapped source ID
+                    if (!context.IdMappings.TryGetNewId(entityName, m2mData.SourceId, out var sourceNewId))
+                    {
+                        _logger?.LogDebug("Skipping M2M for unmapped source {Entity}:{Id}",
+                            entityName, m2mData.SourceId);
+                        continue;
+                    }
+
+                    // Map target IDs - special handling for role entity
+                    var mappedTargetIds = new List<Guid>();
+                    var isRoleTarget = m2mData.TargetEntityName.Equals("role", StringComparison.OrdinalIgnoreCase);
+
+                    foreach (var targetId in m2mData.TargetIds)
+                    {
+                        Guid? mappedId = null;
+
+                        // First try direct ID mapping
+                        if (context.IdMappings.TryGetNewId(m2mData.TargetEntityName, targetId, out var directMappedId))
+                        {
+                            mappedId = directMappedId;
+                        }
+                        // For role entity, try lookup by name
+                        else if (isRoleTarget)
+                        {
+                            roleNameCache ??= await BuildRoleNameCacheAsync(cancellationToken).ConfigureAwait(false);
+                            mappedId = await LookupRoleByIdAsync(targetId, roleNameCache, cancellationToken).ConfigureAwait(false);
+                        }
+
+                        if (mappedId.HasValue)
+                        {
+                            mappedTargetIds.Add(mappedId.Value);
+                        }
+                        else
+                        {
+                            _logger?.LogDebug("Could not map target {Entity}:{Id} for relationship {Relationship}",
+                                m2mData.TargetEntityName, targetId, m2mData.RelationshipName);
+                        }
+                    }
+
+                    if (mappedTargetIds.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    // Create association request
+                    await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    var relatedEntities = new EntityReferenceCollection();
+                    foreach (var targetId in mappedTargetIds)
+                    {
+                        relatedEntities.Add(new EntityReference(m2mData.TargetEntityName, targetId));
+                    }
+
+                    var request = new AssociateRequest
+                    {
+                        Target = new EntityReference(entityName, sourceNewId),
+                        RelatedEntities = relatedEntities,
+                        Relationship = new Relationship(m2mData.RelationshipName)
+                    };
+
+                    try
+                    {
+                        await client.ExecuteAsync(request).ConfigureAwait(false);
+                        totalProcessed += mappedTargetIds.Count;
+                    }
+                    catch (Exception ex)
+                    {
+                        // M2M associations may fail if already exists - log but continue
+                        _logger?.LogDebug(ex, "Failed to associate {Source} with {TargetCount} targets via {Relationship}",
+                            sourceNewId, mappedTargetIds.Count, m2mData.RelationshipName);
+                        failureCount++;
+
+                        if (!context.Options.ContinueOnError)
+                        {
+                            throw;
+                        }
+                    }
+                }
+            }
+
+            stopwatch.Stop();
+            _logger?.LogInformation("Processed {Count} M2M associations in {Duration}ms",
+                totalProcessed, stopwatch.ElapsedMilliseconds);
+
+            return new PhaseResult
+            {
+                Success = failureCount == 0,
+                RecordsProcessed = totalProcessed + failureCount,
+                SuccessCount = totalProcessed,
+                FailureCount = failureCount,
+                Duration = stopwatch.Elapsed
+            };
+        }
+
+        /// <summary>
+        /// Builds a cache of role names to IDs from the target environment.
+        /// </summary>
+        private async Task<Dictionary<string, Guid>> BuildRoleNameCacheAsync(CancellationToken cancellationToken)
+        {
+            var cache = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                var fetchXml = @"<fetch>
+                    <entity name='role'>
+                        <attribute name='roleid' />
+                        <attribute name='name' />
+                    </entity>
+                </fetch>";
+
+                var response = await client.RetrieveMultipleAsync(
+                    new Microsoft.Xrm.Sdk.Query.FetchExpression(fetchXml)).ConfigureAwait(false);
+
+                foreach (var entity in response.Entities)
+                {
+                    var name = entity.GetAttributeValue<string>("name");
+                    var id = entity.Id;
+                    if (!string.IsNullOrEmpty(name) && !cache.ContainsKey(name))
+                    {
+                        cache[name] = id;
+                    }
+                }
+
+                _logger?.LogDebug("Built role name cache with {Count} entries", cache.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to build role name cache");
+            }
+
+            return cache;
+        }
+
+        /// <summary>
+        /// Attempts to find a matching role in the target environment by ID.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method only succeeds when the source and target environments share the same role IDs
+        /// (e.g., same tenant or restored from backup). For cross-environment migrations where role IDs
+        /// differ, this returns null because we don't have the source role name to look up by name.
+        /// </para>
+        /// <para>
+        /// Known limitation: Proper role mapping requires exporting role names alongside IDs in the
+        /// migration schema. This is tracked for future enhancement.
+        /// </para>
+        /// </remarks>
+        private async Task<Guid?> LookupRoleByIdAsync(
+            Guid sourceRoleId,
+            Dictionary<string, Guid> roleNameCache,
+            CancellationToken cancellationToken)
+        {
+            // First, we need to get the role name from source environment
+            // Since we only have the source ID, we need to query for it
+            try
+            {
+                await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // Try to retrieve the role by ID - if it exists in target, we can use it directly
+                var fetchXml = $@"<fetch top='1'>
+                    <entity name='role'>
+                        <attribute name='name' />
+                        <filter>
+                            <condition attribute='roleid' operator='eq' value='{sourceRoleId}' />
+                        </filter>
+                    </entity>
+                </fetch>";
+
+                var response = await client.RetrieveMultipleAsync(
+                    new Microsoft.Xrm.Sdk.Query.FetchExpression(fetchXml)).ConfigureAwait(false);
+
+                if (response.Entities.Count > 0)
+                {
+                    // Role exists with same ID in target
+                    return sourceRoleId;
+                }
+            }
+            catch (Exception ex)
+            {
+                // Role lookup failed - this is expected when source role ID doesn't exist in target
+                _logger?.LogDebug(ex, "Role lookup by ID {RoleId} failed (expected for cross-environment migrations)", sourceRoleId);
+            }
+
+            // Role doesn't exist with source ID - this is the common case
+            // We need to find it by name, but we don't have the source name here
+            // For now, return null - proper solution requires exporting role names
+            return null;
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/SchemaMismatchResult.cs
+++ b/src/PPDS.Migration/Import/SchemaMismatchResult.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Result of schema mismatch detection between exported data and target environment.
+    /// </summary>
+    public class SchemaMismatchResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaMismatchResult"/> class.
+        /// </summary>
+        /// <param name="missingColumns">Dictionary of entity name to list of missing column names.</param>
+        public SchemaMismatchResult(IReadOnlyDictionary<string, List<string>> missingColumns)
+        {
+            MissingColumns = missingColumns ?? throw new ArgumentNullException(nameof(missingColumns));
+        }
+
+        /// <summary>
+        /// Gets the missing columns by entity name.
+        /// </summary>
+        public IReadOnlyDictionary<string, List<string>> MissingColumns { get; }
+
+        /// <summary>
+        /// Gets whether there are any missing columns.
+        /// </summary>
+        public bool HasMissingColumns => MissingColumns.Count > 0;
+
+        /// <summary>
+        /// Gets the total number of missing columns across all entities.
+        /// </summary>
+        public int TotalMissingCount => MissingColumns.Values.Sum(v => v.Count);
+
+        /// <summary>
+        /// Builds a detailed error message describing the missing columns.
+        /// </summary>
+        /// <returns>A formatted error message.</returns>
+        public string BuildDetailedMessage()
+        {
+            var details = new StringBuilder();
+            details.AppendLine($"Schema mismatch: {TotalMissingCount} column(s) in exported data do not exist in target environment.");
+            details.AppendLine();
+
+            foreach (var (entity, columns) in MissingColumns.OrderBy(x => x.Key))
+            {
+                details.AppendLine($"  {entity}:");
+                foreach (var col in columns)
+                {
+                    details.AppendLine($"    - {col}");
+                }
+            }
+
+            details.AppendLine();
+            details.Append("Use --skip-missing-columns to import anyway (these columns will be skipped).");
+
+            return details.ToString();
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/SchemaValidator.cs
+++ b/src/PPDS.Migration/Import/SchemaValidator.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Validates schema compatibility between exported data and target environment.
+    /// </summary>
+    public class SchemaValidator : ISchemaValidator
+    {
+        private readonly IDataverseConnectionPool _connectionPool;
+        private readonly ILogger<SchemaValidator>? _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SchemaValidator"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The connection pool.</param>
+        /// <param name="logger">Optional logger.</param>
+        public SchemaValidator(
+            IDataverseConnectionPool connectionPool,
+            ILogger<SchemaValidator>? logger = null)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<FieldMetadataCollection> LoadTargetFieldMetadataAsync(
+            IEnumerable<string> entityNames,
+            IProgressReporter? progress,
+            CancellationToken cancellationToken)
+        {
+            var result = new Dictionary<string, Dictionary<string, FieldValidity>>(StringComparer.OrdinalIgnoreCase);
+
+            progress?.Report(new ProgressEventArgs
+            {
+                Phase = MigrationPhase.Analyzing,
+                Message = "Loading target environment field metadata..."
+            });
+
+            await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            foreach (var entityName in entityNames)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    var request = new RetrieveEntityRequest
+                    {
+                        LogicalName = entityName,
+                        EntityFilters = EntityFilters.Attributes
+                    };
+
+                    var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+
+                    var attrValidity = new Dictionary<string, FieldValidity>(StringComparer.OrdinalIgnoreCase);
+                    if (response.EntityMetadata.Attributes != null)
+                    {
+                        foreach (var attr in response.EntityMetadata.Attributes)
+                        {
+                            attrValidity[attr.LogicalName] = new FieldValidity(
+                                attr.IsValidForCreate ?? false,
+                                attr.IsValidForUpdate ?? false
+                            );
+                        }
+                    }
+
+                    result[entityName] = attrValidity;
+                    _logger?.LogDebug("Loaded metadata for {Entity}: {Count} attributes", entityName, attrValidity.Count);
+                }
+                catch (FaultException ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to load metadata for entity {Entity}, using schema defaults", entityName);
+                    // Entity might not exist in target - use empty metadata (will use schema defaults)
+                    result[entityName] = new Dictionary<string, FieldValidity>(StringComparer.OrdinalIgnoreCase);
+                }
+            }
+
+            _logger?.LogInformation("Loaded field metadata for {Count} entities", result.Count);
+            return new FieldMetadataCollection(result);
+        }
+
+        /// <inheritdoc />
+        public SchemaMismatchResult DetectMissingColumns(
+            MigrationData data,
+            FieldMetadataCollection targetFieldMetadata)
+        {
+            var missingColumns = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (entityName, records) in data.EntityData)
+            {
+                if (records.Count == 0)
+                    continue;
+
+                // Get all unique field names from exported records
+                var exportedFields = records
+                    .SelectMany(r => r.Attributes.Keys)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                // Get target metadata for this entity
+                var targetFields = targetFieldMetadata.GetFieldsForEntity(entityName);
+
+                // Find fields that exist in export but not in target
+                var missing = exportedFields
+                    .Where(f => !targetFields.ContainsKey(f))
+                    .Where(f => !f.EndsWith("id", StringComparison.OrdinalIgnoreCase) ||
+                                !f.Equals($"{entityName}id", StringComparison.OrdinalIgnoreCase)) // Skip primary key
+                    .OrderBy(f => f)
+                    .ToList();
+
+                if (missing.Count > 0)
+                {
+                    missingColumns[entityName] = missing;
+                }
+            }
+
+            return new SchemaMismatchResult(missingColumns);
+        }
+
+        /// <inheritdoc />
+        public bool ShouldIncludeField(
+            string fieldName,
+            ImportMode mode,
+            IReadOnlyDictionary<string, FieldValidity>? fieldMetadata,
+            out string? reason)
+        {
+            reason = null;
+
+            // If no metadata available for this entity, skip unknown fields to prevent Dataverse errors
+            if (fieldMetadata == null || !fieldMetadata.TryGetValue(fieldName, out var validity))
+            {
+                reason = "not found in target";
+                return false;
+            }
+
+            // Never include fields that are not valid for any write operation
+            if (!validity.IsValidForCreate && !validity.IsValidForUpdate)
+            {
+                reason = "not valid for create or update";
+                return false;
+            }
+
+            // For Update mode, skip fields not valid for update
+            if (mode == ImportMode.Update && !validity.IsValidForUpdate)
+            {
+                reason = "not valid for update";
+                return false;
+            }
+
+            // For Create mode, skip fields not valid for create
+            if (mode == ImportMode.Create && !validity.IsValidForCreate)
+            {
+                reason = "not valid for create";
+                return false;
+            }
+
+            // For Upsert mode, include fields valid for either operation
+            // (the actual operation will determine validity per-record)
+            return true;
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -521,7 +521,7 @@ namespace PPDS.Migration.Import
                         Index = i,
                         RecordId = record.Id != Guid.Empty ? record.Id : null,
                         ErrorCode = -1,
-                        Message = ex.Message
+                        Message = ConnectionStringRedactor.RedactExceptionMessage(ex.Message)
                     });
 
                     if (!options.ContinueOnError)
@@ -902,9 +902,10 @@ namespace PPDS.Migration.Import
                     return sourceRoleId;
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Role doesn't exist with source ID, which is expected
+                // Role lookup failed - this is expected when source role ID doesn't exist in target
+                _logger?.LogDebug(ex, "Role lookup by ID {RoleId} failed (expected for cross-environment migrations)", sourceRoleId);
             }
 
             // Role doesn't exist with source ID - this is the common case

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -872,6 +872,20 @@ namespace PPDS.Migration.Import
             return cache;
         }
 
+        /// <summary>
+        /// Attempts to find a matching role in the target environment by ID.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method only succeeds when the source and target environments share the same role IDs
+        /// (e.g., same tenant or restored from backup). For cross-environment migrations where role IDs
+        /// differ, this returns null because we don't have the source role name to look up by name.
+        /// </para>
+        /// <para>
+        /// Known limitation: Proper role mapping requires exporting role names alongside IDs in the
+        /// migration schema. This is tracked for future enhancement.
+        /// </para>
+        /// </remarks>
         private async Task<Guid?> LookupRoleByIdAsync(
             Guid sourceRoleId,
             Dictionary<string, Guid> roleNameCache,

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -9,6 +9,10 @@ namespace PPDS.Migration.Progress
     /// <summary>
     /// Progress reporter that writes human-readable output to the console.
     /// </summary>
+    /// <remarks>
+    /// This class is not thread-safe. It is designed for single-threaded CLI usage
+    /// where progress events are reported sequentially.
+    /// </remarks>
     public class ConsoleProgressReporter : IProgressReporter
     {
         private const int MaxErrorsToDisplay = 10;

--- a/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
+++ b/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- NU1702: PPDS.Plugins targets net462 (required for Dataverse plugin sandbox) but is
+         referenced transitively from net8.0+. The package contains only attributes/enums
+         with no framework-specific APIs, so cross-framework reference is safe. -->
+    <NoWarn>$(NoWarn);NU1702</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/PPDS.Dataverse.Tests/Progress/ProgressTrackerTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Progress/ProgressTrackerTests.cs
@@ -312,7 +312,7 @@ public class ProgressTrackerTests
     #region Thread Safety Tests
 
     [Fact]
-    public void RecordProgress_ThreadSafe()
+    public async Task RecordProgress_ThreadSafe()
     {
         // Arrange
         var tracker = new ProgressTracker(10000);
@@ -331,14 +331,14 @@ public class ProgressTrackerTests
                 }
             });
         }
-        Task.WaitAll(tasks);
+        await Task.WhenAll(tasks);
 
         // Assert
         tracker.Succeeded.Should().Be(threadCount * incrementsPerThread);
     }
 
     [Fact]
-    public void GetSnapshot_ThreadSafe()
+    public async Task GetSnapshot_ThreadSafe()
     {
         // Arrange
         var tracker = new ProgressTracker(10000);
@@ -369,7 +369,7 @@ public class ProgressTrackerTests
             }
         });
 
-        Task.WaitAll(recordTask, snapshotTask);
+        await Task.WhenAll(recordTask, snapshotTask);
 
         // Assert - all snapshots should be valid (no exceptions thrown)
         snapshots.Count.Should().Be(iterations);

--- a/tests/PPDS.Plugins.Tests/PPDS.Plugins.Tests.csproj
+++ b/tests/PPDS.Plugins.Tests/PPDS.Plugins.Tests.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- NU1702: PPDS.Plugins targets net462 (required for Dataverse plugin sandbox) but is
+         referenced from net8.0+. The package contains only attributes/enums with no
+         framework-specific APIs, so cross-framework reference is safe. -->
+    <NoWarn>$(NoWarn);NU1702</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Comprehensive fixes for code review findings identified in issues #71 and #80 before v1 release.

### Critical Fixes
- **Race condition in ProfileConnectionSource** - Added `SemaphoreSlim` for async synchronization
- **Thread-unsafe List in ServiceClientFactory** - Changed to `ConcurrentBag<ICredentialProvider>`
- **Memory leaks in credential providers** - Added cache unregistration in Dispose methods
- **Double-checked locking bug** - Added `volatile` modifier to `_client` field
- **Copy-paste bug in CertificateStoreCredentialProvider** - Fixed `StoreName=` → `StoreLocation=`

### High Priority Fixes
- **MSAL cache disposal** - Properly unregister token cache in InteractiveBrowserCredentialProvider and GlobalDiscoveryService
- **Console output in library code** - Created `AuthenticationOutput` class for configurable messaging
- **Sync-over-async deadlock risk** - Wrapped blocking calls in `Task.Run()`

### Medium Priority Fixes
- **Thread-safe caching** - Use `ConcurrentDictionary` for entity type code cache
- **Code duplication** - Extracted `ParseBypassPlugins` to `DataCommandGroup`
- **SRP violation in TieredImporter** - Extracted phase processors (1,085 → 646 lines)
  - `SchemaValidator` for metadata loading and mismatch detection
  - `DeferredFieldProcessor` for self-referential lookup updates
  - `RelationshipProcessor` for M2M associations
- **MSAL initialization duplication** - Extracted to `MsalClientBuilder`
- **Input validation** - Added validation to CmtSchemaReader and ImportOptions
- **Error code preservation** - Added `ExtractErrorCode` helper in BulkOperationExecutor

### Low Priority Fixes
- **Dead code removal** - Removed unused `ExecuteBatchesParallelAsync`
- **XML documentation** - Added docs to `ExitCodes` and `PluginRegistrationConfig`
- **Flow control** - Refactored try-catch to use `Uri.TryCreate()`

### Deferred Items
Issues 13, 14, 16 (SRP/ISP refactors) and documentation improvements deferred to post-v1.

## Test plan
- [x] All existing tests pass (`dotnet test`)
- [x] Solution builds without warnings (`dotnet build`)
- [ ] Manual testing of auth flows
- [ ] Manual testing of data import

Closes #71
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)