### PR TITLE
feat: Add ppds data update and delete commands

### DIFF
--- a/.claude/commands/pre-pr.md
+++ b/.claude/commands/pre-pr.md
@@ -79,7 +79,24 @@ public void Add_FirstProfile_SetsAsActive()
 - File is already covered by integration tests in PPDS.LiveTests
 - User explicitly confirms "this doesn't need unit tests because [reason]"
 
-### 6. Push Check
+### 6. CLI README Consistency
+
+**Only applies when `src/PPDS.Cli/Commands/` files are modified.**
+
+1. **Command structure matches reality**
+   ```bash
+   ppds data --help   # or whichever command group changed
+   ```
+   Compare subcommand list against README "Command Structure" section at top of file.
+
+2. **New commands have README sections**
+   - Check `src/PPDS.Cli/README.md` for corresponding `#### CommandName` section
+   - Must have: examples, options list
+   - Destructive commands (update, delete, clean) need "Safety Features" callout
+
+**If README is outdated:** Update it and amend the commit before proceeding.
+
+### 7. Push Check
 
 Before creating PR, ensure changes are pushed:
 
@@ -104,6 +121,7 @@ Pre-PR Validation
 [!] Missing XML docs: MsalClientBuilder.CreateClient()
 [✓] No TODOs found
 [✗] Missing tests for: EnvironmentResolutionService, ProfileValidator
+[✓] CLI README: Command structure matches (or N/A if no CLI changes)
 
 Missing tests is a blocker. Writing tests now...
 ```

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ppds data update` command** - Update records in Dataverse entities ([#135](https://github.com/joshsmithxrm/ppds-sdk/issues/135))
+  - Single record update by GUID (`--id`) or alternate key (`--key`) with `--set field=value`
+  - Bulk update from CSV file (`--file`) containing IDs and values
+  - Query-based update with SQL-like filter (`--filter`)
+  - `--set` option supports multiple fields: `--set "name=New Name,description=Updated"`
+  - Automatic type coercion for strings, numbers, booleans, dates, GUIDs
+  - Safety features: confirmation prompt, `--force` for automation, `--dry-run` for preview, `--limit` to cap updates
+  - Supports `--bypass-plugins`, `--bypass-flows`, `--continue-on-error`
+  - Column mapping via `--mapping` for CSV files
+- **`ppds data delete` command** - Delete records from Dataverse entities ([#135](https://github.com/joshsmithxrm/ppds-sdk/issues/135))
+  - Single record delete by GUID (`--id`) or alternate key (`--key`)
+  - Bulk delete from CSV/JSON file (`--file`)
+  - Query-based delete with SQL-like filter (`--filter`)
+  - Safety features: confirmation prompt (type count to confirm), `--force` for automation, `--dry-run` for preview, `--limit` to cap deletions
+  - Supports `--bypass-plugins`, `--bypass-flows`, `--continue-on-error`
+  - Progress reporting for bulk operations
 - **`ppds docs` command** - Opens CLI documentation in browser ([#165](https://github.com/joshsmithxrm/ppds-sdk/issues/165))
 - **Documentation URL in help** - `ppds --help` now shows documentation URL ([#165](https://github.com/joshsmithxrm/ppds-sdk/issues/165))
 

--- a/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Data/DataCommandGroup.cs
@@ -30,7 +30,7 @@ public static class DataCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("data", "Data operations: export, import, copy, analyze, schema, users, load");
+        var command = new Command("data", "Data operations: export, import, copy, analyze, schema, users, load, update, delete");
 
         command.Subcommands.Add(ExportCommand.Create());
         command.Subcommands.Add(ImportCommand.Create());
@@ -39,6 +39,8 @@ public static class DataCommandGroup
         command.Subcommands.Add(SchemaCommand.Create());
         command.Subcommands.Add(UsersCommand.Create());
         command.Subcommands.Add(LoadCommand.Create());
+        command.Subcommands.Add(UpdateCommand.Create());
+        command.Subcommands.Add(DeleteCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
@@ -1,0 +1,743 @@
+using System.CommandLine;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
+using PPDS.Dataverse.Progress;
+using PPDS.Dataverse.Sql.Parsing;
+using PPDS.Dataverse.Sql.Transpilation;
+
+namespace PPDS.Cli.Commands.Data;
+
+/// <summary>
+/// Delete records from a Dataverse entity.
+/// Supports single-record delete (by ID or alternate key), bulk delete from file, and query-based delete.
+/// </summary>
+public static class DeleteCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static Command Create()
+    {
+        var entityOption = new Option<string>("--entity", "-e")
+        {
+            Description = "Target entity logical name",
+            Required = true
+        };
+        entityOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(entityOption);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("Entity name is required");
+            }
+            else if (value.Contains(' '))
+            {
+                result.AddError("Entity name must be a valid logical name (no spaces)");
+            }
+        });
+
+        var idOption = new Option<Guid?>("--id")
+        {
+            Description = "Record ID (GUID) to delete"
+        };
+
+        var keyOption = new Option<string?>("--key", "-k")
+        {
+            Description = "Alternate key field(s) for lookup. Format: field=value or field1=value1,field2=value2 for composite keys."
+        };
+
+        var fileOption = new Option<FileInfo?>("--file")
+        {
+            Description = "Path to file containing record IDs (JSON array or CSV with ID column)"
+        };
+        fileOption.Validators.Add(result =>
+        {
+            var file = result.GetValue(fileOption);
+            if (file is { Exists: false })
+            {
+                result.AddError($"File not found: {file.FullName}");
+            }
+        });
+
+        var idColumnOption = new Option<string?>("--id-column")
+        {
+            Description = "Column name containing record IDs in CSV file (default: entity primary key)"
+        };
+
+        var filterOption = new Option<string?>("--filter")
+        {
+            Description = "SQL-like filter expression to match records for deletion (e.g., \"name like '%test%'\")"
+        };
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Skip confirmation prompt (required for non-interactive execution)",
+            DefaultValueFactory = _ => false
+        };
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Preview records that would be deleted without actually deleting",
+            DefaultValueFactory = _ => false
+        };
+
+        var limitOption = new Option<int?>("--limit")
+        {
+            Description = "Maximum number of records to delete (fails if query returns more)"
+        };
+        limitOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(limitOption);
+            if (value.HasValue && value.Value < 1)
+            {
+                result.AddError("--limit must be at least 1");
+            }
+        });
+
+        var batchSizeOption = new Option<int>("--batch-size")
+        {
+            Description = "Records per batch (default: 100)",
+            DefaultValueFactory = _ => 100
+        };
+        batchSizeOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(batchSizeOption);
+            if (value < 1 || value > 1000)
+            {
+                result.AddError("--batch-size must be between 1 and 1000");
+            }
+        });
+
+        var bypassPluginsOption = new Option<string?>("--bypass-plugins")
+        {
+            Description = "Bypass custom plugin execution: sync, async, or all (requires prvBypassCustomBusinessLogic privilege)"
+        };
+        bypassPluginsOption.AcceptOnlyFromAmong("sync", "async", "all");
+
+        var bypassFlowsOption = new Option<bool>("--bypass-flows")
+        {
+            Description = "Bypass Power Automate flow triggers",
+            DefaultValueFactory = _ => false
+        };
+
+        var continueOnErrorOption = new Option<bool>("--continue-on-error")
+        {
+            Description = "Continue deleting on individual record failures",
+            DefaultValueFactory = _ => true
+        };
+
+        var command = new Command("delete", "Delete records from a Dataverse entity")
+        {
+            entityOption,
+            idOption,
+            keyOption,
+            fileOption,
+            idColumnOption,
+            filterOption,
+            forceOption,
+            dryRunOption,
+            limitOption,
+            batchSizeOption,
+            bypassPluginsOption,
+            bypassFlowsOption,
+            continueOnErrorOption,
+            DataCommandGroup.ProfileOption,
+            DataCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        // Validate that exactly one input mode is provided
+        command.Validators.Add(result =>
+        {
+            var id = result.GetValue(idOption);
+            var key = result.GetValue(keyOption);
+            var file = result.GetValue(fileOption);
+            var filter = result.GetValue(filterOption);
+
+            var modeCount = (id.HasValue ? 1 : 0) +
+                           (!string.IsNullOrEmpty(key) ? 1 : 0) +
+                           (file != null ? 1 : 0) +
+                           (!string.IsNullOrEmpty(filter) ? 1 : 0);
+
+            if (modeCount == 0)
+            {
+                result.AddError("Specify one of: --id, --key, --file, or --filter");
+            }
+            else if (modeCount > 1)
+            {
+                result.AddError("Only one input mode allowed: --id, --key, --file, or --filter");
+            }
+        });
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityOption)!;
+            var id = parseResult.GetValue(idOption);
+            var key = parseResult.GetValue(keyOption);
+            var file = parseResult.GetValue(fileOption);
+            var idColumn = parseResult.GetValue(idColumnOption);
+            var filter = parseResult.GetValue(filterOption);
+            var force = parseResult.GetValue(forceOption);
+            var dryRun = parseResult.GetValue(dryRunOption);
+            var limit = parseResult.GetValue(limitOption);
+            var batchSize = parseResult.GetValue(batchSizeOption);
+            var bypassPluginsValue = parseResult.GetValue(bypassPluginsOption);
+            var bypassFlows = parseResult.GetValue(bypassFlowsOption);
+            var continueOnError = parseResult.GetValue(continueOnErrorOption);
+            var profile = parseResult.GetValue(DataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(DataCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            var bypassPlugins = DataCommandGroup.ParseBypassPlugins(bypassPluginsValue);
+
+            return await ExecuteAsync(
+                entity, id, key, file, idColumn, filter,
+                force, dryRun, limit, batchSize,
+                bypassPlugins, bypassFlows, continueOnError,
+                profile, environment, globalOptions,
+                cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        Guid? id,
+        string? key,
+        FileInfo? file,
+        string? idColumn,
+        string? filter,
+        bool force,
+        bool dryRun,
+        int? limit,
+        int batchSize,
+        CustomLogicBypass bypassPlugins,
+        bool bypassFlows,
+        bool continueOnError,
+        string? profileName,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Connect to Dataverse
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine("Connecting to Dataverse...");
+            }
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profileName,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var bulkExecutor = serviceProvider.GetRequiredService<IBulkOperationExecutor>();
+
+            // Resolve IDs to delete based on input mode
+            List<Guid> idsToDelete;
+
+            if (id.HasValue)
+            {
+                idsToDelete = [id.Value];
+            }
+            else if (!string.IsNullOrEmpty(key))
+            {
+                var resolvedId = await ResolveAlternateKeyAsync(pool, entity, key, cancellationToken);
+                if (resolvedId == null)
+                {
+                    WriteError(globalOptions, "RECORD_NOT_FOUND", $"No record found with key: {key}");
+                    return ExitCodes.NotFoundError;
+                }
+                idsToDelete = [resolvedId.Value];
+            }
+            else if (file != null)
+            {
+                idsToDelete = await LoadIdsFromFileAsync(file, idColumn, entity, pool, cancellationToken);
+                if (idsToDelete.Count == 0)
+                {
+                    WriteError(globalOptions, "NO_RECORDS", "No record IDs found in file");
+                    return ExitCodes.ValidationError;
+                }
+            }
+            else if (!string.IsNullOrEmpty(filter))
+            {
+                idsToDelete = await QueryIdsAsync(pool, entity, filter, limit, globalOptions, cancellationToken);
+                if (idsToDelete.Count == 0)
+                {
+                    if (!globalOptions.IsJsonMode)
+                    {
+                        Console.Error.WriteLine("No records match the filter.");
+                    }
+                    else
+                    {
+                        WriteJsonResult(new DeleteResult { Success = true, DeletedCount = 0 });
+                    }
+                    return ExitCodes.Success;
+                }
+            }
+            else
+            {
+                WriteError(globalOptions, "INVALID_INPUT", "No input mode specified");
+                return ExitCodes.InvalidArguments;
+            }
+
+            // Check limit
+            if (limit.HasValue && idsToDelete.Count > limit.Value)
+            {
+                WriteError(globalOptions, "LIMIT_EXCEEDED",
+                    $"Query returned {idsToDelete.Count} records, exceeds --limit {limit.Value}");
+                return ExitCodes.ValidationError;
+            }
+
+            // Show preview and get confirmation
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"Records to delete: {idsToDelete.Count}");
+
+                if (idsToDelete.Count <= 10)
+                {
+                    Console.Error.WriteLine();
+                    foreach (var deleteId in idsToDelete)
+                    {
+                        Console.Error.WriteLine($"  {deleteId}");
+                    }
+                }
+                else
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"  (showing first 5 of {idsToDelete.Count})");
+                    foreach (var deleteId in idsToDelete.Take(5))
+                    {
+                        Console.Error.WriteLine($"  {deleteId}");
+                    }
+                    Console.Error.WriteLine("  ...");
+                }
+
+                Console.Error.WriteLine();
+            }
+
+            // Dry-run mode: show what would be deleted and exit
+            if (dryRun)
+            {
+                if (globalOptions.IsJsonMode)
+                {
+                    WriteJsonResult(new DeleteResult
+                    {
+                        Success = true,
+                        DryRun = true,
+                        RecordCount = idsToDelete.Count,
+                        RecordIds = idsToDelete
+                    });
+                }
+                else
+                {
+                    Console.Error.WriteLine("[Dry-Run] No records deleted.");
+                }
+                return ExitCodes.Success;
+            }
+
+            // Confirmation prompt (unless --force)
+            if (!force)
+            {
+                if (!Console.IsInputRedirected)
+                {
+                    Console.Error.Write($"Type 'delete {idsToDelete.Count}' to confirm, or Ctrl+C to cancel: ");
+                    var confirmation = Console.ReadLine();
+
+                    if (confirmation != $"delete {idsToDelete.Count}")
+                    {
+                        Console.Error.WriteLine("Cancelled.");
+                        return ExitCodes.Success;
+                    }
+                    Console.Error.WriteLine();
+                }
+                else
+                {
+                    WriteError(globalOptions, "CONFIRMATION_REQUIRED",
+                        "Use --force to skip confirmation in non-interactive mode");
+                    return ExitCodes.InvalidArguments;
+                }
+            }
+
+            // Execute delete
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"Deleting {idsToDelete.Count} record(s) from '{entity}'...");
+                Console.Error.WriteLine();
+            }
+
+            var options = new BulkOperationOptions
+            {
+                BatchSize = batchSize,
+                ContinueOnError = continueOnError,
+                BypassCustomLogic = bypassPlugins,
+                BypassPowerAutomateFlows = bypassFlows
+            };
+
+            // Progress reporting
+            var progress = new Progress<ProgressSnapshot>(snapshot =>
+            {
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.Write($"\r  Progress: {snapshot.Processed:N0}/{snapshot.Total:N0} " +
+                        $"({snapshot.PercentComplete:F1}%) | {snapshot.InstantRatePerSecond:F0}/s");
+                }
+            });
+
+            var result = await bulkExecutor.DeleteMultipleAsync(
+                entity,
+                idsToDelete,
+                options,
+                progress,
+                cancellationToken);
+
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine();
+            }
+
+            // Output results
+            if (globalOptions.IsJsonMode)
+            {
+                WriteJsonResult(new DeleteResult
+                {
+                    Success = result.IsSuccess,
+                    DeletedCount = result.SuccessCount,
+                    FailedCount = result.FailureCount,
+                    DurationMs = result.Duration.TotalMilliseconds,
+                    Errors = result.Errors.Select(e => new DeleteErrorInfo
+                    {
+                        RecordId = e.RecordId,
+                        ErrorCode = e.ErrorCode.ToString(),
+                        Message = e.Message
+                    }).ToList()
+                });
+            }
+            else
+            {
+                WriteTextResult(result);
+            }
+
+            return result.IsSuccess ? ExitCodes.Success : ExitCodes.PartialSuccess;
+        }
+        catch (OperationCanceledException)
+        {
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Delete cancelled.");
+            }
+            return ExitCodes.Failure;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "deleting records", debug: globalOptions.Debug);
+            if (globalOptions.IsJsonMode)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = false, error }, JsonOptions));
+            }
+            else
+            {
+                Console.Error.WriteLine($"Error: {error.Message}");
+                if (globalOptions.Debug && !string.IsNullOrEmpty(error.Details))
+                {
+                    Console.Error.WriteLine(error.Details);
+                }
+            }
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static async Task<Guid?> ResolveAlternateKeyAsync(
+        IDataverseConnectionPool pool,
+        string entity,
+        string keyString,
+        CancellationToken cancellationToken)
+    {
+        // Parse key=value pairs and build a query
+        var query = new QueryExpression(entity)
+        {
+            ColumnSet = new ColumnSet(false),
+            TopCount = 1
+        };
+
+        foreach (var pair in keyString.Split(','))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length != 2)
+            {
+                throw new ArgumentException($"Invalid key format: {pair}. Expected field=value.");
+            }
+            query.Criteria.AddCondition(parts[0].Trim(), ConditionOperator.Equal, parts[1].Trim());
+        }
+
+        await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var results = await client.RetrieveMultipleAsync(query, cancellationToken);
+        return results.Entities.Count > 0 ? results.Entities[0].Id : null;
+    }
+
+    private static async Task<List<Guid>> LoadIdsFromFileAsync(
+        FileInfo file,
+        string? idColumn,
+        string entity,
+        IDataverseConnectionPool pool,
+        CancellationToken cancellationToken)
+    {
+        var content = await File.ReadAllTextAsync(file.FullName, cancellationToken);
+        content = content.Trim();
+
+        // Try JSON first
+        if (content.StartsWith('[') || content.StartsWith('{'))
+        {
+            return ParseJsonIds(content);
+        }
+
+        // Assume CSV
+        return ParseCsvIds(content, idColumn, entity);
+    }
+
+    private static List<Guid> ParseJsonIds(string content)
+    {
+        var ids = new List<Guid>();
+
+        using var doc = JsonDocument.Parse(content);
+
+        if (doc.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind == JsonValueKind.String && Guid.TryParse(element.GetString(), out var id))
+                {
+                    ids.Add(id);
+                }
+                else if (element.ValueKind == JsonValueKind.Object)
+                {
+                    // Look for common ID property names
+                    foreach (var prop in element.EnumerateObject())
+                    {
+                        if (prop.Name.EndsWith("id", StringComparison.OrdinalIgnoreCase) &&
+                            prop.Value.ValueKind == JsonValueKind.String &&
+                            Guid.TryParse(prop.Value.GetString(), out var objId))
+                        {
+                            ids.Add(objId);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else if (doc.RootElement.ValueKind == JsonValueKind.Object)
+        {
+            // Handle { "records": [...] } format
+            if (doc.RootElement.TryGetProperty("records", out var records) &&
+                records.ValueKind == JsonValueKind.Array)
+            {
+                return ParseJsonIds(records.GetRawText());
+            }
+        }
+
+        return ids;
+    }
+
+    private static List<Guid> ParseCsvIds(string content, string? idColumn, string entity)
+    {
+        var ids = new List<Guid>();
+        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        if (lines.Length == 0) return ids;
+
+        // Parse header
+        var headers = lines[0].Split(',').Select(h => h.Trim().Trim('"')).ToList();
+
+        // Find ID column
+        var idColIndex = -1;
+        if (!string.IsNullOrEmpty(idColumn))
+        {
+            idColIndex = headers.FindIndex(h => h.Equals(idColumn, StringComparison.OrdinalIgnoreCase));
+            if (idColIndex < 0)
+            {
+                throw new ArgumentException($"Column '{idColumn}' not found in CSV. Available: {string.Join(", ", headers)}");
+            }
+        }
+        else
+        {
+            // Try to find primary key column (entityid or id)
+            idColIndex = headers.FindIndex(h =>
+                h.Equals($"{entity}id", StringComparison.OrdinalIgnoreCase) ||
+                h.Equals("id", StringComparison.OrdinalIgnoreCase));
+
+            if (idColIndex < 0)
+            {
+                throw new ArgumentException($"Could not find ID column. Specify --id-column. Available: {string.Join(", ", headers)}");
+            }
+        }
+
+        // Parse data rows
+        for (var i = 1; i < lines.Length; i++)
+        {
+            var values = lines[i].Split(',').Select(v => v.Trim().Trim('"')).ToList();
+            if (values.Count > idColIndex && Guid.TryParse(values[idColIndex], out var id))
+            {
+                ids.Add(id);
+            }
+        }
+
+        return ids;
+    }
+
+    private static async Task<List<Guid>> QueryIdsAsync(
+        IDataverseConnectionPool pool,
+        string entity,
+        string filter,
+        int? limit,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        if (!globalOptions.IsJsonMode)
+        {
+            Console.Error.WriteLine("Querying records to delete...");
+        }
+
+        // Build SQL query and transpile to FetchXML
+        var sql = $"SELECT {entity}id FROM {entity} WHERE {filter}";
+        if (limit.HasValue)
+        {
+            sql = $"SELECT TOP {limit.Value + 1} {entity}id FROM {entity} WHERE {filter}";
+        }
+
+        var parser = new SqlParser(sql);
+        var ast = parser.Parse();
+        var transpiler = new SqlToFetchXmlTranspiler();
+        var fetchXml = transpiler.Transpile(ast);
+
+        await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var query = new FetchExpression(fetchXml);
+        var results = await client.RetrieveMultipleAsync(query, cancellationToken);
+
+        var ids = new List<Guid>();
+        var primaryKeyAttribute = $"{entity}id";
+
+        foreach (var record in results.Entities)
+        {
+            if (record.Contains(primaryKeyAttribute) && record[primaryKeyAttribute] is Guid id)
+            {
+                ids.Add(id);
+            }
+            else
+            {
+                ids.Add(record.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    private static void WriteTextResult(BulkOperationResult result)
+    {
+        Console.Error.WriteLine("Delete complete");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"  Deleted: {result.SuccessCount:N0}");
+
+        if (result.FailureCount > 0)
+        {
+            Console.Error.WriteLine($"  Failed: {result.FailureCount:N0}");
+        }
+
+        Console.Error.WriteLine($"  Duration: {result.Duration:mm\\:ss\\.fff}");
+
+        if (result.Errors.Count > 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Errors:");
+
+            // Group errors by error code
+            var groupedErrors = result.Errors
+                .GroupBy(e => e.ErrorCode)
+                .OrderByDescending(g => g.Count());
+
+            foreach (var group in groupedErrors.Take(5))
+            {
+                Console.Error.WriteLine($"  {group.Key}: {group.Count()} occurrence(s)");
+                foreach (var error in group.Take(3))
+                {
+                    Console.Error.WriteLine($"    [{error.RecordId}] {error.Message}");
+                }
+                if (group.Count() > 3)
+                {
+                    Console.Error.WriteLine($"    ... and {group.Count() - 3} more");
+                }
+            }
+
+            if (groupedErrors.Count() > 5)
+            {
+                Console.Error.WriteLine($"  ... and {groupedErrors.Count() - 5} more error types");
+            }
+        }
+    }
+
+    private static void WriteJsonResult(DeleteResult result)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+    }
+
+    private static void WriteError(GlobalOptionValues globalOptions, string code, string message)
+    {
+        if (globalOptions.IsJsonMode)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code, message }
+            }, JsonOptions));
+        }
+        else
+        {
+            Console.Error.WriteLine($"Error: {message}");
+        }
+    }
+
+    private sealed class DeleteResult
+    {
+        public bool Success { get; init; }
+        public bool DryRun { get; init; }
+        public int RecordCount { get; init; }
+        public int DeletedCount { get; init; }
+        public int FailedCount { get; init; }
+        public double DurationMs { get; init; }
+        public List<Guid>? RecordIds { get; init; }
+        public List<DeleteErrorInfo>? Errors { get; init; }
+    }
+
+    private sealed class DeleteErrorInfo
+    {
+        public Guid? RecordId { get; init; }
+        public string? ErrorCode { get; init; }
+        public string? Message { get; init; }
+    }
+}

