### PR TITLE
feat: add authentication integration tests (Phase 2)

### DIFF
--- a/.claude/commands/review-bot-comments.md
+++ b/.claude/commands/review-bot-comments.md
@@ -21,7 +21,10 @@ For each bot comment, determine verdict and rationale:
 |---------|---------|
 | **Valid** | Bot is correct, code should be changed |
 | **False Positive** | Bot is wrong, explain why |
+| **Duplicate** | Same issue reported by another bot - still needs reply |
 | **Unclear** | Need to investigate before deciding |
+
+**IMPORTANT:** Every comment needs a reply, including duplicates. Track all comment IDs to ensure none are missed.
 
 ### 3. Present Summary and WAIT FOR APPROVAL
 
@@ -69,6 +72,7 @@ gh api repos/joshsmithxrm/ppds-sdk/pulls/{pr}/comments \
 | Valid (fixed) | `Fixed in {commit_sha} - {brief description}` |
 | Declined | `Declining - {reason}` |
 | False positive | `False positive - {explanation}` |
+| Duplicate | Same reply as original (reference the fix commit) |
 
 ## Common False Positives
 
@@ -88,6 +92,17 @@ gh api repos/joshsmithxrm/ppds-sdk/pulls/{pr}/comments \
 | Missing null check | Check context |
 | Resource not disposed | Yes - but verify interface first |
 | Generic catch clause | Context-dependent |
+
+### 6. Verify All Comments Addressed
+
+Before completing, verify every comment has a reply:
+
+```bash
+# Count original comments vs replies
+gh api repos/joshsmithxrm/ppds-sdk/pulls/{pr}/comments --jq "length"
+```
+
+If any comments are missing replies, address them before marking complete.
 
 ## When to Use
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,6 +40,9 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     environment: test-dataverse
     needs: unit-tests
+    permissions:
+      contents: read
+      id-token: write  # Required for GitHub OIDC federated authentication
 
     steps:
     - uses: actions/checkout@v6
@@ -62,10 +65,12 @@ jobs:
 
     - name: Run Integration Tests
       env:
-        DATAVERSE_URL: ${{ secrets.DATAVERSE_URL }}
-        PPDS_TEST_APP_ID: ${{ secrets.PPDS_TEST_APP_ID }}
+        # Repository variables (non-sensitive)
+        DATAVERSE_URL: ${{ vars.DATAVERSE_URL }}
+        PPDS_TEST_APP_ID: ${{ vars.PPDS_TEST_APP_ID }}
+        PPDS_TEST_TENANT_ID: ${{ vars.PPDS_TEST_TENANT_ID }}
+        # Repository secrets (sensitive)
         PPDS_TEST_CLIENT_SECRET: ${{ secrets.PPDS_TEST_CLIENT_SECRET }}
