### PR TITLE
feat: Self-contained CLI publishing and release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact }}
           path: ./publish/${{ matrix.artifact }}
@@ -83,6 +83,17 @@ jobs:
           # Move all binaries to release folder (artifacts are in subdirectories)
           find ./artifacts -type f -name "ppds-*" -exec mv {} ./release/ \;
           ls -la ./release/
+
+      - name: Validate all binaries present
+        run: |
+          EXPECTED="ppds-win-x64.exe ppds-win-arm64.exe ppds-osx-x64 ppds-osx-arm64 ppds-linux-x64"
+          for binary in $EXPECTED; do
+            if [ ! -f "./release/$binary" ]; then
+              echo "ERROR: Missing expected binary: $binary"
+              exit 1
+            fi
+          done
+          echo "All 5 platform binaries present"
 
       - name: Generate checksums
         working-directory: ./release

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,112 @@
+name: Release CLI Binaries
+
+on:
+  push:
+    tags:
+      - 'Cli-v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - rid: win-x64
+            os: windows-latest
+            artifact: ppds-win-x64.exe
+          - rid: win-arm64
+            os: windows-latest
+            artifact: ppds-win-arm64.exe
+          - rid: osx-x64
+            os: macos-latest
+            artifact: ppds-osx-x64
+          - rid: osx-arm64
+            os: macos-latest
+            artifact: ppds-osx-arm64
+          - rid: linux-x64
+            os: ubuntu-latest
+            artifact: ppds-linux-x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Required for MinVer to read git history
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Publish self-contained binary
+        run: |
+          dotnet publish src/PPDS.Cli/PPDS.Cli.csproj \
+            -c Release \
+            -r ${{ matrix.rid }} \
+            -f net8.0 \
+            -p:PublishSingleFile=true \
+            --self-contained \
+            -o ./publish
+        shell: bash
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: mv ./publish/ppds ./publish/${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: mv ./publish/ppds.exe ./publish/${{ matrix.artifact }}
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./publish/${{ matrix.artifact }}
+          retention-days: 1
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir -p ./release
+          # Move all binaries to release folder (artifacts are in subdirectories)
+          find ./artifacts -type f -name "ppds-*" -exec mv {} ./release/ \;
+          ls -la ./release/
+
+      - name: Generate checksums
+        working-directory: ./release
+        run: |
+          sha256sum ppds-* > checksums.sha256
+          cat checksums.sha256
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#Cli-v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: PPDS CLI v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            ./release/ppds-win-x64.exe
+            ./release/ppds-win-arm64.exe
+            ./release/ppds-osx-x64
+            ./release/ppds-osx-arm64
+            ./release/ppds-linux-x64
+            ./release/checksums.sha256

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Self-contained binary publishing** - CLI can now be published as self-contained single-file executables for Windows, macOS, and Linux (x64 and ARM64) ([#53](https://github.com/joshsmithxrm/ppds-sdk/issues/53))
+- **Automated release workflow** - GitHub Actions workflow builds and publishes platform binaries with SHA256 checksums to GitHub Releases on `Cli-v*` tags ([#54](https://github.com/joshsmithxrm/ppds-sdk/issues/54))
+
 ### Changed
 
 - **PluginRegistrationService refactored to use early-bound entities** - Replaced all magic string attribute access with strongly-typed `PPDS.Dataverse.Generated` classes (`PluginAssembly`, `PluginPackage`, `PluginType`, `SdkMessageProcessingStep`, `SdkMessageProcessingStepImage`, `SdkMessage`, `SdkMessageFilter`, `SystemUser`). Provides compile-time type safety and IntelliSense for all Dataverse entity operations. ([#56](https://github.com/joshsmithxrm/ppds-sdk/issues/56))

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -8,7 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <!-- Self-Contained Publish Configuration (applies when PublishSingleFile=true) -->
+    <!-- Self-Contained Publish Configuration
+         These are defaults for normal builds. CI/release workflows override
+         PublishSingleFile and SelfContained via -p: command-line parameters. -->
     <PublishSingleFile>false</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -7,6 +7,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Self-Contained Publish Configuration (applies when PublishSingleFile=true) -->
+    <PublishSingleFile>false</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- NU1702: PPDS.Plugins targets net462 (required for Dataverse plugin sandbox) but is
          referenced from net8.0+. The package contains only attributes/enums with no
          framework-specific APIs, so cross-framework reference is safe. -->


### PR DESCRIPTION
## Summary

- Configure CLI to publish as self-contained single-file executables for all major platforms
- Add GitHub Actions workflow to build and release binaries when `Cli-v*` tags are pushed

## Changes

**Issue #53 - Self-Contained Publishing:**
- Added publish settings to `PPDS.Cli.csproj`:
  - `EnableCompressionInSingleFile=true` - reduces binary size (~38MB compressed)
  - `IncludeNativeLibrariesForSelfExtract=true` - ensures native dependencies work
  - Defaults to `false` for normal builds, enabled via `-p:PublishSingleFile=true`

**Issue #54 - Release Workflow:**
- Created `.github/workflows/release-cli.yml`:
  - Triggers on `Cli-v*` tags (runs alongside existing NuGet publish workflow)
  - Parallel matrix build for 5 platforms: win-x64, win-arm64, osx-x64, osx-arm64, linux-x64
  - Uses net8.0 (LTS) for self-contained binaries
  - Generates SHA256 checksums (`checksums.sha256`)
  - Creates GitHub Release with auto-generated release notes

## Platforms

| Runtime ID | Binary Name |
|------------|-------------|
| win-x64 | ppds-win-x64.exe |
| win-arm64 | ppds-win-arm64.exe |
| osx-x64 | ppds-osx-x64 |
| osx-arm64 | ppds-osx-arm64 |
| linux-x64 | ppds-linux-x64 |

## Test plan

- [x] Build succeeds with new csproj settings
- [x] `dotnet publish -p:PublishSingleFile=true --self-contained -r win-x64` produces ~38MB executable
- [x] `ppds --version` outputs correct version from MinVer
- [x] All unit tests pass
- [ ] After merge, create test tag (e.g., `Cli-v1.0.0-beta.6`) to verify workflow

Closes #53, closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)