--- a/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
@@ -551,14 +551,12 @@ public static class DeleteCommand
                 }
             }
         }
-        else if (doc.RootElement.ValueKind == JsonValueKind.Object)
+        else if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                 doc.RootElement.TryGetProperty("records", out var records) &&
+                 records.ValueKind == JsonValueKind.Array)
         {
             // Handle { "records": [...] } format
-            if (doc.RootElement.TryGetProperty("records", out var records) &&
-                records.ValueKind == JsonValueKind.Array)
-            {
-                return ParseJsonIds(records.GetRawText());
-            }
+            return ParseJsonIds(records.GetRawText());
         }
 
         return ids;

--- a/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
@@ -567,7 +567,7 @@ public static class DeleteCommand
     private static List<Guid> ParseCsvIds(string content, string? idColumn, string entity)
     {
         var ids = new List<Guid>();
-        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = content.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
 
         if (lines.Length == 0) return ids;
 

--- a/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
@@ -676,8 +676,8 @@ public static class UpdateCommand
         var lines = content.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
         if (lines.Length == 0) return new List<Entity>();
 
-        // Parse header
-        var headers = lines[0].Split(',').Select(h => h.Trim().Trim('"')).ToList();
+        // Parse header using same CSV parser as data rows for consistency
+        var headers = ParseCsvLine(lines[0]).Select(h => h.Trim()).ToList();
 
         // Find ID column
         var idColIndex = -1;

--- a/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
@@ -1,0 +1,886 @@
+using System.CommandLine;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
+using PPDS.Dataverse.Progress;
+using PPDS.Dataverse.Sql.Parsing;
+using PPDS.Dataverse.Sql.Transpilation;
+
+namespace PPDS.Cli.Commands.Data;
+
+/// <summary>
+/// Update records in a Dataverse entity.
+/// Supports single-record update (by ID or alternate key), bulk update from file, and query-based update.
+/// Unlike load (upsert), update fails if the record doesn't exist.
+/// </summary>
+public static class UpdateCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static Command Create()
+    {
+        var entityOption = new Option<string>("--entity", "-e")
+        {
+            Description = "Target entity logical name",
+            Required = true
+        };
+        entityOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(entityOption);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result.AddError("Entity name is required");
+            }
+            else if (value.Contains(' '))
+            {
+                result.AddError("Entity name must be a valid logical name (no spaces)");
+            }
+        });
+
+        var idOption = new Option<Guid?>("--id")
+        {
+            Description = "Record ID (GUID) to update"
+        };
+
+        var keyOption = new Option<string?>("--key", "-k")
+        {
+            Description = "Alternate key field(s) for lookup. Format: field=value or field1=value1,field2=value2 for composite keys."
+        };
+
+        var fileOption = new Option<FileInfo?>("--file")
+        {
+            Description = "Path to CSV file containing records to update (must include ID column and columns to update)"
+        };
+        fileOption.Validators.Add(result =>
+        {
+            var file = result.GetValue(fileOption);
+            if (file is { Exists: false })
+            {
+                result.AddError($"File not found: {file.FullName}");
+            }
+        });
+
+        var idColumnOption = new Option<string?>("--id-column")
+        {
+            Description = "Column name containing record IDs in CSV file (default: entity primary key)"
+        };
+
+        var filterOption = new Option<string?>("--filter")
+        {
+            Description = "SQL-like filter expression to match records for update (e.g., \"statecode eq 0\")"
+        };
+
+        var setOption = new Option<string?>("--set", "-s")
+        {
+            Description = "Field values to set. Format: field=value or field1=value1,field2=value2. Required for --id, --key, or --filter modes."
+        };
+
+        var mappingOption = new Option<FileInfo?>("--mapping", "-m")
+        {
+            Description = "Path to column mapping JSON file (for --file mode)"
+        };
+        mappingOption.Validators.Add(result =>
+        {
+            var file = result.GetValue(mappingOption);
+            if (file is { Exists: false })
+            {
+                result.AddError($"Mapping file not found: {file.FullName}");
+            }
+        });
+
+        var forceOption = new Option<bool>("--force")
+        {
+            Description = "Skip confirmation prompt (required for non-interactive execution)",
+            DefaultValueFactory = _ => false
+        };
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Preview records that would be updated without actually updating",
+            DefaultValueFactory = _ => false
+        };
+
+        var limitOption = new Option<int?>("--limit")
+        {
+            Description = "Maximum number of records to update (fails if query returns more)"
+        };
+        limitOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(limitOption);
+            if (value.HasValue && value.Value < 1)
+            {
+                result.AddError("--limit must be at least 1");
+            }
+        });
+
+        var batchSizeOption = new Option<int>("--batch-size")
+        {
+            Description = "Records per batch (default: 100)",
+            DefaultValueFactory = _ => 100
+        };
+        batchSizeOption.Validators.Add(result =>
+        {
+            var value = result.GetValue(batchSizeOption);
+            if (value < 1 || value > 1000)
+            {
+                result.AddError("--batch-size must be between 1 and 1000");
+            }
+        });
+
+        var bypassPluginsOption = new Option<string?>("--bypass-plugins")
+        {
+            Description = "Bypass custom plugin execution: sync, async, or all (requires prvBypassCustomBusinessLogic privilege)"
+        };
+        bypassPluginsOption.AcceptOnlyFromAmong("sync", "async", "all");
+
+        var bypassFlowsOption = new Option<bool>("--bypass-flows")
+        {
+            Description = "Bypass Power Automate flow triggers",
+            DefaultValueFactory = _ => false
+        };
+
+        var continueOnErrorOption = new Option<bool>("--continue-on-error")
+        {
+            Description = "Continue updating on individual record failures",
+            DefaultValueFactory = _ => true
+        };
+
+        var command = new Command("update", "Update records in a Dataverse entity (fails if record doesn't exist)")
+        {
+            entityOption,
+            idOption,
+            keyOption,
+            fileOption,
+            idColumnOption,
+            filterOption,
+            setOption,
+            mappingOption,
+            forceOption,
+            dryRunOption,
+            limitOption,
+            batchSizeOption,
+            bypassPluginsOption,
+            bypassFlowsOption,
+            continueOnErrorOption,
+            DataCommandGroup.ProfileOption,
+            DataCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        // Validate input modes and --set requirement
+        command.Validators.Add(result =>
+        {
+            var id = result.GetValue(idOption);
+            var key = result.GetValue(keyOption);
+            var file = result.GetValue(fileOption);
+            var filter = result.GetValue(filterOption);
+            var set = result.GetValue(setOption);
+
+            var modeCount = (id.HasValue ? 1 : 0) +
+                           (!string.IsNullOrEmpty(key) ? 1 : 0) +
+                           (file != null ? 1 : 0) +
+                           (!string.IsNullOrEmpty(filter) ? 1 : 0);
+
+            if (modeCount == 0)
+            {
+                result.AddError("Specify one of: --id, --key, --file, or --filter");
+            }
+            else if (modeCount > 1)
+            {
+                result.AddError("Only one input mode allowed: --id, --key, --file, or --filter");
+            }
+
+            // --set is required for --id, --key, and --filter modes (not for --file which has values in the file)
+            if (file == null && string.IsNullOrEmpty(set) && modeCount == 1)
+            {
+                result.AddError("--set is required when using --id, --key, or --filter. Use --set \"field=value\" to specify values to update.");
+            }
+        });
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entity = parseResult.GetValue(entityOption)!;
+            var id = parseResult.GetValue(idOption);
+            var key = parseResult.GetValue(keyOption);
+            var file = parseResult.GetValue(fileOption);
+            var idColumn = parseResult.GetValue(idColumnOption);
+            var filter = parseResult.GetValue(filterOption);
+            var set = parseResult.GetValue(setOption);
+            var mapping = parseResult.GetValue(mappingOption);
+            var force = parseResult.GetValue(forceOption);
+            var dryRun = parseResult.GetValue(dryRunOption);
+            var limit = parseResult.GetValue(limitOption);
+            var batchSize = parseResult.GetValue(batchSizeOption);
+            var bypassPluginsValue = parseResult.GetValue(bypassPluginsOption);
+            var bypassFlows = parseResult.GetValue(bypassFlowsOption);
+            var continueOnError = parseResult.GetValue(continueOnErrorOption);
+            var profile = parseResult.GetValue(DataCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(DataCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            var bypassPlugins = DataCommandGroup.ParseBypassPlugins(bypassPluginsValue);
+
+            return await ExecuteAsync(
+                entity, id, key, file, idColumn, filter, set, mapping,
+                force, dryRun, limit, batchSize,
+                bypassPlugins, bypassFlows, continueOnError,
+                profile, environment, globalOptions,
+                cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entity,
+        Guid? id,
+        string? key,
+        FileInfo? file,
+        string? idColumn,
+        string? filter,
+        string? set,
+        FileInfo? mapping,
+        bool force,
+        bool dryRun,
+        int? limit,
+        int batchSize,
+        CustomLogicBypass bypassPlugins,
+        bool bypassFlows,
+        bool continueOnError,
+        string? profileName,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Connect to Dataverse
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine("Connecting to Dataverse...");
+            }
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profileName,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
+            var bulkExecutor = serviceProvider.GetRequiredService<IBulkOperationExecutor>();
+
+            // Build entities to update based on input mode
+            List<Entity> entitiesToUpdate;
+
+            if (id.HasValue)
+            {
+                var updateEntity = new Entity(entity, id.Value);
+                ApplySetValues(updateEntity, set!);
+                entitiesToUpdate = [updateEntity];
+            }
+            else if (!string.IsNullOrEmpty(key))
+            {
+                var resolvedId = await ResolveAlternateKeyAsync(pool, entity, key, cancellationToken);
+                if (resolvedId == null)
+                {
+                    WriteError(globalOptions, "RECORD_NOT_FOUND", $"No record found with key: {key}");
+                    return ExitCodes.NotFoundError;
+                }
+                var updateEntity = new Entity(entity, resolvedId.Value);
+                ApplySetValues(updateEntity, set!);
+                entitiesToUpdate = [updateEntity];
+            }
+            else if (file != null)
+            {
+                entitiesToUpdate = await LoadEntitiesFromFileAsync(file, idColumn, entity, mapping, cancellationToken);
+                if (entitiesToUpdate.Count == 0)
+                {
+                    WriteError(globalOptions, "NO_RECORDS", "No records found in file");
+                    return ExitCodes.ValidationError;
+                }
+            }
+            else if (!string.IsNullOrEmpty(filter))
+            {
+                var ids = await QueryIdsAsync(pool, entity, filter, limit, globalOptions, cancellationToken);
+                if (ids.Count == 0)
+                {
+                    if (!globalOptions.IsJsonMode)
+                    {
+                        Console.Error.WriteLine("No records match the filter.");
+                    }
+                    else
+                    {
+                        WriteJsonResult(new UpdateResult { Success = true, UpdatedCount = 0 });
+                    }
+                    return ExitCodes.Success;
+                }
+
+                // Build update entities with the --set values
+                entitiesToUpdate = ids.Select(recordId =>
+                {
+                    var updateEntity = new Entity(entity, recordId);
+                    ApplySetValues(updateEntity, set!);
+                    return updateEntity;
+                }).ToList();
+            }
+            else
+            {
+                WriteError(globalOptions, "INVALID_INPUT", "No input mode specified");
+                return ExitCodes.InvalidArguments;
+            }
+
+            // Check limit
+            if (limit.HasValue && entitiesToUpdate.Count > limit.Value)
+            {
+                WriteError(globalOptions, "LIMIT_EXCEEDED",
+                    $"Query returned {entitiesToUpdate.Count} records, exceeds --limit {limit.Value}");
+                return ExitCodes.ValidationError;
+            }
+
+            // Show preview and get confirmation
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"Records to update: {entitiesToUpdate.Count}");
+
+                // Show fields being updated
+                var sampleEntity = entitiesToUpdate[0];
+                var fieldsToUpdate = sampleEntity.Attributes.Keys.ToList();
+                Console.Error.WriteLine($"Fields to update: {string.Join(", ", fieldsToUpdate)}");
+
+                if (entitiesToUpdate.Count <= 10)
+                {
+                    Console.Error.WriteLine();
+                    foreach (var updateEntity in entitiesToUpdate)
+                    {
+                        Console.Error.WriteLine($"  {updateEntity.Id}");
+                    }
+                }
+                else
+                {
+                    Console.Error.WriteLine();
+                    Console.Error.WriteLine($"  (showing first 5 of {entitiesToUpdate.Count})");
+                    foreach (var updateEntity in entitiesToUpdate.Take(5))
+                    {
+                        Console.Error.WriteLine($"  {updateEntity.Id}");
+                    }
+                    Console.Error.WriteLine("  ...");
+                }
+
+                Console.Error.WriteLine();
+            }
+
+            // Dry-run mode: show what would be updated and exit
+            if (dryRun)
+            {
+                if (globalOptions.IsJsonMode)
+                {
+                    WriteJsonResult(new UpdateResult
+                    {
+                        Success = true,
+                        DryRun = true,
+                        RecordCount = entitiesToUpdate.Count,
+                        RecordIds = entitiesToUpdate.Select(e => e.Id).ToList()
+                    });
+                }
+                else
+                {
+                    Console.Error.WriteLine("[Dry-Run] No records updated.");
+                }
+                return ExitCodes.Success;
+            }
+
+            // Confirmation prompt (unless --force)
+            if (!force)
+            {
+                if (!Console.IsInputRedirected)
+                {
+                    Console.Error.Write($"Type 'update {entitiesToUpdate.Count}' to confirm, or Ctrl+C to cancel: ");
+                    var confirmation = Console.ReadLine();
+
+                    if (confirmation != $"update {entitiesToUpdate.Count}")
+                    {
+                        Console.Error.WriteLine("Cancelled.");
+                        return ExitCodes.Success;
+                    }
+                    Console.Error.WriteLine();
+                }
+                else
+                {
+                    WriteError(globalOptions, "CONFIRMATION_REQUIRED",
+                        "Use --force to skip confirmation in non-interactive mode");
+                    return ExitCodes.InvalidArguments;
+                }
+            }
+
+            // Execute update
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"Updating {entitiesToUpdate.Count} record(s) in '{entity}'...");
+                Console.Error.WriteLine();
+            }
+
+            var options = new BulkOperationOptions
+            {
+                BatchSize = batchSize,
+                ContinueOnError = continueOnError,
+                BypassCustomLogic = bypassPlugins,
+                BypassPowerAutomateFlows = bypassFlows
+            };
+
+            // Progress reporting
+            var progress = new Progress<ProgressSnapshot>(snapshot =>
+            {
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.Write($"\r  Progress: {snapshot.Processed:N0}/{snapshot.Total:N0} " +
+                        $"({snapshot.PercentComplete:F1}%) | {snapshot.InstantRatePerSecond:F0}/s");
+                }
+            });
+
+            var result = await bulkExecutor.UpdateMultipleAsync(
+                entity,
+                entitiesToUpdate,
+                options,
+                progress,
+                cancellationToken);
+
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine();
+            }
+
+            // Output results
+            if (globalOptions.IsJsonMode)
+            {
+                WriteJsonResult(new UpdateResult
+                {
+                    Success = result.IsSuccess,
+                    UpdatedCount = result.SuccessCount,
+                    FailedCount = result.FailureCount,
+                    DurationMs = result.Duration.TotalMilliseconds,
+                    Errors = result.Errors.Select(e => new UpdateErrorInfo
+                    {
+                        RecordId = e.RecordId,
+                        ErrorCode = e.ErrorCode.ToString(),
+                        Message = e.Message
+                    }).ToList()
+                });
+            }
+            else
+            {
+                WriteTextResult(result);
+            }
+
+            return result.IsSuccess ? ExitCodes.Success : ExitCodes.PartialSuccess;
+        }
+        catch (OperationCanceledException)
+        {
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Update cancelled.");
+            }
+            return ExitCodes.Failure;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "updating records", debug: globalOptions.Debug);
+            if (globalOptions.IsJsonMode)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { success = false, error }, JsonOptions));
+            }
+            else
+            {
+                Console.Error.WriteLine($"Error: {error.Message}");
+                if (globalOptions.Debug && !string.IsNullOrEmpty(error.Details))
+                {
+                    Console.Error.WriteLine(error.Details);
+                }
+            }
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static void ApplySetValues(Entity entity, string setString)
+    {
+        // Parse field=value pairs from --set option
+        foreach (var pair in setString.Split(','))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length != 2)
+            {
+                throw new ArgumentException($"Invalid --set format: {pair}. Expected field=value.");
+            }
+
+            var field = parts[0].Trim();
+            var value = parts[1].Trim();
+
+            // Handle special values
+            if (value.Equals("null", StringComparison.OrdinalIgnoreCase))
+            {
+                entity[field] = null;
+            }
+            else if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                entity[field] = true;
+            }
+            else if (value.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                entity[field] = false;
+            }
+            else if (int.TryParse(value, out var intValue))
+            {
+                entity[field] = intValue;
+            }
+            else if (decimal.TryParse(value, out var decimalValue))
+            {
+                entity[field] = decimalValue;
+            }
+            else if (Guid.TryParse(value, out var guidValue))
+            {
+                entity[field] = guidValue;
+            }
+            else if (DateTime.TryParse(value, out var dateValue))
+            {
+                entity[field] = dateValue;
+            }
+            else
+            {
+                // Default to string
+                entity[field] = value;
+            }
+        }
+    }
+
+    private static async Task<Guid?> ResolveAlternateKeyAsync(
+        IDataverseConnectionPool pool,
+        string entity,
+        string keyString,
+        CancellationToken cancellationToken)
+    {
+        // Parse key=value pairs and build a query
+        var query = new QueryExpression(entity)
+        {
+            ColumnSet = new ColumnSet(false),
+            TopCount = 1
+        };
+
+        foreach (var pair in keyString.Split(','))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length != 2)
+            {
+                throw new ArgumentException($"Invalid key format: {pair}. Expected field=value.");
+            }
+            query.Criteria.AddCondition(parts[0].Trim(), ConditionOperator.Equal, parts[1].Trim());
+        }
+
+        await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var results = await client.RetrieveMultipleAsync(query, cancellationToken);
+        return results.Entities.Count > 0 ? results.Entities[0].Id : null;
+    }
+
+    private static async Task<List<Entity>> LoadEntitiesFromFileAsync(
+        FileInfo file,
+        string? idColumn,
+        string entity,
+        FileInfo? mappingFile,
+        CancellationToken cancellationToken)
+    {
+        var content = await File.ReadAllTextAsync(file.FullName, cancellationToken);
+        content = content.Trim();
+
+        // Load mapping if provided
+        Dictionary<string, string>? columnMappings = null;
+        if (mappingFile != null)
+        {
+            var mappingContent = await File.ReadAllTextAsync(mappingFile.FullName, cancellationToken);
+            var mappingDoc = JsonDocument.Parse(mappingContent);
+            if (mappingDoc.RootElement.TryGetProperty("columns", out var columns))
+            {
+                columnMappings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var col in columns.EnumerateObject())
+                {
+                    if (col.Value.TryGetProperty("field", out var field))
+                    {
+                        columnMappings[col.Name] = field.GetString()!;
+                    }
+                }
+            }
+        }
+
+        // Parse CSV
+        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0) return new List<Entity>();
+
+        // Parse header
+        var headers = lines[0].Split(',').Select(h => h.Trim().Trim('"')).ToList();
+
+        // Find ID column
+        var idColIndex = -1;
+        var actualIdColumn = idColumn ?? $"{entity}id";
+
+        idColIndex = headers.FindIndex(h => h.Equals(actualIdColumn, StringComparison.OrdinalIgnoreCase));
+        if (idColIndex < 0)
+        {
+            // Try common alternatives
+            idColIndex = headers.FindIndex(h => h.Equals("id", StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (idColIndex < 0)
+        {
+            throw new ArgumentException($"Could not find ID column '{actualIdColumn}'. Specify --id-column. Available: {string.Join(", ", headers)}");
+        }
+
+        var entities = new List<Entity>();
+
+        // Parse data rows
+        for (var i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+            if (string.IsNullOrEmpty(line)) continue;
+
+            var values = ParseCsvLine(line);
+            if (values.Count <= idColIndex) continue;
+
+            if (!Guid.TryParse(values[idColIndex].Trim().Trim('"'), out var recordId))
+            {
+                continue; // Skip rows with invalid IDs
+            }
+
+            var updateEntity = new Entity(entity, recordId);
+
+            // Add all columns except the ID column
+            for (var j = 0; j < Math.Min(headers.Count, values.Count); j++)
+            {
+                if (j == idColIndex) continue;
+
+                var header = headers[j];
+                var value = values[j].Trim().Trim('"');
+
+                // Apply mapping if available
+                var fieldName = columnMappings != null && columnMappings.TryGetValue(header, out var mapped)
+                    ? mapped
+                    : header;
+
+                // Set the value (basic type inference)
+                if (string.IsNullOrEmpty(value))
+                {
+                    updateEntity[fieldName] = null;
+                }
+                else if (value.Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    updateEntity[fieldName] = true;
+                }
+                else if (value.Equals("false", StringComparison.OrdinalIgnoreCase))
+                {
+                    updateEntity[fieldName] = false;
+                }
+                else if (int.TryParse(value, out var intVal))
+                {
+                    updateEntity[fieldName] = intVal;
+                }
+                else if (decimal.TryParse(value, out var decVal))
+                {
+                    updateEntity[fieldName] = decVal;
+                }
+                else if (Guid.TryParse(value, out var guidVal))
+                {
+                    updateEntity[fieldName] = guidVal;
+                }
+                else if (DateTime.TryParse(value, out var dateVal))
+                {
+                    updateEntity[fieldName] = dateVal;
+                }
+                else
+                {
+                    updateEntity[fieldName] = value;
+                }
+            }
+
+            entities.Add(updateEntity);
+        }
+
+        return entities;
+    }
+
+    private static List<string> ParseCsvLine(string line)
+    {
+        var values = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+
+        foreach (var c in line)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                current.Append(c);
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                values.Add(current.ToString());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        values.Add(current.ToString());
+        return values;
+    }
+
+    private static async Task<List<Guid>> QueryIdsAsync(
+        IDataverseConnectionPool pool,
+        string entity,
+        string filter,
+        int? limit,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        if (!globalOptions.IsJsonMode)
+        {
+            Console.Error.WriteLine("Querying records to update...");
+        }
+
+        // Build SQL query and transpile to FetchXML
+        var sql = $"SELECT {entity}id FROM {entity} WHERE {filter}";
+        if (limit.HasValue)
+        {
+            sql = $"SELECT TOP {limit.Value + 1} {entity}id FROM {entity} WHERE {filter}";
+        }
+
+        var parser = new SqlParser(sql);
+        var ast = parser.Parse();
+        var transpiler = new SqlToFetchXmlTranspiler();
+        var fetchXml = transpiler.Transpile(ast);
+
+        await using var client = await pool.GetClientAsync(cancellationToken: cancellationToken);
+
+        var query = new FetchExpression(fetchXml);
+        var results = await client.RetrieveMultipleAsync(query, cancellationToken);
+
+        var ids = new List<Guid>();
+        var primaryKeyAttribute = $"{entity}id";
+
+        foreach (var record in results.Entities)
+        {
+            if (record.Contains(primaryKeyAttribute) && record[primaryKeyAttribute] is Guid recordId)
+            {
+                ids.Add(recordId);
+            }
+            else
+            {
+                ids.Add(record.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    private static void WriteTextResult(BulkOperationResult result)
+    {
+        Console.Error.WriteLine("Update complete");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"  Updated: {result.SuccessCount:N0}");
+
+        if (result.FailureCount > 0)
+        {
+            Console.Error.WriteLine($"  Failed: {result.FailureCount:N0}");
+        }
+
+        Console.Error.WriteLine($"  Duration: {result.Duration:mm\\:ss\\.fff}");
+
+        if (result.Errors.Count > 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Errors:");
+
+            // Group errors by error code
+            var groupedErrors = result.Errors
+                .GroupBy(e => e.ErrorCode)
+                .OrderByDescending(g => g.Count());
+
+            foreach (var group in groupedErrors.Take(5))
+            {
+                Console.Error.WriteLine($"  {group.Key}: {group.Count()} occurrence(s)");
+                foreach (var error in group.Take(3))
+                {
+                    Console.Error.WriteLine($"    [{error.RecordId}] {error.Message}");
+                }
+                if (group.Count() > 3)
+                {
+                    Console.Error.WriteLine($"    ... and {group.Count() - 3} more");
+                }
+            }
+
+            if (groupedErrors.Count() > 5)
+            {
+                Console.Error.WriteLine($"  ... and {groupedErrors.Count() - 5} more error types");
+            }
+        }
+    }
+
+    private static void WriteJsonResult(UpdateResult result)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+    }
+
+    private static void WriteError(GlobalOptionValues globalOptions, string code, string message)
+    {
+        if (globalOptions.IsJsonMode)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code, message }
+            }, JsonOptions));
+        }
+        else
+        {
+            Console.Error.WriteLine($"Error: {message}");
+        }
+    }
+
+    private sealed class UpdateResult
+    {
+        public bool Success { get; init; }
+        public bool DryRun { get; init; }
+        public int RecordCount { get; init; }
+        public int UpdatedCount { get; init; }
+        public int FailedCount { get; init; }
+        public double DurationMs { get; init; }
+        public List<Guid>? RecordIds { get; init; }
+        public List<UpdateErrorInfo>? Errors { get; init; }
+    }
+
+    private sealed class UpdateErrorInfo
+    {
+        public Guid? RecordId { get; init; }
+        public string? ErrorCode { get; init; }
+        public string? Message { get; init; }
+    }
+}