-        PPDS_TEST_TENANT_ID: ${{ secrets.PPDS_TEST_TENANT_ID }}
         PPDS_TEST_CERT_BASE64: ${{ secrets.PPDS_TEST_CERT_BASE64 }}
         PPDS_TEST_CERT_PASSWORD: ${{ secrets.PPDS_TEST_CERT_PASSWORD }}
       run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category=Integration"

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Integration tests for credential providers** - Live tests for `ClientSecretCredentialProvider`, `CertificateFileCredentialProvider`, and `GitHubFederatedCredentialProvider` ([#55](https://github.com/joshsmithxrm/ppds-sdk/issues/55))
+- Manual test procedures documentation for interactive browser and device code authentication
+
+
 ## [1.0.0-beta.3] - 2026-01-02
 
 ### Fixed

--- a/tests/PPDS.LiveTests/Authentication/CertificateAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/CertificateAuthenticationTests.cs
@@ -13,26 +13,19 @@ namespace PPDS.LiveTests.Authentication;
 [Trait("Category", "Integration")]
 public class CertificateAuthenticationTests : LiveTestBase, IDisposable
 {
-    private readonly LiveTestConfiguration _config;
-
-    public CertificateAuthenticationTests()
-    {
-        _config = new LiveTestConfiguration();
-    }
-
     [SkipIfNoCertificate]
     public async Task CertificateFileCredentialProvider_CreatesWorkingServiceClient()
     {
         // Arrange
-        var certPath = _config.GetCertificatePath();
+        var certPath = Configuration.GetCertificatePath();
         using var provider = new CertificateFileCredentialProvider(
-            _config.ApplicationId!,
+            Configuration.ApplicationId!,
             certPath,
-            _config.CertificatePassword,
-            _config.TenantId!);
+            Configuration.CertificatePassword,
+            Configuration.TenantId!);
 
         // Act
-        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
 
         // Assert
         client.Should().NotBeNull();
@@ -43,14 +36,14 @@ public class CertificateAuthenticationTests : LiveTestBase, IDisposable
     public async Task CertificateFileCredentialProvider_CanExecuteWhoAmI()
     {
         // Arrange
-        var certPath = _config.GetCertificatePath();
+        var certPath = Configuration.GetCertificatePath();
         using var provider = new CertificateFileCredentialProvider(
-            _config.ApplicationId!,
+            Configuration.ApplicationId!,
             certPath,
-            _config.CertificatePassword,
-            _config.TenantId!);
+            Configuration.CertificatePassword,
+            Configuration.TenantId!);
 
-        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
 
         // Act
         var response = (Microsoft.Crm.Sdk.Messages.WhoAmIResponse)client.Execute(
@@ -63,15 +56,15 @@ public class CertificateAuthenticationTests : LiveTestBase, IDisposable
     }
 
     [SkipIfNoCertificate]
-    public async Task CertificateFileCredentialProvider_SetsIdentityProperty()
+    public void CertificateFileCredentialProvider_SetsIdentityProperty()
     {
         // Arrange
-        var certPath = _config.GetCertificatePath();
+        var certPath = Configuration.GetCertificatePath();
         using var provider = new CertificateFileCredentialProvider(
-            _config.ApplicationId!,
+            Configuration.ApplicationId!,
             certPath,
-            _config.CertificatePassword,
-            _config.TenantId!);
+            Configuration.CertificatePassword,
+            Configuration.TenantId!);
 
         // Assert - Identity is set before authentication
         provider.Identity.Should().NotBeNullOrWhiteSpace();
@@ -83,18 +76,18 @@ public class CertificateAuthenticationTests : LiveTestBase, IDisposable
     public async Task CertificateFileCredentialProvider_SetsTokenExpirationAfterAuth()
     {
         // Arrange
-        var certPath = _config.GetCertificatePath();
+        var certPath = Configuration.GetCertificatePath();
         using var provider = new CertificateFileCredentialProvider(
-            _config.ApplicationId!,
+            Configuration.ApplicationId!,
             certPath,
-            _config.CertificatePassword,
-            _config.TenantId!);
+            Configuration.CertificatePassword,
+            Configuration.TenantId!);
 
         // Token expiration is null before authentication
         provider.TokenExpiresAt.Should().BeNull();
 
         // Act
-        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
 
         // Assert - Token expiration is set after authentication
         provider.TokenExpiresAt.Should().NotBeNull();
@@ -105,7 +98,7 @@ public class CertificateAuthenticationTests : LiveTestBase, IDisposable
     public void LiveTestConfiguration_CanLoadCertificate()
     {
         // Arrange & Act
-        using var cert = _config.LoadCertificate();
+        using var cert = Configuration.LoadCertificate();
 
         // Assert
         cert.Should().NotBeNull();
@@ -144,6 +137,6 @@ public class CertificateAuthenticationTests : LiveTestBase, IDisposable
 
     public void Dispose()
     {
-        _config.Dispose();
+        Configuration.Dispose();
     }
 }

--- a/tests/PPDS.LiveTests/Authentication/CertificateAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/CertificateAuthenticationTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using PPDS.Auth.Credentials;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Authentication;
+
+/// <summary>
+/// Integration tests for certificate-based (service principal) authentication.
+/// These tests verify that CertificateFileCredentialProvider can successfully
+/// authenticate to Dataverse using a certificate file.
+/// </summary>
+[Trait("Category", "Integration")]
+public class CertificateAuthenticationTests : LiveTestBase, IDisposable
+{
+    private readonly LiveTestConfiguration _config;
+
+    public CertificateAuthenticationTests()
+    {
+        _config = new LiveTestConfiguration();
+    }
+
+    [SkipIfNoCertificate]
+    public async Task CertificateFileCredentialProvider_CreatesWorkingServiceClient()
+    {
+        // Arrange
+        var certPath = _config.GetCertificatePath();
+        using var provider = new CertificateFileCredentialProvider(
+            _config.ApplicationId!,
+            certPath,
+            _config.CertificatePassword,
+            _config.TenantId!);
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+
+        // Assert
+        client.Should().NotBeNull();
+        client.IsReady.Should().BeTrue("ServiceClient should be ready after successful authentication");
+    }
+
+    [SkipIfNoCertificate]
+    public async Task CertificateFileCredentialProvider_CanExecuteWhoAmI()
+    {
+        // Arrange
+        var certPath = _config.GetCertificatePath();
+        using var provider = new CertificateFileCredentialProvider(
+            _config.ApplicationId!,
+            certPath,
+            _config.CertificatePassword,
+            _config.TenantId!);
+
+        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+
+        // Act
+        var response = (Microsoft.Crm.Sdk.Messages.WhoAmIResponse)client.Execute(
+            new Microsoft.Crm.Sdk.Messages.WhoAmIRequest());
+
+        // Assert
+        response.Should().NotBeNull();
+        response.UserId.Should().NotBeEmpty("WhoAmI should return a valid user ID");
+        response.OrganizationId.Should().NotBeEmpty("WhoAmI should return a valid organization ID");
+    }
+
+    [SkipIfNoCertificate]
+    public async Task CertificateFileCredentialProvider_SetsIdentityProperty()
+    {
+        // Arrange
+        var certPath = _config.GetCertificatePath();
+        using var provider = new CertificateFileCredentialProvider(
+            _config.ApplicationId!,
+            certPath,
+            _config.CertificatePassword,
+            _config.TenantId!);
+
+        // Assert - Identity is set before authentication
+        provider.Identity.Should().NotBeNullOrWhiteSpace();
+        provider.Identity.Should().StartWith("app:");
+        provider.AuthMethod.Should().Be(PPDS.Auth.Profiles.AuthMethod.CertificateFile);
+    }
+
+    [SkipIfNoCertificate]
+    public async Task CertificateFileCredentialProvider_SetsTokenExpirationAfterAuth()
+    {
+        // Arrange
+        var certPath = _config.GetCertificatePath();
+        using var provider = new CertificateFileCredentialProvider(
+            _config.ApplicationId!,
+            certPath,
+            _config.CertificatePassword,
+            _config.TenantId!);
+
+        // Token expiration is null before authentication
+        provider.TokenExpiresAt.Should().BeNull();
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(_config.DataverseUrl!);
+
+        // Assert - Token expiration is set after authentication
+        provider.TokenExpiresAt.Should().NotBeNull();
+        provider.TokenExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow);
+    }
+
+    [SkipIfNoCertificate]
+    public void LiveTestConfiguration_CanLoadCertificate()
+    {
+        // Arrange & Act
+        using var cert = _config.LoadCertificate();
+
+        // Assert
+        cert.Should().NotBeNull();
+        cert.HasPrivateKey.Should().BeTrue("Certificate must have private key for authentication");
+        cert.Thumbprint.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void CertificateFileCredentialProvider_ThrowsOnNullArguments()
+    {
+        // Act & Assert
+        var act1 = () => new CertificateFileCredentialProvider(null!, "path", null, "tenant");
+        var act2 = () => new CertificateFileCredentialProvider("app", null!, null, "tenant");
+        var act3 = () => new CertificateFileCredentialProvider("app", "path", null, null!);
+
+        act1.Should().Throw<ArgumentNullException>().WithParameterName("applicationId");
+        act2.Should().Throw<ArgumentNullException>().WithParameterName("certificatePath");
+        act3.Should().Throw<ArgumentNullException>().WithParameterName("tenantId");
+    }
+
+    [Fact]
+    public async Task CertificateFileCredentialProvider_ThrowsOnMissingFile()
+    {
+        // Arrange
+        using var provider = new CertificateFileCredentialProvider(
+            "00000000-0000-0000-0000-000000000000",
+            "/nonexistent/path/cert.pfx",
+            null,
+            "00000000-0000-0000-0000-000000000000");
+
+        // Act & Assert
+        var act = () => provider.CreateServiceClientAsync("https://fake.crm.dynamics.com");
+        await act.Should().ThrowAsync<AuthenticationException>()
+            .WithMessage("*not found*");
+    }
+
+    public void Dispose()
+    {
+        _config.Dispose();
+    }
+}

--- a/tests/PPDS.LiveTests/Authentication/ClientSecretAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/ClientSecretAuthenticationTests.cs
@@ -11,7 +11,7 @@ namespace PPDS.LiveTests.Authentication;
 /// authenticate to Dataverse using a client ID and secret.
 /// </summary>
 [Trait("Category", "Integration")]
-public class ClientSecretAuthenticationTests : LiveTestBase
+public class ClientSecretAuthenticationTests : LiveTestBase, IDisposable
 {
     [SkipIfNoClientSecret]
     public async Task ClientSecretCredentialProvider_CreatesWorkingServiceClient()
@@ -52,7 +52,7 @@ public class ClientSecretAuthenticationTests : LiveTestBase
     }
 
     [SkipIfNoClientSecret]
-    public async Task ClientSecretCredentialProvider_SetsIdentityProperty()
+    public void ClientSecretCredentialProvider_SetsIdentityProperty()
     {
         // Arrange
         using var provider = new ClientSecretCredentialProvider(
@@ -111,5 +111,10 @@ public class ClientSecretAuthenticationTests : LiveTestBase
         // Act & Assert
         var act = () => provider.CreateServiceClientAsync("https://fake.crm.dynamics.com");
         await act.Should().ThrowAsync<AuthenticationException>();
+    }
+
+    public void Dispose()
+    {
+        Configuration.Dispose();
     }
 }

--- a/tests/PPDS.LiveTests/Authentication/ClientSecretAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/ClientSecretAuthenticationTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using PPDS.Auth.Credentials;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Authentication;
+
+/// <summary>
+/// Integration tests for client secret (service principal) authentication.
+/// These tests verify that ClientSecretCredentialProvider can successfully
+/// authenticate to Dataverse using a client ID and secret.
+/// </summary>
+[Trait("Category", "Integration")]
+public class ClientSecretAuthenticationTests : LiveTestBase
+{
+    [SkipIfNoClientSecret]
+    public async Task ClientSecretCredentialProvider_CreatesWorkingServiceClient()
+    {
+        // Arrange
+        using var provider = new ClientSecretCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.ClientSecret!,
+            Configuration.TenantId!);
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Assert
+        client.Should().NotBeNull();
+        client.IsReady.Should().BeTrue("ServiceClient should be ready after successful authentication");
+    }
+
+    [SkipIfNoClientSecret]
+    public async Task ClientSecretCredentialProvider_CanExecuteWhoAmI()
+    {
+        // Arrange
+        using var provider = new ClientSecretCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.ClientSecret!,
+            Configuration.TenantId!);
+
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Act
+        var response = (Microsoft.Crm.Sdk.Messages.WhoAmIResponse)client.Execute(
+            new Microsoft.Crm.Sdk.Messages.WhoAmIRequest());
+
+        // Assert
+        response.Should().NotBeNull();
+        response.UserId.Should().NotBeEmpty("WhoAmI should return a valid user ID");
+        response.OrganizationId.Should().NotBeEmpty("WhoAmI should return a valid organization ID");
+    }
+
+    [SkipIfNoClientSecret]
+    public async Task ClientSecretCredentialProvider_SetsIdentityProperty()
+    {
+        // Arrange
+        using var provider = new ClientSecretCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.ClientSecret!,
+            Configuration.TenantId!);
+
+        // Assert - Identity is set before authentication
+        provider.Identity.Should().NotBeNullOrWhiteSpace();
+        provider.Identity.Should().StartWith("app:");
+        provider.AuthMethod.Should().Be(PPDS.Auth.Profiles.AuthMethod.ClientSecret);
+    }
+
+    [SkipIfNoClientSecret]
+    public async Task ClientSecretCredentialProvider_SetsTokenExpirationAfterAuth()
+    {
+        // Arrange
+        using var provider = new ClientSecretCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.ClientSecret!,
+            Configuration.TenantId!);
+
+        // Token expiration is null before authentication
+        provider.TokenExpiresAt.Should().BeNull();
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Assert - Token expiration is set after authentication
+        provider.TokenExpiresAt.Should().NotBeNull();
+        provider.TokenExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void ClientSecretCredentialProvider_ThrowsOnNullArguments()
+    {
+        // Act & Assert
+        var act1 = () => new ClientSecretCredentialProvider(null!, "secret", "tenant");
+        var act2 = () => new ClientSecretCredentialProvider("app", null!, "tenant");
+        var act3 = () => new ClientSecretCredentialProvider("app", "secret", null!);
+
+        act1.Should().Throw<ArgumentNullException>().WithParameterName("applicationId");
+        act2.Should().Throw<ArgumentNullException>().WithParameterName("clientSecret");
+        act3.Should().Throw<ArgumentNullException>().WithParameterName("tenantId");
+    }
+
+    [Fact]
+    public async Task ClientSecretCredentialProvider_ThrowsOnInvalidCredentials()
+    {
+        // Arrange - Use fake credentials that will fail
+        using var provider = new ClientSecretCredentialProvider(
+            "00000000-0000-0000-0000-000000000000",
+            "invalid-secret",
+            "00000000-0000-0000-0000-000000000000");
+
+        // Act & Assert
+        var act = () => provider.CreateServiceClientAsync("https://fake.crm.dynamics.com");
+        await act.Should().ThrowAsync<AuthenticationException>();
+    }
+}

