### PR TITLE
feat: improve CLI discoverability - filter UX and docs command

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ppds docs` command** - Opens CLI documentation in browser ([#165](https://github.com/joshsmithxrm/ppds-sdk/issues/165))
+- **Documentation URL in help** - `ppds --help` now shows documentation URL ([#165](https://github.com/joshsmithxrm/ppds-sdk/issues/165))
+
+### Changed
+
+- **Improved `--filter` UX for metadata commands** - Filter without wildcards now performs contains search instead of exact match. `--filter zipcode` matches `ppds_zipcode`, `zipcode`, `zipcode_lookup`. Use wildcards for explicit patterns: `foo*` (starts with), `*foo` (ends with). ([#167](https://github.com/joshsmithxrm/ppds-sdk/issues/167))
+
 ## [1.0.0-beta.7] - 2026-01-04
 
 ### Added

--- a/src/PPDS.Cli/Commands/DocsCommand.cs
+++ b/src/PPDS.Cli/Commands/DocsCommand.cs
@@ -1,0 +1,58 @@
+using System.CommandLine;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace PPDS.Cli.Commands;
+
+/// <summary>
+/// Opens CLI documentation in the default browser.
+/// </summary>
+public static class DocsCommand
+{
+    /// <summary>
+    /// URL to the CLI documentation.
+    /// </summary>
+    public const string DocsUrl = "https://github.com/joshsmithxrm/ppds-sdk/blob/main/src/PPDS.Cli/README.md";
+
+    /// <summary>
+    /// Creates the 'docs' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("docs", "Open CLI documentation in browser");
+
+        command.SetAction((parseResult, cancellationToken) =>
+        {
+            Console.Error.WriteLine($"Opening documentation: {DocsUrl}");
+            OpenBrowser(DocsUrl);
+            return Task.FromResult(0);
+        });
+
+        return command;
+    }
+
+    private static void OpenBrowser(string url)
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Process.Start("open", url);
+            }
+            else
+            {
+                // Linux and other Unix-like systems
+                Process.Start("xdg-open", url);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Could not open browser: {ex.Message}");
+            Console.Error.WriteLine($"Please visit: {url}");
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
@@ -19,7 +19,7 @@ public static class EntitiesCommand
     {
         var filterOption = new Option<string?>("--filter")
         {
-            Description = "Filter entities by name pattern (supports * wildcard, e.g., 'account*')"
+            Description = "Filter by name. Without wildcards, matches names containing the text. Use * for patterns: 'foo*' (starts with), '*foo' (ends with)"
         };
 
         var customOnlyOption = new Option<bool>("--custom-only")

--- a/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
@@ -19,7 +19,7 @@ public static class OptionSetsCommand
     {
         var filterOption = new Option<string?>("--filter")
         {
-            Description = "Filter option sets by name pattern (supports * wildcard, e.g., 'new_*')"
+            Description = "Filter by name. Without wildcards, matches names containing the text. Use * for patterns: 'foo*' (starts with), '*foo' (ends with)"
         };
 
         var command = new Command("optionsets", "List global option sets")

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -7,6 +7,7 @@ using PPDS.Cli.Commands.Plugins;
 using PPDS.Cli.Commands.Query;
 using PPDS.Cli.Commands.Internal;
 using PPDS.Cli.Commands.Serve;
+using PPDS.Cli.Commands;
 using PPDS.Cli.Infrastructure;
 
 namespace PPDS.Cli;
@@ -18,7 +19,10 @@ public static class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        var rootCommand = new RootCommand("PPDS CLI - Power Platform Developer Suite command-line tool");
+        var rootCommand = new RootCommand(
+            "PPDS CLI - Power Platform Developer Suite command-line tool" + Environment.NewLine +
+            Environment.NewLine +
+            "Documentation: https://github.com/joshsmithxrm/ppds-sdk/blob/main/src/PPDS.Cli/README.md");
 
         // Add command groups
         rootCommand.Subcommands.Add(AuthCommandGroup.Create());
@@ -29,6 +33,7 @@ public static class Program
         rootCommand.Subcommands.Add(MetadataCommandGroup.Create());
         rootCommand.Subcommands.Add(QueryCommandGroup.Create());
         rootCommand.Subcommands.Add(ServeCommand.Create());
+        rootCommand.Subcommands.Add(DocsCommand.Create());
 
         // Internal/debug commands - only visible when PPDS_INTERNAL=1
         if (Environment.GetEnvironmentVariable("PPDS_INTERNAL") == "1")

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -746,8 +746,18 @@ public class DataverseMetadataService : IMetadataService
             return null;
         }
 
-        // Convert wildcard pattern to regex: * -> .*
-        var pattern = "^" + Regex.Escape(filter).Replace("\\*", ".*") + "$";
+        string pattern;
+        if (filter.Contains('*'))
+        {
+            // Wildcards present: anchored pattern matching (e.g., 'foo*' = starts with)
+            pattern = "^" + Regex.Escape(filter).Replace("\\*", ".*") + "$";
+        }
+        else
+        {
+            // No wildcards: contains search (more intuitive default)
+            pattern = Regex.Escape(filter);
+        }
+
         return new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
     }
 

--- a/tests/PPDS.Cli.Tests/Commands/DocsCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/DocsCommandTests.cs
@@ -1,0 +1,64 @@
+using System.CommandLine;
+using PPDS.Cli.Commands;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+public class DocsCommandTests
+{
+    private readonly Command _command;
+
+    public DocsCommandTests()
+    {
+        _command = DocsCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("docs", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("documentation", _command.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Create_HasNoSubcommands()
+    {
+        // docs is a standalone command, not a command group
+        Assert.Empty(_command.Subcommands);
+    }
+
+    [Fact]
+    public void Create_HasNoOptions()
+    {
+        // docs has no options - it just opens the browser
+        Assert.Empty(_command.Options);
+    }
+
+    [Fact]
+    public void Create_HasAction()
+    {
+        // The command should have a handler set
+        Assert.NotNull(_command.Action);
+    }
+
+    [Fact]
+    public void DocsUrl_IsValidHttpsUrl()
+    {
+        // Verify the URL is well-formed
+        Assert.StartsWith("https://", DocsCommand.DocsUrl);
+        Assert.True(Uri.TryCreate(DocsCommand.DocsUrl, UriKind.Absolute, out var uri));
+        Assert.Equal(Uri.UriSchemeHttps, uri.Scheme);
+    }
+
+    [Fact]
+    public void DocsUrl_PointsToGitHubReadme()
+    {
+        Assert.Contains("github.com", DocsCommand.DocsUrl);
+        Assert.Contains("README.md", DocsCommand.DocsUrl);
+    }
+}

--- a/tests/PPDS.Dataverse.Tests/Metadata/FilterRegexTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Metadata/FilterRegexTests.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using PPDS.Dataverse.Metadata;
+using Xunit;
+
+namespace PPDS.Dataverse.Tests.Metadata;
+
+/// <summary>
+/// Tests for the filter regex behavior in DataverseMetadataService.
+/// </summary>
+public class FilterRegexTests
+{
+    private static Regex? CreateFilterRegex(string? filter)
+    {
+        // Use reflection to call the private static method
+        var method = typeof(DataverseMetadataService)
+            .GetMethod("CreateFilterRegex", BindingFlags.NonPublic | BindingFlags.Static);
+
+        return (Regex?)method?.Invoke(null, [filter]);
+    }
+
+    [Fact]
+    public void CreateFilterRegex_NullFilter_ReturnsNull()
+    {
+        var regex = CreateFilterRegex(null);
+        regex.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateFilterRegex_EmptyFilter_ReturnsNull()
+    {
+        var regex = CreateFilterRegex("");
+        regex.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateFilterRegex_WhitespaceFilter_ReturnsNull()
+    {
+        var regex = CreateFilterRegex("   ");
+        regex.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("zipcode", "ppds_zipcode", true)]  // Contains match
+    [InlineData("zipcode", "zipcode", true)]       // Exact match still works
+    [InlineData("zipcode", "zipcode_lookup", true)] // Contains at start
+    [InlineData("zipcode", "account", false)]      // No match
+    public void CreateFilterRegex_WithoutWildcard_MatchesContaining(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch,
+            $"'{filter}' (no wildcards = contains) should {(shouldMatch ? "" : "not ")}match '{testValue}'");
+    }
+
+    [Theory]
+    [InlineData("zipcode*", "zipcode", true)]        // Starts with - exact
+    [InlineData("zipcode*", "zipcode_lookup", true)] // Starts with
+    [InlineData("zipcode*", "ppds_zipcode", false)]  // Does not start with
+    public void CreateFilterRegex_StartsWithWildcard_MatchesStartsWith(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch,
+            $"'{filter}' (starts with) should {(shouldMatch ? "" : "not ")}match '{testValue}'");
+    }
+
+    [Theory]
+    [InlineData("*zipcode", "zipcode", true)]        // Ends with - exact
+    [InlineData("*zipcode", "ppds_zipcode", true)]   // Ends with
+    [InlineData("*zipcode", "zipcode_lookup", false)] // Does not end with
+    public void CreateFilterRegex_EndsWithWildcard_MatchesEndsWith(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch,
+            $"'{filter}' (ends with) should {(shouldMatch ? "" : "not ")}match '{testValue}'");
+    }
+
+    [Theory]
+    [InlineData("*zipcode*", "zipcode", true)]
+    [InlineData("*zipcode*", "ppds_zipcode", true)]
+    [InlineData("*zipcode*", "zipcode_lookup", true)]
+    [InlineData("*zipcode*", "ppds_zipcode_lookup", true)]
+    [InlineData("*zipcode*", "account", false)]
+    public void CreateFilterRegex_ContainsWildcard_MatchesContaining(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch,
+            $"'{filter}' (explicit contains) should {(shouldMatch ? "" : "not ")}match '{testValue}'");
+    }
+
+    [Theory]
+    [InlineData("Account", "account", true)]  // Case insensitive
+    [InlineData("ACCOUNT", "account", true)]
+    [InlineData("account", "ACCOUNT", true)]
+    public void CreateFilterRegex_IsCaseInsensitive(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch);
+    }
+
+    [Fact]
+    public void CreateFilterRegex_SpecialRegexCharacters_AreEscaped()
+    {
+        // Filter with special regex characters should be escaped
+        var regex = CreateFilterRegex("test.name");
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch("testXname").Should().BeFalse("'.' should be literal, not regex wildcard");
+        regex!.IsMatch("test.name").Should().BeTrue("literal '.' should match");
+    }
+
+    [Theory]
+    [InlineData("new_*", "new_custom_entity", true)]
+    [InlineData("new_*", "old_custom_entity", false)]
+    [InlineData("ppds_*", "ppds_zipcode", true)]
+    public void CreateFilterRegex_PrefixPattern_MatchesCustomEntities(
+        string filter, string testValue, bool shouldMatch)
+    {
+        var regex = CreateFilterRegex(filter);
+
+        regex.Should().NotBeNull();
+        regex!.IsMatch(testValue).Should().Be(shouldMatch);
+    }
+}


### PR DESCRIPTION
## Summary

- **#167 Filter UX**: `--filter` without wildcards now performs contains search instead of exact match
  - `--filter zipcode` matches `ppds_zipcode`, `zipcode`, `zipcode_lookup`
  - Wildcards still work for explicit patterns: `foo*` (starts with), `*foo` (ends with)
  - Updated help text for metadata commands

- **#165 Documentation discoverability**: Users can now discover documentation from the CLI
  - Added `ppds docs` command that opens browser to GitHub README
  - Added docs URL to root command description (visible on `ppds --help`)

## Test plan

- [x] FilterRegexTests - 25 tests covering contains, starts-with, ends-with, case-insensitivity
- [x] DocsCommandTests - 7 tests covering command structure and URL validation
- [x] Full test suite passes (531+ tests)
- [ ] Manual: `ppds --help` shows documentation URL
- [ ] Manual: `ppds docs` opens browser
- [ ] Manual: `ppds metadata entities --filter account` returns entities containing "account"

Closes #167, Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)