--- a/src/PPDS.Cli/README.md
+++ b/src/PPDS.Cli/README.md
@@ -158,7 +158,7 @@ Options:
 - `--environment`, `-env` - Override environment URL
 - `--parallel` - Max concurrent entity exports (default: CPU * 2)
 - `--batch-size` - Records per API request (default: 5000)
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 - `--verbose`, `-v` - Verbose logging
 - `--debug` - Diagnostic logging
 
@@ -179,7 +179,7 @@ Options:
 - `--bypass-plugins` - Bypass plugins: sync, async, or all
 - `--bypass-flows` - Bypass Power Automate flows
 - `--continue-on-error` - Continue on individual record failures
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 - `--verbose`, `-v` - Verbose logging
 - `--debug` - Diagnostic logging
 
@@ -217,7 +217,7 @@ Options:
 - `--disable-plugins` - Set disableplugins=true on all entities
 - `--include-attributes`, `-a` - Whitelist specific attributes
 - `--exclude-attributes` - Blacklist specific attributes
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 #### Users
 
@@ -237,7 +237,7 @@ Options:
 - `--source-profile`, `-sp` - Profile for source (default: active)
 - `--target-profile`, `-tp` - Profile for target (default: active)
 - `--analyze` - Preview without generating file
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 Use the mapping file with import:
 ```bash
@@ -267,7 +267,7 @@ Options:
 - `--force` - Skip unmatched columns (when auto-mapping is incomplete)
 - `--profile`, `-p` - Profile name
 - `--environment`, `-env` - Override environment URL
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 #### Update
 
@@ -314,7 +314,7 @@ Options:
 - `--continue-on-error` - Continue on individual record failures
 - `--profile`, `-p` - Profile name
 - `--environment`, `-env` - Override environment URL
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 **Safety Features:**
 - All updates require confirmation by default (type `update N` where N is the count)
@@ -361,7 +361,7 @@ Options:
 - `--continue-on-error` - Continue on individual record failures
 - `--profile`, `-p` - Profile name
 - `--environment`, `-env` - Override environment URL
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 **Safety Features:**
 - All deletes require confirmation by default (type `delete N` where N is the count)
@@ -531,7 +531,7 @@ Options:
 - `--filter` - Filter by name pattern (supports `*` wildcard, e.g., `*account*`)
 - `--custom-only` - Show only custom entities/attributes
 - `--type` - Filter attributes by type (String, Lookup, DateTime, etc.)
-- `--output-format`, `-f` - Output format (Text or Json)
+- `--output-format`, `-o` - Output format (Text or Json)
 
 ---
 
@@ -596,7 +596,7 @@ These options are available on all commands:
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--output-format` | `-f` | Output format: `text` (default) or `json` |
+| `--output-format` | `-o` | Output format: `text` (default) or `json` |
 | `--quiet` | `-q` | Show only warnings and errors |
 | `--verbose` | `-v` | Show debug messages |
 | `--debug` | | Show trace-level diagnostics |

