### PR TITLE
fix: use correct MessagePropertyName for plugin images based on SDK message

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -363,7 +363,7 @@ public static class DeployCommand
                         }
                         else
                         {
-                            await service.UpsertImageAsync(stepId, imageConfig);
+                            await service.UpsertImageAsync(stepId, imageConfig, stepConfig.Message);
                             if (!globalOptions.IsJsonMode)
                                 Console.Error.WriteLine($"      Image {(imageIsNew ? "created" : "updated")}: {imageConfig.Name}");
 

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
@@ -310,4 +310,62 @@ public class PluginRegistrationServiceTests
     }
 
     #endregion
+
+    #region GetDefaultImagePropertyName Tests
+
+    [Theory]
+    [InlineData("Create", "id")]
+    [InlineData("CreateMultiple", "Ids")]
+    [InlineData("Update", "Target")]
+    [InlineData("UpdateMultiple", "Targets")]
+    [InlineData("Delete", "Target")]
+    [InlineData("Assign", "Target")]
+    [InlineData("SetState", "EntityMoniker")]
+    [InlineData("SetStateDynamicEntity", "EntityMoniker")]
+    [InlineData("Route", "Target")]
+    [InlineData("Send", "EmailId")]
+    [InlineData("DeliverIncoming", "EmailId")]
+    [InlineData("DeliverPromote", "EmailId")]
+    [InlineData("ExecuteWorkflow", "Target")]
+    [InlineData("Merge", "Target")]
+    public void GetDefaultImagePropertyName_ReturnsCorrectPropertyName_ForKnownMessages(string messageName, string expectedPropertyName)
+    {
+        // Act
+        var result = PluginRegistrationService.GetDefaultImagePropertyName(messageName);
+
+        // Assert
+        Assert.Equal(expectedPropertyName, result);
+    }
+
+    [Theory]
+    [InlineData("create")]
+    [InlineData("CREATE")]
+    [InlineData("SetState")]
+    [InlineData("SETSTATE")]
+    [InlineData("setstate")]
+    public void GetDefaultImagePropertyName_IsCaseInsensitive(string messageName)
+    {
+        // Act
+        var result = PluginRegistrationService.GetDefaultImagePropertyName(messageName);
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Theory]
+    [InlineData("Retrieve")]
+    [InlineData("RetrieveMultiple")]
+    [InlineData("CustomAction")]
+    [InlineData("UnknownMessage")]
+    [InlineData("")]
+    public void GetDefaultImagePropertyName_ReturnsNull_ForUnsupportedMessages(string messageName)
+    {
+        // Act
+        var result = PluginRegistrationService.GetDefaultImagePropertyName(messageName);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Fixes hardcoded `MessagePropertyName = "Target"` which was incorrect for many SDK messages
- Adds static mapping based on extension's `MessageMetadataService.ts` to determine correct property name per message
- Throws `InvalidOperationException` for unsupported messages instead of silently using wrong value

## Message Property Mappings

| Message | Property Name |
|---------|---------------|
| Create | `id` |
| CreateMultiple | `Ids` |
| Update | `Target` |
| UpdateMultiple | `Targets` |
| Delete | `Target` |
| Assign | `Target` |
| SetState | `EntityMoniker` |
| SetStateDynamicEntity | `EntityMoniker` |
| Route | `Target` |
| Send | `EmailId` |
| DeliverIncoming | `EmailId` |
| DeliverPromote | `EmailId` |
| ExecuteWorkflow | `Target` |
| Merge | `Target` |

## Test plan

- [x] Unit tests for `GetDefaultImagePropertyName` (24 tests)
- [x] Tests verify correct property name for all supported messages
- [x] Tests verify case-insensitivity
- [x] Tests verify null return for unsupported messages
- [x] All existing tests pass

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)