### PR TITLE
fix: use ConnectionOptions constructor for ServiceClient org metadata discovery

### DIFF
--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor instead of token provider constructor, which triggers org metadata discovery. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
+
 ### Added
 
 - **Integration tests for credential providers** - Live tests for `ClientSecretCredentialProvider`, `CertificateFileCredentialProvider`, and `GitHubFederatedCredentialProvider` ([#55](https://github.com/joshsmithxrm/ppds-sdk/issues/55))

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -77,13 +77,12 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
-        var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
-
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // The provider function acquires tokens on demand and refreshes when needed.
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Profiles;
 
@@ -78,10 +79,13 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
 
         var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
 
-        var client = new ServiceClient(
-            new Uri(environmentUrl),
-            _ => Task.FromResult(token),
-            useUniqueInstance: true);
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        var options = new ConnectionOptions
+        {
+            ServiceUri = new Uri(environmentUrl),
+            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+        };
+        var client = new ServiceClient(options);
 
         if (!client.IsReady)
         {

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Profiles;
 
@@ -110,11 +111,13 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         // Get token
         var token = await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient with token provider
-        var client = new ServiceClient(
-            new Uri(environmentUrl),
-            _ => Task.FromResult(token),
-            useUniqueInstance: true);
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        var options = new ConnectionOptions
+        {
+            ServiceUri = new Uri(environmentUrl),
+            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+        };
+        var client = new ServiceClient(options);
 
         if (!client.IsReady)
         {

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -77,13 +77,12 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
-        var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
-
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // The provider function acquires tokens on demand and refreshes when needed.
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Profiles;
 
@@ -78,10 +79,13 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
 
         var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
 
-        var client = new ServiceClient(
-            new Uri(environmentUrl),
-            _ => Task.FromResult(token),
-            useUniqueInstance: true);
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        var options = new ConnectionOptions
+        {
+            ServiceUri = new Uri(environmentUrl),
+            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+        };
+        var client = new ServiceClient(options);
 
         if (!client.IsReady)
         {

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Extensions.Msal;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Profiles;
 
@@ -143,11 +144,13 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         // Get token
         var token = await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient with token provider
-        var client = new ServiceClient(
-            new Uri(environmentUrl),
-            _ => Task.FromResult(token),
-            useUniqueInstance: true);
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        var options = new ConnectionOptions
+        {
+            ServiceUri = new Uri(environmentUrl),
+            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+        };
+        var client = new ServiceClient(options);
 
         if (!client.IsReady)
         {

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -141,14 +141,15 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         // Ensure MSAL client is initialized
         await EnsureMsalClientInitializedAsync().ConfigureAwait(false);
 
-        // Get token
-        var token = await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
+        // Get token and prime the cache (may prompt user for interactive auth)
+        await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // The provider function uses cached tokens and refreshes silently when needed.
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -91,17 +91,15 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
         // Normalize URL
         environmentUrl = environmentUrl.TrimEnd('/');
 
-        // Get token
-        var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
-
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // The provider function acquires tokens on demand and refreshes when needed.
         ServiceClient client;
         try
         {
             var options = new ConnectionOptions
             {
                 ServiceUri = new Uri(environmentUrl),
-                AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+                AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
             };
             client = new ServiceClient(options);
         }

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.PowerPlatform.Dataverse.Client;
+using Microsoft.PowerPlatform.Dataverse.Client.Model;
 using PPDS.Auth.Profiles;
 
 namespace PPDS.Auth.Credentials;
@@ -93,14 +94,16 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
         // Get token
         var token = await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient with token provider
+        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery
         ServiceClient client;
         try
         {
-            client = new ServiceClient(
-                new Uri(environmentUrl),
-                _ => Task.FromResult(token),
-                useUniqueInstance: true);
+            var options = new ConnectionOptions
+            {
+                ServiceUri = new Uri(environmentUrl),
+                AccessTokenProviderFunctionAsync = _ => Task.FromResult(token)
+            };
+            client = new ServiceClient(options);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- Credential providers using the token provider constructor don't trigger org metadata discovery
- `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` remain empty
- Switched to `ConnectionOptions` constructor which properly initializes org metadata

**Affected credential providers:**
- `InteractiveBrowserCredentialProvider`
- `DeviceCodeCredentialProvider`
- `ManagedIdentityCredentialProvider`
- `GitHubFederatedCredentialProvider`
- `AzureDevOpsFederatedCredentialProvider`

Note: `ClientSecretCredentialProvider`, `CertificateFileCredentialProvider`, and `CertificateStoreCredentialProvider` use connection strings which already work correctly.

## Test plan

- [ ] `ppds auth create --name test` (interactive browser)
- [ ] `ppds env select --environment "any-env"`
- [ ] `ppds env who` - Verify Unique Name and Friendly Name are populated

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)