### PR TITLE
feat: Add metadata command group for entity browsing (#51)

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ppds metadata` command group** - Browse Dataverse entity metadata without exporting data ([#51](https://github.com/joshsmithxrm/ppds-sdk/issues/51)):
+  - `ppds metadata entities` - List all entities (supports `--custom-only`, `--filter` for wildcard matching)
+  - `ppds metadata entity <name>` - Get full entity details (supports `--include` for specific sections)
+  - `ppds metadata attributes <entity>` - List attributes (supports `--type` filtering by Lookup, String, etc.)
+  - `ppds metadata relationships <entity>` - List 1:N, N:1, N:N relationships (supports `--type` filtering)
+  - `ppds metadata optionsets` - List global option sets (supports `--filter`)
+  - `ppds metadata optionset <name>` - Get option set values and metadata
 - **Structured error handling** - All errors now return hierarchical error codes (`Auth.ProfileNotFound`, `Connection.Failed`, etc.) for reliable programmatic handling ([#77](https://github.com/joshsmithxrm/ppds-sdk/issues/77))
 - **Expanded exit codes** - New exit codes 4 (ConnectionError), 5 (AuthError), 6 (NotFoundError) for finer-grained status ([#77](https://github.com/joshsmithxrm/ppds-sdk/issues/77))
 - **Global options** - `--quiet`/`-q`, `--verbose`/`-v`, `--debug`, `--correlation-id` flags available on all commands ([#76](https://github.com/joshsmithxrm/ppds-sdk/issues/76))

--- a/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
@@ -1,0 +1,123 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Lists attributes for an entity.
+/// </summary>
+public static class AttributesCommand
+{
+    /// <summary>
+    /// Creates the 'attributes' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var entityArgument = new Argument<string>("entity")
+        {
+            Description = "The entity logical name (e.g., 'account')"
+        };
+
+        var typeOption = new Option<string?>("--type", "-t")
+        {
+            Description = "Filter by attribute type (e.g., 'Lookup', 'String', 'DateTime', 'Picklist')"
+        };
+
+        var command = new Command("attributes", "List attributes for an entity")
+        {
+            entityArgument,
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption,
+            typeOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityArgument);
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var type = parseResult.GetValue(typeOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(entity!, profile, environment, type, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        string? profile,
+        string? environment,
+        string? type,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Retrieving attributes for '{entity}'...");
+            }
+
+            var attributes = await metadataService.GetAttributesAsync(entity, type, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(attributes);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"{"Logical Name",-35} {"Type",-20} {"Display Name",-30} {"Flags"}");
+                Console.Error.WriteLine(new string('-', 100));
+
+                foreach (var attr in attributes)
+                {
+                    var flags = new List<string>();
+                    if (attr.IsPrimaryId) flags.Add("PK");
+                    if (attr.IsPrimaryName) flags.Add("name");
+                    if (attr.IsCustomAttribute) flags.Add("custom");
+                    if (!attr.IsValidForCreate && !attr.IsValidForUpdate) flags.Add("readonly");
+                    if (attr.RequiredLevel == "ApplicationRequired" || attr.RequiredLevel == "SystemRequired")
+                        flags.Add("required");
+
+                    var flagText = flags.Count > 0 ? string.Join(", ", flags) : "";
+                    Console.Error.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-20} {attr.DisplayName,-30} {flagText}");
+                }
+
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Total: {attributes.Count} attributes");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"retrieving attributes for '{entity}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
@@ -1,0 +1,117 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Lists all entities with basic metadata.
+/// </summary>
+public static class EntitiesCommand
+{
+    /// <summary>
+    /// Creates the 'entities' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var filterOption = new Option<string?>("--filter")
+        {
+            Description = "Filter entities by name pattern (supports * wildcard, e.g., 'account*')"
+        };
+
+        var customOnlyOption = new Option<bool>("--custom-only")
+        {
+            Description = "Only show custom entities",
+            DefaultValueFactory = _ => false
+        };
+
+        var command = new Command("entities", "List all entities with basic information")
+        {
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption,
+            filterOption,
+            customOnlyOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var filter = parseResult.GetValue(filterOption);
+            var customOnly = parseResult.GetValue(customOnlyOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(profile, environment, filter, customOnly, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string? profile,
+        string? environment,
+        string? filter,
+        bool customOnly,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Retrieving entities...");
+            }
+
+            var entities = await metadataService.GetEntitiesAsync(customOnly, filter, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(entities);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+                foreach (var entity in entities)
+                {
+                    var markers = new List<string>();
+                    if (entity.IsCustomEntity) markers.Add("custom");
+                    if (entity.IsManaged) markers.Add("managed");
+
+                    var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
+                    Console.Error.WriteLine($"  {entity.LogicalName,-40} {entity.DisplayName}{markerText}");
+                }
+
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Total: {entities.Count} entities");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "retrieving entities", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
@@ -1,0 +1,198 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Gets full metadata for a specific entity.
+/// </summary>
+public static class EntityCommand
+{
+    /// <summary>
+    /// Creates the 'entity' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var entityArgument = new Argument<string>("entity")
+        {
+            Description = "The entity logical name (e.g., 'account')"
+        };
+
+        var includeOption = new Option<string[]?>("--include")
+        {
+            Description = "Include specific metadata sections: attributes, relationships, keys, privileges (comma-separated or multiple flags)",
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        var command = new Command("entity", "Get full metadata for a specific entity")
+        {
+            entityArgument,
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption,
+            includeOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityArgument);
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var include = parseResult.GetValue(includeOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(entity!, profile, environment, include, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        string? profile,
+        string? environment,
+        string[]? include,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Retrieving metadata for '{entity}'...");
+            }
+
+            var (includeAttrs, includeRels, includeKeys, includePrivs) = ParseIncludeOptions(include);
+
+            var metadata = await metadataService.GetEntityAsync(
+                entity,
+                includeAttrs,
+                includeRels,
+                includeKeys,
+                includePrivs,
+                cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(metadata);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Entity: {metadata.LogicalName}");
+                Console.Error.WriteLine($"  Display Name:     {metadata.DisplayName}");
+                Console.Error.WriteLine($"  Schema Name:      {metadata.SchemaName}");
+                Console.Error.WriteLine($"  Entity Set Name:  {metadata.EntitySetName}");
+                Console.Error.WriteLine($"  Primary ID:       {metadata.PrimaryIdAttribute}");
+                Console.Error.WriteLine($"  Primary Name:     {metadata.PrimaryNameAttribute}");
+                Console.Error.WriteLine($"  Object Type Code: {metadata.ObjectTypeCode}");
+                Console.Error.WriteLine($"  Ownership Type:   {metadata.OwnershipType}");
+                Console.Error.WriteLine($"  Custom Entity:    {metadata.IsCustomEntity}");
+                Console.Error.WriteLine($"  Managed:          {metadata.IsManaged}");
+
+                if (metadata.Attributes.Count > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"Attributes ({metadata.Attributes.Count}):");
+                    foreach (var attr in metadata.Attributes.Take(20))
+                    {
+                        var markers = new List<string>();
+                        if (attr.IsPrimaryId) markers.Add("PK");
+                        if (attr.IsPrimaryName) markers.Add("name");
+                        if (attr.IsCustomAttribute) markers.Add("custom");
+
+                        var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
+                        Console.Error.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-15} {attr.DisplayName}{markerText}");
+                    }
+
+                    if (metadata.Attributes.Count > 20)
+                    {
+                        Console.Error.WriteLine($"  ... and {metadata.Attributes.Count - 20} more attributes");
+                    }
+                }
+
+                var totalRels = metadata.OneToManyRelationships.Count +
+                                metadata.ManyToOneRelationships.Count +
+                                metadata.ManyToManyRelationships.Count;
+
+                if (totalRels > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"Relationships ({totalRels}):");
+                    Console.Error.WriteLine($"  1:N: {metadata.OneToManyRelationships.Count}");
+                    Console.Error.WriteLine($"  N:1: {metadata.ManyToOneRelationships.Count}");
+                    Console.Error.WriteLine($"  N:N: {metadata.ManyToManyRelationships.Count}");
+                }
+
+                if (metadata.Keys.Count > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"Alternate Keys ({metadata.Keys.Count}):");
+                    foreach (var key in metadata.Keys)
+                    {
+                        Console.Error.WriteLine($"  {key.LogicalName}: {string.Join(", ", key.KeyAttributes)}");
+                    }
+                }
+
+                if (metadata.Privileges.Count > 0)
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"Privileges ({metadata.Privileges.Count}):");
+                    foreach (var priv in metadata.Privileges)
+                    {
+                        Console.Error.WriteLine($"  {priv.PrivilegeType}: {priv.Name}");
+                    }
+                }
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"retrieving entity '{entity}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static (bool attrs, bool rels, bool keys, bool privs) ParseIncludeOptions(string[]? include)
+    {
+        // Default: include all
+        if (include == null || include.Length == 0)
+        {
+            return (true, true, true, true);
+        }
+
+        var sections = include
+            .SelectMany(i => i.Split(',', StringSplitOptions.RemoveEmptyEntries))
+            .Select(s => s.Trim().ToLowerInvariant())
+            .ToHashSet();
+
+        return (
+            sections.Contains("attributes") || sections.Contains("attrs"),
+            sections.Contains("relationships") || sections.Contains("rels"),
+            sections.Contains("keys"),
+            sections.Contains("privileges") || sections.Contains("privs")
+        );
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/MetadataCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/MetadataCommandGroup.cs
@@ -1,0 +1,42 @@
+using System.CommandLine;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Metadata command group for browsing Dataverse entity metadata.
+/// </summary>
+public static class MetadataCommandGroup
+{
+    /// <summary>
+    /// Profile option for authentication.
+    /// </summary>
+    public static readonly Option<string?> ProfileOption = new("--profile", "-p")
+    {
+        Description = "Authentication profile name"
+    };
+
+    /// <summary>
+    /// Environment option for target environment.
+    /// </summary>
+    public static readonly Option<string?> EnvironmentOption = new("--environment", "-env")
+    {
+        Description = "Override the environment URL. Takes precedence over profile's bound environment."
+    };
+
+    /// <summary>
+    /// Creates the 'metadata' command group with all subcommands.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("metadata", "Browse Dataverse entity metadata: entities, attributes, relationships, option sets");
+
+        command.Subcommands.Add(EntitiesCommand.Create());
+        command.Subcommands.Add(EntityCommand.Create());
+        command.Subcommands.Add(AttributesCommand.Create());
+        command.Subcommands.Add(RelationshipsCommand.Create());
+        command.Subcommands.Add(OptionSetsCommand.Create());
+        command.Subcommands.Add(OptionSetCommand.Create());
+
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/OptionSetCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/OptionSetCommand.cs
@@ -1,0 +1,123 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Gets details for a specific option set.
+/// </summary>
+public static class OptionSetCommand
+{
+    /// <summary>
+    /// Creates the 'optionset' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var nameArgument = new Argument<string>("name")
+        {
+            Description = "The option set name (e.g., 'new_customstatus')"
+        };
+
+        var command = new Command("optionset", "Get details for a specific global option set")
+        {
+            nameArgument,
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var name = parseResult.GetValue(nameArgument);
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(name!, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string name,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Retrieving option set '{name}'...");
+            }
+
+            var optionSet = await metadataService.GetOptionSetAsync(name, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(optionSet);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Option Set: {optionSet.Name}");
+                Console.Error.WriteLine($"  Display Name: {optionSet.DisplayName}");
+                Console.Error.WriteLine($"  Type:         {optionSet.OptionSetType}");
+                Console.Error.WriteLine($"  Is Global:    {optionSet.IsGlobal}");
+                Console.Error.WriteLine($"  Is Custom:    {optionSet.IsCustomOptionSet}");
+                Console.Error.WriteLine($"  Is Managed:   {optionSet.IsManaged}");
+
+                if (!string.IsNullOrEmpty(optionSet.Description))
+                {
+                    Console.Error.WriteLine($"  Description:  {optionSet.Description}");
+                }
+
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Options ({optionSet.Options.Count}):");
+                Console.Error.WriteLine($"  {"Value",-10} {"Label",-40} {"Flags"}");
+                Console.Error.WriteLine($"  {new string('-', 70)}");
+
+                foreach (var option in optionSet.Options)
+                {
+                    var flags = new List<string>();
+                    if (option.IsDefault) flags.Add("default");
+                    if (option.State.HasValue) flags.Add($"state={option.State}");
+                    if (!string.IsNullOrEmpty(option.Color)) flags.Add($"color={option.Color}");
+
+                    var flagText = flags.Count > 0 ? string.Join(", ", flags) : "";
+                    Console.Error.WriteLine($"  {option.Value,-10} {option.Label,-40} {flagText}");
+                }
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"retrieving option set '{name}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
@@ -1,0 +1,111 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Lists global option sets.
+/// </summary>
+public static class OptionSetsCommand
+{
+    /// <summary>
+    /// Creates the 'optionsets' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var filterOption = new Option<string?>("--filter")
+        {
+            Description = "Filter option sets by name pattern (supports * wildcard, e.g., 'new_*')"
+        };
+
+        var command = new Command("optionsets", "List global option sets")
+        {
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption,
+            filterOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var filter = parseResult.GetValue(filterOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(profile, environment, filter, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string? profile,
+        string? environment,
+        string? filter,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Retrieving global option sets...");
+            }
+
+            var optionSets = await metadataService.GetGlobalOptionSetsAsync(filter, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(optionSets);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"{"Name",-45} {"Type",-15} {"Display Name",-30} {"Options"}");
+                Console.Error.WriteLine(new string('-', 100));
+
+                foreach (var os in optionSets)
+                {
+                    var markers = new List<string>();
+                    if (os.IsCustomOptionSet) markers.Add("custom");
+                    if (os.IsManaged) markers.Add("managed");
+
+                    var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
+                    Console.Error.WriteLine($"  {os.Name,-45} {os.OptionSetType,-15} {os.DisplayName,-30} {os.OptionCount}{markerText}");
+                }
+
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Total: {optionSets.Count} option sets");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "retrieving option sets", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/RelationshipsCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/RelationshipsCommand.cs
@@ -1,0 +1,153 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Metadata;
+
+namespace PPDS.Cli.Commands.Metadata;
+
+/// <summary>
+/// Lists relationships for an entity.
+/// </summary>
+public static class RelationshipsCommand
+{
+    /// <summary>
+    /// Creates the 'relationships' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var entityArgument = new Argument<string>("entity")
+        {
+            Description = "The entity logical name (e.g., 'account')"
+        };
+
+        var typeOption = new Option<string?>("--type", "-t")
+        {
+            Description = "Filter by relationship type: OneToMany, ManyToOne, ManyToMany"
+        };
+
+        var command = new Command("relationships", "List relationships for an entity")
+        {
+            entityArgument,
+            MetadataCommandGroup.ProfileOption,
+            MetadataCommandGroup.EnvironmentOption,
+            typeOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityArgument);
+            var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
+            var type = parseResult.GetValue(typeOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(entity!, profile, environment, type, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        string? profile,
+        string? environment,
+        string? type,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Retrieving relationships for '{entity}'...");
+            }
+
+            var relationships = await metadataService.GetRelationshipsAsync(entity, type, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(relationships);
+            }
+            else
+            {
+                Console.Error.WriteLine();
+
+                if (relationships.OneToMany.Count > 0)
+                {
+                    Console.Error.WriteLine("One-to-Many (1:N) Relationships:");
+                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Related Entity",-30} {"Lookup Field"}");
+                    Console.Error.WriteLine($"  {new string('-', 90)}");
+
+                    foreach (var rel in relationships.OneToMany)
+                    {
+                        var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
+                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencingEntity,-30} {rel.ReferencingAttribute}{customMarker}");
+                    }
+
+                    Console.Error.WriteLine();
+                }
+
+                if (relationships.ManyToOne.Count > 0)
+                {
+                    Console.Error.WriteLine("Many-to-One (N:1) Relationships:");
+                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Referenced Entity",-30} {"Lookup Field"}");
+                    Console.Error.WriteLine($"  {new string('-', 90)}");
+
+                    foreach (var rel in relationships.ManyToOne)
+                    {
+                        var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
+                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencedEntity,-30} {rel.ReferencingAttribute}{customMarker}");
+                    }
+
+                    Console.Error.WriteLine();
+                }
+
+                if (relationships.ManyToMany.Count > 0)
+                {
+                    Console.Error.WriteLine("Many-to-Many (N:N) Relationships:");
+                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Entity 1",-20} {"Entity 2",-20} {"Intersect Entity"}");
+                    Console.Error.WriteLine($"  {new string('-', 100)}");
+
+                    foreach (var rel in relationships.ManyToMany)
+                    {
+                        var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
+                        var reflexiveMarker = rel.IsReflexive ? " [reflexive]" : "";
+                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.Entity1LogicalName,-20} {rel.Entity2LogicalName,-20} {rel.IntersectEntityName}{customMarker}{reflexiveMarker}");
+                    }
+
+                    Console.Error.WriteLine();
+                }
+
+                var total = relationships.OneToMany.Count + relationships.ManyToOne.Count + relationships.ManyToMany.Count;
+                Console.Error.WriteLine($"Total: {total} relationships (1:N: {relationships.OneToMany.Count}, N:1: {relationships.ManyToOne.Count}, N:N: {relationships.ManyToMany.Count})");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: $"retrieving relationships for '{entity}'", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using PPDS.Cli.Commands.Auth;
 using PPDS.Cli.Commands.Data;
 using PPDS.Cli.Commands.Env;
+using PPDS.Cli.Commands.Metadata;
 using PPDS.Cli.Commands.Plugins;
 using PPDS.Cli.Infrastructure;
 
@@ -22,6 +23,7 @@ public static class Program
         rootCommand.Subcommands.Add(EnvCommandGroup.CreateOrgAlias()); // 'org' alias for 'env'
         rootCommand.Subcommands.Add(DataCommandGroup.Create());
         rootCommand.Subcommands.Add(PluginsCommandGroup.Create());
+        rootCommand.Subcommands.Add(MetadataCommandGroup.Create());
 
         // Prepend [Required] to required option descriptions for scannability
         HelpCustomization.ApplyRequiredOptionStyle(rootCommand);

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Metadata service for entity browsing** - New `IMetadataService` interface and `DataverseMetadataService` implementation providing:
+  - `GetEntitiesAsync()` - List all entities with optional filtering
+  - `GetEntityAsync()` - Get full entity metadata including attributes, relationships, keys, and privileges
+  - `GetAttributesAsync()` - List entity attributes with type filtering
+  - `GetRelationshipsAsync()` - List 1:N, N:1, and N:N relationships
+  - `GetGlobalOptionSetsAsync()` - List global option sets
+  - `GetOptionSetAsync()` - Get option set details with values
+  ([#51](https://github.com/joshsmithxrm/ppds-sdk/issues/51))
+
 ### Changed
 
 - **Replaced Newtonsoft.Json with System.Text.Json** - Removed external dependency; uses built-in JSON serialization with case-insensitive property matching ([#72](https://github.com/joshsmithxrm/ppds-sdk/issues/72))

--- a/src/PPDS.Dataverse/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/PPDS.Dataverse/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Dataverse.BulkOperations;
 using PPDS.Dataverse.Configuration;
+using PPDS.Dataverse.Metadata;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Resilience;
 
@@ -217,6 +218,9 @@ namespace PPDS.Dataverse.DependencyInjection
 
             // Bulk operation executor (transient - stateless)
             services.AddTransient<IBulkOperationExecutor, BulkOperationExecutor>();
+
+            // Metadata service (transient - stateless, uses connection pool)
+            services.AddTransient<IMetadataService, DataverseMetadataService>();
         }
     }
 }

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -1,0 +1,698 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using PPDS.Dataverse.Metadata.Models;
+using PPDS.Dataverse.Pooling;
+
+namespace PPDS.Dataverse.Metadata;
+
+/// <summary>
+/// Provides access to Dataverse metadata using the SDK.
+/// </summary>
+public class DataverseMetadataService : IMetadataService
+{
+    private readonly IDataverseConnectionPool _connectionPool;
+    private readonly ILogger<DataverseMetadataService>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataverseMetadataService"/> class.
+    /// </summary>
+    /// <param name="connectionPool">The connection pool.</param>
+    /// <param name="logger">Optional logger.</param>
+    public DataverseMetadataService(
+        IDataverseConnectionPool connectionPool,
+        ILogger<DataverseMetadataService>? logger = null)
+    {
+        _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EntitySummary>> GetEntitiesAsync(
+        bool customOnly = false,
+        string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger?.LogInformation("Retrieving entity list from Dataverse (customOnly={CustomOnly}, filter={Filter})",
+            customOnly, filter ?? "(none)");
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new RetrieveAllEntitiesRequest
+        {
+            EntityFilters = EntityFilters.Entity,
+            RetrieveAsIfPublished = false
+        };
+
+        var response = (RetrieveAllEntitiesResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var filterRegex = CreateFilterRegex(filter);
+
+        var entities = response.EntityMetadata
+            .Where(e => e.IsIntersect != true)
+            .Where(e => !customOnly || e.IsCustomEntity == true)
+            .Where(e => filterRegex == null || filterRegex.IsMatch(e.LogicalName))
+            .Select(MapToEntitySummary)
+            .OrderBy(e => e.LogicalName)
+            .ToList();
+
+        _logger?.LogInformation("Found {Count} entities", entities.Count);
+
+        return entities;
+    }
+
+    /// <inheritdoc />
+    public async Task<EntityMetadataDto> GetEntityAsync(
+        string logicalName,
+        bool includeAttributes = true,
+        bool includeRelationships = true,
+        bool includeKeys = true,
+        bool includePrivileges = true,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
+        _logger?.LogInformation("Retrieving entity metadata for {Entity}", logicalName);
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var entityFilters = EntityFilters.Entity;
+        if (includeAttributes) entityFilters |= EntityFilters.Attributes;
+        if (includeRelationships) entityFilters |= EntityFilters.Relationships;
+        if (includePrivileges) entityFilters |= EntityFilters.Privileges;
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = logicalName,
+            EntityFilters = entityFilters,
+            RetrieveAsIfPublished = false
+        };
+
+        var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var metadata = response.EntityMetadata;
+
+        var result = new EntityMetadataDto
+        {
+            LogicalName = metadata.LogicalName,
+            DisplayName = GetLocalizedLabel(metadata.DisplayName),
+            SchemaName = metadata.SchemaName,
+            EntitySetName = metadata.EntitySetName,
+            PrimaryIdAttribute = metadata.PrimaryIdAttribute,
+            PrimaryNameAttribute = metadata.PrimaryNameAttribute,
+            PrimaryImageAttribute = metadata.PrimaryImageAttribute,
+            ObjectTypeCode = metadata.ObjectTypeCode ?? 0,
+            IsCustomEntity = metadata.IsCustomEntity ?? false,
+            IsManaged = metadata.IsManaged ?? false,
+            OwnershipType = metadata.OwnershipType?.ToString(),
+            LogicalCollectionName = metadata.LogicalCollectionName,
+            Description = GetLocalizedLabel(metadata.Description),
+            IsActivity = metadata.IsActivity ?? false,
+            IsActivityParty = metadata.IsActivityParty ?? false,
+            IsAuditEnabled = metadata.IsAuditEnabled?.Value ?? false,
+            ChangeTrackingEnabled = metadata.ChangeTrackingEnabled ?? false,
+            IsBusinessProcessEnabled = metadata.IsBusinessProcessEnabled ?? false,
+            IsQuickCreateEnabled = metadata.IsQuickCreateEnabled ?? false,
+            IsDuplicateDetectionEnabled = metadata.IsDuplicateDetectionEnabled?.Value ?? false,
+            IsValidForQueue = metadata.IsValidForQueue?.Value ?? false,
+            IsIntersect = metadata.IsIntersect ?? false,
+            Attributes = includeAttributes ? MapAttributes(metadata).ToList() : [],
+            OneToManyRelationships = includeRelationships ? MapOneToManyRelationships(metadata).ToList() : [],
+            ManyToOneRelationships = includeRelationships ? MapManyToOneRelationships(metadata).ToList() : [],
+            ManyToManyRelationships = includeRelationships ? MapManyToManyRelationships(metadata).ToList() : [],
+            Keys = includeKeys ? MapKeys(metadata).ToList() : [],
+            Privileges = includePrivileges ? MapPrivileges(metadata).ToList() : []
+        };
+
+        _logger?.LogInformation("Retrieved entity {Entity} with {AttrCount} attributes, {RelCount} relationships",
+            logicalName, result.Attributes.Count,
+            result.OneToManyRelationships.Count + result.ManyToOneRelationships.Count + result.ManyToManyRelationships.Count);
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AttributeMetadataDto>> GetAttributesAsync(
+        string entityLogicalName,
+        string? attributeType = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityLogicalName);
+
+        _logger?.LogInformation("Retrieving attributes for {Entity} (type={Type})",
+            entityLogicalName, attributeType ?? "(all)");
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = entityLogicalName,
+            EntityFilters = EntityFilters.Attributes,
+            RetrieveAsIfPublished = false
+        };
+
+        var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var metadata = response.EntityMetadata;
+        var attributes = MapAttributes(metadata);
+
+        if (!string.IsNullOrEmpty(attributeType))
+        {
+            attributes = attributes.Where(a =>
+                a.AttributeType.Equals(attributeType, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var result = attributes.OrderBy(a => a.LogicalName).ToList();
+
+        _logger?.LogInformation("Found {Count} attributes for {Entity}", result.Count, entityLogicalName);
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<EntityRelationshipsDto> GetRelationshipsAsync(
+        string entityLogicalName,
+        string? relationshipType = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityLogicalName);
+
+        _logger?.LogInformation("Retrieving relationships for {Entity} (type={Type})",
+            entityLogicalName, relationshipType ?? "(all)");
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = entityLogicalName,
+            EntityFilters = EntityFilters.Relationships,
+            RetrieveAsIfPublished = false
+        };
+
+        var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var metadata = response.EntityMetadata;
+
+        var result = new EntityRelationshipsDto
+        {
+            EntityLogicalName = entityLogicalName,
+            OneToMany = ShouldIncludeRelationshipType(relationshipType, "OneToMany")
+                ? MapOneToManyRelationships(metadata).OrderBy(r => r.SchemaName).ToList()
+                : [],
+            ManyToOne = ShouldIncludeRelationshipType(relationshipType, "ManyToOne")
+                ? MapManyToOneRelationships(metadata).OrderBy(r => r.SchemaName).ToList()
+                : [],
+            ManyToMany = ShouldIncludeRelationshipType(relationshipType, "ManyToMany")
+                ? MapManyToManyRelationships(metadata).OrderBy(r => r.SchemaName).ToList()
+                : []
+        };
+
+        _logger?.LogInformation("Found {O2M} 1:N, {M2O} N:1, {M2M} N:N relationships for {Entity}",
+            result.OneToMany.Count, result.ManyToOne.Count, result.ManyToMany.Count, entityLogicalName);
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<OptionSetSummary>> GetGlobalOptionSetsAsync(
+        string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger?.LogInformation("Retrieving global option sets (filter={Filter})", filter ?? "(none)");
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new RetrieveAllOptionSetsRequest();
+
+        var response = (RetrieveAllOptionSetsResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var filterRegex = CreateFilterRegex(filter);
+
+        var optionSets = response.OptionSetMetadata
+            .Where(os => filterRegex == null || filterRegex.IsMatch(os.Name))
+            .Select(MapToOptionSetSummary)
+            .OrderBy(os => os.Name)
+            .ToList();
+
+        _logger?.LogInformation("Found {Count} global option sets", optionSets.Count);
+
+        return optionSets;
+    }
+
+    /// <inheritdoc />
+    public async Task<OptionSetMetadataDto> GetOptionSetAsync(
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        _logger?.LogInformation("Retrieving option set {Name}", name);
+
+        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = new RetrieveOptionSetRequest
+        {
+            Name = name
+        };
+
+        var response = (RetrieveOptionSetResponse)await client.ExecuteAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        var result = MapToOptionSetMetadata(response.OptionSetMetadata);
+
+        _logger?.LogInformation("Retrieved option set {Name} with {Count} options",
+            name, result.Options.Count);
+
+        return result;
+    }
+
+    #region Mapping Methods
+
+    private static EntitySummary MapToEntitySummary(EntityMetadata e)
+    {
+        return new EntitySummary
+        {
+            LogicalName = e.LogicalName,
+            DisplayName = GetLocalizedLabel(e.DisplayName),
+            SchemaName = e.SchemaName,
+            EntitySetName = e.EntitySetName,
+            ObjectTypeCode = e.ObjectTypeCode ?? 0,
+            IsCustomEntity = e.IsCustomEntity ?? false,
+            IsManaged = e.IsManaged ?? false,
+            OwnershipType = e.OwnershipType?.ToString(),
+            LogicalCollectionName = e.LogicalCollectionName,
+            Description = GetLocalizedLabel(e.Description)
+        };
+    }
+
+    private static IEnumerable<AttributeMetadataDto> MapAttributes(EntityMetadata metadata)
+    {
+        if (metadata.Attributes == null)
+        {
+            yield break;
+        }
+
+        foreach (var attr in metadata.Attributes)
+        {
+            yield return MapAttribute(attr, metadata);
+        }
+    }
+
+    private static AttributeMetadataDto MapAttribute(AttributeMetadata attr, EntityMetadata entityMetadata)
+    {
+        // Extract type-specific properties first
+        int? maxLength = null;
+        double? minValue = null;
+        double? maxValue = null;
+        int? precision = null;
+        List<string>? targets = null;
+        string? optionSetName = null;
+        bool isGlobalOptionSet = false;
+        List<OptionValueDto>? options = null;
+        string? dateTimeBehavior = null;
+        string? format = null;
+
+        switch (attr)
+        {
+            case StringAttributeMetadata stringAttr:
+                maxLength = stringAttr.MaxLength;
+                format = stringAttr.Format?.ToString();
+                break;
+
+            case MemoAttributeMetadata memoAttr:
+                maxLength = memoAttr.MaxLength;
+                break;
+
+            case IntegerAttributeMetadata intAttr:
+                minValue = intAttr.MinValue;
+                maxValue = intAttr.MaxValue;
+                break;
+
+            case DecimalAttributeMetadata decAttr:
+                minValue = (double?)decAttr.MinValue;
+                maxValue = (double?)decAttr.MaxValue;
+                precision = decAttr.Precision;
+                break;
+
+            case DoubleAttributeMetadata dblAttr:
+                minValue = dblAttr.MinValue;
+                maxValue = dblAttr.MaxValue;
+                precision = dblAttr.Precision;
+                break;
+
+            case MoneyAttributeMetadata moneyAttr:
+                minValue = (double?)moneyAttr.MinValue;
+                maxValue = (double?)moneyAttr.MaxValue;
+                precision = moneyAttr.Precision;
+                break;
+
+            case LookupAttributeMetadata lookupAttr:
+                targets = lookupAttr.Targets?.ToList();
+                break;
+
+            case PicklistAttributeMetadata picklistAttr:
+                optionSetName = picklistAttr.OptionSet?.Name;
+                isGlobalOptionSet = picklistAttr.OptionSet?.IsGlobal ?? false;
+                options = picklistAttr.OptionSet?.Options?.Select(MapOptionValue).ToList();
+                break;
+
+            case MultiSelectPicklistAttributeMetadata multiPicklistAttr:
+                optionSetName = multiPicklistAttr.OptionSet?.Name;
+                isGlobalOptionSet = multiPicklistAttr.OptionSet?.IsGlobal ?? false;
+                options = multiPicklistAttr.OptionSet?.Options?.Select(MapOptionValue).ToList();
+                break;
+
+            case StateAttributeMetadata stateAttr:
+                optionSetName = stateAttr.OptionSet?.Name;
+                options = stateAttr.OptionSet?.Options?.Select(MapOptionValue).ToList();
+                break;
+
+            case StatusAttributeMetadata statusAttr:
+                optionSetName = statusAttr.OptionSet?.Name;
+                options = statusAttr.OptionSet?.Options?
+                    .OfType<StatusOptionMetadata>()
+                    .Select(o => new OptionValueDto
+                    {
+                        Value = o.Value ?? 0,
+                        Label = GetLocalizedLabel(o.Label),
+                        Description = GetLocalizedLabel(o.Description),
+                        Color = o.Color,
+                        State = o.State
+                    })
+                    .ToList();
+                break;
+
+            case DateTimeAttributeMetadata dtAttr:
+                dateTimeBehavior = dtAttr.DateTimeBehavior?.Value;
+                format = dtAttr.Format?.ToString();
+                break;
+
+            case BooleanAttributeMetadata boolAttr:
+                optionSetName = boolAttr.OptionSet?.Name;
+                if (boolAttr.OptionSet != null)
+                {
+                    options =
+                    [
+                        new OptionValueDto
+                        {
+                            Value = boolAttr.OptionSet.FalseOption?.Value ?? 0,
+                            Label = GetLocalizedLabel(boolAttr.OptionSet.FalseOption?.Label),
+                            IsDefault = boolAttr.DefaultValue == false
+                        },
+                        new OptionValueDto
+                        {
+                            Value = boolAttr.OptionSet.TrueOption?.Value ?? 1,
+                            Label = GetLocalizedLabel(boolAttr.OptionSet.TrueOption?.Label),
+                            IsDefault = boolAttr.DefaultValue == true
+                        }
+                    ];
+                }
+                break;
+        }
+
+        return new AttributeMetadataDto
+        {
+            LogicalName = attr.LogicalName,
+            DisplayName = GetLocalizedLabel(attr.DisplayName),
+            SchemaName = attr.SchemaName,
+            AttributeType = attr.AttributeType?.ToString() ?? "Unknown",
+            AttributeTypeName = attr.AttributeTypeName?.Value,
+            IsCustomAttribute = attr.IsCustomAttribute ?? false,
+            IsManaged = attr.IsManaged ?? false,
+            IsPrimaryId = attr.LogicalName == entityMetadata.PrimaryIdAttribute,
+            IsPrimaryName = attr.LogicalName == entityMetadata.PrimaryNameAttribute,
+            RequiredLevel = attr.RequiredLevel?.Value.ToString(),
+            IsValidForCreate = attr.IsValidForCreate ?? false,
+            IsValidForUpdate = attr.IsValidForUpdate ?? false,
+            IsValidForRead = attr.IsValidForRead ?? false,
+            IsSearchable = attr.IsSearchable ?? false,
+            IsFilterable = attr.IsFilterable ?? false,
+            IsSortable = attr.IsSortableEnabled?.Value ?? false,
+            Description = GetLocalizedLabel(attr.Description),
+            MaxLength = maxLength,
+            MinValue = minValue,
+            MaxValue = maxValue,
+            Precision = precision,
+            Targets = targets,
+            OptionSetName = optionSetName,
+            IsGlobalOptionSet = isGlobalOptionSet,
+            Options = options,
+            DateTimeBehavior = dateTimeBehavior,
+            Format = format
+        };
+    }
+
+    private static OptionValueDto MapOptionValue(OptionMetadata opt)
+    {
+        return new OptionValueDto
+        {
+            Value = opt.Value ?? 0,
+            Label = GetLocalizedLabel(opt.Label),
+            Description = GetLocalizedLabel(opt.Description),
+            Color = opt.Color,
+            ExternalValue = opt.ExternalValue
+        };
+    }
+
+    private static IEnumerable<RelationshipMetadataDto> MapOneToManyRelationships(EntityMetadata metadata)
+    {
+        if (metadata.OneToManyRelationships == null)
+        {
+            yield break;
+        }
+
+        foreach (var rel in metadata.OneToManyRelationships)
+        {
+            yield return new RelationshipMetadataDto
+            {
+                SchemaName = rel.SchemaName,
+                RelationshipType = "OneToMany",
+                ReferencedEntity = rel.ReferencedEntity,
+                ReferencedEntityNavigationPropertyName = rel.ReferencedEntityNavigationPropertyName,
+                ReferencedAttribute = rel.ReferencedAttribute,
+                ReferencingEntity = rel.ReferencingEntity,
+                ReferencingEntityNavigationPropertyName = rel.ReferencingEntityNavigationPropertyName,
+                ReferencingAttribute = rel.ReferencingAttribute,
+                IsCustomRelationship = rel.IsCustomRelationship ?? false,
+                IsManaged = rel.IsManaged ?? false,
+                CascadeAssign = rel.CascadeConfiguration?.Assign?.ToString(),
+                CascadeDelete = rel.CascadeConfiguration?.Delete?.ToString(),
+                CascadeMerge = rel.CascadeConfiguration?.Merge?.ToString(),
+                CascadeReparent = rel.CascadeConfiguration?.Reparent?.ToString(),
+                CascadeShare = rel.CascadeConfiguration?.Share?.ToString(),
+                CascadeUnshare = rel.CascadeConfiguration?.Unshare?.ToString()
+            };
+        }
+    }
+
+    private static IEnumerable<RelationshipMetadataDto> MapManyToOneRelationships(EntityMetadata metadata)
+    {
+        if (metadata.ManyToOneRelationships == null)
+        {
+            yield break;
+        }
+
+        foreach (var rel in metadata.ManyToOneRelationships)
+        {
+            yield return new RelationshipMetadataDto
+            {
+                SchemaName = rel.SchemaName,
+                RelationshipType = "ManyToOne",
+                ReferencedEntity = rel.ReferencedEntity,
+                ReferencedEntityNavigationPropertyName = rel.ReferencedEntityNavigationPropertyName,
+                ReferencedAttribute = rel.ReferencedAttribute,
+                ReferencingEntity = rel.ReferencingEntity,
+                ReferencingEntityNavigationPropertyName = rel.ReferencingEntityNavigationPropertyName,
+                ReferencingAttribute = rel.ReferencingAttribute,
+                IsCustomRelationship = rel.IsCustomRelationship ?? false,
+                IsManaged = rel.IsManaged ?? false,
+                CascadeAssign = rel.CascadeConfiguration?.Assign?.ToString(),
+                CascadeDelete = rel.CascadeConfiguration?.Delete?.ToString(),
+                CascadeMerge = rel.CascadeConfiguration?.Merge?.ToString(),
+                CascadeReparent = rel.CascadeConfiguration?.Reparent?.ToString(),
+                CascadeShare = rel.CascadeConfiguration?.Share?.ToString(),
+                CascadeUnshare = rel.CascadeConfiguration?.Unshare?.ToString()
+            };
+        }
+    }
+
+    private static IEnumerable<ManyToManyRelationshipDto> MapManyToManyRelationships(EntityMetadata metadata)
+    {
+        if (metadata.ManyToManyRelationships == null)
+        {
+            yield break;
+        }
+
+        foreach (var rel in metadata.ManyToManyRelationships)
+        {
+            var isReflexive = rel.Entity1LogicalName.Equals(rel.Entity2LogicalName, StringComparison.OrdinalIgnoreCase);
+
+            yield return new ManyToManyRelationshipDto
+            {
+                SchemaName = rel.SchemaName,
+                IntersectEntityName = rel.IntersectEntityName,
+                Entity1LogicalName = rel.Entity1LogicalName,
+                Entity1IntersectAttribute = rel.Entity1IntersectAttribute,
+                Entity1NavigationPropertyName = rel.Entity1NavigationPropertyName,
+                Entity2LogicalName = rel.Entity2LogicalName,
+                Entity2IntersectAttribute = rel.Entity2IntersectAttribute,
+                Entity2NavigationPropertyName = rel.Entity2NavigationPropertyName,
+                IsCustomRelationship = rel.IsCustomRelationship ?? false,
+                IsManaged = rel.IsManaged ?? false,
+                IsReflexive = isReflexive
+            };
+        }
+    }
+
+    private static IEnumerable<EntityKeyDto> MapKeys(EntityMetadata metadata)
+    {
+        if (metadata.Keys == null)
+        {
+            yield break;
+        }
+
+        foreach (var key in metadata.Keys)
+        {
+            yield return new EntityKeyDto
+            {
+                SchemaName = key.SchemaName,
+                LogicalName = key.LogicalName,
+                DisplayName = GetLocalizedLabel(key.DisplayName),
+                KeyAttributes = key.KeyAttributes?.ToList() ?? [],
+                IsCustomizable = key.IsCustomizable?.Value ?? false,
+                IsManaged = key.IsManaged ?? false,
+                EntityKeyIndexStatus = key.EntityKeyIndexStatus.ToString()
+            };
+        }
+    }
+
+    private static IEnumerable<PrivilegeDto> MapPrivileges(EntityMetadata metadata)
+    {
+        if (metadata.Privileges == null)
+        {
+            yield break;
+        }
+
+        foreach (var priv in metadata.Privileges)
+        {
+            yield return new PrivilegeDto
+            {
+                PrivilegeId = priv.PrivilegeId,
+                Name = priv.Name,
+                PrivilegeType = priv.PrivilegeType.ToString(),
+                CanBeLocal = priv.CanBeLocal,
+                CanBeDeep = priv.CanBeDeep,
+                CanBeGlobal = priv.CanBeGlobal,
+                CanBeBasic = priv.CanBeBasic
+            };
+        }
+    }
+
+    private static OptionSetSummary MapToOptionSetSummary(OptionSetMetadataBase os)
+    {
+        var optionCount = os switch
+        {
+            OptionSetMetadata osm => osm.Options?.Count ?? 0,
+            BooleanOptionSetMetadata _ => 2,
+            _ => 0
+        };
+
+        return new OptionSetSummary
+        {
+            Name = os.Name,
+            DisplayName = GetLocalizedLabel(os.DisplayName),
+            OptionSetType = os.OptionSetType?.ToString() ?? "Unknown",
+            IsGlobal = os.IsGlobal ?? false,
+            IsCustomOptionSet = os.IsCustomOptionSet ?? false,
+            IsManaged = os.IsManaged ?? false,
+            Description = GetLocalizedLabel(os.Description),
+            OptionCount = optionCount
+        };
+    }
+
+    private static OptionSetMetadataDto MapToOptionSetMetadata(OptionSetMetadataBase os)
+    {
+        var options = os switch
+        {
+            OptionSetMetadata osm => osm.Options?.Select(MapOptionValue).ToList() ?? [],
+            BooleanOptionSetMetadata bosm =>
+            [
+                new OptionValueDto
+                {
+                    Value = bosm.FalseOption?.Value ?? 0,
+                    Label = GetLocalizedLabel(bosm.FalseOption?.Label)
+                },
+                new OptionValueDto
+                {
+                    Value = bosm.TrueOption?.Value ?? 1,
+                    Label = GetLocalizedLabel(bosm.TrueOption?.Label)
+                }
+            ],
+            _ => []
+        };
+
+        return new OptionSetMetadataDto
+        {
+            Name = os.Name,
+            DisplayName = GetLocalizedLabel(os.DisplayName),
+            OptionSetType = os.OptionSetType?.ToString() ?? "Unknown",
+            IsGlobal = os.IsGlobal ?? false,
+            IsCustomOptionSet = os.IsCustomOptionSet ?? false,
+            IsManaged = os.IsManaged ?? false,
+            Description = GetLocalizedLabel(os.Description),
+            ExternalTypeName = os.ExternalTypeName,
+            Options = options
+        };
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetLocalizedLabel(Label? label)
+    {
+        return label?.UserLocalizedLabel?.Label ?? label?.LocalizedLabels?.FirstOrDefault()?.Label ?? string.Empty;
+    }
+
+    private static Regex? CreateFilterRegex(string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return null;
+        }
+
+        // Convert wildcard pattern to regex: * -> .*
+        var pattern = "^" + Regex.Escape(filter).Replace("\\*", ".*") + "$";
+        return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    }
+
+    private static bool ShouldIncludeRelationshipType(string? filter, string type)
+    {
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return true;
+        }
+
+        return filter.Equals(type, StringComparison.OrdinalIgnoreCase);
+    }
+
+    #endregion
+}

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -320,8 +320,8 @@ public class DataverseMetadataService : IMetadataService
     {
         // Extract type-specific properties first
         int? maxLength = null;
-        double? minValue = null;
-        double? maxValue = null;
+        decimal? minValue = null;
+        decimal? maxValue = null;
         int? precision = null;
         List<string>? targets = null;
         string? optionSetName = null;
@@ -347,20 +347,20 @@ public class DataverseMetadataService : IMetadataService
                 break;
 
             case DecimalAttributeMetadata decAttr:
-                minValue = (double?)decAttr.MinValue;
-                maxValue = (double?)decAttr.MaxValue;
+                minValue = decAttr.MinValue;
+                maxValue = decAttr.MaxValue;
                 precision = decAttr.Precision;
                 break;
 
             case DoubleAttributeMetadata dblAttr:
-                minValue = dblAttr.MinValue;
-                maxValue = dblAttr.MaxValue;
+                minValue = (decimal?)dblAttr.MinValue;
+                maxValue = (decimal?)dblAttr.MaxValue;
                 precision = dblAttr.Precision;
                 break;
 
             case MoneyAttributeMetadata moneyAttr:
-                minValue = (double?)moneyAttr.MinValue;
-                maxValue = (double?)moneyAttr.MaxValue;
+                minValue = (decimal?)moneyAttr.MinValue;
+                maxValue = (decimal?)moneyAttr.MaxValue;
                 precision = moneyAttr.Precision;
                 break;
 

--- a/src/PPDS.Dataverse/Metadata/IMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/IMetadataService.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Dataverse.Metadata.Models;
+
+namespace PPDS.Dataverse.Metadata;
+
+/// <summary>
+/// Provides access to Dataverse metadata for entity browsing and discovery.
+/// </summary>
+public interface IMetadataService
+{
+    /// <summary>
+    /// Gets a list of all entities with basic information.
+    /// </summary>
+    /// <param name="customOnly">If true, only return custom entities.</param>
+    /// <param name="filter">Optional filter pattern to match entity logical names (supports * wildcard).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of entity summaries.</returns>
+    Task<IReadOnlyList<EntitySummary>> GetEntitiesAsync(
+        bool customOnly = false,
+        string? filter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets full metadata for a specific entity including attributes, relationships, keys, and privileges.
+    /// </summary>
+    /// <param name="logicalName">The entity logical name.</param>
+    /// <param name="includeAttributes">Include attributes in the response.</param>
+    /// <param name="includeRelationships">Include relationships in the response.</param>
+    /// <param name="includeKeys">Include alternate keys in the response.</param>
+    /// <param name="includePrivileges">Include privileges in the response.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Full entity metadata.</returns>
+    Task<EntityMetadataDto> GetEntityAsync(
+        string logicalName,
+        bool includeAttributes = true,
+        bool includeRelationships = true,
+        bool includeKeys = true,
+        bool includePrivileges = true,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all attributes for an entity.
+    /// </summary>
+    /// <param name="entityLogicalName">The entity logical name.</param>
+    /// <param name="attributeType">Optional filter by attribute type (e.g., "Lookup", "String").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of attribute metadata.</returns>
+    Task<IReadOnlyList<AttributeMetadataDto>> GetAttributesAsync(
+        string entityLogicalName,
+        string? attributeType = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all relationships for an entity.
+    /// </summary>
+    /// <param name="entityLogicalName">The entity logical name.</param>
+    /// <param name="relationshipType">Optional filter by type (OneToMany, ManyToOne, ManyToMany).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Entity relationships grouped by type.</returns>
+    Task<EntityRelationshipsDto> GetRelationshipsAsync(
+        string entityLogicalName,
+        string? relationshipType = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all global option sets.
+    /// </summary>
+    /// <param name="filter">Optional filter pattern to match option set names (supports * wildcard).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of option set summaries.</returns>
+    Task<IReadOnlyList<OptionSetSummary>> GetGlobalOptionSetsAsync(
+        string? filter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a specific global option set with all values.
+    /// </summary>
+    /// <param name="name">The option set name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Full option set metadata with values.</returns>
+    Task<OptionSetMetadataDto> GetOptionSetAsync(
+        string name,
+        CancellationToken cancellationToken = default);
+}

--- a/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Detailed attribute metadata for entity browsing.
+/// </summary>
+public sealed class AttributeMetadataDto
+{
+    /// <summary>
+    /// Gets the attribute logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public required string LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the attribute display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the attribute schema name.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the attribute type (String, Integer, Lookup, etc.).
+    /// </summary>
+    [JsonPropertyName("attributeType")]
+    public required string AttributeType { get; init; }
+
+    /// <summary>
+    /// Gets the attribute type name for virtual attributes.
+    /// </summary>
+    [JsonPropertyName("attributeTypeName")]
+    public string? AttributeTypeName { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a custom attribute.
+    /// </summary>
+    [JsonPropertyName("isCustomAttribute")]
+    public bool IsCustomAttribute { get; init; }
+
+    /// <summary>
+    /// Gets whether this attribute is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets whether this attribute is the primary ID.
+    /// </summary>
+    [JsonPropertyName("isPrimaryId")]
+    public bool IsPrimaryId { get; init; }
+
+    /// <summary>
+    /// Gets whether this attribute is the primary name.
+    /// </summary>
+    [JsonPropertyName("isPrimaryName")]
+    public bool IsPrimaryName { get; init; }
+
+    /// <summary>
+    /// Gets the required level (None, Recommended, ApplicationRequired, SystemRequired).
+    /// </summary>
+    [JsonPropertyName("requiredLevel")]
+    public string? RequiredLevel { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is valid for create.
+    /// </summary>
+    [JsonPropertyName("isValidForCreate")]
+    public bool IsValidForCreate { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is valid for update.
+    /// </summary>
+    [JsonPropertyName("isValidForUpdate")]
+    public bool IsValidForUpdate { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is valid for read.
+    /// </summary>
+    [JsonPropertyName("isValidForRead")]
+    public bool IsValidForRead { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is searchable.
+    /// </summary>
+    [JsonPropertyName("isSearchable")]
+    public bool IsSearchable { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is filterable.
+    /// </summary>
+    [JsonPropertyName("isFilterable")]
+    public bool IsFilterable { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is sortable.
+    /// </summary>
+    [JsonPropertyName("isSortable")]
+    public bool IsSortable { get; init; }
+
+    /// <summary>
+    /// Gets the maximum length for string attributes.
+    /// </summary>
+    [JsonPropertyName("maxLength")]
+    public int? MaxLength { get; init; }
+
+    /// <summary>
+    /// Gets the minimum value for numeric attributes.
+    /// </summary>
+    [JsonPropertyName("minValue")]
+    public double? MinValue { get; init; }
+
+    /// <summary>
+    /// Gets the maximum value for numeric attributes.
+    /// </summary>
+    [JsonPropertyName("maxValue")]
+    public double? MaxValue { get; init; }
+
+    /// <summary>
+    /// Gets the precision for decimal/money attributes.
+    /// </summary>
+    [JsonPropertyName("precision")]
+    public int? Precision { get; init; }
+
+    /// <summary>
+    /// Gets the lookup targets for lookup attributes (pipe-delimited for polymorphic).
+    /// </summary>
+    [JsonPropertyName("targets")]
+    public List<string>? Targets { get; init; }
+
+    /// <summary>
+    /// Gets the option set name for picklist attributes.
+    /// </summary>
+    [JsonPropertyName("optionSetName")]
+    public string? OptionSetName { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a global option set.
+    /// </summary>
+    [JsonPropertyName("isGlobalOptionSet")]
+    public bool IsGlobalOptionSet { get; init; }
+
+    /// <summary>
+    /// Gets the date time behavior for datetime attributes.
+    /// </summary>
+    [JsonPropertyName("dateTimeBehavior")]
+    public string? DateTimeBehavior { get; init; }
+
+    /// <summary>
+    /// Gets the format for datetime attributes.
+    /// </summary>
+    [JsonPropertyName("format")]
+    public string? Format { get; init; }
+
+    /// <summary>
+    /// Gets the description of the attribute.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the inline option set values for local picklist attributes.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public List<OptionValueDto>? Options { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
@@ -114,13 +114,13 @@ public sealed class AttributeMetadataDto
     /// Gets the minimum value for numeric attributes.
     /// </summary>
     [JsonPropertyName("minValue")]
-    public double? MinValue { get; init; }
+    public decimal? MinValue { get; init; }
 
     /// <summary>
     /// Gets the maximum value for numeric attributes.
     /// </summary>
     [JsonPropertyName("maxValue")]
-    public double? MaxValue { get; init; }
+    public decimal? MaxValue { get; init; }
 
     /// <summary>
     /// Gets the precision for decimal/money attributes.

--- a/src/PPDS.Dataverse/Metadata/Models/EntityKeyDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/EntityKeyDto.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Represents an alternate key definition for an entity.
+/// </summary>
+public sealed class EntityKeyDto
+{
+    /// <summary>
+    /// Gets the schema name of the key.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the logical name of the key.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public required string LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the display name of the key.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the attributes that make up this key.
+    /// </summary>
+    [JsonPropertyName("keyAttributes")]
+    public List<string> KeyAttributes { get; init; } = [];
+
+    /// <summary>
+    /// Gets whether this is a custom key.
+    /// </summary>
+    [JsonPropertyName("isCustomizable")]
+    public bool IsCustomizable { get; init; }
+
+    /// <summary>
+    /// Gets whether this key is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the entity key index status.
+    /// </summary>
+    [JsonPropertyName("entityKeyIndexStatus")]
+    public string? EntityKeyIndexStatus { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/EntityMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/EntityMetadataDto.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Full entity metadata including attributes, relationships, keys, and privileges.
+/// </summary>
+public sealed class EntityMetadataDto
+{
+    /// <summary>
+    /// Gets the entity logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public required string LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the entity display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the entity schema name.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the entity set name (for Web API).
+    /// </summary>
+    [JsonPropertyName("entitySetName")]
+    public string? EntitySetName { get; init; }
+
+    /// <summary>
+    /// Gets the primary ID attribute.
+    /// </summary>
+    [JsonPropertyName("primaryIdAttribute")]
+    public string? PrimaryIdAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the primary name attribute.
+    /// </summary>
+    [JsonPropertyName("primaryNameAttribute")]
+    public string? PrimaryNameAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the primary image attribute.
+    /// </summary>
+    [JsonPropertyName("primaryImageAttribute")]
+    public string? PrimaryImageAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the entity type code.
+    /// </summary>
+    [JsonPropertyName("objectTypeCode")]
+    public int ObjectTypeCode { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a custom entity.
+    /// </summary>
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the ownership type (UserOwned, OrganizationOwned, None).
+    /// </summary>
+    [JsonPropertyName("ownershipType")]
+    public string? OwnershipType { get; init; }
+
+    /// <summary>
+    /// Gets the logical collection name.
+    /// </summary>
+    [JsonPropertyName("logicalCollectionName")]
+    public string? LogicalCollectionName { get; init; }
+
+    /// <summary>
+    /// Gets the description of the entity.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets whether the entity is activity.
+    /// </summary>
+    [JsonPropertyName("isActivity")]
+    public bool IsActivity { get; init; }
+
+    /// <summary>
+    /// Gets whether the entity is activity party.
+    /// </summary>
+    [JsonPropertyName("isActivityParty")]
+    public bool IsActivityParty { get; init; }
+
+    /// <summary>
+    /// Gets whether audit is enabled.
+    /// </summary>
+    [JsonPropertyName("isAuditEnabled")]
+    public bool IsAuditEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether change tracking is enabled.
+    /// </summary>
+    [JsonPropertyName("changeTrackingEnabled")]
+    public bool ChangeTrackingEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether business process flows are enabled.
+    /// </summary>
+    [JsonPropertyName("isBusinessProcessEnabled")]
+    public bool IsBusinessProcessEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether quick create is enabled.
+    /// </summary>
+    [JsonPropertyName("isQuickCreateEnabled")]
+    public bool IsQuickCreateEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether duplicate detection is enabled.
+    /// </summary>
+    [JsonPropertyName("isDuplicateDetectionEnabled")]
+    public bool IsDuplicateDetectionEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the entity is valid for queue.
+    /// </summary>
+    [JsonPropertyName("isValidForQueue")]
+    public bool IsValidForQueue { get; init; }
+
+    /// <summary>
+    /// Gets whether this is an intersect entity.
+    /// </summary>
+    [JsonPropertyName("isIntersect")]
+    public bool IsIntersect { get; init; }
+
+    /// <summary>
+    /// Gets the entity attributes.
+    /// </summary>
+    [JsonPropertyName("attributes")]
+    public List<AttributeMetadataDto> Attributes { get; init; } = [];
+
+    /// <summary>
+    /// Gets the one-to-many relationships.
+    /// </summary>
+    [JsonPropertyName("oneToManyRelationships")]
+    public List<RelationshipMetadataDto> OneToManyRelationships { get; init; } = [];
+
+    /// <summary>
+    /// Gets the many-to-one relationships.
+    /// </summary>
+    [JsonPropertyName("manyToOneRelationships")]
+    public List<RelationshipMetadataDto> ManyToOneRelationships { get; init; } = [];
+
+    /// <summary>
+    /// Gets the many-to-many relationships.
+    /// </summary>
+    [JsonPropertyName("manyToManyRelationships")]
+    public List<ManyToManyRelationshipDto> ManyToManyRelationships { get; init; } = [];
+
+    /// <summary>
+    /// Gets the entity alternate keys.
+    /// </summary>
+    [JsonPropertyName("keys")]
+    public List<EntityKeyDto> Keys { get; init; } = [];
+
+    /// <summary>
+    /// Gets the entity privileges.
+    /// </summary>
+    [JsonPropertyName("privileges")]
+    public List<PrivilegeDto> Privileges { get; init; } = [];
+}

--- a/src/PPDS.Dataverse/Metadata/Models/EntityRelationshipsDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/EntityRelationshipsDto.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Container for all relationship types for an entity.
+/// </summary>
+public sealed class EntityRelationshipsDto
+{
+    /// <summary>
+    /// Gets the entity logical name.
+    /// </summary>
+    [JsonPropertyName("entityLogicalName")]
+    public required string EntityLogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the one-to-many relationships where this entity is the primary (referenced) entity.
+    /// </summary>
+    [JsonPropertyName("oneToMany")]
+    public List<RelationshipMetadataDto> OneToMany { get; init; } = [];
+
+    /// <summary>
+    /// Gets the many-to-one relationships where this entity is the related (referencing) entity.
+    /// </summary>
+    [JsonPropertyName("manyToOne")]
+    public List<RelationshipMetadataDto> ManyToOne { get; init; } = [];
+
+    /// <summary>
+    /// Gets the many-to-many relationships.
+    /// </summary>
+    [JsonPropertyName("manyToMany")]
+    public List<ManyToManyRelationshipDto> ManyToMany { get; init; } = [];
+}

--- a/src/PPDS.Dataverse/Metadata/Models/EntitySummary.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/EntitySummary.cs
@@ -1,0 +1,69 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Summary information for an entity in list views.
+/// </summary>
+public sealed class EntitySummary
+{
+    /// <summary>
+    /// Gets the entity logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public required string LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the entity display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the entity schema name.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the entity set name (for Web API).
+    /// </summary>
+    [JsonPropertyName("entitySetName")]
+    public string? EntitySetName { get; init; }
+
+    /// <summary>
+    /// Gets the entity type code.
+    /// </summary>
+    [JsonPropertyName("objectTypeCode")]
+    public int ObjectTypeCode { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a custom entity.
+    /// </summary>
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; init; }
+
+    /// <summary>
+    /// Gets whether this entity is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the ownership type (UserOwned, OrganizationOwned, None).
+    /// </summary>
+    [JsonPropertyName("ownershipType")]
+    public string? OwnershipType { get; init; }
+
+    /// <summary>
+    /// Gets the logical collection name.
+    /// </summary>
+    [JsonPropertyName("logicalCollectionName")]
+    public string? LogicalCollectionName { get; init; }
+
+    /// <summary>
+    /// Gets the description of the entity.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/ManyToManyRelationshipDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/ManyToManyRelationshipDto.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Represents a many-to-many relationship.
+/// </summary>
+public sealed class ManyToManyRelationshipDto
+{
+    /// <summary>
+    /// Gets the schema name of the relationship.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the intersect entity logical name.
+    /// </summary>
+    [JsonPropertyName("intersectEntityName")]
+    public required string IntersectEntityName { get; init; }
+
+    /// <summary>
+    /// Gets the first entity logical name.
+    /// </summary>
+    [JsonPropertyName("entity1LogicalName")]
+    public required string Entity1LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the first entity intersect attribute.
+    /// </summary>
+    [JsonPropertyName("entity1IntersectAttribute")]
+    public required string Entity1IntersectAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the first entity navigation property name.
+    /// </summary>
+    [JsonPropertyName("entity1NavigationPropertyName")]
+    public string? Entity1NavigationPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets the second entity logical name.
+    /// </summary>
+    [JsonPropertyName("entity2LogicalName")]
+    public required string Entity2LogicalName { get; init; }
+
+    /// <summary>
+    /// Gets the second entity intersect attribute.
+    /// </summary>
+    [JsonPropertyName("entity2IntersectAttribute")]
+    public required string Entity2IntersectAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the second entity navigation property name.
+    /// </summary>
+    [JsonPropertyName("entity2NavigationPropertyName")]
+    public string? Entity2NavigationPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a custom relationship.
+    /// </summary>
+    [JsonPropertyName("isCustomRelationship")]
+    public bool IsCustomRelationship { get; init; }
+
+    /// <summary>
+    /// Gets whether this relationship is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a reflexive (self-referencing) relationship.
+    /// </summary>
+    [JsonPropertyName("isReflexive")]
+    public bool IsReflexive { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/OptionSetMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/OptionSetMetadataDto.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Full option set metadata including all values.
+/// </summary>
+public sealed class OptionSetMetadataDto
+{
+    /// <summary>
+    /// Gets the option set name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the option set display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the option set type (Picklist, State, Status, Boolean).
+    /// </summary>
+    [JsonPropertyName("optionSetType")]
+    public required string OptionSetType { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is global.
+    /// </summary>
+    [JsonPropertyName("isGlobal")]
+    public bool IsGlobal { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is custom.
+    /// </summary>
+    [JsonPropertyName("isCustomOptionSet")]
+    public bool IsCustomOptionSet { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the description of the option set.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the external type name for virtual entity integration.
+    /// </summary>
+    [JsonPropertyName("externalTypeName")]
+    public string? ExternalTypeName { get; init; }
+
+    /// <summary>
+    /// Gets the option values.
+    /// </summary>
+    [JsonPropertyName("options")]
+    public List<OptionValueDto> Options { get; init; } = [];
+}

--- a/src/PPDS.Dataverse/Metadata/Models/OptionSetSummary.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/OptionSetSummary.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Summary information for a global option set in list views.
+/// </summary>
+public sealed class OptionSetSummary
+{
+    /// <summary>
+    /// Gets the option set name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the option set display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    /// <summary>
+    /// Gets the option set type (Picklist, State, Status, Boolean).
+    /// </summary>
+    [JsonPropertyName("optionSetType")]
+    public required string OptionSetType { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is global.
+    /// </summary>
+    [JsonPropertyName("isGlobal")]
+    public bool IsGlobal { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is custom.
+    /// </summary>
+    [JsonPropertyName("isCustomOptionSet")]
+    public bool IsCustomOptionSet { get; init; }
+
+    /// <summary>
+    /// Gets whether this option set is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the description of the option set.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the number of options in the set.
+    /// </summary>
+    [JsonPropertyName("optionCount")]
+    public int OptionCount { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/OptionValueDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/OptionValueDto.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Represents a single option value in an option set.
+/// </summary>
+public sealed class OptionValueDto
+{
+    /// <summary>
+    /// Gets the numeric value of the option.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public int Value { get; init; }
+
+    /// <summary>
+    /// Gets the display label of the option.
+    /// </summary>
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    /// <summary>
+    /// Gets the description of the option.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets the color associated with the option (for status options).
+    /// </summary>
+    [JsonPropertyName("color")]
+    public string? Color { get; init; }
+
+    /// <summary>
+    /// Gets the external value for integration scenarios.
+    /// </summary>
+    [JsonPropertyName("externalValue")]
+    public string? ExternalValue { get; init; }
+
+    /// <summary>
+    /// Gets the parent value for dependent option sets (status linked to state).
+    /// </summary>
+    [JsonPropertyName("parentValue")]
+    public int? ParentValue { get; init; }
+
+    /// <summary>
+    /// Gets the state (0=Active, 1=Inactive) for status options.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public int? State { get; init; }
+
+    /// <summary>
+    /// Gets whether this option is the default value.
+    /// </summary>
+    [JsonPropertyName("isDefault")]
+    public bool IsDefault { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/PrivilegeDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/PrivilegeDto.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Represents a security privilege for an entity.
+/// </summary>
+public sealed class PrivilegeDto
+{
+    /// <summary>
+    /// Gets the privilege ID.
+    /// </summary>
+    [JsonPropertyName("privilegeId")]
+    public Guid PrivilegeId { get; init; }
+
+    /// <summary>
+    /// Gets the privilege name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the privilege type (Create, Read, Write, Delete, Assign, Share, Append, AppendTo).
+    /// </summary>
+    [JsonPropertyName("privilegeType")]
+    public required string PrivilegeType { get; init; }
+
+    /// <summary>
+    /// Gets whether the privilege can have a local scope.
+    /// </summary>
+    [JsonPropertyName("canBeLocal")]
+    public bool CanBeLocal { get; init; }
+
+    /// <summary>
+    /// Gets whether the privilege can have a deep scope.
+    /// </summary>
+    [JsonPropertyName("canBeDeep")]
+    public bool CanBeDeep { get; init; }
+
+    /// <summary>
+    /// Gets whether the privilege can have a global scope.
+    /// </summary>
+    [JsonPropertyName("canBeGlobal")]
+    public bool CanBeGlobal { get; init; }
+
+    /// <summary>
+    /// Gets whether the privilege can have a basic scope.
+    /// </summary>
+    [JsonPropertyName("canBeBasic")]
+    public bool CanBeBasic { get; init; }
+}

--- a/src/PPDS.Dataverse/Metadata/Models/RelationshipMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/RelationshipMetadataDto.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Dataverse.Metadata.Models;
+
+/// <summary>
+/// Represents a one-to-many or many-to-one relationship.
+/// </summary>
+public sealed class RelationshipMetadataDto
+{
+    /// <summary>
+    /// Gets the schema name of the relationship.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public required string SchemaName { get; init; }
+
+    /// <summary>
+    /// Gets the relationship type (OneToMany or ManyToOne).
+    /// </summary>
+    [JsonPropertyName("relationshipType")]
+    public required string RelationshipType { get; init; }
+
+    /// <summary>
+    /// Gets the referenced (primary) entity logical name.
+    /// </summary>
+    [JsonPropertyName("referencedEntity")]
+    public required string ReferencedEntity { get; init; }
+
+    /// <summary>
+    /// Gets the referenced entity navigation property name.
+    /// </summary>
+    [JsonPropertyName("referencedEntityNavigationPropertyName")]
+    public string? ReferencedEntityNavigationPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets the referenced attribute (primary key).
+    /// </summary>
+    [JsonPropertyName("referencedAttribute")]
+    public required string ReferencedAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the referencing (child) entity logical name.
+    /// </summary>
+    [JsonPropertyName("referencingEntity")]
+    public required string ReferencingEntity { get; init; }
+
+    /// <summary>
+    /// Gets the referencing entity navigation property name.
+    /// </summary>
+    [JsonPropertyName("referencingEntityNavigationPropertyName")]
+    public string? ReferencingEntityNavigationPropertyName { get; init; }
+
+    /// <summary>
+    /// Gets the referencing attribute (foreign key/lookup).
+    /// </summary>
+    [JsonPropertyName("referencingAttribute")]
+    public required string ReferencingAttribute { get; init; }
+
+    /// <summary>
+    /// Gets whether this is a custom relationship.
+    /// </summary>
+    [JsonPropertyName("isCustomRelationship")]
+    public bool IsCustomRelationship { get; init; }
+
+    /// <summary>
+    /// Gets whether this relationship is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for assign operations.
+    /// </summary>
+    [JsonPropertyName("cascadeAssign")]
+    public string? CascadeAssign { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for delete operations.
+    /// </summary>
+    [JsonPropertyName("cascadeDelete")]
+    public string? CascadeDelete { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for merge operations.
+    /// </summary>
+    [JsonPropertyName("cascadeMerge")]
+    public string? CascadeMerge { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for reparent operations.
+    /// </summary>
+    [JsonPropertyName("cascadeReparent")]
+    public string? CascadeReparent { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for share operations.
+    /// </summary>
+    [JsonPropertyName("cascadeShare")]
+    public string? CascadeShare { get; init; }
+
+    /// <summary>
+    /// Gets the cascade configuration for unshare operations.
+    /// </summary>
+    [JsonPropertyName("cascadeUnshare")]
+    public string? CascadeUnshare { get; init; }
+}

--- a/tests/PPDS.Cli.Tests/Commands/Metadata/MetadataCommandGroupTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Metadata/MetadataCommandGroupTests.cs
@@ -1,0 +1,443 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Metadata;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Metadata;
+
+public class MetadataCommandGroupTests
+{
+    private readonly Command _command;
+
+    public MetadataCommandGroupTests()
+    {
+        _command = MetadataCommandGroup.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("metadata", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("metadata", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasAllSubcommands()
+    {
+        var subcommandNames = _command.Subcommands.Select(c => c.Name).ToList();
+
+        Assert.Contains("entities", subcommandNames);
+        Assert.Contains("entity", subcommandNames);
+        Assert.Contains("attributes", subcommandNames);
+        Assert.Contains("relationships", subcommandNames);
+        Assert.Contains("optionsets", subcommandNames);
+        Assert.Contains("optionset", subcommandNames);
+    }
+
+    [Fact]
+    public void ProfileOption_IsOptional()
+    {
+        Assert.False(MetadataCommandGroup.ProfileOption.Required);
+    }
+
+    [Fact]
+    public void ProfileOption_HasCorrectName()
+    {
+        Assert.Equal("--profile", MetadataCommandGroup.ProfileOption.Name);
+    }
+
+    [Fact]
+    public void ProfileOption_HasAlias()
+    {
+        Assert.Contains("-p", MetadataCommandGroup.ProfileOption.Aliases);
+    }
+
+    [Fact]
+    public void EnvironmentOption_IsOptional()
+    {
+        Assert.False(MetadataCommandGroup.EnvironmentOption.Required);
+    }
+
+    [Fact]
+    public void EnvironmentOption_HasCorrectName()
+    {
+        Assert.Equal("--environment", MetadataCommandGroup.EnvironmentOption.Name);
+    }
+
+    [Fact]
+    public void EnvironmentOption_HasAlias()
+    {
+        Assert.Contains("-env", MetadataCommandGroup.EnvironmentOption.Aliases);
+    }
+
+    #endregion
+}
+
+public class EntitiesCommandTests
+{
+    private readonly Command _command;
+
+    public EntitiesCommandTests()
+    {
+        _command = EntitiesCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("entities", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("List", _command.Description);
+    }
+
+    [Fact]
+    public void Create_HasOptionalCustomOnlyOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--custom-only");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasOptionalFilterOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--filter");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Parse_WithNoOptions_Succeeds()
+    {
+        var result = _command.Parse("");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithCustomOnly_Succeeds()
+    {
+        var result = _command.Parse("--custom-only");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithFilter_Succeeds()
+    {
+        var result = _command.Parse("--filter new_*");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("--profile dev --environment Dev --custom-only --filter new_*");
+        Assert.Empty(result.Errors);
+    }
+}
+
+public class EntityCommandTests
+{
+    private readonly Command _command;
+
+    public EntityCommandTests()
+    {
+        _command = EntityCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("entity", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("metadata", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasEntityArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "entity");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Create_HasOptionalIncludeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--include");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Parse_WithEntityArgument_Succeeds()
+    {
+        var result = _command.Parse("account");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithInclude_Succeeds()
+    {
+        var result = _command.Parse("account --include attributes,relationships");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("account --profile dev --include attributes --include keys");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithoutEntityArgument_HasErrors()
+    {
+        var result = _command.Parse("");
+        Assert.NotEmpty(result.Errors);
+    }
+}
+
+public class AttributesCommandTests
+{
+    private readonly Command _command;
+
+    public AttributesCommandTests()
+    {
+        _command = AttributesCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("attributes", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("attributes", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasEntityArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "entity");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Create_HasOptionalTypeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--type");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Parse_WithEntityArgument_Succeeds()
+    {
+        var result = _command.Parse("account");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithType_Succeeds()
+    {
+        var result = _command.Parse("account --type Lookup");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("account --profile dev --type String");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithoutEntityArgument_HasErrors()
+    {
+        var result = _command.Parse("");
+        Assert.NotEmpty(result.Errors);
+    }
+}
+
+public class RelationshipsCommandTests
+{
+    private readonly Command _command;
+
+    public RelationshipsCommandTests()
+    {
+        _command = RelationshipsCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("relationships", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("relationship", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasEntityArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "entity");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Create_HasOptionalTypeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--type");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Parse_WithEntityArgument_Succeeds()
+    {
+        var result = _command.Parse("account");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithType_Succeeds()
+    {
+        var result = _command.Parse("account --type OneToMany");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("account --profile dev --type ManyToOne");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithoutEntityArgument_HasErrors()
+    {
+        var result = _command.Parse("");
+        Assert.NotEmpty(result.Errors);
+    }
+}
+
+public class OptionSetsCommandTests
+{
+    private readonly Command _command;
+
+    public OptionSetsCommandTests()
+    {
+        _command = OptionSetsCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("optionsets", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("option set", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasOptionalFilterOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--filter");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Parse_WithNoOptions_Succeeds()
+    {
+        var result = _command.Parse("");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithFilter_Succeeds()
+    {
+        var result = _command.Parse("--filter new_*");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("--profile dev --filter new_*");
+        Assert.Empty(result.Errors);
+    }
+}
+
+public class OptionSetCommandTests
+{
+    private readonly Command _command;
+
+    public OptionSetCommandTests()
+    {
+        _command = OptionSetCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("optionset", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("option set", _command.Description?.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void Create_HasNameArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "name");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Parse_WithNameArgument_Succeeds()
+    {
+        var result = _command.Parse("new_customstatus");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse("new_customstatus --profile dev");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithoutNameArgument_HasErrors()
+    {
+        var result = _command.Parse("");
+        Assert.NotEmpty(result.Errors);
+    }
+}

--- a/tests/PPDS.Dataverse.Tests/Metadata/DataverseMetadataServiceTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Metadata/DataverseMetadataServiceTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Dataverse.Configuration;
+using PPDS.Dataverse.DependencyInjection;
+using PPDS.Dataverse.Metadata;
+using PPDS.Dataverse.Pooling;
+using Xunit;
+
+namespace PPDS.Dataverse.Tests.Metadata;
+
+public class DataverseMetadataServiceTests
+{
+    [Fact]
+    public void Constructor_ThrowsOnNullConnectionPool()
+    {
+        // Act
+        var act = () => new DataverseMetadataService(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("connectionPool");
+    }
+
+    [Fact]
+    public void AddDataverseConnectionPool_RegistersIMetadataService()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDataverseConnectionPool(options =>
+        {
+            options.Connections.Add(new DataverseConnection("Primary")
+            {
+                Url = "https://test.crm.dynamics.com",
+                ClientId = "test-client-id",
+                ClientSecret = "test-secret",
+                AuthType = DataverseAuthType.ClientSecret
+            });
+        });
+
+        // Act
+        var provider = services.BuildServiceProvider();
+        var metadataService = provider.GetService<IMetadataService>();
+
+        // Assert
+        metadataService.Should().NotBeNull();
+        metadataService.Should().BeOfType<DataverseMetadataService>();
+    }
+
+    [Fact]
+    public void AddDataverseConnectionPool_MetadataServiceIsTransient()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDataverseConnectionPool(options =>
+        {
+            options.Connections.Add(new DataverseConnection("Primary")
+            {
+                Url = "https://test.crm.dynamics.com",
+                ClientId = "test-client-id",
+                ClientSecret = "test-secret",
+                AuthType = DataverseAuthType.ClientSecret
+            });
+        });
+
+        // Act
+        var provider = services.BuildServiceProvider();
+        var service1 = provider.GetService<IMetadataService>();
+        var service2 = provider.GetService<IMetadataService>();
+
+        // Assert
+        service1.Should().NotBeSameAs(service2);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ppds metadata` command group for browsing Dataverse entity metadata without exporting data
- New `IMetadataService` interface and `DataverseMetadataService` implementation in PPDS.Dataverse
- 6 CLI commands: `entities`, `entity`, `attributes`, `relationships`, `optionsets`, `optionset`
- 11 DTO models for comprehensive metadata representation
- Full unit test coverage for CLI command structure and DI registration

## Test plan

- [x] Build passes with no warnings (`dotnet build -c Release --warnaserror`)
- [x] All unit tests pass (2,341 tests across target frameworks)
- [x] CLI command parsing tests verify all options/arguments
- [x] DI registration tests verify service availability
- [ ] Manual testing with live Dataverse environment (integration tests)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)