### PR TITLE
fix: profile selection and auth create environment resolution

### DIFF
--- a/.claude/commands/pre-pr.md
+++ b/.claude/commands/pre-pr.md
@@ -96,17 +96,37 @@ public void Add_FirstProfile_SetsAsActive()
 
 **If README is outdated:** Update it and amend the commit before proceeding.
 
-### 7. Push Check
+### 7. Base Branch Check & Push
 
-Before creating PR, ensure changes are pushed:
+Before creating PR, ensure the branch is based on latest `origin/main`:
 
 ```bash
-# Fetch latest and check if ahead of remote
-git fetch
+# Fetch latest from origin
+git fetch origin
+
+# Check if current branch is behind origin/main
+git rev-list --count HEAD..origin/main
+```
+
+**If the count is > 0, the branch is behind `origin/main`.** Rebase before pushing:
+
+```bash
+# Rebase onto latest main
+git rebase origin/main
+
+# If conflicts, resolve them and continue
+git rebase --continue
+```
+
+**Only after rebasing (if needed)**, push the branch:
+
+```bash
+# Check status
 git status
 
-# If ahead, push
+# Push (or force-push after rebase)
 git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+# If rebased, may need: git push --force-with-lease
 ```
 
 **The PR cannot be created if commits aren't pushed.** This is a common oversight.
@@ -122,6 +142,7 @@ Pre-PR Validation
 [✓] No TODOs found
 [✗] Missing tests for: EnvironmentResolutionService, ProfileValidator
 [✓] CLI README: Command structure matches (or N/A if no CLI changes)