--- a/src/PPDS.Cli/README.md
+++ b/src/PPDS.Cli/README.md
@@ -31,7 +31,7 @@ ppds data export --schema schema.xml --output data.zip
 ppds
 ├── auth      Authentication profile management
 ├── env       Environment discovery and selection
-├── data      Data operations (export, import, copy, analyze, schema, users)
+├── data      Data operations (export, import, copy, load, update, delete, schema, users)
 ├── plugins   Plugin registration management
 ├── query     Execute FetchXML and SQL queries
 └── metadata  Browse entity and attribute metadata
@@ -141,6 +141,9 @@ Data migration operations.
 | `ppds data analyze` | Analyze schema (offline, no connection) |
 | `ppds data schema` | Generate migration schema from metadata |
 | `ppds data users` | Generate user mapping for cross-environment migrations |
+| `ppds data load` | Load CSV data into an entity |
+| `ppds data update` | Update records in an entity |
+| `ppds data delete` | Delete records from an entity |
 
 #### Export
 
@@ -240,6 +243,131 @@ Use the mapping file with import:
 ```bash
 ppds data import --data data.zip --user-mapping user-mapping.xml
 ```
+
+#### Load
+
+Load CSV data into a Dataverse entity using bulk upsert.
+
+```bash
+ppds data load --entity account --file accounts.csv
+```
+
+Options:
+- `--entity`, `-e` (required) - Target entity logical name
+- `--file`, `-f` (required) - Path to CSV file
+- `--key`, `-k` - Alternate key field(s) for upsert (comma-separated for composite)
+- `--mapping`, `-m` - Path to column mapping JSON file
+- `--generate-mapping` - Generate mapping template to file
+- `--dry-run` - Validate without writing to Dataverse
+- `--analyze` - Analyze mapping without loading data
+- `--batch-size` - Records per batch (default: 100)
+- `--bypass-plugins` - Bypass plugins: sync, async, or all
+- `--bypass-flows` - Bypass Power Automate flows
+- `--continue-on-error` - Continue on individual record failures
+- `--force` - Skip unmatched columns (when auto-mapping is incomplete)
+- `--profile`, `-p` - Profile name
+- `--environment`, `-env` - Override environment URL
+- `--output-format`, `-f` - Output format (Text or Json)
+
+#### Update
+
+Update records in a Dataverse entity. Unlike load (upsert), update fails if the record doesn't exist.
+
+```bash
+# Single record by GUID
+ppds data update --entity account --id 00000000-0000-0000-0000-000000000001 --set "description=Updated"
+
+# Single record by alternate key
+ppds data update --entity account --key accountnumber=ACCT001 --set "description=Updated"
+
+# Update multiple fields
+ppds data update --entity account --id 00000000-0000-0000-0000-000000000001 --set "description=Updated,websiteurl=https://example.com"
+
+# Bulk update from CSV file (each row has ID + fields to update)
+ppds data update --entity account --file updates.csv --id-column accountid
+
+# Query-based update
+ppds data update --entity account --filter "statecode eq 0" --set "description=Active account"
+
+# Dry-run (preview without updating)
+ppds data update --entity account --filter "statecode eq 0" --set "description=Updated" --dry-run
+
+# Non-interactive (for CI/CD)
+ppds data update --entity account --filter "statecode eq 0" --set "description=Updated" --force
+```
+
+Options:
+- `--entity`, `-e` (required) - Target entity logical name
+- `--id` - Single record GUID to update
+- `--key`, `-k` - Alternate key for lookup (field=value, comma-separated for composite)
+- `--file` - Path to CSV file containing IDs and values to update
+- `--id-column` - Column name for ID in CSV file (default: entity primary key)
+- `--filter` - SQL-like filter expression to match records
+- `--set`, `-s` - Field values to set (field=value, comma-separated)
+- `--mapping`, `-m` - Path to column mapping JSON file (for --file mode)
+- `--force` - Skip confirmation prompt (required for non-interactive)
+- `--dry-run` - Preview records without updating
+- `--limit` - Maximum records to update (fails if query returns more)
+- `--batch-size` - Records per batch (default: 100)
+- `--bypass-plugins` - Bypass plugins: sync, async, or all
+- `--bypass-flows` - Bypass Power Automate flows
+- `--continue-on-error` - Continue on individual record failures
+- `--profile`, `-p` - Profile name
+- `--environment`, `-env` - Override environment URL
+- `--output-format`, `-f` - Output format (Text or Json)
+
+**Safety Features:**
+- All updates require confirmation by default (type `update N` where N is the count)
+- Use `--force` to bypass confirmation in scripts/CI
+- Use `--dry-run` to preview what would be updated
+
+#### Delete
+
+Delete records from a Dataverse entity. Supports single-record delete, bulk delete from file, and query-based delete.
+
+```bash
+# Single record by GUID
+ppds data delete --entity account --id 00000000-0000-0000-0000-000000000001
+
+# Single record by alternate key
+ppds data delete --entity account --key accountnumber=ACCT001
+
+# Bulk from CSV file
+ppds data delete --entity account --file ids.csv --id-column accountid
+
+# Query-based delete
+ppds data delete --entity account --filter "name like '%test%'"
+
+# Dry-run (preview without deleting)
+ppds data delete --entity account --filter "name like '%test%'" --dry-run
+
+# Non-interactive (for CI/CD)
+ppds data delete --entity account --filter "name like '%test%'" --force --limit 500
+```
+
+Options:
+- `--entity`, `-e` (required) - Target entity logical name
+- `--id` - Single record GUID to delete
+- `--key`, `-k` - Alternate key for lookup (field=value, comma-separated for composite)
+- `--file` - Path to file containing record IDs (JSON array or CSV)
+- `--id-column` - Column name for CSV file (default: entity primary key)
+- `--filter` - SQL-like filter expression to match records
+- `--force` - Skip confirmation prompt (required for non-interactive)
+- `--dry-run` - Preview records without deleting
+- `--limit` - Maximum records to delete (fails if query returns more)
+- `--batch-size` - Records per batch (default: 100)
+- `--bypass-plugins` - Bypass plugins: sync, async, or all
+- `--bypass-flows` - Bypass Power Automate flows
+- `--continue-on-error` - Continue on individual record failures
+- `--profile`, `-p` - Profile name
+- `--environment`, `-env` - Override environment URL
+- `--output-format`, `-f` - Output format (Text or Json)
+
+**Safety Features:**
+- All deletes require confirmation by default (type `delete N` where N is the count)
+- Use `--force` to bypass confirmation in scripts/CI
+- Use `--dry-run` to preview what would be deleted
+- Use `--limit` to cap the number of records (fails if query exceeds limit)
 
 ### `ppds query`
 

