### PR TITLE
docs: add Plan Mode Checklist to prevent code duplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,25 @@ dotnet clean
 6. Create PR to `main`
 7. Run `/review-bot-comments` after bots comment
 
+### Plan Mode Checklist
+
+When designing implementation in plan mode, verify:
+
+- [ ] **Shared utilities identified** - Will any logic be needed in multiple files?
+- [ ] **Constants centralized** - Are there magic numbers/strings that should be shared?
+- [ ] **Code reuse anticipated** - Does Feature A's logic overlap with Feature B?
+- [ ] **Existing patterns checked** - Does similar functionality already exist to extend?
+
+**Anti-pattern:** Planning WHAT without WHERE
+
+| Planned | Should Also Plan |
+|---------|------------------|
+| "Add prefix-aware matching" | "Who else needs this matching? Extract to shared class?" |
+| "Implement `--analyze` mode" | "Does analyze share logic with load? Factor out common code?" |
+| "Add schema version validation" | "Where should version constants live? Single source of truth?" |
+
+**Lesson learned:** Duplication discovered during bot review is expensive. Anticipate shared code during planning, not after implementation.
+
 ### Code Conventions
 
 ```csharp


### PR DESCRIPTION
## Summary

Adds a "Plan Mode Checklist" section to CLAUDE.md that prompts consideration of shared code during the planning phase.

## Background

During the sdk-data-load session (PR #136), we had to perform mid-session refactoring to extract `ColumnMatcher` and `CsvMappingSchema` after bot review identified duplicated logic between `CsvDataLoader` and `MappingGenerator`.

**Root cause:** The plan focused on WHAT features to implement but didn't anticipate WHERE shared code should live.

## What This Adds

A checklist for plan mode:

- [ ] **Shared utilities identified** - Will any logic be needed in multiple files?
- [ ] **Constants centralized** - Are there magic numbers/strings that should be shared?
- [ ] **Code reuse anticipated** - Does Feature A's logic overlap with Feature B?
- [ ] **Existing patterns checked** - Does similar functionality already exist to extend?

Plus an anti-pattern table showing the planning gap that led to duplication.

## Test plan

- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)