--- a/tests/PPDS.LiveTests/Authentication/GitHubFederatedAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/GitHubFederatedAuthenticationTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using PPDS.Auth.Credentials;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Authentication;
+
+/// <summary>
+/// Integration tests for GitHub OIDC federated authentication.
+/// These tests only run inside GitHub Actions with:
+/// - 'id-token: write' permission in the workflow
+/// - Federated credential configured in Azure AD App Registration
+/// </summary>
+[Trait("Category", "Integration")]
+public class GitHubFederatedAuthenticationTests : LiveTestBase
+{
+    [SkipIfNoGitHubOidc]
+    public async Task GitHubFederatedCredentialProvider_CreatesWorkingServiceClient()
+    {
+        // Arrange
+        using var provider = new GitHubFederatedCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.TenantId!);
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Assert
+        client.Should().NotBeNull();
+        client.IsReady.Should().BeTrue("ServiceClient should be ready after successful authentication");
+    }
+
+    [SkipIfNoGitHubOidc]
+    public async Task GitHubFederatedCredentialProvider_CanExecuteWhoAmI()
+    {
+        // Arrange
+        using var provider = new GitHubFederatedCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.TenantId!);
+
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Act
+        var response = (Microsoft.Crm.Sdk.Messages.WhoAmIResponse)client.Execute(
+            new Microsoft.Crm.Sdk.Messages.WhoAmIRequest());
+
+        // Assert
+        response.Should().NotBeNull();
+        response.UserId.Should().NotBeEmpty("WhoAmI should return a valid user ID");
+        response.OrganizationId.Should().NotBeEmpty("WhoAmI should return a valid organization ID");
+    }
+
+    [SkipIfNoGitHubOidc]
+    public async Task GitHubFederatedCredentialProvider_SetsAccessTokenAfterAuth()
+    {
+        // Arrange
+        using var provider = new GitHubFederatedCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.TenantId!);
+
+        // Act
+        using var client = await provider.CreateServiceClientAsync(Configuration.DataverseUrl!);
+
+        // Assert - Access token is available after authentication
+        provider.AccessToken.Should().NotBeNullOrWhiteSpace();
+        provider.TokenExpiresAt.Should().NotBeNull();
+        provider.TokenExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow);
+    }
+
+    [SkipIfNoGitHubOidc]
+    public void GitHubFederatedCredentialProvider_SetsIdentityProperty()
+    {
+        // Arrange
+        using var provider = new GitHubFederatedCredentialProvider(
+            Configuration.ApplicationId!,
+            Configuration.TenantId!);
+
+        // Assert
+        provider.Identity.Should().NotBeNullOrWhiteSpace();
+        provider.Identity.Should().StartWith("app:");
+        provider.AuthMethod.Should().Be(PPDS.Auth.Profiles.AuthMethod.GitHubFederated);
+    }
+
+    [Fact]
+    public void GitHubFederatedCredentialProvider_ThrowsOnNullArguments()
+    {
+        // Act & Assert
+        var act1 = () => new GitHubFederatedCredentialProvider(null!, "tenant");
+        var act2 = () => new GitHubFederatedCredentialProvider("app", null!);
+
+        act1.Should().Throw<ArgumentNullException>().WithParameterName("applicationId");
+        act2.Should().Throw<ArgumentNullException>().WithParameterName("tenantId");
+    }
+
+    [Fact]
+    public void Configuration_DetectsGitHubOidcEnvironment()
+    {
+        // This test verifies the configuration correctly detects OIDC environment
+        var hasOidc = Configuration.HasGitHubOidcCredentials;
+
+        // If we're in GitHub Actions with OIDC configured, this should be true
+        // Otherwise it should be false (and tests using SkipIfNoGitHubOidc will skip)
+        var tokenUrl = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL");
+        var expectedHasOidc = !string.IsNullOrWhiteSpace(tokenUrl) &&
+                              !string.IsNullOrWhiteSpace(Configuration.ApplicationId) &&
+                              !string.IsNullOrWhiteSpace(Configuration.TenantId) &&
+                              !string.IsNullOrWhiteSpace(Configuration.DataverseUrl);
+
+        hasOidc.Should().Be(expectedHasOidc);
+    }
+}