--- a/tests/PPDS.Cli.Tests/Commands/DeleteCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/DeleteCommandTests.cs
@@ -1,0 +1,418 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Data;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+public class DeleteCommandTests
+{
+    private readonly Command _command;
+
+    public DeleteCommandTests()
+    {
+        _command = DeleteCommand.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("delete", _command.Name);
+    }
+
+    [Fact]
+    public void Create_HasRequiredEntityOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--entity");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+        Assert.Contains("-e", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasIdOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--id");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasKeyOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--key");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-k", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasFileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--file");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasIdColumnOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--id-column");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasFilterOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--filter");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasForceOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--force");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasDryRunOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--dry-run");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasLimitOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--limit");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBatchSizeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--batch-size");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassPluginsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-plugins");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassFlowsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-flows");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasContinueOnErrorOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--continue-on-error");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasProfileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasEnvironmentOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasOutputFormatOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--output-format");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasVerboseOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--verbose");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasDebugOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--debug");
+        Assert.NotNull(option);
+    }
+
+    #endregion
+
+    #region Input Mode Validation Tests
+
+    [Fact]
+    public void Parse_NoInputMode_HasError()
+    {
+        var result = _command.Parse("--entity account");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("--id") || e.Message.Contains("--key") || e.Message.Contains("--file") || e.Message.Contains("--filter"));
+    }
+
+    [Fact]
+    public void Parse_WithIdOnly_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_WithKeyOnly_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --key name=Test");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_WithFilterOnly_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\"");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_IdAndKey_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --key name=Test");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_IdAndFilter_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --filter \"name like '%test%'\"");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_KeyAndFilter_HasError()
+    {
+        var result = _command.Parse("--entity account --key name=Test --filter \"name like '%test%'\"");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    #endregion
+
+    #region Entity Validation Tests
+
+    [Fact]
+    public void Parse_MissingEntity_HasError()
+    {
+        var result = _command.Parse("--id 00000000-0000-0000-0000-000000000001");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_EntityWithSpaces_HasError()
+    {
+        var result = _command.Parse("--entity \"account name\" --id 00000000-0000-0000-0000-000000000001");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Batch Size Validation Tests
+
+    [Fact]
+    public void Parse_InvalidBatchSize_Zero_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --batch-size 0");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("batch-size"));
+    }
+
+    [Fact]
+    public void Parse_InvalidBatchSize_TooLarge_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --batch-size 5000");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("batch-size"));
+    }
+
+    [Fact]
+    public void Parse_ValidBatchSize_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --batch-size 100");
+        var batchSizeErrors = result.Errors.Where(e => e.Message.Contains("batch-size"));
+        Assert.Empty(batchSizeErrors);
+    }
+
+    #endregion
+
+    #region Limit Validation Tests
+
+    [Fact]
+    public void Parse_InvalidLimit_Zero_HasError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --limit 0");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("limit"));
+    }
+
+    [Fact]
+    public void Parse_ValidLimit_NoError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --limit 100");
+        var limitErrors = result.Errors.Where(e => e.Message.Contains("limit"));
+        Assert.Empty(limitErrors);
+    }
+
+    #endregion
+
+    #region Bypass Plugins Validation Tests
+
+    [Fact]
+    public void Parse_InvalidBypassPlugins_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --bypass-plugins invalid");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Sync_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --bypass-plugins sync");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Async_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --bypass-plugins async");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_All_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --bypass-plugins all");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    #endregion
+
+    #region Flag Combination Tests
+
+    [Fact]
+    public void Parse_WithDryRun_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --dry-run");
+        var dryRunErrors = result.Errors.Where(e => e.Message.Contains("dry-run"));
+        Assert.Empty(dryRunErrors);
+    }
+
+    [Fact]
+    public void Parse_WithForce_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --force");
+        var forceErrors = result.Errors.Where(e => e.Message.Contains("force"));
+        Assert.Empty(forceErrors);
+    }
+
+    [Fact]
+    public void Parse_WithDryRunAndForce_NoError()
+    {
+        // Both flags together is valid - dry-run takes precedence
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --dry-run --force");
+        var flagErrors = result.Errors.Where(e => e.Message.Contains("dry-run") || e.Message.Contains("force"));
+        Assert.Empty(flagErrors);
+    }
+
+    [Fact]
+    public void Parse_WithBypassFlows_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --bypass-flows");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-flows"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_WithContinueOnError_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --continue-on-error");
+        var continueErrors = result.Errors.Where(e => e.Message.Contains("continue-on-error"));
+        Assert.Empty(continueErrors);
+    }
+
+    #endregion
+
+    #region Complex Scenario Tests
+
+    [Fact]
+    public void Parse_FilterWithLimit_NoError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --limit 500 --force");
+        var relevantErrors = result.Errors.Where(e =>
+            e.Message.Contains("filter") ||
+            e.Message.Contains("limit") ||
+            e.Message.Contains("force"));
+        Assert.Empty(relevantErrors);
+    }
+
+    [Fact]
+    public void Parse_FullOptionsWithId_NoError()
+    {
+        var result = _command.Parse(
+            "--entity account " +
+            "--id 00000000-0000-0000-0000-000000000001 " +
+            "--force " +
+            "--batch-size 50 " +
+            "--bypass-plugins sync " +
+            "--bypass-flows " +
+            "--continue-on-error " +
+            "--profile dev");
+
+        // Should only fail on profile validation (profile doesn't exist), not on option parsing
+        var parseErrors = result.Errors.Where(e =>
+            e.Message.Contains("batch-size") ||
+            e.Message.Contains("bypass") ||
+            e.Message.Contains("force") ||
+            e.Message.Contains("Only one input mode"));
+        Assert.Empty(parseErrors);
+    }
+
+    [Fact]
+    public void Parse_WithCompositeKey_NoError()
+    {
+        var result = _command.Parse("--entity account --key \"name=Test,stateid=CA\"");
+        var keyErrors = result.Errors.Where(e => e.Message.Contains("key"));
+        Assert.Empty(keyErrors);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/Commands/UpdateCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/UpdateCommandTests.cs
@@ -1,0 +1,464 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Data;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+public class UpdateCommandTests
+{
+    private readonly Command _command;
+
+    public UpdateCommandTests()
+    {
+        _command = UpdateCommand.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("update", _command.Name);
+    }
+
+    [Fact]
+    public void Create_HasRequiredEntityOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--entity");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+        Assert.Contains("-e", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasIdOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--id");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasKeyOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--key");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-k", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasFileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--file");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasIdColumnOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--id-column");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasFilterOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--filter");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasSetOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--set");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-s", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasMappingOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--mapping");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-m", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasForceOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--force");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasDryRunOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--dry-run");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasLimitOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--limit");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBatchSizeOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--batch-size");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassPluginsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-plugins");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasBypassFlowsOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--bypass-flows");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasContinueOnErrorOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--continue-on-error");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasProfileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasEnvironmentOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasOutputFormatOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--output-format");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasVerboseOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--verbose");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Create_HasDebugOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--debug");
+        Assert.NotNull(option);
+    }
+
+    #endregion
+
+    #region Input Mode Validation Tests
+
+    [Fact]
+    public void Parse_NoInputMode_HasError()
+    {
+        var result = _command.Parse("--entity account --set name=Test");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("--id") || e.Message.Contains("--key") || e.Message.Contains("--file") || e.Message.Contains("--filter"));
+    }
+
+    [Fact]
+    public void Parse_WithIdOnly_NoSet_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("--set"));
+    }
+
+    [Fact]
+    public void Parse_WithIdAndSet_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_WithKeyAndSet_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --key accountnumber=ACCT001 --set name=Test");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_WithFilterAndSet_NoInputModeError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --set statecode=1");
+        var inputModeErrors = result.Errors.Where(e => e.Message.Contains("--id") && e.Message.Contains("--key"));
+        Assert.Empty(inputModeErrors);
+    }
+
+    [Fact]
+    public void Parse_WithFileOnly_NoSetRequired()
+    {
+        // --file mode doesn't require --set because the file contains the values
+        var result = _command.Parse("--entity account --file test.csv");
+        var setErrors = result.Errors.Where(e => e.Message.Contains("--set"));
+        Assert.Empty(setErrors);
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_IdAndKey_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --key name=Test --set name=Test");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_IdAndFilter_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --filter \"name like '%test%'\" --set name=Test");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    [Fact]
+    public void Parse_MultipleInputModes_KeyAndFilter_HasError()
+    {
+        var result = _command.Parse("--entity account --key name=Test --filter \"name like '%test%'\" --set name=Test");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("Only one input mode"));
+    }
+
+    #endregion
+
+    #region Entity Validation Tests
+
+    [Fact]
+    public void Parse_MissingEntity_HasError()
+    {
+        var result = _command.Parse("--id 00000000-0000-0000-0000-000000000001 --set name=Test");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_EntityWithSpaces_HasError()
+    {
+        var result = _command.Parse("--entity \"account name\" --id 00000000-0000-0000-0000-000000000001 --set name=Test");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Batch Size Validation Tests
+
+    [Fact]
+    public void Parse_InvalidBatchSize_Zero_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --batch-size 0");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("batch-size"));
+    }
+
+    [Fact]
+    public void Parse_InvalidBatchSize_TooLarge_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --batch-size 5000");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("batch-size"));
+    }
+
+    [Fact]
+    public void Parse_ValidBatchSize_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --batch-size 100");
+        var batchSizeErrors = result.Errors.Where(e => e.Message.Contains("batch-size"));
+        Assert.Empty(batchSizeErrors);
+    }
+
+    #endregion
+
+    #region Limit Validation Tests
+
+    [Fact]
+    public void Parse_InvalidLimit_Zero_HasError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --set statecode=1 --limit 0");
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Message.Contains("limit"));
+    }
+
+    [Fact]
+    public void Parse_ValidLimit_NoError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --set statecode=1 --limit 100");
+        var limitErrors = result.Errors.Where(e => e.Message.Contains("limit"));
+        Assert.Empty(limitErrors);
+    }
+
+    #endregion
+
+    #region Bypass Plugins Validation Tests
+
+    [Fact]
+    public void Parse_InvalidBypassPlugins_HasError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --bypass-plugins invalid");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Sync_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --bypass-plugins sync");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_Async_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --bypass-plugins async");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_ValidBypassPlugins_All_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --bypass-plugins all");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-plugins"));
+        Assert.Empty(bypassErrors);
+    }
+
+    #endregion
+
+    #region Flag Combination Tests
+
+    [Fact]
+    public void Parse_WithDryRun_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --dry-run");
+        var dryRunErrors = result.Errors.Where(e => e.Message.Contains("dry-run"));
+        Assert.Empty(dryRunErrors);
+    }
+
+    [Fact]
+    public void Parse_WithForce_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --force");
+        var forceErrors = result.Errors.Where(e => e.Message.Contains("force"));
+        Assert.Empty(forceErrors);
+    }
+
+    [Fact]
+    public void Parse_WithDryRunAndForce_NoError()
+    {
+        // Both flags together is valid - dry-run takes precedence
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --dry-run --force");
+        var flagErrors = result.Errors.Where(e => e.Message.Contains("dry-run") || e.Message.Contains("force"));
+        Assert.Empty(flagErrors);
+    }
+
+    [Fact]
+    public void Parse_WithBypassFlows_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --bypass-flows");
+        var bypassErrors = result.Errors.Where(e => e.Message.Contains("bypass-flows"));
+        Assert.Empty(bypassErrors);
+    }
+
+    [Fact]
+    public void Parse_WithContinueOnError_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test --continue-on-error");
+        var continueErrors = result.Errors.Where(e => e.Message.Contains("continue-on-error"));
+        Assert.Empty(continueErrors);
+    }
+
+    #endregion
+
+    #region Complex Scenario Tests
+
+    [Fact]
+    public void Parse_FilterWithLimitAndSet_NoError()
+    {
+        var result = _command.Parse("--entity account --filter \"name like '%test%'\" --set statecode=1 --limit 500 --force");
+        var relevantErrors = result.Errors.Where(e =>
+            e.Message.Contains("filter") ||
+            e.Message.Contains("limit") ||
+            e.Message.Contains("set") ||
+            e.Message.Contains("force"));
+        Assert.Empty(relevantErrors);
+    }
+
+    [Fact]
+    public void Parse_FullOptionsWithId_NoError()
+    {
+        var result = _command.Parse(
+            "--entity account " +
+            "--id 00000000-0000-0000-0000-000000000001 " +
+            "--set name=Updated,description=NewDesc " +
+            "--force " +
+            "--batch-size 50 " +
+            "--bypass-plugins sync " +
+            "--bypass-flows " +
+            "--continue-on-error " +
+            "--profile dev");
+
+        // Should only fail on profile validation (profile doesn't exist), not on option parsing
+        var parseErrors = result.Errors.Where(e =>
+            e.Message.Contains("batch-size") ||
+            e.Message.Contains("bypass") ||
+            e.Message.Contains("force") ||
+            e.Message.Contains("Only one input mode") ||
+            e.Message.Contains("--set"));
+        Assert.Empty(parseErrors);
+    }
+
+    [Fact]
+    public void Parse_WithCompositeKey_NoError()
+    {
+        var result = _command.Parse("--entity account --key \"name=Test,stateid=CA\" --set description=Updated");
+        var keyErrors = result.Errors.Where(e => e.Message.Contains("key"));
+        Assert.Empty(keyErrors);
+    }
+
+    [Fact]
+    public void Parse_WithMultipleSetValues_NoError()
+    {
+        var result = _command.Parse("--entity account --id 00000000-0000-0000-0000-000000000001 --set name=Test,description=Desc,statecode=1");
+        var setErrors = result.Errors.Where(e => e.Message.Contains("set"));
+        Assert.Empty(setErrors);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
@@ -1,0 +1,555 @@
+using FluentAssertions;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// E2E tests for ppds data delete command.
+/// Deletes records from Dataverse entities.
+/// Tests only run on .NET 8.0 since CLI is spawned with --framework net8.0.
+/// </summary>
+/// <remarks>
+/// Tier 1 tests use --dry-run and are safe for all environments.
+/// Tier 2 tests (marked with DestructiveE2E trait) actually delete records.
+/// </remarks>
+public class DataDeleteCommandE2ETests : CliE2ETestBase
+{
+    /// <summary>
+    /// Unique identifier prefix for test records to avoid conflicts.
+    /// </summary>
+    private readonly string _testPrefix = $"PPDS_E2EDelete_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Tracks account IDs created during tests for cleanup.
+    /// </summary>
+    private readonly List<Guid> _createdAccountIds = new();
+
+    /// <summary>
+    /// Profile name used across tests in this class.
+    /// </summary>
+    private string? _profileName;
+
+    #region Tier 1: Validation tests (no credentials needed)
+
+    [CliE2EFact]
+    public async Task Delete_MissingEntity_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--id", Guid.NewGuid().ToString());
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--entity", "-e", "required");
+    }
+
+    [CliE2EFact]
+    public async Task Delete_MissingInputMode_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--id", "--key", "--file", "--filter");
+    }
+
+    [CliE2EFact]
+    public async Task Delete_MultipleInputModes_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", Guid.NewGuid().ToString(),
+            "--filter", "name like '%test%'");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("Only one", "input mode");
+    }
+
+    [CliE2EFact]
+    public async Task Delete_FileNotFound_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--file", "nonexistent-file.csv");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("not found", "does not exist", "File");
+    }
+
+    [CliE2EFact]
+    public async Task Delete_InvalidBatchSize_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", Guid.NewGuid().ToString(),
+            "--batch-size", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("batch-size");
+    }
+
+    [CliE2EFact]
+    public async Task Delete_InvalidLimit_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--filter", "name like '%test%'",
+            "--limit", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("limit");
+    }
+
+    #endregion
+
+    #region Tier 1: Safe tests (--dry-run)
+
+    [CliE2EWithCredentials]
+    public async Task Delete_DryRun_ById_ShowsPreview()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        result.StdErr.Should().Contain("Dry-Run");
+        result.StdErr.Should().Contain("1"); // Record count
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Delete_DryRun_ById_JsonFormat_ReturnsValidJson()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--dry-run",
+            "--output-format", "json",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        result.StdOut.Trim().Should().StartWith("{");
+        result.StdOut.Should().Contain("\"dryRun\": true");
+        result.StdOut.Should().Contain("\"recordCount\": 1");
+        result.StdOut.Should().Contain(testId.ToString());
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Delete_DryRun_ByFilter_ShowsMatchedRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Use a filter that should match 0 records (unique test prefix)
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--filter", $"name like '%{_testPrefix}_UNLIKELY_TO_EXIST%'",
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        // Should either show "No records match" or dry-run preview with 0 records
+        (result.StdOut + result.StdErr).Should().ContainAny("No records", "0", "Dry-Run");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Delete_NonInteractive_WithoutForce_FailsWithError()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        // Without --dry-run or --force, should fail in non-interactive mode
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--profile", _profileName!);
+
+        // Expect failure because input is redirected (non-interactive) and --force not provided
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("force", "confirmation", "non-interactive");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Delete_WithProfileOption_UsesSpecifiedProfile()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Delete_WithEnvironmentOverride_UsesSpecifiedEnvironment()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--dry-run",
+            "--profile", _profileName!,
+            "--environment", Configuration.DataverseUrl!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+    }
+
+    #endregion
+
+    #region Tier 2: Destructive tests (actual delete)
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_ById_WithForce_DeletesRecord()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record first
+        var accountId = await CreateTestAccountAsync($"{_testPrefix}_DeleteById");
+
+        try
+        {
+            // Delete the record
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--id", accountId.ToString(),
+                "--force",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdErr.Should().Contain("Deleted");
+            deleteResult.StdErr.Should().Contain("1");
+
+            // Verify record was deleted
+            var exists = await RecordExistsAsync(accountId);
+            exists.Should().BeFalse("Record should have been deleted");
+
+            // Remove from cleanup list since it's already deleted
+            _createdAccountIds.Remove(accountId);
+        }
+        catch
+        {
+            // Leave in cleanup list if test fails
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_ById_JsonFormat_ReturnsResult()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record first
+        var accountId = await CreateTestAccountAsync($"{_testPrefix}_DeleteByIdJson");
+
+        try
+        {
+            // Delete the record with JSON output
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--id", accountId.ToString(),
+                "--force",
+                "--output-format", "json",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdOut.Trim().Should().StartWith("{");
+            deleteResult.StdOut.Should().Contain("\"success\": true");
+            deleteResult.StdOut.Should().Contain("\"deletedCount\": 1");
+
+            _createdAccountIds.Remove(accountId);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_ByFilter_WithForce_DeletesMatchingRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Create test records
+        var filterValue = $"{_testPrefix}_FilterDelete";
+        var account1 = await CreateTestAccountAsync(filterValue + "_1");
+        var account2 = await CreateTestAccountAsync(filterValue + "_2");
+
+        try
+        {
+            // Delete by filter
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--filter", $"name like '{filterValue}%'",
+                "--force",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdErr.Should().Contain("Deleted");
+            deleteResult.StdErr.Should().Contain("2");
+
+            // Verify records were deleted
+            (await RecordExistsAsync(account1)).Should().BeFalse("First record should be deleted");
+            (await RecordExistsAsync(account2)).Should().BeFalse("Second record should be deleted");
+
+            _createdAccountIds.Remove(account1);
+            _createdAccountIds.Remove(account2);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_FromCsvFile_WithForce_DeletesRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Create test records
+        var account1 = await CreateTestAccountAsync($"{_testPrefix}_CsvDelete_1");
+        var account2 = await CreateTestAccountAsync($"{_testPrefix}_CsvDelete_2");
+
+        // Create CSV file with IDs
+        var csvPath = GenerateTempFilePath(".csv");
+        var csvContent = $"accountid,name\n{account1},Test1\n{account2},Test2";
+        await File.WriteAllTextAsync(csvPath, csvContent);
+
+        try
+        {
+            // Delete from file
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--file", csvPath,
+                "--id-column", "accountid",
+                "--force",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdErr.Should().Contain("Deleted");
+            deleteResult.StdErr.Should().Contain("2");
+
+            // Verify records were deleted
+            (await RecordExistsAsync(account1)).Should().BeFalse();
+            (await RecordExistsAsync(account2)).Should().BeFalse();
+
+            _createdAccountIds.Remove(account1);
+            _createdAccountIds.Remove(account2);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_FromJsonFile_WithForce_DeletesRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Create test records
+        var account1 = await CreateTestAccountAsync($"{_testPrefix}_JsonDelete_1");
+        var account2 = await CreateTestAccountAsync($"{_testPrefix}_JsonDelete_2");
+
+        // Create JSON file with ID array
+        var jsonPath = GenerateTempFilePath(".json");
+        var jsonContent = $"[\"{account1}\", \"{account2}\"]";
+        await File.WriteAllTextAsync(jsonPath, jsonContent);
+
+        try
+        {
+            // Delete from file
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--file", jsonPath,
+                "--force",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdErr.Should().Contain("Deleted");
+            deleteResult.StdErr.Should().Contain("2");
+
+            // Verify records were deleted
+            (await RecordExistsAsync(account1)).Should().BeFalse();
+            (await RecordExistsAsync(account2)).Should().BeFalse();
+
+            _createdAccountIds.Remove(account1);
+            _createdAccountIds.Remove(account2);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_ByKey_WithForce_DeletesRecord()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record with a known name
+        var uniqueName = $"{_testPrefix}_KeyDelete_{Guid.NewGuid():N}";
+        var accountId = await CreateTestAccountAsync(uniqueName);
+
+        try
+        {
+            // Delete by alternate key (name - though account doesn't have a true alternate key,
+            // the command uses query-based lookup for --key)
+            var deleteResult = await RunCliAsync(
+                "data", "delete",
+                "--entity", "account",
+                "--key", $"name={uniqueName}",
+                "--force",
+                "--profile", _profileName!);
+
+            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+            deleteResult.StdErr.Should().Contain("Deleted");
+            deleteResult.StdErr.Should().Contain("1");
+
+            // Verify record was deleted
+            (await RecordExistsAsync(accountId)).Should().BeFalse();
+
+            _createdAccountIds.Remove(accountId);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_NonexistentId_WithForce_HandlesGracefully()
+    {
+        await EnsureProfileAsync();
+
+        // Try to delete a non-existent record
+        var fakeId = Guid.NewGuid();
+
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", fakeId.ToString(),
+            "--force",
+            "--profile", _profileName!);
+
+        // Should handle the error (record not found during delete)
+        // With --continue-on-error (default true), it may still return 0
+        // but should show the error in output
+        (deleteResult.StdOut + deleteResult.StdErr).Should().ContainAny("Failed", "0", "not found", "Error", "does not exist");
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Delete_ByKey_RecordNotFound_ReturnsError()
+    {
+        await EnsureProfileAsync();
+
+        // Try to delete with a key that doesn't match any record
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--key", $"name={_testPrefix}_NONEXISTENT_RECORD_{Guid.NewGuid():N}",
+            "--force",
+            "--profile", _profileName!);
+
+        // Should fail with "record not found"
+        deleteResult.ExitCode.Should().NotBe(0);
+        (deleteResult.StdOut + deleteResult.StdErr).Should().ContainAny("not found", "No record", "RECORD_NOT_FOUND");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task EnsureProfileAsync()
+    {
+        if (_profileName != null) return;
+
+        _profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", _profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", _profileName);
+    }
+
+    private async Task<Guid> CreateTestAccountAsync(string name)
+    {
+        // Use the CLI to create a simple account record via a workaround:
+        // Since we don't have a create command, we'll use the Dataverse pool directly
+        // through a helper that creates via SDK
+
+        // For now, use a direct SDK call through infrastructure
+        var id = await LiveTestHelpers.CreateAccountAsync(Configuration, name);
+        _createdAccountIds.Add(id);
+        return id;
+    }
+
+    private async Task<bool> RecordExistsAsync(Guid accountId)
+    {
+        return await LiveTestHelpers.AccountExistsAsync(Configuration, accountId);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        // Clean up any test accounts that weren't deleted by tests
+        if (_createdAccountIds.Count > 0)
+        {
+            try
+            {
+                await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        await base.DisposeAsync();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
@@ -235,32 +235,24 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         // Create a test record first
         var accountId = await CreateTestAccountAsync($"{_testPrefix}_DeleteById");
 
-        try
-        {
-            // Delete the record
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--id", accountId.ToString(),
-                "--force",
-                "--profile", _profileName!);
+        // Delete the record
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", accountId.ToString(),
+            "--force",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdErr.Should().Contain("Deleted");
-            deleteResult.StdErr.Should().Contain("1");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdErr.Should().Contain("Deleted");
+        deleteResult.StdErr.Should().Contain("1");
 
-            // Verify record was deleted
-            var exists = await RecordExistsAsync(accountId);
-            exists.Should().BeFalse("Record should have been deleted");
+        // Verify record was deleted
+        var exists = await RecordExistsAsync(accountId);
+        exists.Should().BeFalse("Record should have been deleted");
 
-            // Remove from cleanup list since it's already deleted
-            _createdAccountIds.Remove(accountId);
-        }
-        catch
-        {
-            // Leave in cleanup list if test fails
-            throw;
-        }
+        // Remove from cleanup list since it's already deleted
+        _createdAccountIds.Remove(accountId);
     }
 
     [CliE2EWithCredentials]
@@ -272,28 +264,21 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         // Create a test record first
         var accountId = await CreateTestAccountAsync($"{_testPrefix}_DeleteByIdJson");
 
-        try
-        {
-            // Delete the record with JSON output
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--id", accountId.ToString(),
-                "--force",
-                "--output-format", "json",
-                "--profile", _profileName!);
+        // Delete the record with JSON output
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--id", accountId.ToString(),
+            "--force",
+            "--output-format", "json",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdOut.Trim().Should().StartWith("{");
-            deleteResult.StdOut.Should().Contain("\"success\": true");
-            deleteResult.StdOut.Should().Contain("\"deletedCount\": 1");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdOut.Trim().Should().StartWith("{");
+        deleteResult.StdOut.Should().Contain("\"success\": true");
+        deleteResult.StdOut.Should().Contain("\"deletedCount\": 1");
 
-            _createdAccountIds.Remove(accountId);
-        }
-        catch
-        {
-            throw;
-        }
+        _createdAccountIds.Remove(accountId);
     }
 
     [CliE2EWithCredentials]
@@ -307,31 +292,24 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         var account1 = await CreateTestAccountAsync(filterValue + "_1");
         var account2 = await CreateTestAccountAsync(filterValue + "_2");
 
-        try
-        {
-            // Delete by filter
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--filter", $"name like '{filterValue}%'",
-                "--force",
-                "--profile", _profileName!);
+        // Delete by filter
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--filter", $"name like '{filterValue}%'",
+            "--force",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdErr.Should().Contain("Deleted");
-            deleteResult.StdErr.Should().Contain("2");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdErr.Should().Contain("Deleted");
+        deleteResult.StdErr.Should().Contain("2");
 
-            // Verify records were deleted
-            (await RecordExistsAsync(account1)).Should().BeFalse("First record should be deleted");
-            (await RecordExistsAsync(account2)).Should().BeFalse("Second record should be deleted");
+        // Verify records were deleted
+        (await RecordExistsAsync(account1)).Should().BeFalse("First record should be deleted");
+        (await RecordExistsAsync(account2)).Should().BeFalse("Second record should be deleted");
 
-            _createdAccountIds.Remove(account1);
-            _createdAccountIds.Remove(account2);
-        }
-        catch
-        {
-            throw;
-        }
+        _createdAccountIds.Remove(account1);
+        _createdAccountIds.Remove(account2);
     }
 
     [CliE2EWithCredentials]
@@ -349,32 +327,25 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         var csvContent = $"accountid,name\n{account1},Test1\n{account2},Test2";
         await File.WriteAllTextAsync(csvPath, csvContent);
 
-        try
-        {
-            // Delete from file
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--file", csvPath,
-                "--id-column", "accountid",
-                "--force",
-                "--profile", _profileName!);
+        // Delete from file
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--file", csvPath,
+            "--id-column", "accountid",
+            "--force",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdErr.Should().Contain("Deleted");
-            deleteResult.StdErr.Should().Contain("2");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdErr.Should().Contain("Deleted");
+        deleteResult.StdErr.Should().Contain("2");
 
-            // Verify records were deleted
-            (await RecordExistsAsync(account1)).Should().BeFalse();
-            (await RecordExistsAsync(account2)).Should().BeFalse();
+        // Verify records were deleted
+        (await RecordExistsAsync(account1)).Should().BeFalse();
+        (await RecordExistsAsync(account2)).Should().BeFalse();
 
-            _createdAccountIds.Remove(account1);
-            _createdAccountIds.Remove(account2);
-        }
-        catch
-        {
-            throw;
-        }
+        _createdAccountIds.Remove(account1);
+        _createdAccountIds.Remove(account2);
     }
 
     [CliE2EWithCredentials]