+[✓] Base branch: Up to date with origin/main (or "Behind by N commits - rebasing...")
 
 Missing tests is a blocker. Writing tests now...
 ```

--- a/.claude/commands/review-bot-comments.md
+++ b/.claude/commands/review-bot-comments.md
@@ -163,6 +163,36 @@ If any PR comments are missing replies or alerts remain open, address them befor
 
 **Note:** Code scanning alerts don't need replies - they're resolved by fixing code or dismissing via API.
 
+### 7. Base Branch Check & Push
+
+Before pushing fixes, ensure the branch is based on latest `origin/main`:
+
+```bash
+# Fetch latest from origin
+git fetch origin
+
+# Check if current branch is behind origin/main
+git rev-list --count HEAD..origin/main
+```
+
+**If the count is > 0, the branch is behind `origin/main`.** Rebase before pushing:
+
+```bash
+# Rebase onto latest main
+git rebase origin/main
+
+# If conflicts, resolve them and continue
+git rebase --continue
+```
+
+**Only after rebasing (if needed)**, push the fixes:
+
+```bash
+# Push (or force-push after rebase)
+git push
+# If rebased, may need: git push --force-with-lease
+```
+
 ## When to Use
 
 - After opening a PR (before requesting review)

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unnamed profile selection silently failed** - Selecting a profile without a name (`ppds auth select --index N`) appeared to succeed but would revert to the first profile on next command. Active profile tracking now uses index-based lookup instead of name-based, with backwards compatibility for existing profiles.json files.
+
 ## [1.0.0-beta.4] - 2026-01-03
 
 ### Changed

--- a/src/PPDS.Auth/Profiles/ProfileCollection.cs
+++ b/src/PPDS.Auth/Profiles/ProfileCollection.cs
@@ -25,8 +25,14 @@ public sealed class ProfileCollection
     public int Version { get; set; } = 2;
 
     /// <summary>
+    /// Gets or sets the index of the active profile. Primary tracking mechanism.
+    /// </summary>
+    [JsonPropertyName("activeProfileIndex")]
+    public int? ActiveProfileIndex { get; set; }
+
+    /// <summary>
     /// Gets or sets the name of the active profile.
-    /// Null if no profile is active (collection empty).
+    /// Kept for backwards compatibility with v2 profiles.json files and for display purposes.
     /// </summary>
     [JsonPropertyName("activeProfile")]
     public string? ActiveProfileName { get; set; }
@@ -45,10 +51,27 @@ public sealed class ProfileCollection
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(ActiveProfileName))
-                return Profiles.FirstOrDefault();
+            // Primary: Use index-based lookup
+            if (ActiveProfileIndex.HasValue)
+            {
+                var byIndex = GetByIndex(ActiveProfileIndex.Value);
+                if (byIndex != null) return byIndex;
+            }
 
-            return GetByName(ActiveProfileName) ?? Profiles.FirstOrDefault();
+            // Backwards compat: Legacy name-based lookup for old profiles.json
+            if (!string.IsNullOrWhiteSpace(ActiveProfileName))
+            {
+                var byName = GetByName(ActiveProfileName);
+                if (byName != null)
+                {
+                    // Migrate: update index so next save is index-based
+                    ActiveProfileIndex = byName.Index;
+                    return byName;
+                }
+            }
+
+            // No active profile
+            return null;
         }
     }
 
@@ -93,6 +116,7 @@ public sealed class ProfileCollection
         // Auto-select first profile as active, or if explicitly requested
         if (setAsActive || Profiles.Count == 1)
         {
+            ActiveProfileIndex = profile.Index;
             ActiveProfileName = profile.Name;
         }
     }
@@ -157,9 +181,11 @@ public sealed class ProfileCollection
         Profiles.Remove(profile);
 
         // If we removed the active profile, select the first remaining profile
-        if (string.Equals(ActiveProfileName, profile.Name, StringComparison.OrdinalIgnoreCase))
+        if (ActiveProfileIndex == profile.Index)
         {
-            ActiveProfileName = Profiles.FirstOrDefault()?.Name;
+            var next = Profiles.FirstOrDefault();
+            ActiveProfileIndex = next?.Index;
+            ActiveProfileName = next?.Name;
         }
 
         return true;
@@ -189,7 +215,8 @@ public sealed class ProfileCollection
             throw new InvalidOperationException($"Profile with index {index} not found.");
         }
 
-        ActiveProfileName = profile.Name;
+        ActiveProfileIndex = index;
+        ActiveProfileName = profile.Name;  // Keep for display, may be null
     }
 
     /// <summary>
@@ -205,6 +232,7 @@ public sealed class ProfileCollection
             throw new InvalidOperationException($"Profile with name '{name}' not found.");
         }
 
+        ActiveProfileIndex = profile.Index;
         ActiveProfileName = profile.Name;
     }
 
@@ -214,6 +242,7 @@ public sealed class ProfileCollection
     public void Clear()
     {
         Profiles.Clear();
+        ActiveProfileIndex = null;
         ActiveProfileName = null;
     }
 
@@ -241,6 +270,7 @@ public sealed class ProfileCollection
         var copy = new ProfileCollection
         {
             Version = Version,
+            ActiveProfileIndex = ActiveProfileIndex,
             ActiveProfileName = ActiveProfileName
         };
 

--- a/src/PPDS.Auth/Profiles/ProfileCollection.cs
+++ b/src/PPDS.Auth/Profiles/ProfileCollection.cs
@@ -12,14 +12,14 @@ namespace PPDS.Auth.Profiles;
 /// <para>Schema v2 changes from v1:</para>
 /// <list type="bullet">
 /// <item><description>Profiles stored as array instead of dictionary</description></item>
-/// <item><description>Active profile tracked by name instead of index</description></item>
+/// <item><description>Active profile tracked by index (with name kept for backwards compatibility)</description></item>
 /// <item><description>Secrets moved to secure credential store</description></item>
 /// </list>
 /// </remarks>
 public sealed class ProfileCollection
 {
     /// <summary>
-    /// Storage format version. v2 uses array storage and name-based active profile.
+    /// Storage format version. v2 uses array storage and index-based active profile tracking.
     /// </summary>
     [JsonPropertyName("version")]
     public int Version { get; set; } = 2;
@@ -180,10 +180,10 @@ public sealed class ProfileCollection
 
         Profiles.Remove(profile);
 
-        // If we removed the active profile, select the first remaining profile
+        // If we removed the active profile, select the lowest-indexed remaining profile
         if (ActiveProfileIndex == profile.Index)
         {
-            var next = Profiles.FirstOrDefault();
+            var next = Profiles.OrderBy(p => p.Index).FirstOrDefault();
             ActiveProfileIndex = next?.Index;
             ActiveProfileName = next?.Name;
         }

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`auth create -env` failed to resolve environment** - Creating profiles with InteractiveBrowser or DeviceCode auth and specifying `-env <url>` would fail with "Auth method '' is not supported" because the auth method wasn't passed to Global Discovery Service.
+
 ## [1.0.0-beta.9] - 2026-01-05
 
 ### Changed

--- a/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
@@ -404,7 +404,8 @@ public static class AuthCommandGroup
                         Console.Error.WriteLine("Resolving environment...");
                         try
                         {
-                            using var gds = new GlobalDiscoveryService(options.Cloud, options.Tenant);
+                            using var gds = new GlobalDiscoveryService(options.Cloud, options.Tenant,
+                                preferredAuthMethod: authMethod);
                             var environments = await gds.DiscoverEnvironmentsAsync(cancellationToken);
 
                             DiscoveredEnvironment? resolved;
@@ -740,7 +741,8 @@ public static class AuthCommandGroup
     {
         var output = new
         {
-            activeProfile = collection.ActiveProfileName,
+            activeProfile = collection.ActiveProfile?.Name,
+            activeProfileIndex = collection.ActiveProfileIndex,
             profiles = collection.All.Select(p => new
             {
                 index = p.Index,

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -83,7 +83,8 @@ public class RpcMethodHandler
 
         return new AuthListResponse
         {
-            ActiveProfile = collection.ActiveProfileName,
+            ActiveProfile = collection.ActiveProfile?.Name,
+            ActiveProfileIndex = collection.ActiveProfileIndex,
             Profiles = profiles
         };
     }
@@ -769,6 +770,9 @@ public class AuthListResponse
 {
     [JsonPropertyName("activeProfile")]
     public string? ActiveProfile { get; set; }
+
+    [JsonPropertyName("activeProfileIndex")]
+    public int? ActiveProfileIndex { get; set; }
 
     [JsonPropertyName("profiles")]
     public List<ProfileInfo> Profiles { get; set; } = [];

--- a/tests/PPDS.Auth.Tests/Profiles/ProfileStoreTests.cs
+++ b/tests/PPDS.Auth.Tests/Profiles/ProfileStoreTests.cs
@@ -118,6 +118,7 @@ public class ProfileStoreTests : IDisposable
         var loaded = await _store.LoadAsync();
 
         loaded.ActiveProfile!.Name.Should().Be("second");
+        loaded.ActiveProfileIndex.Should().Be(2);
         loaded.ActiveProfileName.Should().Be("second");
     }
 
@@ -256,7 +257,7 @@ public class ProfileStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task SaveAsync_UsesActiveProfileName()
+    public async Task SaveAsync_UsesActiveProfileIndexAndName()
     {
         var collection = new ProfileCollection();
         collection.Add(new AuthProfile { Name = "myprofile" });
@@ -264,6 +265,7 @@ public class ProfileStoreTests : IDisposable
         await _store.SaveAsync(collection);
         var json = await File.ReadAllTextAsync(_tempFilePath);
 
+        json.Should().Contain("\"activeProfileIndex\": 1");
         json.Should().Contain("\"activeProfile\": \"myprofile\"");
     }
 


### PR DESCRIPTION
## Summary

- **Fix unnamed profile selection silently failing** - Selecting a profile without a name (`ppds auth select --index N`) appeared to succeed but would revert to the first profile on next command. Active profile tracking now uses index-based lookup (`ActiveProfileIndex`) as primary, with name-based fallback for backwards compatibility with existing profiles.json files.

- **Fix `auth create -env` failing to resolve environment** - Creating profiles with InteractiveBrowser or DeviceCode auth and specifying `-env <url>` would fail with "Auth method '' is not supported" because the auth method wasn't passed to Global Discovery Service.

- **Add `activeProfileIndex` to CLI JSON output** - Both `ppds auth list --json` and RPC responses now include `activeProfileIndex` for programmatic use.

- **Update slash commands** - `pre-pr` and `review-bot-comments` now check if branch needs rebasing onto `origin/main` before pushing.

## Test plan

- [x] All 3,924 unit tests pass across .NET 8/9/10
- [ ] Manual test: `ppds auth create` without `--name`, then `ppds auth select --index N`, verify selection persists
- [ ] Manual test: `ppds auth create -env <url>` with interactive auth, verify environment resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)