### PR TITLE
docs: add extension parity roadmap and design session framework

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,140 @@
+# PPDS SDK Roadmap
+
+## Epic: Extension Feature Parity
+
+**Goal:** SDK CLI parity with VS Code extension to enable CLI daemon migration (Extension issues #51-54).
+
+**Status:** In Progress
+
+---
+
+## Phase 1: Core Commands (Design Session 1)
+
+**Status:** In Design
+
+| Feature | Command | Issue | Status |
+|---------|---------|-------|--------|
+| Solutions | `ppds solutions` | [#137](https://github.com/joshsmithxrm/ppds-sdk/issues/137) | Planned |
+| Import Jobs | `ppds importjobs` | [#138](https://github.com/joshsmithxrm/ppds-sdk/issues/138) | Planned |
+| Environment Variables | `ppds envvars` | [#139](https://github.com/joshsmithxrm/ppds-sdk/issues/139) | Planned |
+| Users | `ppds users` | [#119](https://github.com/joshsmithxrm/ppds-sdk/issues/119) | Planned |
+| Roles | `ppds roles` | [#119](https://github.com/joshsmithxrm/ppds-sdk/issues/119) | Planned |
+
+**Scope:**
+- Solution list, get, export, import, components, publish, url
+- Import job list, get, data (XML), wait, url
+- Environment variable list, get, set, export
+- User/role management per issue #119
+
+---
+
+## Phase 2: Connection Management (Design Session 2)
+
+**Status:** Not Started
+
+| Feature | Command | Issue | Status |
+|---------|---------|-------|--------|
+| Flows | `ppds flows` | [#142](https://github.com/joshsmithxrm/ppds-sdk/issues/142) | Planned |
+| Connection References | `ppds connrefs` | [#143](https://github.com/joshsmithxrm/ppds-sdk/issues/143) | Planned |
+| Connections | `ppds connections` | [#144](https://github.com/joshsmithxrm/ppds-sdk/issues/144) | Planned |
+| Deployment Settings | `ppds deployment-settings` | [#145](https://github.com/joshsmithxrm/ppds-sdk/issues/145) | Planned |
+
+**Scope:**
+- Flow/ConnRef/Connection entity relationships
+- Orphaned connection reference detection
+- Deployment settings generation (Microsoft format)
+
+**Session Prompt:** [SESSION_2_CONNREFS_PROMPT.md](design-sessions/SESSION_2_CONNREFS_PROMPT.md)
+
+---
+
+## Phase 3: Plugin Traces (Design Session 3)
+
+**Status:** Not Started
+
+| Feature | Command | Issue | Status |
+|---------|---------|-------|--------|
+| Plugin Traces | `ppds plugintraces` | [#140](https://github.com/joshsmithxrm/ppds-sdk/issues/140) | Planned |
+
+**Scope:**
+- Full filtering (25 fields, 11 operators, 8 quick filters)
+- Timeline correlation view
+- Trace level management
+- Export/delete operations
+
+**Session Prompt:** [SESSION_3_PLUGINTRACES_PROMPT.md](design-sessions/SESSION_3_PLUGINTRACES_PROMPT.md)
+
+---
+
+## Phase 4: Web Resources (Design Session 4)
+
+**Status:** Not Started
+
+| Feature | Command | Issue | Status |
+|---------|---------|-------|--------|
+| Web Resources | `ppds webresources` | [#141](https://github.com/joshsmithxrm/ppds-sdk/issues/141) | Planned |
+
+**Scope:**
+- Published vs unpublished content
+- Conflict detection on push
+- Efficient filtering for 60K+ resources
+
+**Session Prompt:** [SESSION_4_WEBRESOURCES_PROMPT.md](design-sessions/SESSION_4_WEBRESOURCES_PROMPT.md)
+
+---
+
+## Phase 5: Extension CLI Migration
+
+**Status:** Blocked by Phase 1-4
+
+| Feature | Issue | Status |
+|---------|-------|--------|
+| CLI binary bundling | Extension #51 | Blocked |
+| DaemonCliService | Extension #52 | Blocked |
+| Feature migration | Extension #53 | Blocked |
+| TypeScript cleanup | Extension #54 | Blocked |
+
+---
+
+## Separate Track: Plugin Registration
+
+**Status:** Needs Design Session
+
+Full plugin lifecycle:
+- Assemblies, packages, steps, images
+- Service endpoints, webhooks
+- Data providers, custom APIs
+- View modes (by assembly, entity, message)
+
+---
+
+## Architecture Decision Records
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-0009](adr/0009_CLI_COMMAND_TAXONOMY.md) | Use `ppds plugintraces` (not `traces` or `plugins traces`) |
+| [ADR-0010](adr/0010_PUBLISHED_UNPUBLISHED_DEFAULT.md) | Default to published, `--unpublished` flag |
+
+---
+
+## Key Design Decisions
+
+### JSON Output Strategy
+- `list`: Core fields only, expensive fields excluded
+- `get`: All fields included
+- Dedicated commands for large blobs (`ppds importjobs data`)
+
+### Maker URL Pattern
+- JSON output always includes `makerUrl` field
+- `url` subcommand for human convenience
+- Table output excludes URL (too long)
+
+### Three Audiences
+Every command serves Extension (JSON-RPC), Humans (tables), AI/Tooling (structured errors).
+
+---
+
+## References
+
+- [CLI Output Architecture (ADR-0008)](adr/0008_CLI_OUTPUT_ARCHITECTURE.md)
+- [Extension CLI Migration Issues](https://github.com/joshsmithxrm/power-platform-developer-suite/issues?q=is%3Aissue+label%3Aepic%3Acli-daemon)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -89,10 +89,10 @@
 
 | Feature | Issue | Status |
 |---------|-------|--------|
-| CLI binary bundling | Extension #51 | Blocked |
-| DaemonCliService | Extension #52 | Blocked |
-| Feature migration | Extension #53 | Blocked |
-| TypeScript cleanup | Extension #54 | Blocked |
+| CLI binary bundling | [Extension #51](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/51) | Blocked |
+| DaemonCliService | [Extension #52](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/52) | Blocked |
+| Feature migration | [Extension #53](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/53) | Blocked |
+| TypeScript cleanup | [Extension #54](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/54) | Blocked |
 
 ---
 

--- a/docs/adr/0009_CLI_COMMAND_TAXONOMY.md
+++ b/docs/adr/0009_CLI_COMMAND_TAXONOMY.md
@@ -1,0 +1,72 @@
+# ADR-0009: CLI Command Taxonomy
+
+**Status:** Accepted
+**Date:** 2026-01-04
+**Authors:** Josh, Claude
+
+## Context
+
+As we add CLI commands for extension feature parity, we need consistent naming conventions. Specifically, the plugin trace viewer feature raised a naming question:
+
+1. `ppds traces` - Short but ambiguous (traces of what?)
+2. `ppds plugins traces` - Grouped under plugins namespace
+3. `ppds plugintraces` - Specific, maps to entity name
+
+The `plugins` command group currently handles plugin registration:
+- `ppds plugins extract` - Extract from assembly
+- `ppds plugins deploy` - Deploy registrations
+- `ppds plugins list` - List registered plugins
+- `ppds plugins diff` - Compare config vs environment
+- `ppds plugins clean` - Remove orphaned registrations
+
+Plugin traces are an observability/debugging concern, not a registration concern. Mixing them under `plugins` conflates two different domains.
+
+## Decision
+
+Use `ppds plugintraces` as a standalone command group.
+
+### Naming Pattern
+
+| Domain | Command | Entity | Notes |
+|--------|---------|--------|-------|
+| Registration | `ppds plugins` | pluginassembly, plugintype, sdkmessageprocessingstep | Plugin lifecycle management |
+| Observability | `ppds plugintraces` | plugintracelog | Debugging, monitoring |
+| Solutions | `ppds solutions` | solution | Solution management |
+| Import Jobs | `ppds importjobs` | importjob | Specific to avoid "jobs" ambiguity |
+| Web Resources | `ppds webresources` | webresource | Direct entity match |
+| Connection Refs | `ppds connrefs` | connectionreference | Abbreviated for clarity |
+| Flows | `ppds flows` | workflow (cloudflow) | Cloud flow management |
+| Connections | `ppds connections` | connection | Connector instances |
+
+### Principles
+
+1. **Entity alignment** - Command names should map to Dataverse entity logical names where practical
+2. **Specificity over brevity** - `plugintraces` is longer than `traces` but unambiguous
+3. **Domain separation** - Don't nest unrelated features (traces ≠ registration)
+4. **Future-proofing** - Clear naming allows adding related features (e.g., `ppds flowruns` for flow execution history)
+
+## Consequences
+
+### Positive
+- Clear, unambiguous command names
+- Easy to discover via `ppds --help`
+- Entity-aligned naming aids documentation
+- Separation of concerns in command structure
+
+### Negative
+- Slightly longer command names
+- Users must learn domain-specific terms
+
+## Alternatives Considered
+
+### `ppds plugins traces`
+Rejected because:
+- Conflates registration and observability domains
+- Makes `plugins` a catch-all for anything plugin-related
+- Inconsistent with other feature groupings (we don't have `ppds solutions components` as a nested group)
+
+### `ppds traces`
+Rejected because:
+- Ambiguous - could mean application traces, telemetry, etc.
+- Doesn't indicate the feature domain
+- May conflict if we add other trace types later

--- a/docs/adr/0010_PUBLISHED_UNPUBLISHED_DEFAULT.md
+++ b/docs/adr/0010_PUBLISHED_UNPUBLISHED_DEFAULT.md
@@ -1,0 +1,86 @@
+# ADR-0010: Published vs Unpublished Default
+
+**Status:** Accepted
+**Date:** 2026-01-04
+**Authors:** Josh, Claude
+
+## Context
+
+Several Dataverse entities support dual-state content:
+- **Published** - What end users see in the application
+- **Unpublished** - Pending changes not yet published
+
+Affected entities include:
+- Web resources
+- Forms
+- Views
+- Sitemap
+- Ribbons
+
+When querying these entities, the CLI must decide which version to return by default.
+
+## Decision
+
+**Default to published content**, with an `--unpublished` flag to access draft/pending changes.
+
+```bash
+# Default: published content
+ppds webresources get myfile.js
+
+# Explicit: unpublished/draft content
+ppds webresources get myfile.js --unpublished
+
+# Diff against published (default)
+ppds webresources diff myfile.js
+
+# Diff against unpublished
+ppds webresources diff myfile.js --unpublished
+```
+
+## Rationale
+
+### 1. Principle of Least Surprise
+"Show me what's live" is the safe, expected default. Users querying data typically want to see what's actually deployed.
+
+### 2. Scripting Safety
+Automation scripts should operate on stable, published content. If a script unexpectedly gets unpublished changes, it could cause confusion or errors.
+
+### 3. Explicit Intent
+Developers actively working on changes know they want the draft version. Adding `--unpublished` explicitly signals that intent.
+
+### 4. Consistency with Data Queries
+When querying entity data (`ppds query`), you see data against the published schema. The same principle applies to metadata and resources.
+
+## Consequences
+
+### Positive
+- Safe default for automation
+- Clear semantic meaning
+- Explicit flag prevents accidental draft access
+- Matches user expectations ("show me what users see")
+
+### Negative
+- Developers must remember to add `--unpublished` when working on drafts
+- Two round-trips if you need both versions
+
+## Alternatives Considered
+
+### Default to unpublished
+Rejected because:
+- Unsafe for scripting/automation
+- Violates principle of least surprise
+- Users might not realize they're seeing uncommitted changes
+
+### Force explicit choice (no default)
+Rejected because:
+- Adds friction for the common case
+- Most queries want published content
+- Extra typing for every command
+
+### Environment-based default
+(e.g., development environments default to unpublished)
+
+Rejected because:
+- Inconsistent behavior across environments
+- Harder to reason about
+- Scripts may behave differently per environment

--- a/docs/design-sessions/SESSION_2_CONNREFS_PROMPT.md
+++ b/docs/design-sessions/SESSION_2_CONNREFS_PROMPT.md
@@ -1,0 +1,81 @@
+# Design Session 2: Flows + Connection References + Deployment Settings
+
+## Session Prompt
+
+Use this prompt to start the design session:
+
+---
+
+Design session for Flows, Connection References, Connections, and Deployment Settings CLI commands.
+
+## Context
+
+The extension has a Connection References panel that shows flows and their connection references. We need CLI commands to support this and enable deployment settings generation.
+
+### Entity Hierarchy
+```
+Flow (cloudflow/workflow)
+  └─► ConnectionReference (1:N)
+        └─► Connection (1:1, but multiple valid options exist)
+```
+
+### Extension Features
+- Solution selector
+- Flow links (open in Maker)
+- Sync deployment settings button (generates Microsoft-format deployment settings file)
+- Unified view of flows with their connection references
+
+### Current SDK Status
+- No `ppds flows` command
+- No `ppds connrefs` command
+- No `ppds connections` command
+- No `ppds deployment-settings` command
+
+### Key Questions
+1. What Dataverse queries are needed to get flow → connref → connection relationships?
+2. How do we detect orphaned connection references?
+3. What valid connections exist for a given connection reference?
+4. Should we use Microsoft deployment settings format or our own?
+
+## Deliverables
+
+1. **Entity relationship model** with Dataverse queries
+2. **Command structure:**
+   - `ppds flows` (list, get, url)
+   - `ppds connrefs` (list, get, flows, connections, analyze)
+   - `ppds connections` (list, get)
+   - `ppds deployment-settings` (generate, validate)
+3. **ADR on deployment settings format** (Microsoft vs custom)
+4. **JSON output schemas** for each command
+5. **Issue breakdown** for implementation
+
+## Expected Commands
+
+```bash
+# Flows
+ppds flows list [--solution <name>]
+ppds flows get <id>
+ppds flows url <id>
+
+# Connection References
+ppds connrefs list [--solution <name>] [--orphaned]
+ppds connrefs get <id>
+ppds connrefs flows <id>         # Which flows use this ref?
+ppds connrefs connections <id>   # Valid connections for this ref
+ppds connrefs analyze [--solution <name>]  # Unified view
+
+# Connections
+ppds connections list [--connector <name>]
+ppds connections get <id>
+
+# Deployment Settings
+ppds deployment-settings generate [--solution <name>] [--output <path>]
+ppds deployment-settings validate <path>
+```
+
+## References
+
+- [ROADMAP.md](../ROADMAP.md) - Phase 2 overview
+- [ADR-0009](../adr/0009_CLI_COMMAND_TAXONOMY.md) - Command naming conventions
+- [ADR-0008](../adr/0008_CLI_OUTPUT_ARCHITECTURE.md) - Output architecture
+- Extension source: `C:\VS\ppds\extension\src\features\connectionReferences`

--- a/docs/design-sessions/SESSION_3_PLUGINTRACES_PROMPT.md
+++ b/docs/design-sessions/SESSION_3_PLUGINTRACES_PROMPT.md
@@ -1,0 +1,102 @@
+# Design Session 3: Plugin Traces
+
+## Session Prompt
+
+Use this prompt to start the design session:
+
+---
+
+Design session for Plugin Traces CLI command (`ppds plugintraces`).
+
+## Context
+
+The extension has a comprehensive Plugin Trace Viewer with advanced filtering, timeline correlation, and trace level management. We need CLI parity.
+
+### Extension Features (57 files)
+- **Filtering:** 25 filter fields, 11 operators, 8 quick filters
+- **Quick filters:** Exceptions, Last Hour, Last 24h, Today, Async Only, Sync Only, Recursive
+- **Detail panel:** Overview, Details, Timeline, Raw Data tabs
+- **Timeline:** Related traces by correlation ID showing execution pipeline
+- **Actions:** Export CSV/JSON, Delete (selected/all/old), Trace level management
+- **Trace levels:** Off (0), Exception (1), All (2)
+
+### Key Design Challenges
+1. **Expensive fields:** `messageblock`, `configuration`, `secureconfiguration`, `profile` must be excluded from list, included in get
+2. **Filtering complexity:** 25 fields with various operators - need inline flags + filter file
+3. **Timeline view:** Query related traces by correlation ID
+4. **Trace level:** Read/write organization setting
+
+### Current SDK Status
+- No `ppds plugintraces` command
+- Entity: `plugintracelog`
+
+## Deliverables
+
+1. **Full command structure** with all subcommands and flags
+2. **Filter design:**
+   - Inline flags for common filters
+   - Quick filter shortcuts
+   - Filter file schema (JSON)
+3. **JSON output schemas** for list vs get (selective field loading)
+4. **Timeline correlation query** pattern
+5. **Issue breakdown** for implementation
+
+## Expected Commands
+
+```bash
+# List with inline filters
+ppds plugintraces list [--plugin <name>] [--entity <name>] [--message <name>]
+                       [--level exception|all] [--mode sync|async]
+                       [--since <datetime>] [--until <datetime>]
+                       [--min-duration <ms>] [--correlation <guid>]
+                       [--depth <n>] [--top <n>] [--orderby <field>]
+
+# Quick filter shortcuts
+ppds plugintraces list --exceptions
+ppds plugintraces list --last-hour
+ppds plugintraces list --last-24h
+ppds plugintraces list --today
+ppds plugintraces list --async-only
+ppds plugintraces list --sync-only
+ppds plugintraces list --recursive     # depth > 1
+
+# Filter file for complex queries
+ppds plugintraces list --filter-file traces-filter.json
+
+# Get single trace (all fields)
+ppds plugintraces get <id>
+
+# Timeline view (related traces by correlation)
+ppds plugintraces related <correlation-id>
+
+# Delete operations
+ppds plugintraces delete --older-than 30d [--batch-size 100]
+ppds plugintraces delete --all [--confirm]
+
+# Trace level management
+ppds plugintraces settings                        # Get current
+ppds plugintraces settings --level off|exception|all
+
+# Export
+ppds plugintraces export [--format csv|json] [filters...]
+```
+
+## Filter File Schema
+
+```json
+{
+  "$schema": "https://ppds.dev/schemas/plugintrace-filter.json",
+  "conditions": [
+    { "field": "typename", "operator": "contains", "value": "MyPlugin" },
+    { "field": "performanceexecutionduration", "operator": "gt", "value": 1000 }
+  ],
+  "logicalOperator": "and"
+}
+```
+
+## References
+
+- [ROADMAP.md](../ROADMAP.md) - Phase 3 overview
+- [ADR-0009](../adr/0009_CLI_COMMAND_TAXONOMY.md) - Why `plugintraces` not `traces`
+- [ADR-0008](../adr/0008_CLI_OUTPUT_ARCHITECTURE.md) - Output architecture
+- Extension source: `C:\VS\ppds\extension\src\features\pluginTraceViewer`

--- a/docs/design-sessions/SESSION_4_WEBRESOURCES_PROMPT.md
+++ b/docs/design-sessions/SESSION_4_WEBRESOURCES_PROMPT.md
@@ -45,7 +45,7 @@ The extension has a comprehensive Web Resources panel with editing, conflict det
 # List (excludes content field, default: published)
 ppds webresources list [--solution <name>]
                        [--type js|css|html|xml|png|jpg|gif|ico|svg|xsl|xslt|resx]
-                       [--type text]           # Shorthand for js|css|html|xml
+                       [--type text]           # Shorthand for js|css|html|xml|xsl|xslt
                        [--unpublished]
                        [--name <pattern>]
                        [--top <n>]
@@ -68,7 +68,7 @@ ppds webresources diff <local-path> [--unpublished]
 ppds webresources publish [--all | --name <name>]
 
 # Maker URL
-ppds webresources url
+ppds webresources url [<name>]
 ```
 
 ## Conflict Detection Schema
@@ -82,8 +82,8 @@ ppds webresources url
     "new_/scripts/myfile.js": {
       "id": "guid",
       "hash": "sha256:abc123...",
-      "pulledAt": "2024-01-04T12:00:00Z",
-      "modifiedOn": "2024-01-04T11:00:00Z"
+      "pulledAt": "2026-01-04T12:00:00Z",
+      "modifiedOn": "2026-01-04T11:00:00Z"
     }
   }
 }
@@ -91,11 +91,11 @@ ppds webresources url
 
 ## Published vs Unpublished Query
 
-Web resources store content in two places:
-- `content` - Published version
-- `content` with unpublished layer - Draft version
+Web resources have two content states:
+- **Published:** The `content` column contains the live version users see
+- **Unpublished:** Pending changes stored in the customization layer (requires `RetrieveUnpublishedMultiple` or solution export)
 
-Need to determine the correct Dataverse query pattern for each.
+To query unpublished content, use `RetrieveUnpublished` request or check `ismanaged`/`iscustomizable` flags. The exact Dataverse query pattern needs to be determined during implementation.
 
 ## References
 

--- a/docs/design-sessions/SESSION_4_WEBRESOURCES_PROMPT.md
+++ b/docs/design-sessions/SESSION_4_WEBRESOURCES_PROMPT.md
@@ -1,0 +1,105 @@
+# Design Session 4: Web Resources (Advanced)
+
+## Session Prompt
+
+Use this prompt to start the design session:
+
+---
+
+Design session for advanced Web Resources CLI features (`ppds webresources`).
+
+## Context
+
+The extension has a comprehensive Web Resources panel with editing, conflict detection, and publish management. We need CLI parity with some advanced features.
+
+### Extension Features (17 files)
+- Browse and edit web resources in VS Code
+- Syntax highlighting for JS, CSS, HTML, XML
+- **Conflict detection:** On-save diff if server content changed
+- **Unpublished detection:** Show pending changes
+- VS Code file system provider integration
+- Solution component tracking
+- Publish/Publish All
+
+### Key Design Challenges
+1. **Published vs unpublished:** Query either version (default: published per ADR-0010)
+2. **Conflict detection:** Track server hash, warn on push if changed
+3. **Large environments:** Default solution has 60K+ resources
+4. **Content handling:** Base64 encoded, exclude from list
+
+### Current SDK Status
+- No `ppds webresources` command
+- Entity: `webresource`
+
+## Deliverables
+
+1. **Published/unpublished query pattern** (`--unpublished` flag)
+2. **Conflict detection storage schema** (`.ppds/webresources.json`)
+3. **Efficient listing** for large environments (filtering, pagination)
+4. **Command structure** with all subcommands
+5. **Issue breakdown** for implementation
+
+## Expected Commands
+
+```bash
+# List (excludes content field, default: published)
+ppds webresources list [--solution <name>]
+                       [--type js|css|html|xml|png|jpg|gif|ico|svg|xsl|xslt|resx]
+                       [--type text]           # Shorthand for js|css|html|xml
+                       [--unpublished]
+                       [--name <pattern>]
+                       [--top <n>]
+
+# Get single resource (downloads content)
+ppds webresources get <name> [--output <path>] [--unpublished]
+
+# Pull multiple to folder
+ppds webresources pull <folder> [--solution <name>]
+# Tracks hashes in .ppds/webresources.json
+
+# Push (with conflict detection)
+ppds webresources push <path> [--solution <name>] [--force]
+# If server changed since pull: warn, offer --force
+
+# Diff local vs server
+ppds webresources diff <local-path> [--unpublished]
+
+# Publish
+ppds webresources publish [--all | --name <name>]
+
+# Maker URL
+ppds webresources url
+```
+
+## Conflict Detection Schema
+
+`.ppds/webresources.json`:
+```json
+{
+  "version": 1,
+  "environment": "https://org.crm.dynamics.com",
+  "resources": {
+    "new_/scripts/myfile.js": {
+      "id": "guid",
+      "hash": "sha256:abc123...",
+      "pulledAt": "2024-01-04T12:00:00Z",
+      "modifiedOn": "2024-01-04T11:00:00Z"
+    }
+  }
+}
+```
+
+## Published vs Unpublished Query
+
+Web resources store content in two places:
+- `content` - Published version
+- `content` with unpublished layer - Draft version
+
+Need to determine the correct Dataverse query pattern for each.
+
+## References
+
+- [ROADMAP.md](../ROADMAP.md) - Phase 4 overview
+- [ADR-0010](../adr/0010_PUBLISHED_UNPUBLISHED_DEFAULT.md) - Default to published
+- [ADR-0008](../adr/0008_CLI_OUTPUT_ARCHITECTURE.md) - Output architecture
+- Extension source: `C:\VS\ppds\extension\src\features\webResources`


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the SDK-Extension feature parity effort, including:

- **ROADMAP.md** - Epic-level tracking across 4 design sessions
- **ADR-0009** - CLI Command Taxonomy decision (`ppds plugintraces` vs `ppds traces`)
- **ADR-0010** - Published vs Unpublished Default decision
- **Design Session Prompts** - Ready-to-use prompts for Sessions 2-4

## New Issues Filed

| Issue | Command | Phase |
|-------|---------|-------|
| #137 | `ppds solutions` | 1 |
| #138 | `ppds importjobs` | 1 |
| #139 | `ppds envvars` | 1 |
| #140 | `ppds plugintraces` | 3 |
| #141 | `ppds webresources` | 4 |
| #142 | `ppds flows` | 2 |
| #143 | `ppds connrefs` | 2 |
| #144 | `ppds connections` | 2 |
| #145 | `ppds deployment-settings` | 2 |

## Key Decisions

1. **Command naming**: Use `ppds plugintraces` (entity-aligned, domain-separated)
2. **Published default**: Default to published content, `--unpublished` flag for drafts
3. **Maker URLs**: Include `makerUrl` in JSON output + `url` subcommand for convenience
4. **Session structure**: Split complex features into dedicated design sessions

## Test plan

- [x] Documentation renders correctly in GitHub
- [x] ADR format matches existing ADRs
- [x] Design session prompts contain all necessary context

🤖 Generated with [Claude Code](https://claude.com/claude-code)