--- a/tests/PPDS.LiveTests/Authentication/GitHubFederatedAuthenticationTests.cs
+++ b/tests/PPDS.LiveTests/Authentication/GitHubFederatedAuthenticationTests.cs
@@ -12,7 +12,7 @@ namespace PPDS.LiveTests.Authentication;
 /// - Federated credential configured in Azure AD App Registration
 /// </summary>
 [Trait("Category", "Integration")]
-public class GitHubFederatedAuthenticationTests : LiveTestBase
+public class GitHubFederatedAuthenticationTests : LiveTestBase, IDisposable
 {
     [SkipIfNoGitHubOidc]
     public async Task GitHubFederatedCredentialProvider_CreatesWorkingServiceClient()
@@ -102,10 +102,16 @@ public class GitHubFederatedAuthenticationTests : LiveTestBase
         // Otherwise it should be false (and tests using SkipIfNoGitHubOidc will skip)
         var tokenUrl = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL");
         var expectedHasOidc = !string.IsNullOrWhiteSpace(tokenUrl) &&
+                              !string.IsNullOrWhiteSpace(Configuration.GitHubOidcRequestToken) &&
                               !string.IsNullOrWhiteSpace(Configuration.ApplicationId) &&
                               !string.IsNullOrWhiteSpace(Configuration.TenantId) &&
                               !string.IsNullOrWhiteSpace(Configuration.DataverseUrl);
 
         hasOidc.Should().Be(expectedHasOidc);
+    }
+
+    public void Dispose()
+    {
+        Configuration.Dispose();
     }
 }

