### PR TITLE
refactor: add logging to GetComponentTypeAsync catch block

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **PluginRegistrationService refactored to use early-bound entities** - Replaced all magic string attribute access with strongly-typed `PPDS.Dataverse.Generated` classes (`PluginAssembly`, `PluginPackage`, `PluginType`, `SdkMessageProcessingStep`, `SdkMessageProcessingStepImage`, `SdkMessage`, `SdkMessageFilter`, `SystemUser`). Provides compile-time type safety and IntelliSense for all Dataverse entity operations. ([#56](https://github.com/joshsmithxrm/ppds-sdk/issues/56))
+- **`PluginRegistrationService` now requires logger** - Constructor now requires `ILogger<PluginRegistrationService>` for diagnostic output. ([#61](https://github.com/joshsmithxrm/ppds-sdk/issues/61))
 
 ### Fixed
 
+- **Improved exception handling in `GetComponentTypeAsync`** - Replaced generic catch clause with specific `FaultException<OrganizationServiceFault>` and `FaultException` handlers. Logs failures at Debug level for troubleshooting while maintaining graceful degradation behavior. ([#61](https://github.com/joshsmithxrm/ppds-sdk/issues/61))
 - **Environment resolution for service principals** - `ppds env select` now works with full URLs for service principals by trying direct Dataverse connection first, before falling back to Global Discovery (which requires user auth). ([#89](https://github.com/joshsmithxrm/ppds-sdk/issues/89))
 - **`auth update --environment` now validates and resolves** - Previously only parsed the URL string without connecting. Now performs full resolution with org metadata population. ([#88](https://github.com/joshsmithxrm/ppds-sdk/issues/88))
 - **`env select` validates connection before saving** - Now performs actual WhoAmI request to verify user has access before saving environment selection. Previously resolved metadata but didn't validate access. ([#91](https://github.com/joshsmithxrm/ppds-sdk/issues/91))

--- a/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
@@ -95,8 +96,9 @@ public static class CleanCommand
                 cancellationToken);
 
             var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
             await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
-            var registrationService = new PluginRegistrationService(client);
+            var registrationService = new PluginRegistrationService(client, logger);
 
             if (outputFormat != OutputFormat.Json)
             {

--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
@@ -109,8 +110,9 @@ public static class DeployCommand
                 cancellationToken);
 
             var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
             await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
-            var registrationService = new PluginRegistrationService(client);
+            var registrationService = new PluginRegistrationService(client, logger);
 
             if (outputFormat != OutputFormat.Json)
             {

--- a/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
@@ -86,8 +87,9 @@ public static class DiffCommand
                 cancellationToken);
 
             var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
             await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
-            var registrationService = new PluginRegistrationService(client);
+            var registrationService = new PluginRegistrationService(client, logger);
 
             if (outputFormat != OutputFormat.Json)
             {

--- a/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Plugins.Registration;
 using PPDS.Dataverse.Pooling;
@@ -73,8 +74,9 @@ public static class ListCommand
                 cancellationToken);
 
             var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
             await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
-            var registrationService = new PluginRegistrationService(client);
+            var registrationService = new PluginRegistrationService(client, logger);
 
             if (outputFormat != OutputFormat.Json)
             {

--- a/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
+++ b/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.*" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using PPDS.Cli.Plugins.Registration;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Plugins.Registration;
+
+public class PluginRegistrationServiceTests
+{
+    private readonly Mock<IOrganizationService> _mockService;
+    private readonly Mock<ILogger<PluginRegistrationService>> _mockLogger;
+    private readonly PluginRegistrationService _sut;
+
+    public PluginRegistrationServiceTests()
+    {
+        _mockService = new Mock<IOrganizationService>();
+        _mockLogger = new Mock<ILogger<PluginRegistrationService>>();
+        _sut = new PluginRegistrationService(_mockService.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ListAssembliesAsync_ReturnsEmptyList_WhenNoAssembliesExist()
+    {
+        // Arrange
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(new EntityCollection());
+
+        // Act
+        var result = await _sut.ListAssembliesAsync();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListAssembliesAsync_ReturnsAssemblies_WhenTheyExist()
+    {
+        // Arrange
+        var entities = new EntityCollection();
+        var assembly = new Entity("pluginassembly", Guid.NewGuid())
+        {
+            ["name"] = "TestAssembly",
+            ["version"] = "1.0.0.0",
+            ["publickeytoken"] = "abc123",
+            ["isolationmode"] = new OptionSetValue(2)
+        };
+        entities.Entities.Add(assembly);
+
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(entities);
+
+        // Act
+        var result = await _sut.ListAssembliesAsync();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("TestAssembly", result[0].Name);
+        Assert.Equal("1.0.0.0", result[0].Version);
+    }
+
+    [Fact]
+    public async Task UpsertAssemblyAsync_CreatesNewAssembly_WhenNotExists()
+    {
+        // Arrange
+        var expectedId = Guid.NewGuid();
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(new EntityCollection());
+        _mockService
+            .Setup(s => s.Create(It.IsAny<Entity>()))
+            .Returns(expectedId);
+
+        // Act
+        var result = await _sut.UpsertAssemblyAsync("TestAssembly", new byte[] { 1, 2, 3 });
+
+        // Assert
+        Assert.Equal(expectedId, result);
+        _mockService.Verify(s => s.Create(It.Is<Entity>(e => e.LogicalName == "pluginassembly")), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpsertAssemblyAsync_UpdatesExisting_WhenAssemblyExists()
+    {
+        // Arrange
+        var existingId = Guid.NewGuid();
+        var entities = new EntityCollection();
+        entities.Entities.Add(new Entity("pluginassembly", existingId)
+        {
+            ["name"] = "TestAssembly",
+            ["version"] = "1.0.0.0"
+        });
+
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(entities);
+
+        // Act
+        var result = await _sut.UpsertAssemblyAsync("TestAssembly", new byte[] { 1, 2, 3 });
+
+        // Assert
+        Assert.Equal(existingId, result);
+        _mockService.Verify(s => s.Update(It.Is<Entity>(e => e.Id == existingId)), Times.Once);
+        _mockService.Verify(s => s.Create(It.IsAny<Entity>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetSdkMessageIdAsync_ReturnsNull_WhenMessageNotFound()
+    {
+        // Arrange
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(new EntityCollection());
+
+        // Act
+        var result = await _sut.GetSdkMessageIdAsync("NonExistentMessage");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetSdkMessageIdAsync_ReturnsId_WhenMessageExists()
+    {
+        // Arrange
+        var messageId = Guid.NewGuid();
+        var entities = new EntityCollection();
+        entities.Entities.Add(new Entity("sdkmessage", messageId));
+
+        _mockService
+            .Setup(s => s.RetrieveMultiple(It.IsAny<Microsoft.Xrm.Sdk.Query.QueryExpression>()))
+            .Returns(entities);
+
+        // Act
+        var result = await _sut.GetSdkMessageIdAsync("Create");
+
+        // Assert
+        Assert.Equal(messageId, result);
+    }
+}


### PR DESCRIPTION
## Summary

- Add required `ILogger<PluginRegistrationService>` dependency to enable diagnostic logging
- Replace generic catch clause with specific `FaultException` handlers for better error categorization
- Log metadata retrieval failures at Debug level for troubleshooting

## Changes

- **PluginRegistrationService** - Added logger dependency, specific exception handling in `GetComponentTypeAsync`
- **Command handlers** - Updated ListCommand, CleanCommand, DiffCommand, DeployCommand to get logger from DI
- **Tests** - Added 6 unit tests for PluginRegistrationService

## Test plan

- [x] All unit tests pass (216 CLI tests, 6 new)
- [x] Build succeeds with warnings as errors
- [x] Changelog updated

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)