### PR TITLE
fix: ServiceClient org metadata and multi-layer environment resolution

### DIFF
--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor with `SkipDiscovery = false` and force eager discovery by accessing `ConnectedOrgFriendlyName` before the client is cloned by the connection pool. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
+- **ServiceClient org metadata not populated** - Credential providers now force eager org metadata discovery by accessing `ConnectedOrgFriendlyName` immediately after creating the ServiceClient. Discovery is lazy by default, and the connection pool clones clients before properties are accessed, resulting in empty metadata. This fix ensures `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` are populated. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
 
 ### Added
 

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor instead of token provider constructor, which triggers org metadata discovery. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
+- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor with `SkipDiscovery = false` to force org metadata discovery. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
 
 ### Added
 
+- **`EnvironmentResolutionService`** - Multi-layer environment resolution that tries direct Dataverse connection first (works for service principals), then falls back to Global Discovery for user authentication. Returns full org metadata. ([#89](https://github.com/joshsmithxrm/ppds-sdk/issues/89), [#88](https://github.com/joshsmithxrm/ppds-sdk/issues/88))
 - **Integration tests for credential providers** - Live tests for `ClientSecretCredentialProvider`, `CertificateFileCredentialProvider`, and `GitHubFederatedCredentialProvider` ([#55](https://github.com/joshsmithxrm/ppds-sdk/issues/55))
 - Manual test procedures documentation for interactive browser and device code authentication
 

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor with `SkipDiscovery = false` to force org metadata discovery. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
+- **ServiceClient org metadata not populated** - Credential providers now use `ConnectionOptions` constructor with `SkipDiscovery = false` and force eager discovery by accessing `ConnectedOrgFriendlyName` before the client is cloned by the connection pool. This populates `ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, and `ConnectedOrgId` properties. ([#86](https://github.com/joshsmithxrm/ppds-sdk/issues/86))
 
 ### Added
 

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -79,10 +79,12 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
 
         // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
         // The provider function acquires tokens on demand and refreshes when needed.
+        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
+            SkipDiscovery = false
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -88,6 +88,10 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
         };
         var client = new ServiceClient(options);
 
+        // Force org metadata discovery before client is cloned by pool.
+        // Discovery is lazy - accessing a property triggers it.
+        _ = client.ConnectedOrgFriendlyName;
+
         if (!client.IsReady)
         {
             var error = client.LastError ?? "Unknown error";

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -77,14 +77,12 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // Create ServiceClient using ConnectionOptions.
         // The provider function acquires tokens on demand and refreshes when needed.
-        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
-            SkipDiscovery = false
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -87,7 +87,10 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
         var client = new ServiceClient(options);
 
         // Force org metadata discovery before client is cloned by pool.
-        // Discovery is lazy - accessing a property triggers it.
+        // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
+        // are only populated when first accessed. The connection pool clones clients before
+        // properties are accessed, so clones would have empty metadata.
+        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -90,7 +90,6 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
         // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
         // are only populated when first accessed. The connection pool clones clients before
         // properties are accessed, so clones would have empty metadata.
-        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -77,8 +77,11 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
+        // Get token and prime the cache (uses cancellationToken for cancellable first request)
+        await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
+
         // Create ServiceClient using ConnectionOptions.
-        // The provider function acquires tokens on demand and refreshes when needed.
+        // The provider function uses cached tokens and refreshes when needed.
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -113,10 +113,12 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
 
         // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
         // The provider function uses cached tokens and refreshes silently when needed.
+        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None),
+            SkipDiscovery = false
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -122,6 +122,10 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         };
         var client = new ServiceClient(options);
 
+        // Force org metadata discovery before client is cloned by pool.
+        // Discovery is lazy - accessing a property triggers it.
+        _ = client.ConnectedOrgFriendlyName;
+
         if (!client.IsReady)
         {
             var error = client.LastError ?? "Unknown error";

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -124,7 +124,6 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
         // are only populated when first accessed. The connection pool clones clients before
         // properties are accessed, so clones would have empty metadata.
-        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -111,14 +111,12 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         // Get token and prime the cache (may prompt user for device code auth)
         await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // Create ServiceClient using ConnectionOptions.
         // The provider function uses cached tokens and refreshes silently when needed.
-        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None),
-            SkipDiscovery = false
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/DeviceCodeCredentialProvider.cs
@@ -121,7 +121,10 @@ public sealed class DeviceCodeCredentialProvider : ICredentialProvider
         var client = new ServiceClient(options);
 
         // Force org metadata discovery before client is cloned by pool.
-        // Discovery is lazy - accessing a property triggers it.
+        // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
+        // are only populated when first accessed. The connection pool clones clients before
+        // properties are accessed, so clones would have empty metadata.
+        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -79,10 +79,12 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
 
         // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
         // The provider function acquires tokens on demand and refreshes when needed.
+        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
+            SkipDiscovery = false
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -87,7 +87,10 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
         var client = new ServiceClient(options);
 
         // Force org metadata discovery before client is cloned by pool.
-        // Discovery is lazy - accessing a property triggers it.
+        // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
+        // are only populated when first accessed. The connection pool clones clients before
+        // properties are accessed, so clones would have empty metadata.
+        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -77,14 +77,12 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // Create ServiceClient using ConnectionOptions.
         // The provider function acquires tokens on demand and refreshes when needed.
-        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
-            SkipDiscovery = false
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -90,7 +90,6 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
         // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
         // are only populated when first accessed. The connection pool clones clients before
         // properties are accessed, so clones would have empty metadata.
-        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -77,8 +77,11 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
 
         EnsureCredentialInitialized();
 
+        // Get token and prime the cache (uses cancellationToken for cancellable first request)
+        await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
+
         // Create ServiceClient using ConnectionOptions.
-        // The provider function acquires tokens on demand and refreshes when needed.
+        // The provider function uses cached tokens and refreshes when needed.
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -88,6 +88,10 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
         };
         var client = new ServiceClient(options);
 
+        // Force org metadata discovery before client is cloned by pool.
+        // Discovery is lazy - accessing a property triggers it.
+        _ = client.ConnectedOrgFriendlyName;
+
         if (!client.IsReady)
         {
             var error = client.LastError ?? "Unknown error";

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -157,7 +157,6 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
         // are only populated when first accessed. The connection pool clones clients before
         // properties are accessed, so clones would have empty metadata.
-        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -154,7 +154,10 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         var client = new ServiceClient(options);
 
         // Force org metadata discovery before client is cloned by pool.
-        // Discovery is lazy - accessing a property triggers it.
+        // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
+        // are only populated when first accessed. The connection pool clones clients before
+        // properties are accessed, so clones would have empty metadata.
+        // PAC CLI uses the same pattern: immediately accessing properties after Connect().
         _ = client.ConnectedOrgFriendlyName;
 
         if (!client.IsReady)

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -144,14 +144,12 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         // Get token and prime the cache (may prompt user for interactive auth)
         await GetTokenAsync(environmentUrl, forceInteractive, cancellationToken).ConfigureAwait(false);
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // Create ServiceClient using ConnectionOptions.
         // The provider function uses cached tokens and refreshes silently when needed.
-        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None),
-            SkipDiscovery = false
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None)
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -155,6 +155,10 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         };
         var client = new ServiceClient(options);
 
+        // Force org metadata discovery before client is cloned by pool.
+        // Discovery is lazy - accessing a property triggers it.
+        _ = client.ConnectedOrgFriendlyName;
+
         if (!client.IsReady)
         {
             var error = client.LastError ?? "Unknown error";

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -146,10 +146,12 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
 
         // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
         // The provider function uses cached tokens and refreshes silently when needed.
+        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         var options = new ConnectionOptions
         {
             ServiceUri = new Uri(environmentUrl),
-            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None)
+            AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, forceInteractive: false, CancellationToken.None),
+            SkipDiscovery = false
         };
         var client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -91,17 +91,15 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
         // Normalize URL
         environmentUrl = environmentUrl.TrimEnd('/');
 
-        // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
+        // Create ServiceClient using ConnectionOptions.
         // The provider function acquires tokens on demand and refreshes when needed.
-        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         ServiceClient client;
         try
         {
             var options = new ConnectionOptions
             {
                 ServiceUri = new Uri(environmentUrl),
-                AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
-                SkipDiscovery = false
+                AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
             };
             client = new ServiceClient(options);
 

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -93,13 +93,15 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
 
         // Create ServiceClient using ConnectionOptions to ensure org metadata discovery.
         // The provider function acquires tokens on demand and refreshes when needed.
+        // SkipDiscovery = false forces org metadata population (ConnectedOrgFriendlyName, etc.)
         ServiceClient client;
         try
         {
             var options = new ConnectionOptions
             {
                 ServiceUri = new Uri(environmentUrl),
-                AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None)
+                AccessTokenProviderFunctionAsync = _ => GetTokenAsync(environmentUrl, CancellationToken.None),
+                SkipDiscovery = false
             };
             client = new ServiceClient(options);
         }

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -107,7 +107,6 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
             // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
             // are only populated when first accessed. The connection pool clones clients before
             // properties are accessed, so clones would have empty metadata.
-            // PAC CLI uses the same pattern: immediately accessing properties after Connect().
             _ = client.ConnectedOrgFriendlyName;
         }
         catch (Exception ex)

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -104,7 +104,10 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
             client = new ServiceClient(options);
 
             // Force org metadata discovery before client is cloned by pool.
-            // Discovery is lazy - accessing a property triggers it.
+            // ServiceClient uses lazy initialization - properties like ConnectedOrgFriendlyName
+            // are only populated when first accessed. The connection pool clones clients before
+            // properties are accessed, so clones would have empty metadata.
+            // PAC CLI uses the same pattern: immediately accessing properties after Connect().
             _ = client.ConnectedOrgFriendlyName;
         }
         catch (Exception ex)

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -91,8 +91,11 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
         // Normalize URL
         environmentUrl = environmentUrl.TrimEnd('/');
 
+        // Get token and prime the cache (uses cancellationToken for cancellable first request)
+        await GetTokenAsync(environmentUrl, cancellationToken).ConfigureAwait(false);
+
         // Create ServiceClient using ConnectionOptions.
-        // The provider function acquires tokens on demand and refreshes when needed.
+        // The provider function uses cached tokens and refreshes when needed.
         ServiceClient client;
         try
         {

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -104,6 +104,10 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
                 SkipDiscovery = false
             };
             client = new ServiceClient(options);
+
+            // Force org metadata discovery before client is cloned by pool.
+            // Discovery is lazy - accessing a property triggers it.
+            _ = client.ConnectedOrgFriendlyName;
         }
         catch (Exception ex)
         {

--- a/src/PPDS.Auth/Credentials/MsalClientBuilder.cs
+++ b/src/PPDS.Auth/Credentials/MsalClientBuilder.cs
@@ -113,9 +113,9 @@ internal static class MsalClientBuilder
             {
                 cacheHelper.UnregisterCache(client.UserTokenCache);
             }
-            catch
+            catch (Exception)
             {
-                // Ignore errors during cleanup
+                // Cleanup should never throw - swallow all errors
             }
         }
     }

--- a/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
+++ b/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Auth.Credentials;
+using PPDS.Auth.Profiles;
+
+namespace PPDS.Auth.Discovery;
+
+/// <summary>
+/// Service for resolving environments using a multi-layer strategy.
+/// </summary>
+/// <remarks>
+/// Resolution strategy:
+/// 1. If identifier looks like a URL → Try direct Dataverse connection first
+/// 2. If not a URL OR direct connection fails → Try Global Discovery (interactive profiles only)
+/// 3. For service principals without a URL → Return helpful error
+/// </remarks>
+public sealed class EnvironmentResolutionService : IDisposable
+{
+    private readonly AuthProfile _profile;
+    private readonly Action<DeviceCodeInfo>? _deviceCodeCallback;
+    private ICredentialProvider? _credentialProvider;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new environment resolution service.
+    /// </summary>
+    /// <param name="profile">The auth profile to use for resolution.</param>
+    /// <param name="deviceCodeCallback">Optional callback for device code display.</param>
+    public EnvironmentResolutionService(
+        AuthProfile profile,
+        Action<DeviceCodeInfo>? deviceCodeCallback = null)
+    {
+        _profile = profile ?? throw new ArgumentNullException(nameof(profile));
+        _deviceCodeCallback = deviceCodeCallback;
+    }
+
+    /// <summary>
+    /// Resolves an environment by identifier using the multi-layer strategy.
+    /// </summary>
+    /// <param name="identifier">The environment identifier (URL, name, ID, etc.).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The resolved environment info, or null if not found.</returns>
+    /// <exception cref="InvalidOperationException">If resolution fails with a specific error.</exception>
+    public async Task<EnvironmentResolutionResult> ResolveAsync(
+        string identifier,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+            return EnvironmentResolutionResult.Failed("Environment identifier is required.");
+
+        identifier = identifier.Trim();
+
+        // Check if identifier looks like a URL
+        if (IsUrl(identifier))
+        {
+            // Try direct connection first (works for all auth types including service principals)
+            var directResult = await TryDirectConnectionAsync(identifier, cancellationToken);
+            if (directResult.Success)
+                return directResult;
+
+            // If direct connection failed and this is NOT an interactive profile,
+            // we can't fall back to Global Discovery
+            if (!CanUseGlobalDiscovery(_profile.AuthMethod))
+            {
+                return EnvironmentResolutionResult.Failed(
+                    $"Failed to connect to environment: {directResult.ErrorMessage}");
+            }
+
+            // Fall through to Global Discovery for interactive profiles
+        }
+        else
+        {
+            // Not a URL - need Global Discovery to resolve by name/ID
+            if (!CanUseGlobalDiscovery(_profile.AuthMethod))
+            {
+                return EnvironmentResolutionResult.Failed(
+                    "Service principals require a full environment URL (e.g., https://org.crm.dynamics.com). " +
+                    "Name-based resolution requires Global Discovery which is only available for user authentication.");
+            }
+        }
+
+        // Try Global Discovery
+        return await TryGlobalDiscoveryAsync(identifier, cancellationToken);
+    }
+
+    /// <summary>
+    /// Attempts to resolve environment via direct Dataverse connection.
+    /// </summary>
+    private async Task<EnvironmentResolutionResult> TryDirectConnectionAsync(
+        string url,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Normalize URL
+            url = NormalizeUrl(url);
+
+            // Create credential provider
+            _credentialProvider ??= CredentialProviderFactory.Create(_profile, _deviceCodeCallback);
+
+            // Connect to Dataverse and get org metadata
+            using var client = await _credentialProvider.CreateServiceClientAsync(
+                url,
+                cancellationToken,
+                forceInteractive: false);
+
+            if (!client.IsReady)
+            {
+                return EnvironmentResolutionResult.Failed(
+                    client.LastError ?? "Failed to connect to Dataverse");
+            }
+
+            // Extract org metadata from ServiceClient
+            var envInfo = new EnvironmentInfo
+            {
+                Url = url,
+                DisplayName = !string.IsNullOrEmpty(client.ConnectedOrgFriendlyName)
+                    ? client.ConnectedOrgFriendlyName
+                    : ExtractEnvironmentName(url),
+                UniqueName = client.ConnectedOrgUniqueName,
+                OrganizationId = client.ConnectedOrgId != Guid.Empty
+                    ? client.ConnectedOrgId.ToString()
+                    : null
+            };
+
+            return EnvironmentResolutionResult.Succeeded(envInfo, ResolutionMethod.DirectConnection);
+        }
+        catch (Exception ex)
+        {
+            return EnvironmentResolutionResult.Failed($"Direct connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Attempts to resolve environment via Global Discovery Service.
+    /// </summary>
+    private async Task<EnvironmentResolutionResult> TryGlobalDiscoveryAsync(
+        string identifier,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var gds = GlobalDiscoveryService.FromProfile(_profile);
+            var environments = await gds.DiscoverEnvironmentsAsync(cancellationToken);
+
+            DiscoveredEnvironment? resolved;
+            try
+            {
+                resolved = EnvironmentResolver.Resolve(environments, identifier);
+            }
+            catch (AmbiguousMatchException ex)
+            {
+                return EnvironmentResolutionResult.Failed(ex.Message);
+            }
+
+            if (resolved == null)
+            {
+                return EnvironmentResolutionResult.Failed(
+                    $"Environment '{identifier}' not found. Use 'ppds env list' to see available environments.");
+            }
+
+            var envInfo = new EnvironmentInfo
+            {
+                Url = resolved.ApiUrl,
+                DisplayName = resolved.FriendlyName,
+                UniqueName = resolved.UniqueName,
+                EnvironmentId = resolved.EnvironmentId,
+                OrganizationId = resolved.Id.ToString(),
+                Type = resolved.EnvironmentType,
+                Region = resolved.Region
+            };
+
+            return EnvironmentResolutionResult.Succeeded(envInfo, ResolutionMethod.GlobalDiscovery);
+        }
+        catch (Exception ex)
+        {
+            return EnvironmentResolutionResult.Failed($"Global Discovery failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Checks if the identifier looks like a URL.
+    /// </summary>
+    private static bool IsUrl(string identifier)
+    {
+        // Check for common URL patterns
+        if (identifier.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            identifier.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Check for hostname patterns like "org.crm.dynamics.com"
+        if (identifier.Contains(".crm", StringComparison.OrdinalIgnoreCase) &&
+            identifier.Contains(".dynamics.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Normalizes a URL to ensure it has https:// prefix.
+    /// </summary>
+    private static string NormalizeUrl(string url)
+    {
+        url = url.Trim().TrimEnd('/');
+
+        if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = "https://" + url;
+        }
+
+        return url;
+    }
+
+    /// <summary>
+    /// Extracts a display name from a URL.
+    /// </summary>
+    private static string ExtractEnvironmentName(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var host = uri.Host;
+
+            // Extract org name from subdomain (e.g., "orgname" from "orgname.crm.dynamics.com")
+            var parts = host.Split('.');
+            if (parts.Length > 0)
+            {
+                return parts[0];
+            }
+
+            return host;
+        }
+        catch
+        {
+            return url;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the auth method can use Global Discovery Service.
+    /// </summary>
+    /// <remarks>
+    /// Global Discovery requires user authentication (delegated permissions).
+    /// Service principals cannot access Global Discovery.
+    /// </remarks>
+    private static bool CanUseGlobalDiscovery(AuthMethod authMethod)
+    {
+        return authMethod switch
+        {
+            // User authentication methods - can use Global Discovery
+            AuthMethod.InteractiveBrowser => true,
+            AuthMethod.DeviceCode => true,
+            AuthMethod.UsernamePassword => true,
+
+            // Service principal methods - cannot use Global Discovery
+            AuthMethod.ClientSecret => false,
+            AuthMethod.CertificateFile => false,
+            AuthMethod.CertificateStore => false,
+            AuthMethod.ManagedIdentity => false,
+            AuthMethod.GitHubFederated => false,
+            AuthMethod.AzureDevOpsFederated => false,
+
+            _ => false
+        };
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _credentialProvider?.Dispose();
+        _disposed = true;
+    }
+}
+
+/// <summary>
+/// Result of an environment resolution attempt.
+/// </summary>
+public sealed class EnvironmentResolutionResult
+{
+    /// <summary>
+    /// Gets whether the resolution was successful.
+    /// </summary>
+    public bool Success { get; private init; }
+
+    /// <summary>
+    /// Gets the resolved environment info (null if failed).
+    /// </summary>
+    public EnvironmentInfo? Environment { get; private init; }
+
+    /// <summary>
+    /// Gets the method used to resolve the environment.
+    /// </summary>
+    public ResolutionMethod Method { get; private init; }
+
+    /// <summary>
+    /// Gets the error message (null if successful).
+    /// </summary>
+    public string? ErrorMessage { get; private init; }
+
+    private EnvironmentResolutionResult() { }
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    public static EnvironmentResolutionResult Succeeded(EnvironmentInfo environment, ResolutionMethod method)
+    {
+        return new EnvironmentResolutionResult
+        {
+            Success = true,
+            Environment = environment,
+            Method = method
+        };
+    }
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    public static EnvironmentResolutionResult Failed(string errorMessage)
+    {
+        return new EnvironmentResolutionResult
+        {
+            Success = false,
+            ErrorMessage = errorMessage
+        };
+    }
+}
+
+/// <summary>
+/// Method used to resolve an environment.
+/// </summary>
+public enum ResolutionMethod
+{
+    /// <summary>
+    /// Resolved via direct Dataverse connection.
+    /// </summary>
+    DirectConnection,
+
+    /// <summary>
+    /// Resolved via Global Discovery Service.
+    /// </summary>
+    GlobalDiscovery
+}

--- a/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
+++ b/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
@@ -40,8 +40,7 @@ public sealed class EnvironmentResolutionService : IDisposable
     /// </summary>
     /// <param name="identifier">The environment identifier (URL, name, ID, etc.).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The resolved environment info, or null if not found.</returns>
-    /// <exception cref="InvalidOperationException">If resolution fails with a specific error.</exception>
+    /// <returns>A result containing the resolved environment info on success, or an error message on failure.</returns>
     public async Task<EnvironmentResolutionResult> ResolveAsync(
         string identifier,
         CancellationToken cancellationToken = default)
@@ -236,8 +235,9 @@ public sealed class EnvironmentResolutionService : IDisposable
 
             return host;
         }
-        catch
+        catch (Exception)
         {
+            // Best-effort parsing - return input if URL parsing fails for any reason
             return url;
         }
     }

--- a/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
+++ b/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
@@ -251,23 +251,9 @@ public sealed class EnvironmentResolutionService : IDisposable
     /// </remarks>
     private static bool CanUseGlobalDiscovery(AuthMethod authMethod)
     {
-        return authMethod switch
-        {
-            // User authentication methods - can use Global Discovery
-            AuthMethod.InteractiveBrowser => true,
-            AuthMethod.DeviceCode => true,
-            AuthMethod.UsernamePassword => true,
-
-            // Service principal methods - cannot use Global Discovery
-            AuthMethod.ClientSecret => false,
-            AuthMethod.CertificateFile => false,
-            AuthMethod.CertificateStore => false,
-            AuthMethod.ManagedIdentity => false,
-            AuthMethod.GitHubFederated => false,
-            AuthMethod.AzureDevOpsFederated => false,
-
-            _ => false
-        };
+        // Global Discovery requires user authentication (delegated permissions).
+        // Service principals cannot access Global Discovery.
+        return authMethod is AuthMethod.InteractiveBrowser or AuthMethod.DeviceCode or AuthMethod.UsernamePassword;
     }
 
     /// <inheritdoc />

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Environment resolution for service principals** - `ppds env select` now works with full URLs for service principals by trying direct Dataverse connection first, before falling back to Global Discovery (which requires user auth). ([#89](https://github.com/joshsmithxrm/ppds-sdk/issues/89))
+- **`auth update --environment` now validates and resolves** - Previously only parsed the URL string without connecting. Now performs full resolution with org metadata population. ([#88](https://github.com/joshsmithxrm/ppds-sdk/issues/88))
+
 ### Changed
 
 - **BREAKING: Standardized output format flag** - Replaced `--json` / `-j` with `--output-format` / `-f` enum option (values: `Text`, `Json`) across all commands for consistency ([#73](https://github.com/joshsmithxrm/ppds-sdk/issues/73))


### PR DESCRIPTION
## Summary

- **Issue #86**: Fixed ServiceClient org metadata not populated (`ConnectedOrgFriendlyName`, `ConnectedOrgUniqueName`, `ConnectedOrgId` were empty)
- **Issues #89 + #88**: Added multi-layer environment resolution for `ppds env select` and `ppds auth update --environment`

## Root Cause (#86)

ServiceClient uses lazy initialization for org metadata properties. The connection pool clones clients before properties are accessed, so clones had empty metadata.

**Fix:** Access `ConnectedOrgFriendlyName` immediately after ServiceClient creation to force lazy initialization before cloning.

## Changes

### Credential Providers (5 files)
- `InteractiveBrowserCredentialProvider.cs`
- `DeviceCodeCredentialProvider.cs`
- `ManagedIdentityCredentialProvider.cs`
- `GitHubFederatedCredentialProvider.cs`
- `AzureDevOpsFederatedCredentialProvider.cs`

Added eager property access after ServiceClient creation.

### New Service
- `EnvironmentResolutionService.cs` - Multi-layer resolution:
  - URL identifier → Direct Dataverse connection first
  - Name/ID identifier → Global Discovery
  - Service principals without URL → Helpful error message

### CLI Commands
- `EnvCommandGroup.cs` - Updated `ppds env select` to use resolver
- `AuthCommandGroup.cs` - Updated `ppds auth update --environment` to use resolver

## Test plan

- [x] `ppds env who` shows populated Unique Name and Friendly Name
- [x] `ppds env select <url>` works with service principals (direct connection)
- [x] `ppds env select <name>` works with user auth (Global Discovery fallback)
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)