@@ -392,31 +363,24 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         var jsonContent = $"[\"{account1}\", \"{account2}\"]";
         await File.WriteAllTextAsync(jsonPath, jsonContent);
 
-        try
-        {
-            // Delete from file
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--file", jsonPath,
-                "--force",
-                "--profile", _profileName!);
+        // Delete from file
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--file", jsonPath,
+            "--force",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdErr.Should().Contain("Deleted");
-            deleteResult.StdErr.Should().Contain("2");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdErr.Should().Contain("Deleted");
+        deleteResult.StdErr.Should().Contain("2");
 
-            // Verify records were deleted
-            (await RecordExistsAsync(account1)).Should().BeFalse();
-            (await RecordExistsAsync(account2)).Should().BeFalse();
+        // Verify records were deleted
+        (await RecordExistsAsync(account1)).Should().BeFalse();
+        (await RecordExistsAsync(account2)).Should().BeFalse();
 
-            _createdAccountIds.Remove(account1);
-            _createdAccountIds.Remove(account2);
-        }
-        catch
-        {
-            throw;
-        }
+        _createdAccountIds.Remove(account1);
+        _createdAccountIds.Remove(account2);
     }
 
     [CliE2EWithCredentials]
@@ -429,30 +393,23 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
         var uniqueName = $"{_testPrefix}_KeyDelete_{Guid.NewGuid():N}";
         var accountId = await CreateTestAccountAsync(uniqueName);
 
