### PR TITLE
fix: CMT export compatibility - boolean format and schema relationships

### DIFF
--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Boolean values now export as True/False** - CMT format uses `True`/`False` for boolean values; PPDS was incorrectly exporting `1`/`0`. This change ensures CMT import compatibility. ([#181](https://github.com/joshsmithxrm/ppds-sdk/issues/181))
+- **Schema export includes relationships section** - The `<relationships>` section from input schemas is now preserved in exported `data_schema.xml` files. ([#182](https://github.com/joshsmithxrm/ppds-sdk/issues/182))
+
 ## [1.0.0-beta.3] - 2026-01-04
 
 ### Changed

--- a/tests/PPDS.Migration.Tests/Formats/CmtDataWriterTests.cs
+++ b/tests/PPDS.Migration.Tests/Formats/CmtDataWriterTests.cs
@@ -1,4 +1,7 @@
+using System.IO.Compression;
+using System.Xml.Linq;
 using FluentAssertions;
+using Microsoft.Xrm.Sdk;
 using PPDS.Migration.Formats;
 using PPDS.Migration.Models;
 using Xunit;
@@ -45,5 +48,229 @@ public class CmtDataWriterTests
         var act = async () => await writer.WriteAsync(data, string.Empty);
 
         await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_BooleanTrue_WritesTrueNotOne()
+    {
+        // Arrange
+        var writer = new CmtDataWriter();
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["boolfield"] = true;
+
+        var schema = new MigrationSchema
+        {
+            Entities = new List<EntitySchema>
+            {
+                new EntitySchema
+                {
+                    LogicalName = "testentity",
+                    DisplayName = "Test Entity",
+                    PrimaryIdField = "testentityid",
+                    Fields = new List<FieldSchema>
+                    {
+                        new FieldSchema { LogicalName = "boolfield", Type = "bool" }
+                    }
+                }
+            }
+        };
+
+        var data = new MigrationData
+        {
+            Schema = schema,
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { "testentity", new List<Entity> { entity } }
+            }
+        };
+
+        // Act
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+
+        // Assert
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var dataEntry = archive.GetEntry("data.xml");
+        using var dataStream = dataEntry!.Open();
+        var doc = XDocument.Load(dataStream);
+
+        var fieldValue = doc.Descendants("field")
+            .Where(f => f.Attribute("name")?.Value == "boolfield")
+            .Select(f => f.Attribute("value")?.Value)
+            .FirstOrDefault();
+
+        fieldValue.Should().Be("True", "CMT format uses 'True' not '1' for boolean true values");
+    }
+
+    [Fact]
+    public async Task WriteAsync_BooleanFalse_WritesFalseNotZero()
+    {
+        // Arrange
+        var writer = new CmtDataWriter();
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["boolfield"] = false;
+
+        var schema = new MigrationSchema
+        {
+            Entities = new List<EntitySchema>
+            {
+                new EntitySchema
+                {
+                    LogicalName = "testentity",
+                    DisplayName = "Test Entity",
+                    PrimaryIdField = "testentityid",
+                    Fields = new List<FieldSchema>
+                    {
+                        new FieldSchema { LogicalName = "boolfield", Type = "bool" }
+                    }
+                }
+            }
+        };
+
+        var data = new MigrationData
+        {
+            Schema = schema,
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { "testentity", new List<Entity> { entity } }
+            }
+        };
+
+        // Act
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+
+        // Assert
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var dataEntry = archive.GetEntry("data.xml");
+        using var dataStream = dataEntry!.Open();
+        var doc = XDocument.Load(dataStream);
+
+        var fieldValue = doc.Descendants("field")
+            .Where(f => f.Attribute("name")?.Value == "boolfield")
+            .Select(f => f.Attribute("value")?.Value)
+            .FirstOrDefault();
+
+        fieldValue.Should().Be("False", "CMT format uses 'False' not '0' for boolean false values");
+    }
+
+    [Fact]
+    public async Task WriteAsync_SchemaWithRelationships_IncludesRelationshipsSection()
+    {
+        // Arrange
+        var writer = new CmtDataWriter();
+
+        var schema = new MigrationSchema
+        {
+            Entities = new List<EntitySchema>
+            {
+                new EntitySchema
+                {
+                    LogicalName = "team",
+                    DisplayName = "Team",
+                    PrimaryIdField = "teamid",
+                    Fields = new List<FieldSchema>
+                    {
+                        new FieldSchema { LogicalName = "teamid", Type = "guid", IsPrimaryKey = true },
+                        new FieldSchema { LogicalName = "name", Type = "string" }
+                    },
+                    Relationships = new List<RelationshipSchema>
+                    {
+                        new RelationshipSchema
+                        {
+                            Name = "teamroles",
+                            IsManyToMany = true,
+                            Entity1 = "team",
+                            Entity2 = "role",
+                            TargetEntityPrimaryKey = "roleid"
+                        },
+                        new RelationshipSchema
+                        {
+                            Name = "teammembership",
+                            IsManyToMany = true,
+                            Entity1 = "team",
+                            Entity2 = "systemuser",
+                            TargetEntityPrimaryKey = "systemuserid"
+                        }
+                    }
+                }
+            }
+        };
+
+        var data = new MigrationData
+        {
+            Schema = schema,
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>()
+        };
+
+        // Act
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+
+        // Assert
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var schemaEntry = archive.GetEntry("data_schema.xml");
+        using var schemaStream = schemaEntry!.Open();
+        var doc = XDocument.Load(schemaStream);
+
+        var relationshipsElement = doc.Descendants("relationships").FirstOrDefault();
+        relationshipsElement.Should().NotBeNull("schema should contain <relationships> section");
+
+        var relationships = relationshipsElement!.Elements("relationship").ToList();
+        relationships.Should().HaveCount(2);
+
+        var teamrolesRel = relationships.FirstOrDefault(r => r.Attribute("name")?.Value == "teamroles");
+        teamrolesRel.Should().NotBeNull();
+        teamrolesRel!.Attribute("manyToMany")?.Value.Should().Be("true");
+        teamrolesRel.Attribute("m2mTargetEntity")?.Value.Should().Be("role");
+        teamrolesRel.Attribute("m2mTargetEntityPrimaryKey")?.Value.Should().Be("roleid");
+    }
+
+    [Fact]
+    public async Task WriteAsync_SchemaWithoutRelationships_OmitsRelationshipsSection()
+    {
+        // Arrange
+        var writer = new CmtDataWriter();
+
+        var schema = new MigrationSchema
+        {
+            Entities = new List<EntitySchema>
+            {
+                new EntitySchema
+                {
+                    LogicalName = "testentity",
+                    DisplayName = "Test Entity",
+                    PrimaryIdField = "testentityid",
+                    Fields = new List<FieldSchema>
+                    {
+                        new FieldSchema { LogicalName = "testentityid", Type = "guid", IsPrimaryKey = true }
+                    },
+                    Relationships = new List<RelationshipSchema>() // Empty
+                }
+            }
+        };
+
+        var data = new MigrationData
+        {
+            Schema = schema,
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>()
+        };
+
+        // Act
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+
+        // Assert
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+        var schemaEntry = archive.GetEntry("data_schema.xml");
+        using var schemaStream = schemaEntry!.Open();
+        var doc = XDocument.Load(schemaStream);
+
+        var relationshipsElement = doc.Descendants("relationships").FirstOrDefault();
+        relationshipsElement.Should().BeNull("schema without relationships should not have empty <relationships> section");
     }
 }


### PR DESCRIPTION
## Summary

- **Boolean values now export as `True`/`False`** instead of `1`/`0` for CMT compatibility
- **Schema export now includes `<relationships>` section** from input schema

## Background

Comparison testing between PPDS SDK export and Microsoft's Configuration Migration Tool (CMT) revealed two format differences:

1. **Boolean format**: PPDS was writing `0`/`1`, CMT writes `True`/`False`
2. **Schema relationships**: PPDS was not preserving the `<relationships>` section in the output schema

These differences could cause compatibility issues when importing PPDS-exported data into CMT or other tools expecting the CMT format.

## Changes

- `CmtDataWriter.cs`: Changed boolean serialization from `b ? "1" : "0"` to `b.ToString()`
- `CmtDataWriter.cs`: Added `<relationships>` section writing in `WriteSchemaXmlAsync`
- `CmtDataWriterTests.cs`: Added tests for boolean format and relationship serialization

## Test plan

- [x] Unit tests pass for boolean True → "True" format
- [x] Unit tests pass for boolean False → "False" format
- [x] Unit tests pass for relationship section inclusion
- [x] Unit tests pass for relationship section omission when empty
- [ ] Manual verification with real export (optional)

Closes #181
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)