--- a/tests/PPDS.LiveTests/Authentication/MANUAL_TESTING.md
+++ b/tests/PPDS.LiveTests/Authentication/MANUAL_TESTING.md
@@ -1,0 +1,140 @@
+# Manual Authentication Testing Procedures
+
+This document describes how to manually test interactive and device code authentication methods that cannot be automated in CI.
+
+## Interactive Browser Authentication
+
+The `InteractiveBrowserCredentialProvider` opens a browser window for the user to sign in.
+
+### Test Procedure
+
+1. **Create a test console app or use the CLI:**
+   ```bash
+   ppds auth create --name test-interactive
+   # Opens browser for sign-in
+   ```
+
+2. **Expected behavior:**
+   - Browser opens automatically
+   - User can sign in with their credentials
+   - After successful sign-in, browser shows success message
+   - CLI/app receives token and continues
+
+3. **Verification:**
+   ```bash
+   ppds env list
+   # Should list available environments
+   ```
+
+4. **Edge cases to test:**
+   - [ ] User cancels browser sign-in
+   - [ ] Browser is closed before completing sign-in
+   - [ ] Network disconnection during sign-in
+   - [ ] Multi-factor authentication (MFA) flow
+   - [ ] Conditional Access policies
+
+---
+
+## Device Code Authentication
+
+The `DeviceCodeCredentialProvider` displays a code for the user to enter at https://microsoft.com/devicelogin.
+
+### Test Procedure
+
+1. **Create a profile with device code:**
+   ```bash
+   ppds auth create --name test-device --deviceCode
+   ```
+
+2. **Expected behavior:**
+   - Console displays a message like:
+     ```
+     To sign in, use a web browser to open the page https://microsoft.com/devicelogin 
+     and enter the code ABC123XYZ to authenticate.
+     ```
+   - User opens the URL in any browser (can be on different device)
+   - User enters the code and signs in
+   - After successful sign-in, CLI/app receives token
+
+3. **Verification:**
+   ```bash
+   ppds env list
+   # Should list available environments
+   ```
+
+4. **Edge cases to test:**
+   - [ ] Code expires (typically 15 minutes)
+   - [ ] Wrong code entered
+   - [ ] User cancels at device login page
+   - [ ] Network disconnection
+   - [ ] MFA flow via device code
+
+---
+
+## Test Matrix
+
+| Auth Method | Automated CI | Manual Test | Notes |
+|-------------|--------------|-------------|-------|
+| Client Secret | ✅ | - | Fully automated |
+| Certificate | ✅ | - | Fully automated |
+| GitHub OIDC | ✅ | - | Only in GitHub Actions |
+| Interactive Browser | ❌ | ✅ | Requires human interaction |
+| Device Code | ❌ | ✅ | Requires human interaction |
+| Managed Identity | ❌ | ✅ | Only in Azure-hosted environments |
+| Azure DevOps OIDC | ❌ | ✅ | Only in Azure Pipelines |
+
+---
+
+## Troubleshooting
+
+### Interactive Browser Issues
+
+**Browser doesn't open:**
+- Check default browser settings
+- Try with `--forceInteractive` flag
+- Check firewall/proxy blocking localhost
+
+**"AADSTS" errors:**
+- `AADSTS50011`: Reply URL mismatch - check app registration
+- `AADSTS65001`: Consent required - admin must grant consent
+- `AADSTS700016`: App not found - check Application ID
+
+### Device Code Issues
+
+**Code not accepted:**
+- Ensure code is entered exactly (case-sensitive)
+- Check code hasn't expired (15-minute window)
+- Verify correct Microsoft account/tenant
+
+**Polling timeout:**
+- Default is 15 minutes
+- User must complete sign-in within this window
+
+---
+
+## Local Development Setup
+
+For local testing of interactive methods:
+
+1. **App Registration requirements:**
+   - Platform: Mobile and desktop applications
+   - Redirect URI: `http://localhost` (for interactive)
+   - Enable public client flows (for device code)
+
+2. **Environment variables (optional):**
+   ```powershell
+   $env:DATAVERSE_URL = "https://your-org.crm.dynamics.com"
+   ```
+
+3. **Run tests:**
+   ```bash
+   # Interactive test
+   ppds auth create --name local-test
+   
+   # Device code test  
+   ppds auth create --name local-device --deviceCode
+   
+   # Verify
+   ppds env list
+   ppds data export --help
+   ```