-        try
-        {
-            // Delete by alternate key (name - though account doesn't have a true alternate key,
-            // the command uses query-based lookup for --key)
-            var deleteResult = await RunCliAsync(
-                "data", "delete",
-                "--entity", "account",
-                "--key", $"name={uniqueName}",
-                "--force",
-                "--profile", _profileName!);
+        // Delete by alternate key (name - though account doesn't have a true alternate key,
+        // the command uses query-based lookup for --key)
+        var deleteResult = await RunCliAsync(
+            "data", "delete",
+            "--entity", "account",
+            "--key", $"name={uniqueName}",
+            "--force",
+            "--profile", _profileName!);
 
-            deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
-            deleteResult.StdErr.Should().Contain("Deleted");
-            deleteResult.StdErr.Should().Contain("1");
+        deleteResult.ExitCode.Should().Be(0, $"Delete failed: {deleteResult.StdErr}");
+        deleteResult.StdErr.Should().Contain("Deleted");
+        deleteResult.StdErr.Should().Contain("1");
 
-            // Verify record was deleted
-            (await RecordExistsAsync(accountId)).Should().BeFalse();
+        // Verify record was deleted
+        (await RecordExistsAsync(accountId)).Should().BeFalse();
 
-            _createdAccountIds.Remove(accountId);
-        }
-        catch
-        {
-            throw;
-        }
+        _createdAccountIds.Remove(accountId);
     }
 
     [CliE2EWithCredentials]

--- a/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataDeleteCommandE2ETests.cs
@@ -499,7 +499,7 @@ public class DataDeleteCommandE2ETests : CliE2ETestBase
             {
                 await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
             }
-            catch
+            catch (Exception)
             {
                 // Ignore cleanup errors
             }

