### PR TITLE
fix: handle pre-existing releases in CLI binary workflow

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -105,9 +105,9 @@ The CLI package has additional automation beyond NuGet publishing. When the `Cli
 1. `publish-nuget.yml` publishes the CLI as a .NET tool to NuGet.org
 2. `release-cli.yml` builds and attaches self-contained binaries
 
-**If you create the release first via `/release`:** The workflow detects the existing release and uploads binaries to it.
+**If a release is created via `/release` before the tag is pushed:** The workflow detects the existing release and uploads binaries to it.
 
-**If the workflow runs first:** The workflow creates the release with auto-generated notes and attaches binaries.
+**If a tag is pushed without a pre-existing release:** The workflow creates the release with auto-generated notes and attaches binaries.
 
 Either order works - the binaries will be attached to the final release.
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -98,6 +98,19 @@ Show final summary:
 3. **Mixed state (some prepped, some not)**: Handle each package independently
 4. **User specifies packages**: Only process those packages (e.g., if user says "just auth and cli")
 
+## CLI Release Special Handling
+
+The CLI package has additional automation beyond NuGet publishing. When the `Cli-v*` tag is pushed:
+
+1. `publish-nuget.yml` publishes the CLI as a .NET tool to NuGet.org
+2. `release-cli.yml` builds and attaches self-contained binaries
+
+**If you create the release first via `/release`:** The workflow detects the existing release and uploads binaries to it.
+
+**If the workflow runs first:** The workflow creates the release with auto-generated notes and attaches binaries.
+
+Either order works - the binaries will be attached to the final release.
+
 ## Example Session
 
 ```

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -109,7 +109,37 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-      - name: Create GitHub Release
+      - name: Check if release exists
+        id: check_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.version.outputs.tag }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.version.outputs.tag }} does not exist"
+          fi
+
+      - name: Upload to existing release
+        if: steps.check_release.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Uploading binaries to existing release..."
+          gh release upload "${{ steps.version.outputs.tag }}" \
+            ./release/ppds-win-x64.exe \
+            ./release/ppds-win-arm64.exe \
+            ./release/ppds-osx-x64 \
+            ./release/ppds-osx-arm64 \
+            ./release/ppds-linux-x64 \
+            ./release/checksums.sha256 \
+            --clobber
+          echo "Successfully uploaded binaries to release"
+
+      - name: Create new release with assets
+        if: steps.check_release.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
           name: PPDS CLI v${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- Fixes `release-cli.yml` failing with "Cannot upload assets to an immutable release" when release was created via `/release` command before workflow runs
- Adds release detection step using `gh release view`
- Uses `gh release upload --clobber` for existing releases, falls back to `softprops/action-gh-release` for new releases
- Documents CLI release special handling in `/release` command docs

Closes #166

## Test plan

- [ ] Verify workflow syntax is valid (CI will check)
- [ ] Test with next CLI release: create release via `/release`, push tag, confirm binaries attach
- [ ] Test workflow-first scenario: push tag without prior release, confirm release created with binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)