--- a/tests/PPDS.LiveTests/Infrastructure/LiveTestConfiguration.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/LiveTestConfiguration.cs
@@ -1,11 +1,16 @@
+using System.Security.Cryptography.X509Certificates;
+
 namespace PPDS.LiveTests.Infrastructure;
 
 /// <summary>
 /// Configuration for live Dataverse integration tests.
 /// Reads credentials from environment variables.
 /// </summary>
-public sealed class LiveTestConfiguration
+public sealed class LiveTestConfiguration : IDisposable
 {
+    private string? _tempCertificatePath;
+    private bool _disposed;
+
     /// <summary>
     /// The Dataverse environment URL (e.g., https://org.crm.dynamics.com).
     /// </summary>
@@ -37,6 +42,22 @@ public sealed class LiveTestConfiguration
     public string? CertificatePassword { get; }
 
     /// <summary>
+    /// Path to certificate file (used for local testing).
+    /// If not set but CertificateBase64 is available, a temp file will be created.
+    /// </summary>
+    public string? CertificatePath { get; }
+
+    /// <summary>
+    /// GitHub Actions OIDC token request URL (set automatically by GitHub).
+    /// </summary>
+    public string? GitHubOidcTokenUrl { get; }
+
+    /// <summary>
+    /// GitHub Actions OIDC token request token (set automatically by GitHub).
+    /// </summary>
+    public string? GitHubOidcRequestToken { get; }
+
+    /// <summary>
     /// Gets a value indicating whether client secret credentials are available.
     /// </summary>
     public bool HasClientSecretCredentials =>
@@ -55,9 +76,20 @@ public sealed class LiveTestConfiguration
         !string.IsNullOrWhiteSpace(TenantId);
 
     /// <summary>
+    /// Gets a value indicating whether GitHub OIDC federated credentials are available.
+    /// This is true when running inside GitHub Actions with id-token permission.
+    /// </summary>
+    public bool HasGitHubOidcCredentials =>
+        !string.IsNullOrWhiteSpace(DataverseUrl) &&
+        !string.IsNullOrWhiteSpace(ApplicationId) &&
+        !string.IsNullOrWhiteSpace(TenantId) &&
+        !string.IsNullOrWhiteSpace(GitHubOidcTokenUrl) &&
+        !string.IsNullOrWhiteSpace(GitHubOidcRequestToken);
+
+    /// <summary>
     /// Gets a value indicating whether any live test credentials are available.
     /// </summary>
-    public bool HasAnyCredentials => HasClientSecretCredentials || HasCertificateCredentials;
+    public bool HasAnyCredentials => HasClientSecretCredentials || HasCertificateCredentials || HasGitHubOidcCredentials;
 
     /// <summary>
     /// Initializes a new instance reading from environment variables.
@@ -70,6 +102,54 @@ public sealed class LiveTestConfiguration
         TenantId = Environment.GetEnvironmentVariable("PPDS_TEST_TENANT_ID");
         CertificateBase64 = Environment.GetEnvironmentVariable("PPDS_TEST_CERT_BASE64");
         CertificatePassword = Environment.GetEnvironmentVariable("PPDS_TEST_CERT_PASSWORD");
+        CertificatePath = Environment.GetEnvironmentVariable("PPDS_TEST_CERT_PATH");
+        GitHubOidcTokenUrl = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_URL");
+        GitHubOidcRequestToken = Environment.GetEnvironmentVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+    }
+
+    /// <summary>
+    /// Gets the path to the certificate file, creating a temp file from base64 if needed.
+    /// </summary>
+    /// <returns>Path to the certificate file.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when certificate is not available.</exception>
+    public string GetCertificatePath()
+    {
+        // Use explicit path if provided
+        if (!string.IsNullOrWhiteSpace(CertificatePath) && File.Exists(CertificatePath))
+        {
+            return CertificatePath;
+        }
+
+        // Decode from base64 if available
+        if (!string.IsNullOrWhiteSpace(CertificateBase64))
+        {
+            if (_tempCertificatePath == null || !File.Exists(_tempCertificatePath))
+            {
+                _tempCertificatePath = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}.pfx");
+                var bytes = Convert.FromBase64String(CertificateBase64);
+                File.WriteAllBytes(_tempCertificatePath, bytes);
+            }
+
+            return _tempCertificatePath;
+        }
+
+        throw new InvalidOperationException("No certificate available. Set PPDS_TEST_CERT_PATH or PPDS_TEST_CERT_BASE64.");
+    }
+
+    /// <summary>
+    /// Loads the certificate from the configured source.
+    /// </summary>
+    /// <returns>The loaded certificate.</returns>
+    public X509Certificate2 LoadCertificate()
+    {
+        var path = GetCertificatePath();
+        var flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.EphemeralKeySet;
+
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12FromFile(path, CertificatePassword, flags);
+#else
+        return new X509Certificate2(path, CertificatePassword, flags);
+#endif
     }
 
     /// <summary>