--- a/tests/PPDS.LiveTests/Cli/DataUpdateCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataUpdateCommandE2ETests.cs
@@ -1,0 +1,511 @@
+using FluentAssertions;
+using PPDS.LiveTests.Infrastructure;
+using Xunit;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// E2E tests for ppds data update command.
+/// Updates records in Dataverse entities.
+/// Tests only run on .NET 8.0 since CLI is spawned with --framework net8.0.
+/// </summary>
+/// <remarks>
+/// Tier 1 tests use --dry-run and are safe for all environments.
+/// Tier 2 tests (marked with DestructiveE2E trait) actually update records.
+/// </remarks>
+public class DataUpdateCommandE2ETests : CliE2ETestBase
+{
+    /// <summary>
+    /// Unique identifier prefix for test records to avoid conflicts.
+    /// </summary>
+    private readonly string _testPrefix = $"PPDS_E2EUpdate_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Tracks account IDs created during tests for cleanup.
+    /// </summary>
+    private readonly List<Guid> _createdAccountIds = new();
+
+    /// <summary>
+    /// Profile name used across tests in this class.
+    /// </summary>
+    private string? _profileName;
+
+    #region Tier 1: Validation tests (no credentials needed)
+
+    [CliE2EFact]
+    public async Task Update_MissingEntity_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--id", Guid.NewGuid().ToString(),
+            "--set", "name=Test");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--entity", "-e", "required");
+    }
+
+    [CliE2EFact]
+    public async Task Update_MissingInputMode_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--set", "name=Test");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("--id", "--key", "--file", "--filter");
+    }
+
+    [CliE2EFact]
+    public async Task Update_MissingSet_ForIdMode_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", Guid.NewGuid().ToString());
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("--set");
+    }
+
+    [CliE2EFact]
+    public async Task Update_MultipleInputModes_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", Guid.NewGuid().ToString(),
+            "--filter", "name like '%test%'",
+            "--set", "name=Test");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("Only one", "input mode");
+    }
+
+    [CliE2EFact]
+    public async Task Update_FileNotFound_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--file", "nonexistent-file.csv");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("not found", "does not exist", "File");
+    }
+
+    [CliE2EFact]
+    public async Task Update_InvalidBatchSize_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", Guid.NewGuid().ToString(),
+            "--set", "name=Test",
+            "--batch-size", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("batch-size");
+    }
+
+    [CliE2EFact]
+    public async Task Update_InvalidLimit_FailsWithError()
+    {
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--filter", "name like '%test%'",
+            "--set", "description=Updated",
+            "--limit", "0");
+
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().Contain("limit");
+    }
+
+    #endregion
+
+    #region Tier 1: Safe tests (--dry-run)
+
+    [CliE2EWithCredentials]
+    public async Task Update_DryRun_ById_ShowsPreview()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--set", "name=Updated",
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        result.StdErr.Should().Contain("Dry-Run");
+        result.StdErr.Should().Contain("1"); // Record count
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Update_DryRun_ById_JsonFormat_ReturnsValidJson()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--set", "name=Updated",
+            "--dry-run",
+            "--output-format", "json",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        result.StdOut.Trim().Should().StartWith("{");
+        result.StdOut.Should().Contain("\"dryRun\": true");
+        result.StdOut.Should().Contain("\"recordCount\": 1");
+        result.StdOut.Should().Contain(testId.ToString());
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Update_DryRun_ByFilter_ShowsMatchedRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Use a filter that should match 0 records (unique test prefix)
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--filter", $"name like '%{_testPrefix}_UNLIKELY_TO_EXIST%'",
+            "--set", "description=Updated",
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+        // Should either show "No records match" or dry-run preview with 0 records
+        (result.StdOut + result.StdErr).Should().ContainAny("No records", "0", "Dry-Run");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Update_NonInteractive_WithoutForce_FailsWithError()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        // Without --dry-run or --force, should fail in non-interactive mode
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--set", "name=Updated",
+            "--profile", _profileName!);
+
+        // Expect failure because input is redirected (non-interactive) and --force not provided
+        result.ExitCode.Should().NotBe(0);
+        (result.StdOut + result.StdErr).Should().ContainAny("force", "confirmation", "non-interactive");
+    }
+
+    [CliE2EWithCredentials]
+    public async Task Update_WithProfileOption_UsesSpecifiedProfile()
+    {
+        await EnsureProfileAsync();
+
+        var testId = Guid.NewGuid();
+
+        var result = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--id", testId.ToString(),
+            "--set", "name=Updated",
+            "--dry-run",
+            "--profile", _profileName!);
+
+        result.ExitCode.Should().Be(0, $"StdErr: {result.StdErr}");
+    }
+
+    #endregion
+
+    #region Tier 2: Destructive tests (actual update)
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_ById_WithForce_UpdatesRecord()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record first
+        var originalName = $"{_testPrefix}_UpdateById";
+        var accountId = await CreateTestAccountAsync(originalName);
+
+        try
+        {
+            // Update the record
+            var newDescription = "Updated by E2E test";
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--id", accountId.ToString(),
+                "--set", $"description={newDescription}",
+                "--force",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdErr.Should().Contain("Updated");
+            updateResult.StdErr.Should().Contain("1");
+
+            // Verify record was updated
+            var description = await GetAccountDescriptionAsync(accountId);
+            description.Should().Be(newDescription);
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_ById_JsonFormat_ReturnsResult()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record first
+        var accountId = await CreateTestAccountAsync($"{_testPrefix}_UpdateByIdJson");
+
+        try
+        {
+            // Update the record with JSON output
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--id", accountId.ToString(),
+                "--set", "description=JSON test update",
+                "--force",
+                "--output-format", "json",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdOut.Trim().Should().StartWith("{");
+            updateResult.StdOut.Should().Contain("\"success\": true");
+            updateResult.StdOut.Should().Contain("\"updatedCount\": 1");
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_ByFilter_WithForce_UpdatesMatchingRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Create test records
+        var filterValue = $"{_testPrefix}_FilterUpdate";
+        var account1 = await CreateTestAccountAsync(filterValue + "_1");
+        var account2 = await CreateTestAccountAsync(filterValue + "_2");
+
+        try
+        {
+            // Update by filter
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--filter", $"name like '{filterValue}%'",
+                "--set", "description=Bulk updated",
+                "--force",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdErr.Should().Contain("Updated");
+            updateResult.StdErr.Should().Contain("2");
+
+            // Verify records were updated
+            (await GetAccountDescriptionAsync(account1)).Should().Be("Bulk updated");
+            (await GetAccountDescriptionAsync(account2)).Should().Be("Bulk updated");
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_FromCsvFile_WithForce_UpdatesRecords()
+    {
+        await EnsureProfileAsync();
+
+        // Create test records
+        var account1 = await CreateTestAccountAsync($"{_testPrefix}_CsvUpdate_1");
+        var account2 = await CreateTestAccountAsync($"{_testPrefix}_CsvUpdate_2");
+
+        // Create CSV file with IDs and values to update
+        var csvPath = GenerateTempFilePath(".csv");
+        var csvContent = $"accountid,description\n{account1},CSV Updated 1\n{account2},CSV Updated 2";
+        await File.WriteAllTextAsync(csvPath, csvContent);
+
+        try
+        {
+            // Update from file
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--file", csvPath,
+                "--id-column", "accountid",
+                "--force",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdErr.Should().Contain("Updated");
+            updateResult.StdErr.Should().Contain("2");
+
+            // Verify records were updated
+            (await GetAccountDescriptionAsync(account1)).Should().Be("CSV Updated 1");
+            (await GetAccountDescriptionAsync(account2)).Should().Be("CSV Updated 2");
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_ByKey_WithForce_UpdatesRecord()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record with a known name
+        var uniqueName = $"{_testPrefix}_KeyUpdate_{Guid.NewGuid():N}";
+        var accountId = await CreateTestAccountAsync(uniqueName);
+
+        try
+        {
+            // Update by alternate key (name - uses query-based lookup)
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--key", $"name={uniqueName}",
+                "--set", "description=Key updated",
+                "--force",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdErr.Should().Contain("Updated");
+            updateResult.StdErr.Should().Contain("1");
+
+            // Verify record was updated
+            (await GetAccountDescriptionAsync(accountId)).Should().Be("Key updated");
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_ByKey_RecordNotFound_ReturnsError()
+    {
+        await EnsureProfileAsync();
+
+        // Try to update with a key that doesn't match any record
+        var updateResult = await RunCliAsync(
+            "data", "update",
+            "--entity", "account",
+            "--key", $"name={_testPrefix}_NONEXISTENT_RECORD_{Guid.NewGuid():N}",
+            "--set", "description=Should fail",
+            "--force",
+            "--profile", _profileName!);
+
+        // Should fail with "record not found"
+        updateResult.ExitCode.Should().NotBe(0);
+        (updateResult.StdOut + updateResult.StdErr).Should().ContainAny("not found", "No record", "RECORD_NOT_FOUND");
+    }
+
+    [CliE2EWithCredentials]
+    [Trait("Category", "DestructiveE2E")]
+    public async Task Update_MultipleFields_WithForce_UpdatesAllFields()
+    {
+        await EnsureProfileAsync();
+
+        // Create a test record
+        var accountId = await CreateTestAccountAsync($"{_testPrefix}_MultiField");
+
+        try
+        {
+            // Update multiple fields at once
+            var updateResult = await RunCliAsync(
+                "data", "update",
+                "--entity", "account",
+                "--id", accountId.ToString(),
+                "--set", "description=Multi updated,websiteurl=https://example.com",
+                "--force",
+                "--profile", _profileName!);
+
+            updateResult.ExitCode.Should().Be(0, $"Update failed: {updateResult.StdErr}");
+            updateResult.StdErr.Should().Contain("Updated");
+        }
+        finally
+        {
+            // Cleanup handled by DisposeAsync
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task EnsureProfileAsync()
+    {
+        if (_profileName != null) return;
+
+        _profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", _profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", _profileName);
+    }
+
+    private async Task<Guid> CreateTestAccountAsync(string name)
+    {
+        var id = await LiveTestHelpers.CreateAccountAsync(Configuration, name);
+        _createdAccountIds.Add(id);
+        return id;
+    }
+
+    private async Task<string?> GetAccountDescriptionAsync(Guid accountId)
+    {
+        return await LiveTestHelpers.GetAccountDescriptionAsync(Configuration, accountId);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        // Clean up any test accounts that weren't deleted by tests
+        if (_createdAccountIds.Count > 0)
+        {
+            try
+            {
+                await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        await base.DisposeAsync();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.LiveTests/Cli/DataUpdateCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataUpdateCommandE2ETests.cs
@@ -498,7 +498,7 @@ public class DataUpdateCommandE2ETests : CliE2ETestBase
             {
                 await LiveTestHelpers.DeleteAccountsAsync(Configuration, _createdAccountIds);
             }
-            catch
+            catch (Exception)
             {
                 // Ignore cleanup errors
             }

--- a/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
@@ -127,12 +127,23 @@ public static class LiveTestHelpers
             var result = client.Retrieve("account", accountId, new ColumnSet(false));
             return result != null;
         }
-        catch (Exception ex) when (ex.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
-                                   ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
-                                   ex.Message.Contains("ObjectNotFound", StringComparison.OrdinalIgnoreCase))
+        catch (Exception ex) when (IsNotFoundError(ex))
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Checks if an exception indicates a record was not found.
+    /// Handles FaultException where error text is in Detail, not Message.
+    /// </summary>
+    private static bool IsNotFoundError(Exception ex)
+    {
+        // Check the full exception text (includes FaultException.Detail)
+        var fullText = ex.ToString();
+        return fullText.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+               fullText.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+               fullText.Contains("ObjectNotFound", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
@@ -127,9 +127,9 @@ public static class LiveTestHelpers
             var result = client.Retrieve("account", accountId, new ColumnSet(false));
             return result != null;
         }
-        catch (Exception ex) when (ex.Message.Contains("does not exist") ||
-                                   ex.Message.Contains("not found") ||
-                                   ex.Message.Contains("ObjectNotFound"))
+        catch (Exception ex) when (ex.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+                                   ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+                                   ex.Message.Contains("ObjectNotFound", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }

--- a/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/LiveTestHelpers.cs
@@ -162,9 +162,9 @@ public static class LiveTestHelpers
             {
                 client.Delete("account", id);
             }
-            catch
+            catch (Exception ex) when (IsNotFoundError(ex))
             {
-                // Ignore delete errors (record may already be deleted)
+                // Ignore delete errors when record doesn't exist
             }
         }
     }
@@ -184,7 +184,7 @@ public static class LiveTestHelpers
             var result = client.Retrieve("account", accountId, new ColumnSet("description"));
             return result.GetAttributeValue<string>("description");
         }
-        catch
+        catch (Exception ex) when (IsNotFoundError(ex))
         {
             return null;
         }


### PR DESCRIPTION
## Summary

- **`ppds data update`** - Update records in Dataverse entities
  - Single record by GUID (`--id`) or alternate key (`--key`) with `--set`
  - Bulk update from CSV file (`--file`) containing IDs and values
  - Query-based update with SQL-like filter (`--filter`)
  - Automatic type coercion for strings, numbers, booleans, dates, GUIDs

- **`ppds data delete`** - Delete records from Dataverse entities  
  - Single record by GUID (`--id`) or alternate key (`--key`)
  - Bulk delete from CSV/JSON file (`--file`)
  - Query-based delete with SQL-like filter (`--filter`)

Both commands include:
- Safety features: confirmation prompt, `--force`, `--dry-run`, `--limit`
- `--bypass-plugins` (sync/async/all), `--bypass-flows`
- `--continue-on-error` for bulk operations
- Progress reporting

Also adds CLI README consistency check to `/pre-pr` command.

Closes #135

## Test plan

- [x] 50 unit tests for UpdateCommand parsing/validation
- [x] 47 unit tests for DeleteCommand parsing/validation
- [x] E2E tests for both commands (Tier 1: dry-run, Tier 2: destructive with cleanup)
- [x] Manual CLI smoke test: load → update → verify → delete → verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)