### PR TITLE
feat: Add CSV import command `ppds data load` (#36)

### DIFF
--- a/schemas/csv-mapping.schema.json
+++ b/schemas/csv-mapping.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/joshsmithxrm/ppds-sdk/main/schemas/csv-mapping.schema.json",
+  "title": "PPDS CSV Mapping Configuration",
+  "description": "Schema for CSV-to-Dataverse column mapping configuration files used by the ppds data load command.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON schema reference for validation."
+    },
+    "version": {
+      "type": "string",
+      "description": "Schema version for forward compatibility.",
+      "default": "1.0"
+    },
+    "entity": {
+      "type": "string",
+      "description": "Target entity logical name."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the mapping was generated (Zulu time format)."
+    },
+    "columns": {
+      "type": "object",
+      "description": "Column mappings keyed by CSV header name.",
+      "additionalProperties": {
+        "$ref": "#/$defs/columnMapping"
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "description": "Default values applied to all rows. Keys are attribute logical names.",
+      "additionalProperties": true
+    }
+  },
+  "required": ["version"],
+  "additionalProperties": true,
+  "$defs": {
+    "columnMapping": {
+      "type": "object",
+      "description": "Mapping configuration for a single CSV column.",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Target attribute logical name."
+        },
+        "skip": {
+          "type": "boolean",
+          "description": "Skip this column during import.",
+          "default": false
+        },
+        "lookup": {
+          "$ref": "#/$defs/lookupConfig"
+        },
+        "dateFormat": {
+          "type": "string",
+          "description": "Custom date format string (e.g., 'MM/dd/yyyy'). Uses .NET DateTime format specifiers."
+        },
+        "optionsetMap": {
+          "type": "object",
+          "description": "Map CSV text labels to optionset integer values.",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        },
+        "_status": {
+          "type": "string",
+          "enum": ["auto-matched", "needs-configuration", "no-match"],
+          "description": "Generated status indicator. Ignored at runtime."
+        },
+        "_note": {
+          "type": "string",
+          "description": "Generated note for user guidance. Ignored at runtime."
+        },
+        "_csvSample": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Sample values from CSV for reference. Ignored at runtime."
+        },
+        "_autoMatched": {
+          "type": "boolean",
+          "description": "Indicates column was auto-matched. Ignored at runtime."
+        },
+        "_needsConfiguration": {
+          "type": "boolean",
+          "description": "Indicates column needs user configuration. Ignored at runtime."
+        },
+        "_noMatch": {
+          "type": "boolean",
+          "description": "Indicates no matching attribute was found. Ignored at runtime."
+        },
+        "_similarAttributes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Suggested similar attribute names. Ignored at runtime."
+        },
+        "_optionsetValues": {
+          "type": "object",
+          "description": "Available optionset values for reference. Ignored at runtime.",
+          "additionalProperties": {
+            "type": "integer"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "lookupConfig": {
+      "type": "object",
+      "description": "Configuration for resolving lookup field values.",
+      "properties": {
+        "entity": {
+          "type": "string",
+          "description": "Target entity logical name for the lookup."
+        },
+        "matchBy": {
+          "type": "string",
+          "enum": ["guid", "field"],
+          "description": "Resolution strategy. 'guid' expects GUID values, 'field' queries by keyField.",
+          "default": "guid"
+        },
+        "keyField": {
+          "type": "string",
+          "description": "Attribute to match against when matchBy is 'field'."
+        },
+        "_options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Available matching options for reference. Ignored at runtime."
+        }
+      },
+      "required": ["entity"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ppds metadata relationships <entity>` - List 1:N, N:1, N:N relationships (supports `--type` filtering)
   - `ppds metadata optionsets` - List global option sets (supports `--filter`)
   - `ppds metadata optionset <name>` - Get option set values and metadata
+- **`ppds data load` command** - Load CSV data into Dataverse entities with auto-mapping, type coercion, lookup resolution, and bulk upsert operations ([#36](https://github.com/joshsmithxrm/ppds-sdk/issues/36))
+  - Auto-maps CSV headers to entity attributes by name matching
+  - `--generate-mapping` generates a mapping template with auto-matched columns and optionset values
+  - Supports GUID auto-detection for lookups; field-based matching via mapping file
+  - Type coercion for all Dataverse attribute types (strings, numbers, dates, booleans, optionsets, money, lookups)
+  - Multi-profile support for connection pooling (`--profile app1,app2,app3`)
+  - `--dry-run` mode for validation without writing
+  - `--key` option for alternate key upsert semantics
+  - JSON Schema for mapping files at `schemas/csv-mapping.schema.json`
 - **Structured error handling** - All errors now return hierarchical error codes (`Auth.ProfileNotFound`, `Connection.Failed`, etc.) for reliable programmatic handling ([#77](https://github.com/joshsmithxrm/ppds-sdk/issues/77))
 - **Expanded exit codes** - New exit codes 4 (ConnectionError), 5 (AuthError), 6 (NotFoundError) for finer-grained status ([#77](https://github.com/joshsmithxrm/ppds-sdk/issues/77))
 - **Global options** - `--quiet`/`-q`, `--verbose`/`-v`, `--debug`, `--correlation-id` flags available on all commands ([#76](https://github.com/joshsmithxrm/ppds-sdk/issues/76))

--- a/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
@@ -30,7 +30,7 @@ public static class DataCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("data", "Data operations: export, import, copy, analyze, schema, users");
+        var command = new Command("data", "Data operations: export, import, copy, analyze, schema, users, load");
 
         command.Subcommands.Add(ExportCommand.Create());
         command.Subcommands.Add(ImportCommand.Create());
@@ -38,6 +38,7 @@ public static class DataCommandGroup
         command.Subcommands.Add(AnalyzeCommand.Create());
         command.Subcommands.Add(SchemaCommand.Create());
         command.Subcommands.Add(UsersCommand.Create());
+        command.Subcommands.Add(LoadCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Commands/Data/LoadCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/LoadCommand.cs
@@ -1,0 +1,472 @@
+using System.CommandLine;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using PPDS.Cli.CsvLoader;
+using PPDS.Cli.Infrastructure;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
+using PPDS.Dataverse.Progress;
+
+namespace PPDS.Cli.Commands.Data;
+
+/// <summary>
+/// Load CSV data into a Dataverse entity.
+/// </summary>
+public static class LoadCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static Command Create()
+    {
+        var entityOption = new Option<string>("--entity", "-e")
+        {
+            Description = "Target entity logical name",
+            Required = true
+        };
+        entityOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(entityOption);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("Entity name is required");
+            }
+            else if (value.Contains(' '))
+            {
+                result.AddError("Entity name must be a valid logical name (no spaces)");
+            }
+        });
+
+        var fileOption = new Option<FileInfo>("--file", "-f")
+        {
+            Description = "Path to CSV file",
+            Required = true
+        }.AcceptExistingOnly();
+
+        var keyOption = new Option<string?>("--key", "-k")
+        {
+            Description = "Alternate key field(s) for upsert. Comma-separated for composite keys."
+        };
+
+        var mappingOption = new Option<FileInfo?>("--mapping", "-m")
+        {
+            Description = "Path to column mapping JSON file"
+        };
+        mappingOption.Validators.Add(result =>
+        {
+            var file = result.GetValue(mappingOption);
+            if (file is { Exists: false })
+            {
+                result.AddError($"Mapping file not found: {file.FullName}");
+            }
+        });
+
+        var generateMappingOption = new Option<FileInfo?>("--generate-mapping")
+        {
+            Description = "Generate mapping template to specified file"
+        };
+        generateMappingOption.Validators.Add(result =>
+        {
+            var file = result.GetValue(generateMappingOption);
+            if (file?.Directory is { Exists: false })
+            {
+                result.AddError($"Output directory does not exist: {file.Directory.FullName}");
+            }
+        });
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Validate without writing to Dataverse",
+            DefaultValueFactory = _ => false
+        };
+
+        var batchSizeOption = new Option<int>("--batch-size")
+        {
+            Description = "Records per batch (default: 100)",
+            DefaultValueFactory = _ => 100
+        };
+        batchSizeOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(batchSizeOption);
+            if (value < 1 || value > 1000)
+            {
+                result.AddError("--batch-size must be between 1 and 1000");
+            }
+        });
+
+        var bypassPluginsOption = new Option<string?>("--bypass-plugins")
+        {
+            Description = "Bypass custom plugin execution: sync, async, or all (requires prvBypassCustomBusinessLogic privilege)"
+        };
+        bypassPluginsOption.AcceptOnlyFromAmong("sync", "async", "all");
+
+        var bypassFlowsOption = new Option<bool>("--bypass-flows")
+        {
+            Description = "Bypass Power Automate flow triggers",
+            DefaultValueFactory = _ => false
+        };
+
+        var continueOnErrorOption = new Option<bool>("--continue-on-error")
+        {
+            Description = "Continue loading on individual record failures",
+            DefaultValueFactory = _ => true
+        };
+
+        var outputFormatOption = new Option<OutputFormat>("--output-format", "-o")
+        {
+            Description = "Output format",
+            DefaultValueFactory = _ => OutputFormat.Text
+        };
+
+        var verboseOption = new Option<bool>("--verbose", "-v")
+        {
+            Description = "Enable verbose logging output",
+            DefaultValueFactory = _ => false
+        };
+
+        var debugOption = new Option<bool>("--debug")
+        {
+            Description = "Enable diagnostic logging output",
+            DefaultValueFactory = _ => false
+        };
+
+        var command = new Command("load", "Load CSV data into a Dataverse entity")
+        {
+            entityOption,
+            fileOption,
+            keyOption,
+            mappingOption,
+            generateMappingOption,
+            dryRunOption,
+            batchSizeOption,
+            bypassPluginsOption,
+            bypassFlowsOption,
+            continueOnErrorOption,
+            DataCommandGroup.ProfileOption,
+            DataCommandGroup.EnvironmentOption,
+            outputFormatOption,
+            verboseOption,
+            debugOption
+        };
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityOption)!;
+            var file = parseResult.GetValue(fileOption)!;
+            var key = parseResult.GetValue(keyOption);
+            var mappingFile = parseResult.GetValue(mappingOption);
+            var generateMappingFile = parseResult.GetValue(generateMappingOption);
+            var dryRun = parseResult.GetValue(dryRunOption);
+            var batchSize = parseResult.GetValue(batchSizeOption);
+            var bypassPluginsValue = parseResult.GetValue(bypassPluginsOption);
+            var bypassFlows = parseResult.GetValue(bypassFlowsOption);
+            var continueOnError = parseResult.GetValue(continueOnErrorOption);
+            var profile = parseResult.GetValue(DataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(DataCommandGroup.EnvironmentOption);
+            var outputFormat = parseResult.GetValue(outputFormatOption);
+            var verbose = parseResult.GetValue(verboseOption);
+            var debug = parseResult.GetValue(debugOption);
+
+            var bypassPlugins = DataCommandGroup.ParseBypassPlugins(bypassPluginsValue);
+
+            return await ExecuteAsync(
+                entity, file, key, mappingFile, generateMappingFile,
+                dryRun, batchSize, bypassPlugins, bypassFlows, continueOnError,
+                profile, environment, outputFormat, verbose, debug,
+                cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        FileInfo file,
+        string? key,
+        FileInfo? mappingFile,
+        FileInfo? generateMappingFile,
+        bool dryRun,
+        int batchSize,
+        CustomLogicBypass bypassPlugins,
+        bool bypassFlows,
+        bool continueOnError,
+        string? profileName,
+        string? environment,
+        OutputFormat outputFormat,
+        bool verbose,
+        bool debug,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Connect to Dataverse
+            Console.Error.WriteLine($"Connecting to Dataverse...");
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profileName,
+                environment,
+                verbose,
+                debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            if (outputFormat != OutputFormat.Json)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+
+            // Handle --generate-mapping mode
+            if (generateMappingFile != null)
+            {
+                return await GenerateMappingAsync(
+                    pool, entity, file.FullName, generateMappingFile.FullName,
+                    outputFormat, cancellationToken);
+            }
+
+            // Load mapping file if provided
+            CsvMappingConfig? mapping = null;
+            if (mappingFile != null)
+            {
+                Console.Error.WriteLine($"Loading mapping from {mappingFile.Name}...");
+                var mappingJson = await File.ReadAllTextAsync(mappingFile.FullName, cancellationToken);
+                mapping = JsonSerializer.Deserialize<CsvMappingConfig>(mappingJson, JsonOptions);
+            }
+
+            // Create load options
+            var loadOptions = new CsvLoadOptions
+            {
+                EntityLogicalName = entity,
+                AlternateKeyFields = key,
+                Mapping = mapping,
+                BatchSize = batchSize,
+                BypassPlugins = bypassPlugins,
+                BypassFlows = bypassFlows,
+                ContinueOnError = continueOnError,
+                DryRun = dryRun
+            };
+
+            // Execute load
+            var bulkExecutor = serviceProvider.GetRequiredService<IBulkOperationExecutor>();
+            var logger = serviceProvider.GetService<ILogger<CsvDataLoader>>();
+            var loader = new CsvDataLoader(pool, bulkExecutor, logger);
+
+            Console.Error.WriteLine($"Loading {file.Name} into '{entity}'...");
+            Console.Error.WriteLine();
+
+            // Progress reporting
+            var progress = new Progress<ProgressSnapshot>(snapshot =>
+            {
+                if (outputFormat != OutputFormat.Json)
+                {
+                    Console.Error.Write($"\r  Progress: {snapshot.Processed:N0}/{snapshot.Total:N0} " +
+                        $"({snapshot.PercentComplete:F1}%) | {snapshot.InstantRatePerSecond:F0}/s");
+                }
+            });
+
+            var result = await loader.LoadAsync(file.FullName, loadOptions, progress, cancellationToken);
+
+            Console.Error.WriteLine();
+            Console.Error.WriteLine();
+
+            // Output results
+            if (outputFormat == OutputFormat.Json)
+            {
+                WriteJsonResult(result);
+            }
+            else
+            {
+                WriteTextResult(result, dryRun);
+            }
+
+            return result.Success ? ExitCodes.Success : ExitCodes.PartialSuccess;
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Load cancelled by user.");
+            return ExitCodes.Failure;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            if (debug)
+            {
+                Console.Error.WriteLine(ex.StackTrace);
+            }
+            return ExitCodes.Failure;
+        }
+    }
+
+    private static async Task<int> GenerateMappingAsync(
+        IDataverseConnectionPool pool,
+        string entityName,
+        string csvPath,
+        string outputPath,
+        OutputFormat outputFormat,
+        CancellationToken cancellationToken)
+    {
+        Console.Error.WriteLine($"Retrieving metadata for '{entityName}'...");
+
+        await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = entityName,
+            EntityFilters = EntityFilters.Attributes
+        };
+
+        var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken);
+        var entityMetadata = response.EntityMetadata;
+
+        Console.Error.WriteLine($"Generating mapping from {Path.GetFileName(csvPath)}...");
+
+        var generator = new MappingGenerator();
+        var config = await generator.GenerateAsync(csvPath, entityMetadata, cancellationToken);
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+        await File.WriteAllTextAsync(outputPath, json, cancellationToken);
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Mapping file generated: {outputPath}");
+        Console.Error.WriteLine();
+
+        // Show summary
+        var autoMatched = config.Columns.Count(c => c.Value.Status == "auto-matched");
+        var needsConfig = config.Columns.Count(c => c.Value.Status == "needs-configuration");
+        var noMatch = config.Columns.Count(c => c.Value.Status == "no-match");
+
+        Console.Error.WriteLine($"  Columns: {config.Columns.Count}");
+        Console.Error.WriteLine($"    Auto-matched: {autoMatched}");
+        if (needsConfig > 0)
+        {
+            Console.Error.WriteLine($"    Needs configuration: {needsConfig} (lookup fields)");
+        }
+        if (noMatch > 0)
+        {
+            Console.Error.WriteLine($"    No match (will skip): {noMatch}");
+        }
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Next steps:");
+        Console.Error.WriteLine($"  1. Edit {Path.GetFileName(outputPath)} to configure lookup fields");
+        Console.Error.WriteLine($"  2. Run: ppds data load --entity {entityName} --file {Path.GetFileName(csvPath)} --mapping {Path.GetFileName(outputPath)}");
+
+        return ExitCodes.Success;
+    }
+
+    private static void WriteTextResult(LoadResult result, bool dryRun)
+    {
+        if (dryRun)
+        {
+            Console.Error.WriteLine("Dry-run complete (no records written)");
+        }
+        else
+        {
+            Console.Error.WriteLine("Load complete");
+        }
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"  Total rows: {result.TotalRows:N0}");
+        Console.Error.WriteLine($"  Successful: {result.SuccessCount:N0}");
+
+        if (result.CreatedCount.HasValue && result.UpdatedCount.HasValue)
+        {
+            Console.Error.WriteLine($"    Created: {result.CreatedCount:N0}");
+            Console.Error.WriteLine($"    Updated: {result.UpdatedCount:N0}");
+        }
+
+        if (result.FailureCount > 0)
+        {
+            Console.Error.WriteLine($"  Failed: {result.FailureCount:N0}");
+        }
+
+        if (result.SkippedCount > 0)
+        {
+            Console.Error.WriteLine($"  Skipped: {result.SkippedCount:N0}");
+        }
+
+        Console.Error.WriteLine($"  Duration: {result.Duration:mm\\:ss\\.fff}");
+
+        if (result.Warnings.Count > 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Warnings:");
+            foreach (var warning in result.Warnings.Take(10))
+            {
+                Console.Error.WriteLine($"  {warning}");
+            }
+            if (result.Warnings.Count > 10)
+            {
+                Console.Error.WriteLine($"  ... and {result.Warnings.Count - 10} more");
+            }
+        }
+
+        if (result.Errors.Count > 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Errors:");
+
+            // Group errors by error code
+            var groupedErrors = result.Errors
+                .GroupBy(e => e.ErrorCode)
+                .OrderByDescending(g => g.Count());
+
+            foreach (var group in groupedErrors.Take(5))
+            {
+                Console.Error.WriteLine($"  {group.Key}: {group.Count()} occurrence(s)");
+                foreach (var error in group.Take(3))
+                {
+                    var rowInfo = error.RowNumber > 0 ? $"Row {error.RowNumber}" : "";
+                    var colInfo = !string.IsNullOrEmpty(error.Column) ? $", Column '{error.Column}'" : "";
+                    Console.Error.WriteLine($"    [{rowInfo}{colInfo}] {error.Message}");
+                }
+                if (group.Count() > 3)
+                {
+                    Console.Error.WriteLine($"    ... and {group.Count() - 3} more");
+                }
+            }
+
+            if (groupedErrors.Count() > 5)
+            {
+                Console.Error.WriteLine($"  ... and {groupedErrors.Count() - 5} more error types");
+            }
+        }
+    }
+
+    private static void WriteJsonResult(LoadResult result)
+    {
+        var output = new
+        {
+            success = result.Success,
+            totalRows = result.TotalRows,
+            successCount = result.SuccessCount,
+            failureCount = result.FailureCount,
+            createdCount = result.CreatedCount,
+            updatedCount = result.UpdatedCount,
+            skippedCount = result.SkippedCount,
+            durationMs = result.Duration.TotalMilliseconds,
+            warnings = result.Warnings,
+            errors = result.Errors.Select(e => new
+            {
+                rowNumber = e.RowNumber,
+                column = e.Column,
+                errorCode = e.ErrorCode,
+                message = e.Message,
+                value = e.Value
+            })
+        };
+
+        Console.WriteLine(JsonSerializer.Serialize(output, JsonOptions));
+    }
+}

--- a/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
@@ -1,0 +1,482 @@
+using System.Diagnostics;
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
+using PPDS.Dataverse.Progress;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Loads CSV data into Dataverse entities.
+/// </summary>
+public sealed class CsvDataLoader
+{
+    private readonly IDataverseConnectionPool _pool;
+    private readonly IBulkOperationExecutor _bulkExecutor;
+    private readonly ILogger<CsvDataLoader>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CsvDataLoader"/> class.
+    /// </summary>
+    public CsvDataLoader(
+        IDataverseConnectionPool pool,
+        IBulkOperationExecutor bulkExecutor,
+        ILogger<CsvDataLoader>? logger = null)
+    {
+        _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+        _bulkExecutor = bulkExecutor ?? throw new ArgumentNullException(nameof(bulkExecutor));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Loads CSV data into Dataverse.
+    /// </summary>
+    public async Task<LoadResult> LoadAsync(
+        string csvPath,
+        CsvLoadOptions options,
+        IProgress<ProgressSnapshot>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var errors = new List<LoadError>();
+        var warnings = new List<string>();
+
+        _logger?.LogInformation("Loading CSV file: {CsvPath}", csvPath);
+
+        // 1. Retrieve entity metadata
+        var entityMetadata = await RetrieveEntityMetadataAsync(
+            options.EntityLogicalName, cancellationToken);
+
+        // 2. Build attribute lookup
+        var attributesByName = BuildAttributeLookup(entityMetadata);
+
+        // 3. Determine column mappings
+        var mappings = options.Mapping?.Columns
+            ?? await AutoMapColumnsAsync(csvPath, attributesByName, warnings, cancellationToken);
+
+        // 4. Identify and preload lookup caches
+        var lookupResolver = new LookupResolver(_pool);
+        var lookupConfigs = GetLookupConfigs(mappings, attributesByName);
+
+        if (lookupConfigs.Any(l => l.Config.MatchBy == "field"))
+        {
+            _logger?.LogInformation("Preloading lookup caches...");
+            await lookupResolver.PreloadLookupsAsync(lookupConfigs, cancellationToken);
+        }
+
+        // 5. Parse CSV and build entities
+        var (entities, parseErrors) = await BuildEntitiesAsync(
+            csvPath,
+            options,
+            mappings,
+            attributesByName,
+            lookupResolver,
+            cancellationToken);
+
+        errors.AddRange(parseErrors);
+        errors.AddRange(lookupResolver.Errors);
+
+        _logger?.LogInformation("Built {Count} entities from CSV", entities.Count);
+
+        // 6. Dry-run mode - just return validation results
+        if (options.DryRun)
+        {
+            stopwatch.Stop();
+            return new LoadResult
+            {
+                TotalRows = entities.Count + errors.Count,
+                SuccessCount = entities.Count,
+                FailureCount = errors.Count,
+                SkippedCount = 0,
+                Duration = stopwatch.Elapsed,
+                Errors = errors,
+                Warnings = warnings
+            };
+        }
+
+        // 7. Execute bulk upsert
+        if (entities.Count == 0)
+        {
+            stopwatch.Stop();
+            return new LoadResult
+            {
+                TotalRows = errors.Count,
+                SuccessCount = 0,
+                FailureCount = errors.Count,
+                Duration = stopwatch.Elapsed,
+                Errors = errors,
+                Warnings = warnings
+            };
+        }
+
+        _logger?.LogInformation("Executing bulk upsert for {Count} records...", entities.Count);
+
+        var bulkResult = await _bulkExecutor.UpsertMultipleAsync(
+            options.EntityLogicalName,
+            entities,
+            new BulkOperationOptions
+            {
+                BatchSize = options.BatchSize,
+                BypassCustomLogic = options.BypassPlugins,
+                BypassPowerAutomateFlows = options.BypassFlows,
+                ContinueOnError = options.ContinueOnError
+            },
+            progress,
+            cancellationToken);
+
+        // 8. Map bulk operation errors
+        foreach (var bulkError in bulkResult.Errors)
+        {
+            errors.Add(new LoadError
+            {
+                RowNumber = bulkError.Index + 1, // 1-based row number
+                ErrorCode = LoadErrorCodes.DataverseError,
+                Message = bulkError.Message
+            });
+        }
+
+        stopwatch.Stop();
+
+        return new LoadResult
+        {
+            TotalRows = entities.Count + parseErrors.Count,
+            SuccessCount = bulkResult.SuccessCount,
+            FailureCount = bulkResult.FailureCount + parseErrors.Count,
+            CreatedCount = bulkResult.CreatedCount,
+            UpdatedCount = bulkResult.UpdatedCount,
+            SkippedCount = parseErrors.Count,
+            Duration = stopwatch.Elapsed,
+            Errors = errors,
+            Warnings = warnings
+        };
+    }
+
+    private async Task<EntityMetadata> RetrieveEntityMetadataAsync(
+        string entityLogicalName,
+        CancellationToken cancellationToken)
+    {
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = entityLogicalName,
+            EntityFilters = EntityFilters.Attributes
+        };
+
+        var response = (RetrieveEntityResponse)await client.ExecuteAsync(request, cancellationToken);
+        return response.EntityMetadata;
+    }
+
+    private static Dictionary<string, AttributeMetadata> BuildAttributeLookup(EntityMetadata entityMetadata)
+    {
+        var lookup = new Dictionary<string, AttributeMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        if (entityMetadata.Attributes == null)
+        {
+            return lookup;
+        }
+
+        foreach (var attr in entityMetadata.Attributes)
+        {
+            if (attr.LogicalName != null)
+            {
+                lookup[attr.LogicalName] = attr;
+            }
+        }
+
+        return lookup;
+    }
+
+    private async Task<Dictionary<string, ColumnMappingEntry>> AutoMapColumnsAsync(
+        string csvPath,
+        Dictionary<string, AttributeMetadata> attributesByName,
+        List<string> warnings,
+        CancellationToken cancellationToken)
+    {
+        var mappings = new Dictionary<string, ColumnMappingEntry>(StringComparer.OrdinalIgnoreCase);
+
+        var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            MissingFieldFound = null,
+            HeaderValidated = null
+        };
+
+        using var reader = new StreamReader(csvPath);
+        using var csv = new CsvReader(reader, csvConfig);
+
+        await csv.ReadAsync();
+        csv.ReadHeader();
+        var headers = csv.HeaderRecord ?? [];
+
+        foreach (var header in headers)
+        {
+            var normalizedHeader = NormalizeForMatching(header);
+
+            // Try exact match first
+            if (attributesByName.TryGetValue(header, out var attr))
+            {
+                mappings[header] = CreateAutoMapping(header, attr);
+            }
+            // Try normalized match
+            else if (TryFindAttribute(normalizedHeader, attributesByName, out attr))
+            {
+                mappings[header] = CreateAutoMapping(header, attr!);
+            }
+            else
+            {
+                warnings.Add($"Column '{header}' does not match any attribute. It will be skipped.");
+                mappings[header] = new ColumnMappingEntry { Skip = true };
+            }
+        }
+
+        return mappings;
+    }
+
+    private static ColumnMappingEntry CreateAutoMapping(string header, AttributeMetadata attr)
+    {
+        var entry = new ColumnMappingEntry
+        {
+            Field = attr.LogicalName
+        };
+
+        // Auto-configure lookups with GUID-only matching
+        if (IsLookupAttribute(attr))
+        {
+            var lookupAttr = (LookupAttributeMetadata)attr;
+            entry.Lookup = new LookupConfig
+            {
+                Entity = lookupAttr.Targets?.FirstOrDefault() ?? "unknown",
+                MatchBy = "guid"
+            };
+        }
+
+        return entry;
+    }
+
+    private static bool TryFindAttribute(
+        string normalizedHeader,
+        Dictionary<string, AttributeMetadata> attributes,
+        out AttributeMetadata? found)
+    {
+        foreach (var kvp in attributes)
+        {
+            if (NormalizeForMatching(kvp.Key) == normalizedHeader)
+            {
+                found = kvp.Value;
+                return true;
+            }
+        }
+
+        found = null;
+        return false;
+    }
+
+    private static string NormalizeForMatching(string value)
+    {
+        return value
+            .Replace(" ", "")
+            .Replace("_", "")
+            .Replace("-", "")
+            .ToLowerInvariant();
+    }
+
+    private static IEnumerable<(string ColumnName, LookupConfig Config)> GetLookupConfigs(
+        Dictionary<string, ColumnMappingEntry> mappings,
+        Dictionary<string, AttributeMetadata> attributes)
+    {
+        foreach (var (columnName, mapping) in mappings)
+        {
+            if (mapping.Skip || mapping.Lookup == null)
+            {
+                continue;
+            }
+
+            yield return (columnName, mapping.Lookup);
+        }
+    }
+
+    private async Task<(List<Entity> Entities, List<LoadError> Errors)> BuildEntitiesAsync(
+        string csvPath,
+        CsvLoadOptions options,
+        Dictionary<string, ColumnMappingEntry> mappings,
+        Dictionary<string, AttributeMetadata> attributesByName,
+        LookupResolver lookupResolver,
+        CancellationToken cancellationToken)
+    {
+        var entities = new List<Entity>();
+        var errors = new List<LoadError>();
+        var parser = new CsvRecordParser();
+
+        var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            MissingFieldFound = null,
+            HeaderValidated = null
+        };
+
+        using var reader = new StreamReader(csvPath);
+        using var csv = new CsvReader(reader, csvConfig);
+
+        await csv.ReadAsync();
+        csv.ReadHeader();
+        var headers = csv.HeaderRecord ?? [];
+
+        var rowNumber = 0;
+        while (await csv.ReadAsync())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            rowNumber++;
+
+            var entity = new Entity(options.EntityLogicalName);
+            var hasError = false;
+
+            // Set alternate key if specified
+            if (!string.IsNullOrEmpty(options.AlternateKeyFields))
+            {
+                var keyFields = options.AlternateKeyFields.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var keyField in keyFields)
+                {
+                    var trimmedKey = keyField.Trim();
+                    // Find the header that maps to this key field
+                    var keyHeader = FindHeaderForField(headers, mappings, trimmedKey);
+                    if (keyHeader != null)
+                    {
+                        var keyValue = csv.GetField(keyHeader);
+                        if (!string.IsNullOrEmpty(keyValue))
+                        {
+                            // Coerce key value if we have metadata
+                            if (attributesByName.TryGetValue(trimmedKey, out var keyAttr))
+                            {
+                                var coercedKey = parser.CoerceValue(keyValue, keyAttr, mappings.GetValueOrDefault(keyHeader));
+                                if (coercedKey != null)
+                                {
+                                    entity.KeyAttributes[trimmedKey] = coercedKey;
+                                }
+                            }
+                            else
+                            {
+                                entity.KeyAttributes[trimmedKey] = keyValue;
+                            }
+                        }
+                    }
+                }
+            }
+
+            foreach (var header in headers)
+            {
+                if (!mappings.TryGetValue(header, out var mapping) || mapping.Skip)
+                {
+                    continue;
+                }
+
+                var fieldName = mapping.Field;
+                if (string.IsNullOrEmpty(fieldName))
+                {
+                    continue;
+                }
+
+                var rawValue = csv.GetField(header);
+
+                if (string.IsNullOrEmpty(rawValue))
+                {
+                    continue;
+                }
+
+                // Handle lookups
+                if (mapping.Lookup != null)
+                {
+                    var entityRef = lookupResolver.Resolve(rawValue, mapping.Lookup, rowNumber, header);
+                    if (entityRef != null)
+                    {
+                        entity[fieldName] = entityRef;
+                    }
+                    // Errors are collected in lookupResolver.Errors
+                    continue;
+                }
+
+                // Handle regular attributes
+                if (!attributesByName.TryGetValue(fieldName, out var attrMetadata))
+                {
+                    errors.Add(new LoadError
+                    {
+                        RowNumber = rowNumber,
+                        Column = header,
+                        ErrorCode = LoadErrorCodes.ColumnNotFound,
+                        Message = $"Attribute '{fieldName}' not found in entity",
+                        Value = rawValue
+                    });
+                    hasError = true;
+                    continue;
+                }
+
+                var (success, value, errorMessage) = parser.TryCoerceValue(rawValue, attrMetadata, mapping);
+
+                if (!success)
+                {
+                    errors.Add(new LoadError
+                    {
+                        RowNumber = rowNumber,
+                        Column = header,
+                        ErrorCode = LoadErrorCodes.TypeCoercionFailed,
+                        Message = errorMessage ?? $"Cannot convert value",
+                        Value = rawValue
+                    });
+                    hasError = true;
+                    continue;
+                }
+
+                if (value != null)
+                {
+                    entity[fieldName] = value;
+                }
+            }
+
+            if (!hasError || options.ContinueOnError)
+            {
+                entities.Add(entity);
+            }
+        }
+
+        return (entities, errors);
+    }
+
+    private static string? FindHeaderForField(
+        string[] headers,
+        Dictionary<string, ColumnMappingEntry> mappings,
+        string fieldName)
+    {
+        foreach (var header in headers)
+        {
+            if (mappings.TryGetValue(header, out var mapping) &&
+                string.Equals(mapping.Field, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return header;
+            }
+        }
+
+        // Also check if header directly matches field name
+        foreach (var header in headers)
+        {
+            if (string.Equals(header, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return header;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsLookupAttribute(AttributeMetadata attr)
+    {
+        return attr.AttributeType == AttributeTypeCode.Lookup ||
+               attr.AttributeType == AttributeTypeCode.Customer ||
+               attr.AttributeType == AttributeTypeCode.Owner;
+    }
+}

--- a/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
@@ -359,6 +359,19 @@ public sealed class CsvDataLoader
                                 {
                                     entity.KeyAttributes[trimmedKey] = coercedKey;
                                 }
+                                else
+                                {
+                                    // Key coercion failed - this is a critical error
+                                    errors.Add(new LoadError
+                                    {
+                                        RowNumber = rowNumber,
+                                        Column = keyHeader,
+                                        ErrorCode = LoadErrorCodes.TypeCoercionFailed,
+                                        Message = $"Cannot convert key value '{keyValue}' to {keyAttr.AttributeType}",
+                                        Value = keyValue
+                                    });
+                                    hasError = true;
+                                }
                             }
                             else
                             {
@@ -438,7 +451,10 @@ public sealed class CsvDataLoader
                 }
             }
 
-            if (!hasError || options.ContinueOnError)
+            // Only add entities without errors to the batch
+            // Errors are collected and reported; ContinueOnError controls whether
+            // we proceed with valid entities or abort entirely (checked by caller)
+            if (!hasError)
             {
                 entities.Add(entity);
             }

--- a/src/PPDS.Cli/CsvLoader/CsvLoadOptions.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvLoadOptions.cs
@@ -1,0 +1,49 @@
+using PPDS.Dataverse.BulkOperations;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Options for CSV data loading operations.
+/// </summary>
+public sealed class CsvLoadOptions
+{
+    /// <summary>
+    /// Target entity logical name.
+    /// </summary>
+    public required string EntityLogicalName { get; init; }
+
+    /// <summary>
+    /// Alternate key field(s) for upsert operations. Comma-separated for composite keys.
+    /// </summary>
+    public string? AlternateKeyFields { get; init; }
+
+    /// <summary>
+    /// Column mapping configuration. If null, auto-mapping is used.
+    /// </summary>
+    public CsvMappingConfig? Mapping { get; init; }
+
+    /// <summary>
+    /// Number of records per batch.
+    /// </summary>
+    public int BatchSize { get; init; } = 100;
+
+    /// <summary>
+    /// Bypass custom plugin execution.
+    /// </summary>
+    public CustomLogicBypass BypassPlugins { get; init; } = CustomLogicBypass.None;
+
+    /// <summary>
+    /// Bypass Power Automate flow triggers.
+    /// </summary>
+    public bool BypassFlows { get; init; }
+
+    /// <summary>
+    /// Continue loading on individual record failures.
+    /// </summary>
+    public bool ContinueOnError { get; init; } = true;
+
+    /// <summary>
+    /// Validate without writing to Dataverse.
+    /// </summary>
+    public bool DryRun { get; init; }
+}

--- a/src/PPDS.Cli/CsvLoader/CsvMappingConfig.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvMappingConfig.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PPDS.Cli.Plugins.Models;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Configuration for CSV-to-Dataverse column mapping.
+/// </summary>
+public sealed class CsvMappingConfig
+{
+    /// <summary>
+    /// JSON schema reference for validation.
+    /// </summary>
+    [JsonPropertyName("$schema")]
+    public string? Schema { get; set; }
+
+    /// <summary>
+    /// Schema version for forward compatibility.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>
+    /// Target entity logical name.
+    /// </summary>
+    [JsonPropertyName("entity")]
+    public string? Entity { get; set; }
+
+    /// <summary>
+    /// Timestamp when the mapping was generated.
+    /// </summary>
+    [JsonPropertyName("generatedAt")]
+    [JsonConverter(typeof(ZuluTimeConverter))]
+    public DateTimeOffset? GeneratedAt { get; set; }
+
+    /// <summary>
+    /// Column mappings keyed by CSV header name.
+    /// </summary>
+    [JsonPropertyName("columns")]
+    public Dictionary<string, ColumnMappingEntry> Columns { get; set; } = new();
+
+    /// <summary>
+    /// Default values applied to all rows. Keys are attribute logical names.
+    /// </summary>
+    [JsonPropertyName("defaults")]
+    public Dictionary<string, JsonElement>? Defaults { get; set; }
+
+    /// <summary>
+    /// Extension data for forward compatibility.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+
+    /// <summary>
+    /// Schema URL for generated mapping files.
+    /// </summary>
+    public const string SchemaUrl = "https://raw.githubusercontent.com/joshsmithxrm/ppds-sdk/main/schemas/csv-mapping.schema.json";
+}
+
+/// <summary>
+/// Mapping configuration for a single CSV column.
+/// </summary>
+public sealed class ColumnMappingEntry
+{
+    /// <summary>
+    /// Target attribute logical name.
+    /// </summary>
+    [JsonPropertyName("field")]
+    public string? Field { get; set; }
+
+    /// <summary>
+    /// Skip this column during import.
+    /// </summary>
+    [JsonPropertyName("skip")]
+    public bool Skip { get; set; }
+
+    /// <summary>
+    /// Lookup resolution configuration.
+    /// </summary>
+    [JsonPropertyName("lookup")]
+    public LookupConfig? Lookup { get; set; }
+
+    /// <summary>
+    /// Custom date format string (e.g., 'MM/dd/yyyy').
+    /// </summary>
+    [JsonPropertyName("dateFormat")]
+    public string? DateFormat { get; set; }
+
+    /// <summary>
+    /// Map CSV text labels to optionset integer values.
+    /// </summary>
+    [JsonPropertyName("optionsetMap")]
+    public Dictionary<string, int>? OptionsetMap { get; set; }
+
+    // Generated metadata (ignored at runtime)
+
+    /// <summary>
+    /// Generated status indicator. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_status")]
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Generated note for user guidance. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_note")]
+    public string? Note { get; set; }
+
+    /// <summary>
+    /// Sample values from CSV for reference. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_csvSample")]
+    public List<string>? CsvSample { get; set; }
+
+    /// <summary>
+    /// Available optionset values for reference. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_optionsetValues")]
+    public Dictionary<string, int>? OptionsetValues { get; set; }
+
+    /// <summary>
+    /// Suggested similar attribute names. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_similarAttributes")]
+    public List<string>? SimilarAttributes { get; set; }
+
+    /// <summary>
+    /// Extension data for forward compatibility.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+}
+
+/// <summary>
+/// Configuration for resolving lookup field values.
+/// </summary>
+public sealed class LookupConfig
+{
+    /// <summary>
+    /// Target entity logical name for the lookup.
+    /// </summary>
+    [JsonPropertyName("entity")]
+    public required string Entity { get; set; }
+
+    /// <summary>
+    /// Resolution strategy: 'guid' expects GUID values, 'field' queries by keyField.
+    /// </summary>
+    [JsonPropertyName("matchBy")]
+    public string MatchBy { get; set; } = "guid";
+
+    /// <summary>
+    /// Attribute to match against when matchBy is 'field'.
+    /// </summary>
+    [JsonPropertyName("keyField")]
+    public string? KeyField { get; set; }
+
+    /// <summary>
+    /// Available matching options for reference. Ignored at runtime.
+    /// </summary>
+    [JsonPropertyName("_options")]
+    public List<string>? Options { get; set; }
+
+    /// <summary>
+    /// Extension data for forward compatibility.
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+}

--- a/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
@@ -1,0 +1,341 @@
+using System.Globalization;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Parses CSV values and coerces them to Dataverse attribute types.
+/// </summary>
+public sealed class CsvRecordParser
+{
+    private static readonly HashSet<string> TrueValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "true", "yes", "1", "y"
+    };
+
+    private static readonly HashSet<string> FalseValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "false", "no", "0", "n"
+    };
+
+    /// <summary>
+    /// Coerces a CSV string value to the appropriate Dataverse type based on attribute metadata.
+    /// </summary>
+    /// <param name="csvValue">The raw string value from the CSV.</param>
+    /// <param name="attributeMetadata">The target attribute metadata.</param>
+    /// <param name="mapping">Optional column mapping with additional configuration.</param>
+    /// <returns>The coerced value, or null if the value is empty or cannot be converted.</returns>
+    public object? CoerceValue(
+        string? csvValue,
+        AttributeMetadata attributeMetadata,
+        ColumnMappingEntry? mapping = null)
+    {
+        if (string.IsNullOrEmpty(csvValue))
+        {
+            return null;
+        }
+
+        return attributeMetadata.AttributeType switch
+        {
+            AttributeTypeCode.String or AttributeTypeCode.Memo => csvValue,
+
+            AttributeTypeCode.Integer => CoerceInteger(csvValue),
+
+            AttributeTypeCode.BigInt => CoerceBigInt(csvValue),
+
+            AttributeTypeCode.Decimal => CoerceDecimal(csvValue),
+
+            AttributeTypeCode.Double => CoerceDouble(csvValue),
+
+            AttributeTypeCode.Money => CoerceMoney(csvValue),
+
+            AttributeTypeCode.Boolean => CoerceBoolean(csvValue),
+
+            AttributeTypeCode.DateTime => CoerceDateTime(csvValue, mapping?.DateFormat),
+
+            AttributeTypeCode.Uniqueidentifier => CoerceGuid(csvValue),
+
+            AttributeTypeCode.Picklist or
+            AttributeTypeCode.State or
+            AttributeTypeCode.Status => CoerceOptionSet(csvValue, mapping?.OptionsetMap),
+
+            // Lookups are handled separately by LookupResolver
+            AttributeTypeCode.Lookup or
+            AttributeTypeCode.Customer or
+            AttributeTypeCode.Owner => null,
+
+            _ => csvValue // Unknown types passed as string
+        };
+    }
+
+    /// <summary>
+    /// Attempts to coerce a value, returning success status and any error.
+    /// </summary>
+    public (bool Success, object? Value, string? ErrorMessage) TryCoerceValue(
+        string? csvValue,
+        AttributeMetadata attributeMetadata,
+        ColumnMappingEntry? mapping = null)
+    {
+        if (string.IsNullOrEmpty(csvValue))
+        {
+            return (true, null, null);
+        }
+
+        try
+        {
+            var result = attributeMetadata.AttributeType switch
+            {
+                AttributeTypeCode.String or AttributeTypeCode.Memo => (true, (object?)csvValue, (string?)null),
+
+                AttributeTypeCode.Integer => TryCoerceInteger(csvValue),
+
+                AttributeTypeCode.BigInt => TryCoerceBigInt(csvValue),
+
+                AttributeTypeCode.Decimal => TryCoerceDecimal(csvValue),
+
+                AttributeTypeCode.Double => TryCoerceDouble(csvValue),
+
+                AttributeTypeCode.Money => TryCoerceMoney(csvValue),
+
+                AttributeTypeCode.Boolean => TryCoerceBoolean(csvValue),
+
+                AttributeTypeCode.DateTime => TryCoerceDateTime(csvValue, mapping?.DateFormat),
+
+                AttributeTypeCode.Uniqueidentifier => TryCoerceGuid(csvValue),
+
+                AttributeTypeCode.Picklist or
+                AttributeTypeCode.State or
+                AttributeTypeCode.Status => TryCoerceOptionSet(csvValue, mapping?.OptionsetMap),
+
+                AttributeTypeCode.Lookup or
+                AttributeTypeCode.Customer or
+                AttributeTypeCode.Owner => (true, null, null), // Handled by LookupResolver
+
+                _ => (true, csvValue, null)
+            };
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            return (false, null, ex.Message);
+        }
+    }
+
+    private static int? CoerceInteger(string value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            ? result
+            : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceInteger(string value)
+    {
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+        {
+            return (true, result, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to integer");
+    }
+
+    private static long? CoerceBigInt(string value)
+    {
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            ? result
+            : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceBigInt(string value)
+    {
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+        {
+            return (true, result, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to big integer");
+    }
+
+    private static decimal? CoerceDecimal(string value)
+    {
+        return decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+            ? result
+            : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceDecimal(string value)
+    {
+        if (decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+        {
+            return (true, result, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to decimal");
+    }
+
+    private static double? CoerceDouble(string value)
+    {
+        return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result)
+            ? result
+            : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceDouble(string value)
+    {
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+        {
+            return (true, result, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to double");
+    }
+
+    private static Money? CoerceMoney(string value)
+    {
+        // Remove currency symbols and parse
+        var cleanValue = value.Trim('$', '€', '£', '¥', ' ');
+        return decimal.TryParse(cleanValue, NumberStyles.Currency, CultureInfo.InvariantCulture, out var result)
+            ? new Money(result)
+            : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceMoney(string value)
+    {
+        var cleanValue = value.Trim('$', '€', '£', '¥', ' ');
+        if (decimal.TryParse(cleanValue, NumberStyles.Currency, CultureInfo.InvariantCulture, out var result))
+        {
+            return (true, new Money(result), null);
+        }
+        return (false, null, $"Cannot convert '{value}' to money");
+    }
+
+    private static bool? CoerceBoolean(string value)
+    {
+        if (TrueValues.Contains(value))
+        {
+            return true;
+        }
+        if (FalseValues.Contains(value))
+        {
+            return false;
+        }
+        return null;
+    }
+
+    private static (bool, object?, string?) TryCoerceBoolean(string value)
+    {
+        if (TrueValues.Contains(value))
+        {
+            return (true, true, null);
+        }
+        if (FalseValues.Contains(value))
+        {
+            return (true, false, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to boolean. Use true/false, yes/no, 1/0, or y/n.");
+    }
+
+    private static DateTime? CoerceDateTime(string value, string? format)
+    {
+        if (!string.IsNullOrEmpty(format))
+        {
+            return DateTime.TryParseExact(
+                value,
+                format,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var dtExact) ? dtExact : null;
+        }
+
+        // Flexible parsing with common formats
+        return DateTime.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dt) ? dt : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceDateTime(string value, string? format)
+    {
+        if (!string.IsNullOrEmpty(format))
+        {
+            if (DateTime.TryParseExact(
+                value,
+                format,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var dtExact))
+            {
+                return (true, dtExact, null);
+            }
+            return (false, null, $"Cannot convert '{value}' to datetime using format '{format}'");
+        }
+
+        if (DateTime.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dt))
+        {
+            return (true, dt, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to datetime");
+    }
+
+    private static Guid? CoerceGuid(string value)
+    {
+        return Guid.TryParse(value, out var result) ? result : null;
+    }
+
+    private static (bool, object?, string?) TryCoerceGuid(string value)
+    {
+        if (Guid.TryParse(value, out var result))
+        {
+            return (true, result, null);
+        }
+        return (false, null, $"Cannot convert '{value}' to GUID");
+    }
+
+    private static OptionSetValue? CoerceOptionSet(string value, Dictionary<string, int>? labelMap)
+    {
+        // First try label map from mapping file
+        if (labelMap != null && labelMap.TryGetValue(value, out var mapped))
+        {
+            return new OptionSetValue(mapped);
+        }
+
+        // Then try numeric value
+        if (int.TryParse(value, out var numericValue))
+        {
+            return new OptionSetValue(numericValue);
+        }
+
+        return null;
+    }
+
+    private static (bool, object?, string?) TryCoerceOptionSet(string value, Dictionary<string, int>? labelMap)
+    {
+        // First try label map from mapping file
+        if (labelMap != null && labelMap.TryGetValue(value, out var mapped))
+        {
+            return (true, new OptionSetValue(mapped), null);
+        }
+
+        // Then try numeric value
+        if (int.TryParse(value, out var numericValue))
+        {
+            return (true, new OptionSetValue(numericValue), null);
+        }
+
+        var hint = labelMap != null && labelMap.Count > 0
+            ? $" Valid labels: {string.Join(", ", labelMap.Keys.Take(5))}"
+            : " Use numeric value or add optionsetMap in mapping file.";
+
+        return (false, null, $"Cannot convert '{value}' to optionset.{hint}");
+    }
+
+    /// <summary>
+    /// Checks if a value appears to be a GUID.
+    /// </summary>
+    public static bool IsGuid(string? value)
+    {
+        return !string.IsNullOrEmpty(value) && Guid.TryParse(value, out _);
+    }
+}

--- a/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
@@ -117,7 +117,15 @@ public sealed class CsvRecordParser
 
             return result;
         }
-        catch (Exception ex)
+        catch (FormatException ex)
+        {
+            return (false, null, ex.Message);
+        }
+        catch (OverflowException ex)
+        {
+            return (false, null, ex.Message);
+        }
+        catch (ArgumentException ex)
         {
             return (false, null, ex.Message);
         }

--- a/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvRecordParser.cs
@@ -86,7 +86,7 @@ public sealed class CsvRecordParser
         {
             var result = attributeMetadata.AttributeType switch
             {
-                AttributeTypeCode.String or AttributeTypeCode.Memo => (true, (object?)csvValue, (string?)null),
+                AttributeTypeCode.String or AttributeTypeCode.Memo => (true, csvValue, null),
 
                 AttributeTypeCode.Integer => TryCoerceInteger(csvValue),
 

--- a/src/PPDS.Cli/CsvLoader/LoadResult.cs
+++ b/src/PPDS.Cli/CsvLoader/LoadResult.cs
@@ -1,0 +1,134 @@
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Result of a CSV load operation.
+/// </summary>
+public sealed record LoadResult
+{
+    /// <summary>
+    /// Whether the load completed without errors.
+    /// </summary>
+    public bool Success => FailureCount == 0;
+
+    /// <summary>
+    /// Total number of rows in the CSV file.
+    /// </summary>
+    public int TotalRows { get; init; }
+
+    /// <summary>
+    /// Number of records successfully loaded.
+    /// </summary>
+    public int SuccessCount { get; init; }
+
+    /// <summary>
+    /// Number of records that failed to load.
+    /// </summary>
+    public int FailureCount { get; init; }
+
+    /// <summary>
+    /// Number of records created (for upsert operations).
+    /// </summary>
+    public int? CreatedCount { get; init; }
+
+    /// <summary>
+    /// Number of records updated (for upsert operations).
+    /// </summary>
+    public int? UpdatedCount { get; init; }
+
+    /// <summary>
+    /// Number of rows skipped due to validation errors.
+    /// </summary>
+    public int SkippedCount { get; init; }
+
+    /// <summary>
+    /// Duration of the load operation.
+    /// </summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// List of errors encountered during loading.
+    /// </summary>
+    public IReadOnlyList<LoadError> Errors { get; init; } = [];
+
+    /// <summary>
+    /// List of warnings generated during loading.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}
+
+/// <summary>
+/// Error encountered during CSV loading.
+/// </summary>
+public sealed record LoadError
+{
+    /// <summary>
+    /// Row number in the CSV file (1-based, excluding header).
+    /// </summary>
+    public int RowNumber { get; init; }
+
+    /// <summary>
+    /// Column name where the error occurred.
+    /// </summary>
+    public string? Column { get; init; }
+
+    /// <summary>
+    /// Error code for categorization.
+    /// </summary>
+    public string ErrorCode { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable error message.
+    /// </summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The problematic value from the CSV, if applicable.
+    /// </summary>
+    public string? Value { get; init; }
+}
+
+/// <summary>
+/// Error codes for CSV loading operations.
+/// </summary>
+public static class LoadErrorCodes
+{
+    /// <summary>
+    /// CSV file could not be parsed.
+    /// </summary>
+    public const string CsvParseError = "CSV_PARSE_ERROR";
+
+    /// <summary>
+    /// CSV column does not match any entity attribute.
+    /// </summary>
+    public const string ColumnNotFound = "COLUMN_NOT_FOUND";
+
+    /// <summary>
+    /// Value could not be converted to the target attribute type.
+    /// </summary>
+    public const string TypeCoercionFailed = "TYPE_COERCION_FAILED";
+
+    /// <summary>
+    /// Lookup value could not be resolved to a record.
+    /// </summary>
+    public const string LookupNotResolved = "LOOKUP_NOT_RESOLVED";
+
+    /// <summary>
+    /// Lookup value matched multiple records.
+    /// </summary>
+    public const string LookupDuplicate = "LOOKUP_DUPLICATE";
+
+    /// <summary>
+    /// Duplicate alternate key value in CSV.
+    /// </summary>
+    public const string DuplicateKey = "DUPLICATE_KEY";
+
+    /// <summary>
+    /// Dataverse rejected the record.
+    /// </summary>
+    public const string DataverseError = "DATAVERSE_ERROR";
+
+    /// <summary>
+    /// Required field is missing.
+    /// </summary>
+    public const string RequiredFieldMissing = "REQUIRED_FIELD_MISSING";
+}

--- a/src/PPDS.Cli/CsvLoader/LookupResolver.cs
+++ b/src/PPDS.Cli/CsvLoader/LookupResolver.cs
@@ -1,0 +1,267 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using PPDS.Dataverse.Pooling;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Resolves lookup field values by querying target entities.
+/// </summary>
+public sealed class LookupResolver
+{
+    private readonly IDataverseConnectionPool _pool;
+    private readonly Dictionary<string, LookupCache> _caches = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<LoadError> _errors = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LookupResolver"/> class.
+    /// </summary>
+    public LookupResolver(IDataverseConnectionPool pool)
+    {
+        _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+    }
+
+    /// <summary>
+    /// Gets errors encountered during lookup resolution.
+    /// </summary>
+    public IReadOnlyList<LoadError> Errors => _errors;
+
+    /// <summary>
+    /// Preloads lookup caches for the specified lookup configurations.
+    /// </summary>
+    /// <param name="lookups">Lookup configurations to preload.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task PreloadLookupsAsync(
+        IEnumerable<(string ColumnName, LookupConfig Config)> lookups,
+        CancellationToken cancellationToken = default)
+    {
+        // Group by entity:keyField to avoid duplicate queries
+        var groupedByEntity = lookups
+            .Where(l => l.Config.MatchBy == "field" && !string.IsNullOrEmpty(l.Config.KeyField))
+            .GroupBy(l => $"{l.Config.Entity}:{l.Config.KeyField}".ToLowerInvariant());
+
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        foreach (var group in groupedByEntity)
+        {
+            var cacheKey = group.Key;
+            var first = group.First();
+            var entityName = first.Config.Entity;
+            var keyField = first.Config.KeyField!;
+
+            if (_caches.ContainsKey(cacheKey))
+            {
+                continue;
+            }
+
+            var cache = await LoadLookupCacheAsync(client, entityName, keyField, cancellationToken);
+            _caches[cacheKey] = cache;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a lookup value to an EntityReference.
+    /// </summary>
+    /// <param name="value">The value to resolve.</param>
+    /// <param name="config">The lookup configuration.</param>
+    /// <param name="rowNumber">Row number for error reporting.</param>
+    /// <param name="columnName">Column name for error reporting.</param>
+    /// <returns>The resolved EntityReference, or null if not resolved.</returns>
+    public EntityReference? Resolve(
+        string? value,
+        LookupConfig config,
+        int rowNumber,
+        string columnName)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return null;
+        }
+
+        // GUID matching - always works
+        if (config.MatchBy == "guid" || CsvRecordParser.IsGuid(value))
+        {
+            if (Guid.TryParse(value, out var guid))
+            {
+                return new EntityReference(config.Entity, guid);
+            }
+
+            // Non-GUID value with matchBy=guid is an error
+            if (config.MatchBy == "guid")
+            {
+                _errors.Add(new LoadError
+                {
+                    RowNumber = rowNumber,
+                    Column = columnName,
+                    ErrorCode = LoadErrorCodes.LookupNotResolved,
+                    Message = $"Expected GUID for lookup to '{config.Entity}', got '{value}'. " +
+                              "Use --generate-mapping to configure field-based matching.",
+                    Value = value
+                });
+                return null;
+            }
+        }
+
+        // Field-based matching
+        if (config.MatchBy == "field" && !string.IsNullOrEmpty(config.KeyField))
+        {
+            var cacheKey = $"{config.Entity}:{config.KeyField}";
+
+            if (_caches.TryGetValue(cacheKey, out var cache))
+            {
+                return ResolveFromCache(value, cache, config.Entity, rowNumber, columnName);
+            }
+
+            _errors.Add(new LoadError
+            {
+                RowNumber = rowNumber,
+                Column = columnName,
+                ErrorCode = LoadErrorCodes.LookupNotResolved,
+                Message = $"Lookup cache not loaded for {config.Entity}.{config.KeyField}",
+                Value = value
+            });
+            return null;
+        }
+
+        _errors.Add(new LoadError
+        {
+            RowNumber = rowNumber,
+            Column = columnName,
+            ErrorCode = LoadErrorCodes.LookupNotResolved,
+            Message = $"Cannot resolve lookup value '{value}' without configuration. " +
+                      "Use --generate-mapping to configure lookup resolution.",
+            Value = value
+        });
+        return null;
+    }
+
+    private EntityReference? ResolveFromCache(
+        string value,
+        LookupCache cache,
+        string entityName,
+        int rowNumber,
+        string columnName)
+    {
+        if (cache.SingleMatches.TryGetValue(value, out var id))
+        {
+            return new EntityReference(entityName, id);
+        }
+
+        if (cache.Duplicates.TryGetValue(value, out var duplicateIds))
+        {
+            _errors.Add(new LoadError
+            {
+                RowNumber = rowNumber,
+                Column = columnName,
+                ErrorCode = LoadErrorCodes.LookupDuplicate,
+                Message = $"Multiple records found for '{value}' in {entityName}: {string.Join(", ", duplicateIds.Take(3))}",
+                Value = value
+            });
+            return null;
+        }
+
+        _errors.Add(new LoadError
+        {
+            RowNumber = rowNumber,
+            Column = columnName,
+            ErrorCode = LoadErrorCodes.LookupNotResolved,
+            Message = $"No {entityName} record found with value '{value}'",
+            Value = value
+        });
+        return null;
+    }
+
+    private async Task<LookupCache> LoadLookupCacheAsync(
+        IPooledClient client,
+        string entityName,
+        string keyField,
+        CancellationToken cancellationToken)
+    {
+        var cache = new LookupCache();
+
+        var query = new QueryExpression(entityName)
+        {
+            ColumnSet = new ColumnSet(keyField),
+            PageInfo = new PagingInfo
+            {
+                Count = 5000,
+                PageNumber = 1
+            }
+        };
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var response = await client.RetrieveMultipleAsync(query, cancellationToken);
+
+            foreach (var entity in response.Entities)
+            {
+                var keyValue = GetKeyValue(entity, keyField);
+                if (string.IsNullOrEmpty(keyValue))
+                {
+                    continue;
+                }
+
+                if (cache.SingleMatches.TryGetValue(keyValue, out var existingId))
+                {
+                    // Duplicate found - move to duplicates
+                    cache.SingleMatches.Remove(keyValue);
+                    cache.Duplicates[keyValue] = new List<Guid> { existingId, entity.Id };
+                }
+                else if (cache.Duplicates.TryGetValue(keyValue, out var duplicates))
+                {
+                    // Add to existing duplicates
+                    duplicates.Add(entity.Id);
+                }
+                else
+                {
+                    // First occurrence
+                    cache.SingleMatches[keyValue] = entity.Id;
+                }
+            }
+
+            if (!response.MoreRecords)
+            {
+                break;
+            }
+
+            query.PageInfo.PageNumber++;
+            query.PageInfo.PagingCookie = response.PagingCookie;
+        }
+
+        return cache;
+    }
+
+    private static string? GetKeyValue(Entity entity, string keyField)
+    {
+        if (!entity.Contains(keyField))
+        {
+            return null;
+        }
+
+        var value = entity[keyField];
+        return value switch
+        {
+            string s => s,
+            EntityReference er => er.Id.ToString(),
+            Guid g => g.ToString(),
+            _ => value?.ToString()
+        };
+    }
+
+    /// <summary>
+    /// Clears all loaded caches.
+    /// </summary>
+    public void ClearCaches()
+    {
+        _caches.Clear();
+        _errors.Clear();
+    }
+
+    private sealed class LookupCache
+    {
+        public Dictionary<string, Guid> SingleMatches { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, List<Guid>> Duplicates { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/PPDS.Cli/CsvLoader/LookupResolver.cs
+++ b/src/PPDS.Cli/CsvLoader/LookupResolver.cs
@@ -241,12 +241,17 @@ public sealed class LookupResolver
         }
 
         var value = entity[keyField];
+        if (value is null)
+        {
+            return null;
+        }
+
         return value switch
         {
             string s => s,
             EntityReference er => er.Id.ToString(),
             Guid g => g.ToString(),
-            _ => value?.ToString()
+            _ => value.ToString()
         };
     }
 

--- a/src/PPDS.Cli/CsvLoader/MappingGenerator.cs
+++ b/src/PPDS.Cli/CsvLoader/MappingGenerator.cs
@@ -1,0 +1,342 @@
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace PPDS.Cli.CsvLoader;
+
+/// <summary>
+/// Generates CSV mapping configuration from CSV headers and entity metadata.
+/// </summary>
+public sealed class MappingGenerator
+{
+    private const int MaxSampleValues = 3;
+
+    /// <summary>
+    /// Generates a mapping configuration from CSV headers and entity metadata.
+    /// </summary>
+    /// <param name="csvPath">Path to the CSV file.</param>
+    /// <param name="entityMetadata">Entity metadata from Dataverse.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Generated mapping configuration.</returns>
+    public async Task<CsvMappingConfig> GenerateAsync(
+        string csvPath,
+        EntityMetadata entityMetadata,
+        CancellationToken cancellationToken = default)
+    {
+        var (headers, sampleValues) = await ReadCsvHeadersAndSamplesAsync(csvPath, cancellationToken);
+
+        var attributesByName = BuildAttributeLookup(entityMetadata);
+
+        var config = new CsvMappingConfig
+        {
+            Schema = CsvMappingConfig.SchemaUrl,
+            Version = "1.0",
+            Entity = entityMetadata.LogicalName,
+            GeneratedAt = DateTimeOffset.UtcNow,
+            Columns = new Dictionary<string, ColumnMappingEntry>()
+        };
+
+        foreach (var header in headers)
+        {
+            var entry = CreateMappingEntry(
+                header,
+                attributesByName,
+                entityMetadata,
+                sampleValues.GetValueOrDefault(header));
+
+            config.Columns[header] = entry;
+        }
+
+        return config;
+    }
+
+    /// <summary>
+    /// Auto-maps CSV headers to entity attributes without generating metadata.
+    /// </summary>
+    public Dictionary<string, AttributeMetadata> AutoMapHeaders(
+        IEnumerable<string> headers,
+        EntityMetadata entityMetadata)
+    {
+        var attributesByName = BuildAttributeLookup(entityMetadata);
+        var result = new Dictionary<string, AttributeMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var header in headers)
+        {
+            var normalizedHeader = NormalizeForMatching(header);
+
+            if (attributesByName.TryGetValue(normalizedHeader, out var attr))
+            {
+                result[header] = attr;
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<(string[] Headers, Dictionary<string, List<string>> SampleValues)> ReadCsvHeadersAndSamplesAsync(
+        string csvPath,
+        CancellationToken cancellationToken)
+    {
+        var csvConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            HasHeaderRecord = true,
+            MissingFieldFound = null,
+            HeaderValidated = null
+        };
+
+        using var reader = new StreamReader(csvPath);
+        using var csv = new CsvReader(reader, csvConfig);
+
+        await csv.ReadAsync();
+        csv.ReadHeader();
+        var headers = csv.HeaderRecord ?? [];
+
+        // Collect sample values for each column
+        var sampleValues = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in headers)
+        {
+            sampleValues[header] = new List<string>();
+        }
+
+        var rowCount = 0;
+        while (await csv.ReadAsync() && rowCount < MaxSampleValues)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var header in headers)
+            {
+                var value = csv.GetField(header);
+                if (!string.IsNullOrEmpty(value) && sampleValues[header].Count < MaxSampleValues)
+                {
+                    // Avoid duplicate samples
+                    if (!sampleValues[header].Contains(value))
+                    {
+                        sampleValues[header].Add(value);
+                    }
+                }
+            }
+            rowCount++;
+        }
+
+        return (headers, sampleValues);
+    }
+
+    private static Dictionary<string, AttributeMetadata> BuildAttributeLookup(EntityMetadata entityMetadata)
+    {
+        var lookup = new Dictionary<string, AttributeMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        if (entityMetadata.Attributes == null)
+        {
+            return lookup;
+        }
+
+        foreach (var attr in entityMetadata.Attributes)
+        {
+            if (attr.LogicalName == null || !attr.IsValidForUpdate.GetValueOrDefault())
+            {
+                continue;
+            }
+
+            // Index by logical name
+            lookup[attr.LogicalName] = attr;
+
+            // Also index by display name if different
+            var displayName = attr.DisplayName?.UserLocalizedLabel?.Label;
+            if (!string.IsNullOrEmpty(displayName))
+            {
+                var normalizedDisplay = NormalizeForMatching(displayName);
+                if (!lookup.ContainsKey(normalizedDisplay))
+                {
+                    lookup[normalizedDisplay] = attr;
+                }
+            }
+        }
+
+        return lookup;
+    }
+
+    private static string NormalizeForMatching(string value)
+    {
+        // Remove spaces, underscores, and convert to lowercase for matching
+        return value
+            .Replace(" ", "")
+            .Replace("_", "")
+            .Replace("-", "")
+            .ToLowerInvariant();
+    }
+
+    private ColumnMappingEntry CreateMappingEntry(
+        string header,
+        Dictionary<string, AttributeMetadata> attributesByName,
+        EntityMetadata entityMetadata,
+        List<string>? sampleValues)
+    {
+        var normalizedHeader = NormalizeForMatching(header);
+        var samples = sampleValues?.Take(MaxSampleValues).ToList();
+
+        // Try to find matching attribute
+        if (attributesByName.TryGetValue(normalizedHeader, out var matchedAttr))
+        {
+            return CreateMatchedEntry(matchedAttr, samples, entityMetadata);
+        }
+
+        // Also try direct logical name match
+        if (attributesByName.TryGetValue(header, out matchedAttr))
+        {
+            return CreateMatchedEntry(matchedAttr, samples, entityMetadata);
+        }
+
+        // No match found
+        return CreateUnmatchedEntry(header, entityMetadata, samples);
+    }
+
+    private ColumnMappingEntry CreateMatchedEntry(
+        AttributeMetadata attr,
+        List<string>? samples,
+        EntityMetadata entityMetadata)
+    {
+        var entry = new ColumnMappingEntry
+        {
+            Field = attr.LogicalName,
+            Status = "auto-matched",
+            Note = "Remove this entry if auto-match is correct",
+            CsvSample = samples?.Count > 0 ? samples : null
+        };
+
+        // Add lookup configuration if this is a lookup field
+        if (IsLookupAttribute(attr))
+        {
+            var lookupAttr = (LookupAttributeMetadata)attr;
+            var targetEntity = lookupAttr.Targets?.FirstOrDefault() ?? "unknown";
+
+            // Check if samples contain non-GUID values
+            var hasNonGuidValues = samples?.Any(s => !CsvRecordParser.IsGuid(s)) ?? false;
+
+            entry.Status = hasNonGuidValues ? "needs-configuration" : "auto-matched";
+            entry.Note = hasNonGuidValues
+                ? "Lookup field - configure resolution below"
+                : "Lookup field with GUID values - no configuration needed";
+
+            entry.Lookup = new LookupConfig
+            {
+                Entity = targetEntity,
+                MatchBy = "guid",
+                KeyField = null,
+                Options = new List<string>
+                {
+                    "matchBy: 'guid' - CSV values must be GUIDs",
+                    $"matchBy: 'field', keyField: 'name' - match by {targetEntity} name",
+                    $"matchBy: 'field', keyField: '<field>' - match by specific field"
+                }
+            };
+        }
+
+        // Add optionset values if this is an optionset field
+        if (IsOptionSetAttribute(attr))
+        {
+            var optionSetValues = GetOptionSetValues(attr);
+            if (optionSetValues.Count > 0)
+            {
+                entry.OptionsetValues = optionSetValues;
+                entry.Note = "OptionSet field - add optionsetMap if CSV has labels instead of values";
+            }
+        }
+
+        return entry;
+    }
+
+    private ColumnMappingEntry CreateUnmatchedEntry(
+        string header,
+        EntityMetadata entityMetadata,
+        List<string>? samples)
+    {
+        var similarAttributes = FindSimilarAttributes(header, entityMetadata);
+
+        return new ColumnMappingEntry
+        {
+            Skip = true,
+            Status = "no-match",
+            Note = "No matching attribute found. Set 'field' to map, or keep 'skip' to ignore.",
+            SimilarAttributes = similarAttributes.Count > 0 ? similarAttributes : null,
+            CsvSample = samples?.Count > 0 ? samples : null
+        };
+    }
+
+    private static bool IsLookupAttribute(AttributeMetadata attr)
+    {
+        return attr.AttributeType == AttributeTypeCode.Lookup ||
+               attr.AttributeType == AttributeTypeCode.Customer ||
+               attr.AttributeType == AttributeTypeCode.Owner;
+    }
+
+    private static bool IsOptionSetAttribute(AttributeMetadata attr)
+    {
+        return attr.AttributeType == AttributeTypeCode.Picklist ||
+               attr.AttributeType == AttributeTypeCode.State ||
+               attr.AttributeType == AttributeTypeCode.Status;
+    }
+
+    private static Dictionary<string, int> GetOptionSetValues(AttributeMetadata attr)
+    {
+        var result = new Dictionary<string, int>();
+
+        OptionMetadataCollection? options = attr switch
+        {
+            PicklistAttributeMetadata picklist => picklist.OptionSet?.Options,
+            StateAttributeMetadata state => state.OptionSet?.Options,
+            StatusAttributeMetadata status => status.OptionSet?.Options,
+            _ => null
+        };
+
+        if (options == null)
+        {
+            return result;
+        }
+
+        foreach (var option in options)
+        {
+            var label = option.Label?.UserLocalizedLabel?.Label;
+            if (!string.IsNullOrEmpty(label) && option.Value.HasValue)
+            {
+                result[label] = option.Value.Value;
+            }
+        }
+
+        return result;
+    }
+
+    private static List<string> FindSimilarAttributes(string header, EntityMetadata entityMetadata)
+    {
+        if (entityMetadata.Attributes == null)
+        {
+            return new List<string>();
+        }
+
+        var normalizedHeader = NormalizeForMatching(header);
+        var results = new List<(string Name, int Score)>();
+
+        foreach (var attr in entityMetadata.Attributes)
+        {
+            if (attr.LogicalName == null || !attr.IsValidForUpdate.GetValueOrDefault())
+            {
+                continue;
+            }
+
+            var normalizedAttr = NormalizeForMatching(attr.LogicalName);
+
+            // Simple similarity: check if one contains the other
+            if (normalizedAttr.Contains(normalizedHeader) || normalizedHeader.Contains(normalizedAttr))
+            {
+                var score = Math.Abs(normalizedAttr.Length - normalizedHeader.Length);
+                results.Add((attr.LogicalName, score));
+            }
+        }
+
+        return results
+            .OrderBy(r => r.Score)
+            .Take(3)
+            .Select(r => r.Name)
+            .ToList();
+    }
+}

--- a/src/PPDS.Cli/CsvLoader/MappingGenerator.cs
+++ b/src/PPDS.Cli/CsvLoader/MappingGenerator.cs
@@ -107,13 +107,11 @@ public sealed class MappingGenerator
             foreach (var header in headers)
             {
                 var value = csv.GetField(header);
-                if (!string.IsNullOrEmpty(value) && sampleValues[header].Count < MaxSampleValues)
+                if (!string.IsNullOrEmpty(value)
+                    && sampleValues[header].Count < MaxSampleValues
+                    && !sampleValues[header].Contains(value))
                 {
-                    // Avoid duplicate samples
-                    if (!sampleValues[header].Contains(value))
-                    {
-                        sampleValues[header].Add(value);
-                    }
+                    sampleValues[header].Add(value);
                 }
             }
             rowCount++;

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -50,6 +50,7 @@
     <ProjectReference Include="..\PPDS.Migration\PPDS.Migration.csproj" />
     <ProjectReference Include="..\PPDS.Dataverse\PPDS.Dataverse.csproj" />
     <ProjectReference Include="..\PPDS.Plugins\PPDS.Plugins.csproj" />
+    <PackageReference Include="CsvHelper" Version="33.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
     <PackageReference Include="MinVer" Version="6.1.0" PrivateAssets="all" />

--- a/tests/PPDS.Cli.Tests/Commands/LoadCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/LoadCommandTests.cs
@@ -1,0 +1,248 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Data;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+public class LoadCommandTests
+{
+    private readonly Command _command;
+
+    public LoadCommandTests()
+    {
+        _command = LoadCommand.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("load", _command.Name);
+    }
+
+    [Fact]
+    public void Create_HasRequiredEntityOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--entity");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+        Assert.Contains("-e", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasRequiredFileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--file");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+        Assert.Contains("-f", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasKeyOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--key");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-k", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasMappingOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--mapping");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-m", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasGenerateMappingOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--generate-mapping");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasDryRunOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--dry-run");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBatchSizeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--batch-size");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassPluginsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-plugins");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassFlowsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-flows");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasContinueOnErrorOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--continue-on-error");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasProfileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasEnvironmentOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasOutputFormatOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--output-format");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasVerboseOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--verbose");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasDebugOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--debug");
+        Assert.NotNull(option);
+    }
+
+    #endregion
+
+    #region Parse Tests
+
+    [Fact]
+    public void Parse_MissingEntity_HasError()
+    {
+        var result = _command.Parse("--file test.csv");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_MissingFile_HasError()
+    {
+        var result = _command.Parse("--entity account");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_InvalidBatchSize_Zero_HasError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --batch-size 0");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_InvalidBatchSize_TooLarge_HasError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --batch-size 5000");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_ValidBatchSize_NoError()
+    {
+        // Note: file validation happens at runtime, not parse time
+        var result = _command.Parse("--entity account --file test.csv --batch-size 100");
+        var batchSizeErrors = result.Errors.Where(e => e.Message.Contains("batch-size"));
+        Assert.Empty(batchSizeErrors);
+    }
+
+    [Fact]
+    public void Parse_InvalidBypassPlugins_HasError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --bypass-plugins invalid");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Sync_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --bypass-plugins sync");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Async_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --bypass-plugins async");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_All_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --bypass-plugins all");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_EntityWithSpaces_HasError()
+    {
+        var result = _command.Parse("--entity \"account name\" --file test.csv");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithDryRun_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --dry-run");
+        var dryRunErrors = result.Errors.Where(e => e.Message.Contains("dry-run"));
+        Assert.Empty(dryRunErrors);
+    }
+
+    [Fact]
+    public void Parse_WithAlternateKey_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --key accountnumber");
+        var keyErrors = result.Errors.Where(e => e.Message.Contains("key"));
+        Assert.Empty(keyErrors);
+    }
+
+    [Fact]
+    public void Parse_WithCompositeKey_NoError()
+    {
+        var result = _command.Parse("--entity account --file test.csv --key \"name,stateid\"");
+        var keyErrors = result.Errors.Where(e => e.Message.Contains("key"));
+        Assert.Empty(keyErrors);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/CsvLoader/CsvMappingConfigTests.cs
+++ b/tests/PPDS.Cli.Tests/CsvLoader/CsvMappingConfigTests.cs
@@ -1,0 +1,313 @@
+using System.Text.Json;
+using PPDS.Cli.CsvLoader;
+using Xunit;
+
+namespace PPDS.Cli.Tests.CsvLoader;
+
+public class CsvMappingConfigTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    #region Serialization Tests
+
+    [Fact]
+    public void Serialize_MinimalConfig_ProducesValidJson()
+    {
+        var config = new CsvMappingConfig
+        {
+            Version = "1.0",
+            Entity = "account"
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"version\": \"1.0\"", json);
+        Assert.Contains("\"entity\": \"account\"", json);
+    }
+
+    [Fact]
+    public void Serialize_WithSchema_IncludesSchemaUrl()
+    {
+        var config = new CsvMappingConfig
+        {
+            Schema = CsvMappingConfig.SchemaUrl,
+            Version = "1.0"
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"$schema\":", json);
+        Assert.Contains("csv-mapping.schema.json", json);
+    }
+
+    [Fact]
+    public void Serialize_WithColumns_IncludesColumnMappings()
+    {
+        var config = new CsvMappingConfig
+        {
+            Version = "1.0",
+            Entity = "account",
+            Columns = new Dictionary<string, ColumnMappingEntry>
+            {
+                ["Account Name"] = new ColumnMappingEntry { Field = "name" },
+                ["Phone"] = new ColumnMappingEntry { Field = "telephone1" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"Account Name\"", json);
+        Assert.Contains("\"field\": \"name\"", json);
+        Assert.Contains("\"Phone\"", json);
+        Assert.Contains("\"field\": \"telephone1\"", json);
+    }
+
+    [Fact]
+    public void Serialize_WithLookup_IncludesLookupConfig()
+    {
+        var config = new CsvMappingConfig
+        {
+            Version = "1.0",
+            Columns = new Dictionary<string, ColumnMappingEntry>
+            {
+                ["Parent Account"] = new ColumnMappingEntry
+                {
+                    Field = "parentaccountid",
+                    Lookup = new LookupConfig
+                    {
+                        Entity = "account",
+                        MatchBy = "field",
+                        KeyField = "name"
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"lookup\":", json);
+        Assert.Contains("\"entity\": \"account\"", json);
+        Assert.Contains("\"matchBy\": \"field\"", json);
+        Assert.Contains("\"keyField\": \"name\"", json);
+    }
+
+    [Fact]
+    public void Serialize_WithSkipColumn_IncludesSkipFlag()
+    {
+        var config = new CsvMappingConfig
+        {
+            Version = "1.0",
+            Columns = new Dictionary<string, ColumnMappingEntry>
+            {
+                ["Internal ID"] = new ColumnMappingEntry { Skip = true }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"skip\": true", json);
+    }
+
+    [Fact]
+    public void Serialize_WithOptionsetMap_IncludesLabelMap()
+    {
+        var config = new CsvMappingConfig
+        {
+            Version = "1.0",
+            Columns = new Dictionary<string, ColumnMappingEntry>
+            {
+                ["Status"] = new ColumnMappingEntry
+                {
+                    Field = "statuscode",
+                    OptionsetMap = new Dictionary<string, int>
+                    {
+                        ["Active"] = 1,
+                        ["Inactive"] = 0
+                    }
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config, JsonOptions);
+
+        Assert.Contains("\"optionsetMap\":", json);
+        Assert.Contains("\"Active\": 1", json);
+        Assert.Contains("\"Inactive\": 0", json);
+    }
+
+    #endregion
+
+    #region Deserialization Tests
+
+    [Fact]
+    public void Deserialize_MinimalConfig_ReadsVersion()
+    {
+        var json = """
+        {
+            "version": "1.0",
+            "entity": "contact"
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(config);
+        Assert.Equal("1.0", config.Version);
+        Assert.Equal("contact", config.Entity);
+    }
+
+    [Fact]
+    public void Deserialize_WithColumns_ReadsColumnMappings()
+    {
+        var json = """
+        {
+            "version": "1.0",
+            "columns": {
+                "First Name": { "field": "firstname" },
+                "Last Name": { "field": "lastname" }
+            }
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(config);
+        Assert.Equal(2, config.Columns.Count);
+        Assert.Equal("firstname", config.Columns["First Name"].Field);
+        Assert.Equal("lastname", config.Columns["Last Name"].Field);
+    }
+
+    [Fact]
+    public void Deserialize_WithLookup_ReadsLookupConfig()
+    {
+        var json = """
+        {
+            "version": "1.0",
+            "columns": {
+                "Account": {
+                    "field": "parentcustomerid",
+                    "lookup": {
+                        "entity": "account",
+                        "matchBy": "field",
+                        "keyField": "name"
+                    }
+                }
+            }
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(config);
+        var accountMapping = config.Columns["Account"];
+        Assert.NotNull(accountMapping.Lookup);
+        Assert.Equal("account", accountMapping.Lookup.Entity);
+        Assert.Equal("field", accountMapping.Lookup.MatchBy);
+        Assert.Equal("name", accountMapping.Lookup.KeyField);
+    }
+
+    [Fact]
+    public void Deserialize_WithMetadata_ReadsGeneratedFields()
+    {
+        var json = """
+        {
+            "version": "1.0",
+            "columns": {
+                "Name": {
+                    "field": "name",
+                    "_status": "auto-matched",
+                    "_note": "Remove if correct"
+                }
+            }
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(config);
+        var nameMapping = config.Columns["Name"];
+        Assert.Equal("auto-matched", nameMapping.Status);
+        Assert.Equal("Remove if correct", nameMapping.Note);
+    }
+
+    [Fact]
+    public void Deserialize_WithUnknownFields_PreservesInExtensionData()
+    {
+        var json = """
+        {
+            "version": "1.0",
+            "customField": "customValue"
+        }
+        """;
+
+        var config = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(config);
+        Assert.NotNull(config.ExtensionData);
+        Assert.True(config.ExtensionData.ContainsKey("customField"));
+    }
+
+    #endregion
+
+    #region Round-Trip Tests
+
+    [Fact]
+    public void RoundTrip_FullConfig_PreservesAllFields()
+    {
+        var original = new CsvMappingConfig
+        {
+            Schema = CsvMappingConfig.SchemaUrl,
+            Version = "1.0",
+            Entity = "account",
+            GeneratedAt = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero),
+            Columns = new Dictionary<string, ColumnMappingEntry>
+            {
+                ["Name"] = new ColumnMappingEntry
+                {
+                    Field = "name",
+                    Status = "auto-matched"
+                },
+                ["Parent"] = new ColumnMappingEntry
+                {
+                    Field = "parentaccountid",
+                    Lookup = new LookupConfig
+                    {
+                        Entity = "account",
+                        MatchBy = "field",
+                        KeyField = "name"
+                    }
+                },
+                ["Skip Me"] = new ColumnMappingEntry { Skip = true }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(original, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CsvMappingConfig>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(original.Schema, deserialized.Schema);
+        Assert.Equal(original.Version, deserialized.Version);
+        Assert.Equal(original.Entity, deserialized.Entity);
+        Assert.Equal(original.Columns.Count, deserialized.Columns.Count);
+        Assert.Equal("name", deserialized.Columns["Name"].Field);
+        Assert.Equal("account", deserialized.Columns["Parent"].Lookup?.Entity);
+        Assert.True(deserialized.Columns["Skip Me"].Skip);
+    }
+
+    #endregion
+
+    #region LookupConfig Tests
+
+    [Fact]
+    public void LookupConfig_DefaultMatchBy_IsGuid()
+    {
+        var lookup = new LookupConfig { Entity = "account" };
+        Assert.Equal("guid", lookup.MatchBy);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/CsvLoader/CsvRecordParserTests.cs
+++ b/tests/PPDS.Cli.Tests/CsvLoader/CsvRecordParserTests.cs
@@ -1,0 +1,346 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Metadata;
+using PPDS.Cli.CsvLoader;
+using Xunit;
+
+namespace PPDS.Cli.Tests.CsvLoader;
+
+public class CsvRecordParserTests
+{
+    private readonly CsvRecordParser _parser = new();
+
+    #region String Tests
+
+    [Fact]
+    public void CoerceValue_String_ReturnsString()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.String);
+        var result = _parser.CoerceValue("hello world", attr);
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
+    public void CoerceValue_Memo_ReturnsString()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Memo);
+        var result = _parser.CoerceValue("long text here", attr);
+        Assert.Equal("long text here", result);
+    }
+
+    [Fact]
+    public void CoerceValue_NullOrEmpty_ReturnsNull()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.String);
+        Assert.Null(_parser.CoerceValue(null, attr));
+        Assert.Null(_parser.CoerceValue("", attr));
+    }
+
+    #endregion
+
+    #region Integer Tests
+
+    [Fact]
+    public void CoerceValue_Integer_ParsesValidInt()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Integer);
+        var result = _parser.CoerceValue("42", attr);
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void CoerceValue_Integer_ReturnsNullForInvalid()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Integer);
+        Assert.Null(_parser.CoerceValue("not a number", attr));
+    }
+
+    [Fact]
+    public void CoerceValue_Integer_HandlesNegative()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Integer);
+        var result = _parser.CoerceValue("-123", attr);
+        Assert.Equal(-123, result);
+    }
+
+    #endregion
+
+    #region BigInt Tests
+
+    [Fact]
+    public void CoerceValue_BigInt_ParsesValidLong()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.BigInt);
+        var result = _parser.CoerceValue("9223372036854775807", attr);
+        Assert.Equal(9223372036854775807L, result);
+    }
+
+    #endregion
+
+    #region Decimal Tests
+
+    [Fact]
+    public void CoerceValue_Decimal_ParsesWithInvariantCulture()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Decimal);
+        var result = _parser.CoerceValue("123.45", attr);
+        Assert.Equal(123.45m, result);
+    }
+
+    [Fact]
+    public void CoerceValue_Decimal_HandlesNegative()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Decimal);
+        var result = _parser.CoerceValue("-999.99", attr);
+        Assert.Equal(-999.99m, result);
+    }
+
+    #endregion
+
+    #region Double Tests
+
+    [Fact]
+    public void CoerceValue_Double_ParsesValidDouble()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Double);
+        var result = _parser.CoerceValue("3.14159", attr);
+        Assert.Equal(3.14159, result);
+    }
+
+    #endregion
+
+    #region Money Tests
+
+    [Fact]
+    public void CoerceValue_Money_ParsesCurrency()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Money);
+        var result = _parser.CoerceValue("100.50", attr);
+        Assert.IsType<Money>(result);
+        Assert.Equal(100.50m, ((Money)result!).Value);
+    }
+
+    [Fact]
+    public void CoerceValue_Money_HandlesDollarSign()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Money);
+        var result = _parser.CoerceValue("$100.50", attr);
+        Assert.IsType<Money>(result);
+        Assert.Equal(100.50m, ((Money)result!).Value);
+    }
+
+    #endregion
+
+    #region Boolean Tests
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("yes", true)]
+    [InlineData("Yes", true)]
+    [InlineData("1", true)]
+    [InlineData("y", true)]
+    [InlineData("Y", true)]
+    public void CoerceValue_Boolean_ParsesTrueValues(string input, bool expected)
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Boolean);
+        var result = _parser.CoerceValue(input, attr);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData("FALSE", false)]
+    [InlineData("no", false)]
+    [InlineData("No", false)]
+    [InlineData("0", false)]
+    [InlineData("n", false)]
+    [InlineData("N", false)]
+    public void CoerceValue_Boolean_ParsesFalseValues(string input, bool expected)
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Boolean);
+        var result = _parser.CoerceValue(input, attr);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void CoerceValue_Boolean_ReturnsNullForInvalid()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Boolean);
+        Assert.Null(_parser.CoerceValue("maybe", attr));
+    }
+
+    #endregion
+
+    #region DateTime Tests
+
+    [Fact]
+    public void CoerceValue_DateTime_ParsesIsoFormat()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.DateTime);
+        var result = _parser.CoerceValue("2024-01-15T10:30:00Z", attr);
+        Assert.IsType<DateTime>(result);
+        var dt = (DateTime)result!;
+        Assert.Equal(2024, dt.Year);
+        Assert.Equal(1, dt.Month);
+        Assert.Equal(15, dt.Day);
+    }
+
+    [Fact]
+    public void CoerceValue_DateTime_UsesCustomFormat()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.DateTime);
+        var mapping = new ColumnMappingEntry { DateFormat = "MM/dd/yyyy" };
+        var result = _parser.CoerceValue("01/15/2024", attr, mapping);
+        Assert.IsType<DateTime>(result);
+        var dt = (DateTime)result!;
+        Assert.Equal(2024, dt.Year);
+        Assert.Equal(1, dt.Month);
+        Assert.Equal(15, dt.Day);
+    }
+
+    [Fact]
+    public void CoerceValue_DateTime_ReturnsNullForInvalidFormat()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.DateTime);
+        var mapping = new ColumnMappingEntry { DateFormat = "yyyy-MM-dd" };
+        Assert.Null(_parser.CoerceValue("01/15/2024", attr, mapping));
+    }
+
+    #endregion
+
+    #region Guid Tests
+
+    [Fact]
+    public void CoerceValue_Guid_ParsesValidGuid()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Uniqueidentifier);
+        var result = _parser.CoerceValue("a1b2c3d4-e5f6-7890-abcd-ef1234567890", attr);
+        Assert.IsType<Guid>(result);
+        Assert.Equal(Guid.Parse("a1b2c3d4-e5f6-7890-abcd-ef1234567890"), result);
+    }
+
+    [Fact]
+    public void CoerceValue_Guid_ReturnsNullForInvalid()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Uniqueidentifier);
+        Assert.Null(_parser.CoerceValue("not-a-guid", attr));
+    }
+
+    #endregion
+
+    #region OptionSet Tests
+
+    [Fact]
+    public void CoerceValue_OptionSet_ParsesNumericValue()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Picklist);
+        var result = _parser.CoerceValue("5", attr);
+        Assert.IsType<OptionSetValue>(result);
+        Assert.Equal(5, ((OptionSetValue)result!).Value);
+    }
+
+    [Fact]
+    public void CoerceValue_OptionSet_UsesLabelMap()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Picklist);
+        var mapping = new ColumnMappingEntry
+        {
+            OptionsetMap = new Dictionary<string, int>
+            {
+                ["Active"] = 1,
+                ["Inactive"] = 0
+            }
+        };
+        var result = _parser.CoerceValue("Active", attr, mapping);
+        Assert.IsType<OptionSetValue>(result);
+        Assert.Equal(1, ((OptionSetValue)result!).Value);
+    }
+
+    [Fact]
+    public void CoerceValue_OptionSet_ReturnsNullForUnknownLabel()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Picklist);
+        Assert.Null(_parser.CoerceValue("Unknown", attr));
+    }
+
+    #endregion
+
+    #region Lookup Tests
+
+    [Fact]
+    public void CoerceValue_Lookup_ReturnsNull_HandledByResolver()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Lookup);
+        var result = _parser.CoerceValue("some-value", attr);
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region IsGuid Tests
+
+    [Fact]
+    public void IsGuid_ValidGuid_ReturnsTrue()
+    {
+        Assert.True(CsvRecordParser.IsGuid("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    [Fact]
+    public void IsGuid_InvalidGuid_ReturnsFalse()
+    {
+        Assert.False(CsvRecordParser.IsGuid("not-a-guid"));
+        Assert.False(CsvRecordParser.IsGuid("Contoso Ltd"));
+        Assert.False(CsvRecordParser.IsGuid(""));
+        Assert.False(CsvRecordParser.IsGuid(null));
+    }
+
+    #endregion
+
+    #region TryCoerceValue Tests
+
+    [Fact]
+    public void TryCoerceValue_Success_ReturnsSuccessAndValue()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Integer);
+        var (success, value, error) = _parser.TryCoerceValue("42", attr);
+        Assert.True(success);
+        Assert.Equal(42, value);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryCoerceValue_Failure_ReturnsFailureAndError()
+    {
+        var attr = CreateAttributeMetadata(AttributeTypeCode.Integer);
+        var (success, value, error) = _parser.TryCoerceValue("not-a-number", attr);
+        Assert.False(success);
+        Assert.Null(value);
+        Assert.NotNull(error);
+        Assert.Contains("Cannot convert", error);
+    }
+
+    #endregion
+
+    private static AttributeMetadata CreateAttributeMetadata(AttributeTypeCode type)
+    {
+        // The specialized metadata classes already have the correct AttributeType set
+        return type switch
+        {
+            AttributeTypeCode.String => new StringAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Memo => new MemoAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Integer => new IntegerAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.BigInt => new BigIntAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Decimal => new DecimalAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Double => new DoubleAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Money => new MoneyAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Boolean => new BooleanAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.DateTime => new DateTimeAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Uniqueidentifier => new UniqueIdentifierAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Picklist => new PicklistAttributeMetadata { LogicalName = "test" },
+            AttributeTypeCode.Lookup => new LookupAttributeMetadata { LogicalName = "test" },
+            _ => new StringAttributeMetadata { LogicalName = "test" }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ppds data load` command for loading CSV data into Dataverse entities
- Auto-maps CSV headers to entity attributes by name matching
- Type coercion for all Dataverse types (strings, numbers, dates, booleans, optionsets, money, lookups)
- Lookup resolution with GUID auto-detection; field-based matching via mapping file
- `--generate-mapping` creates a mapping template with auto-matched columns and optionset values
- Multi-profile support for connection pooling (`--profile app1,app2,app3`)
- `--dry-run` mode for validation without writing
- `--key` option for alternate key upsert semantics
- JSON Schema for mapping files at `schemas/csv-mapping.schema.json`

## Test plan

- [x] All 414 CLI unit tests pass (84 new tests added)
- [x] Build succeeds on all target frameworks (net8.0, net9.0, net10.0)
- [x] Release build with `--warnaserror` passes
- [ ] Manual testing with real CSV files against Dataverse environment
- [ ] Verify `--generate-mapping` produces valid mapping templates
- [ ] Verify `--dry-run` validates without writing

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)