@@ -86,16 +166,40 @@ public sealed class LiveTestConfiguration
         if (string.IsNullOrWhiteSpace(TenantId))
             missing.Add("PPDS_TEST_TENANT_ID");
 
-        if (!HasClientSecretCredentials && !HasCertificateCredentials)
+        if (!HasClientSecretCredentials && !HasCertificateCredentials && !HasGitHubOidcCredentials)
         {
             if (string.IsNullOrWhiteSpace(ClientSecret))
                 missing.Add("PPDS_TEST_CLIENT_SECRET");
             if (string.IsNullOrWhiteSpace(CertificateBase64))
                 missing.Add("PPDS_TEST_CERT_BASE64");
+            missing.Add("(or GitHub OIDC: ACTIONS_ID_TOKEN_REQUEST_URL)");
         }
 
         return missing.Count > 0
             ? $"Missing environment variables: {string.Join(", ", missing)}"
             : "Unknown reason";
+    }
+
+    /// <summary>
+    /// Cleans up temporary files.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        if (_tempCertificatePath != null && File.Exists(_tempCertificatePath))
+        {
+            try
+            {
+                File.Delete(_tempCertificatePath);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        _disposed = true;
     }
 }

--- a/tests/PPDS.LiveTests/Infrastructure/LiveTestConfiguration.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/LiveTestConfiguration.cs
@@ -139,7 +139,12 @@ public sealed class LiveTestConfiguration : IDisposable
     /// <summary>
     /// Loads the certificate from the configured source.
     /// </summary>
