### PR TITLE
Release prep: Migration v1.0.0-beta.4 + Cli v1.0.0-beta.9

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.9] - 2026-01-05
+
+### Changed
+
+- **Updated PPDS.Migration to v1.0.0-beta.4** - Includes CMT export compatibility fixes: boolean values now export as `True`/`False`, schema preserves relationships section, M2M export shows progress counts. ([#181](https://github.com/joshsmithxrm/ppds-sdk/issues/181), [#182](https://github.com/joshsmithxrm/ppds-sdk/issues/182), [#184](https://github.com/joshsmithxrm/ppds-sdk/issues/184))
+
 ## [1.0.0-beta.8] - 2026-01-05
 
 ### Added
@@ -216,7 +222,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaged as .NET global tool (`ppds`)
 - Targets: `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.8...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.9...HEAD
+[1.0.0-beta.9]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.8...Cli-v1.0.0-beta.9
 [1.0.0-beta.8]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.7...Cli-v1.0.0-beta.8
 [1.0.0-beta.7]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.6...Cli-v1.0.0-beta.7
 [1.0.0-beta.6]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.5...Cli-v1.0.0-beta.6

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2026-01-05
+
 ### Fixed
 
 - **Boolean values now export as True/False** - CMT format uses `True`/`False` for boolean values; PPDS was incorrectly exporting `1`/`0`. This change ensures CMT import compatibility. ([#181](https://github.com/joshsmithxrm/ppds-sdk/issues/181))
@@ -55,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DI integration via `AddDataverseMigration()` extension method
 - Targets: `net8.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.4...HEAD
+[1.0.0-beta.4]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.3...Migration-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.2...Migration-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.1...Migration-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Migration-v1.0.0-beta.1


### PR DESCRIPTION
## Summary

- Prep changelogs for Migration v1.0.0-beta.4 and Cli v1.0.0-beta.9

### Migration v1.0.0-beta.4

- **Boolean values now export as True/False** - CMT compatibility fix (#181)
- **Schema export includes relationships section** - CMT compatibility fix (#182)
- **M2M export shows progress counts** - UX improvement (#184)

### Cli v1.0.0-beta.9

- Updated PPDS.Migration dependency to v1.0.0-beta.4

## Test plan

- [x] Changelog format verified
- [x] Compare links updated

## After merge

Create GitHub releases:
1. `Migration-v1.0.0-beta.4` (prerelease)
2. `Cli-v1.0.0-beta.9` (prerelease)

🤖 Generated with [Claude Code](https://claude.com/claude-code)