-    /// <returns>The loaded certificate.</returns>
+    /// <returns>The loaded certificate. Caller is responsible for disposing.</returns>
+    /// <remarks>
+    /// The returned <see cref="X509Certificate2"/> implements <see cref="IDisposable"/>.
+    /// Callers should use a <c>using</c> statement or call <see cref="X509Certificate2.Dispose"/>
+    /// when the certificate is no longer needed.
+    /// </remarks>
     public X509Certificate2 LoadCertificate()
     {
         var path = GetCertificatePath();

--- a/tests/PPDS.LiveTests/Infrastructure/SkipIfNoCredentialsAttribute.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/SkipIfNoCredentialsAttribute.cs
@@ -59,3 +59,23 @@ public sealed class SkipIfNoCertificateAttribute : FactAttribute
         }
     }
 }
+
+/// <summary>
+/// Skips the test if GitHub OIDC federated credentials are not configured.
+/// This is only available when running inside GitHub Actions with id-token permission.
+/// </summary>
+public sealed class SkipIfNoGitHubOidcAttribute : FactAttribute
+{
+    private static readonly LiveTestConfiguration Configuration = new();
+
+    /// <summary>
+    /// Initializes a new instance that skips if GitHub OIDC credentials are missing.
+    /// </summary>
+    public SkipIfNoGitHubOidcAttribute()
+    {
+        if (!Configuration.HasGitHubOidcCredentials)
+        {
+            Skip = "GitHub OIDC not available. This test only runs in GitHub Actions with 'id-token: write' permission and federated credential configured in Azure.";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add live integration tests for credential providers (Client Secret, Certificate, GitHub OIDC)
- Add infrastructure for GitHub OIDC federated authentication testing
- Add manual test procedures documentation for interactive auth methods

## Changes

### New Test Files
- `ClientSecretAuthenticationTests.cs` - 6 tests
- `CertificateAuthenticationTests.cs` - 7 tests
- `GitHubFederatedAuthenticationTests.cs` - 6 tests
- `MANUAL_TESTING.md` - Manual procedures for interactive/device code auth

### Infrastructure
- `LiveTestConfiguration` - GitHub OIDC detection, certificate temp file handling from base64
- `SkipIfNoGitHubOidcAttribute` - Skip tests when not in GitHub Actions with OIDC
- `integration-tests.yml` - Added `id-token: write` permission, use `vars.*` for non-secrets

## Test Plan

- [x] Build passes locally
- [x] Unit tests pass locally
- [ ] CI unit tests pass
- [ ] CI integration tests pass (requires secrets/variables configured)

## Configuration Required

**Repository Variables:**
- `DATAVERSE_URL`
- `PPDS_TEST_APP_ID`
- `PPDS_TEST_TENANT_ID`

**Repository Secrets:**
- `PPDS_TEST_CLIENT_SECRET`
- `PPDS_TEST_CERT_BASE64`
- `PPDS_TEST_CERT_PASSWORD`

**Azure:**
- Federated credential for GitHub OIDC (entity type: Environment, name: test-dataverse)

Closes #55 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)