### PR TITLE
docs: Release prep - Dataverse beta.4, Migration beta.5, Auth beta.5, Cli beta.10

### DIFF
--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-01-06
+
 ### Added
 
 - **`IPowerPlatformTokenProvider`** - New interface for acquiring tokens for Power Platform REST APIs (Power Apps, Power Automate). Enables CLI commands that interact with Power Platform management APIs. ([#150](https://github.com/joshsmithxrm/ppds-sdk/issues/150))
@@ -104,7 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JWT claims parsing for identity information
 - Targets: `net8.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.5...HEAD
+[1.0.0-beta.5]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.4...Auth-v1.0.0-beta.5
+[1.0.0-beta.4]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.3...Auth-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.2...Auth-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Auth-v1.0.0-beta.1...Auth-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Auth-v1.0.0-beta.1

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,8 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.10] - 2026-01-06
+
 ### Added
 
+- **`ppds interactive` command** - Launch interactive TUI mode for profile/environment selection and SQL queries ([#192](https://github.com/joshsmithxrm/ppds-sdk/issues/192)):
+  - Entry points: `ppds interactive`, `ppds -i`, `ppds --interactive`
+  - Profile and environment selection with Global Discovery integration
+  - SQL query wizard with results displayed in interactive table view
+  - Arrow key navigation for query results (up/down for rows, left/right for columns)
+  - Open record in browser (`O`) or copy URL to clipboard (`C`)
+  - Query history with up/down arrow recall
+  - Session-scoped connection pooling for faster subsequent queries
+  - Graceful degradation when not in a TTY environment
 - **Version header at startup** - CLI now outputs diagnostic header to stderr: version info (CLI, SDK, .NET runtime) and platform. Enables correlating issues to specific builds. Skipped for `--help`, `--version`, or no arguments. See [ADR-0022](../../docs/adr/0022_IMPORT_DIAGNOSTICS_ARCHITECTURE.md).
 - **`ppds solutions` command group** - Manage Power Platform solutions ([#137](https://github.com/joshsmithxrm/ppds-sdk/issues/137)):
   - `ppds solutions list` - List solutions in environment (supports `--include-managed`, `--filter`)
@@ -266,7 +277,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaged as .NET global tool (`ppds`)
 - Targets: `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.9...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.10...HEAD
+[1.0.0-beta.10]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.9...Cli-v1.0.0-beta.10
 [1.0.0-beta.9]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.8...Cli-v1.0.0-beta.9
 [1.0.0-beta.8]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.7...Cli-v1.0.0-beta.8
 [1.0.0-beta.7]: https://github.com/joshsmithxrm/ppds-sdk/compare/Cli-v1.0.0-beta.6...Cli-v1.0.0-beta.7

--- a/src/PPDS.Cli/Commands/InteractiveCommand.cs
+++ b/src/PPDS.Cli/Commands/InteractiveCommand.cs
@@ -1,0 +1,28 @@
+using System.CommandLine;
+using PPDS.Cli.Interactive;
+
+namespace PPDS.Cli.Commands;
+
+/// <summary>
+/// Launches interactive TUI mode for profile/environment selection and SQL querying.
+/// </summary>
+/// <remarks>
+/// Also accessible via 'ppds -i' or 'ppds --interactive' (handled in Program.cs).
+/// </remarks>
+public static class InteractiveCommand
+{
+    /// <summary>
+    /// Creates the 'interactive' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("interactive", "Launch interactive TUI mode for profile selection and SQL queries");
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            return await InteractiveCli.RunAsync();
+        });
+
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Commands/InteractiveCommand.cs
+++ b/src/PPDS.Cli/Commands/InteractiveCommand.cs
@@ -20,7 +20,7 @@ public static class InteractiveCommand
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
-            return await InteractiveCli.RunAsync();
+            return await InteractiveCli.RunAsync(cancellationToken);
         });
 
         return command;

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -39,9 +39,9 @@ public static class Program
             ErrorOutput.WriteVersionHeader();
         }
 
-        // Check for interactive mode before invoking System.CommandLine
-        // This allows a parallel execution path for the TUI
-        if (IsInteractiveMode(args))
+        // Handle -i/--interactive shortcuts before System.CommandLine
+        // (The 'interactive' subcommand goes through normal command processing)
+        if (IsInteractiveShortcut(args))
         {
             return await InteractiveCli.RunAsync();
         }
@@ -66,6 +66,7 @@ public static class Program
         rootCommand.Subcommands.Add(RolesCommandGroup.Create());
         rootCommand.Subcommands.Add(ServeCommand.Create());
         rootCommand.Subcommands.Add(DocsCommand.Create());
+        rootCommand.Subcommands.Add(InteractiveCommand.Create());
 
         // Internal/debug commands - only visible when PPDS_INTERNAL=1
         if (Environment.GetEnvironmentVariable("PPDS_INTERNAL") == "1")
@@ -85,10 +86,10 @@ public static class Program
     }
 
     /// <summary>
-    /// Determines if the CLI should run in interactive mode.
+    /// Determines if the CLI should run in interactive mode (for version header skip).
     /// </summary>
     /// <param name="args">Command line arguments.</param>
-    /// <returns>True if interactive mode was requested.</returns>
+    /// <returns>True if interactive mode was requested via any method.</returns>
     private static bool IsInteractiveMode(string[] args)
     {
         if (args.Length == 0)
@@ -96,5 +97,18 @@ public static class Program
 
         var firstArg = args[0].ToLowerInvariant();
         return firstArg is "interactive" or "-i" or "--interactive";
+    }
+
+    /// <summary>
+    /// Determines if the CLI was invoked with -i or --interactive shortcut.
+    /// The 'interactive' subcommand is handled by System.CommandLine.
+    /// </summary>
+    private static bool IsInteractiveShortcut(string[] args)
+    {
+        if (args.Length == 0)
+            return false;
+
+        var firstArg = args[0].ToLowerInvariant();
+        return firstArg is "-i" or "--interactive";
     }
 }

--- a/src/PPDS.Cli/README.md
+++ b/src/PPDS.Cli/README.md
@@ -29,13 +29,36 @@ ppds data export --schema schema.xml --output data.zip
 
 ```
 ppds
-├── auth      Authentication profile management
-├── env       Environment discovery and selection
-├── data      Data operations (export, import, copy, load, update, delete, schema, users)
-├── plugins   Plugin registration management
-├── query     Execute FetchXML and SQL queries
-└── metadata  Browse entity and attribute metadata
+├── interactive  Launch interactive TUI mode (-i, --interactive)
+├── auth         Authentication profile management
+├── env          Environment discovery and selection
+├── data         Data operations (export, import, copy, load, update, delete, schema, users)
+├── plugins      Plugin registration management
+├── query        Execute FetchXML and SQL queries
+├── metadata     Browse entity and attribute metadata
+├── solutions    Manage Power Platform solutions
+├── users        Manage system users
+└── roles        Manage security roles
 ```
+
+---
+
+## Interactive Mode
+
+Launch the interactive TUI for guided profile/environment selection and SQL querying:
+
+```bash
+ppds interactive    # or ppds -i / ppds --interactive
+```
+
+**Features:**
+- **Profile & Environment Selection** - Browse and switch profiles, discover environments via Global Discovery
+- **SQL Query Wizard** - Write SQL queries with results displayed in an interactive table
+- **Keyboard Navigation** - Arrow keys to navigate results, `O` to open in browser, `C` to copy URL
+- **Query History** - Use up/down arrows to recall previous queries
+- **Session Connection Pooling** - Fast subsequent queries within the same session
+
+**Note:** Requires a TTY terminal. Use standard CLI commands in CI/CD pipelines.
 
 ---
 

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2026-01-06
+
 ### Added
 
 - **`Workflow` early-bound entity** - Entity class for Power Automate flows (classic workflows). Supports flow management operations. ([#149](https://github.com/joshsmithxrm/ppds-sdk/issues/149))
@@ -100,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed rate control presets (`Conservative`, `Balanced`, `Aggressive`) in favor of DOP-based parallelism
 - Removed adaptive rate control in favor of server-recommended limits
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Dataverse-v1.0.0-beta.3...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Dataverse-v1.0.0-beta.4...HEAD
+[1.0.0-beta.4]: https://github.com/joshsmithxrm/ppds-sdk/compare/Dataverse-v1.0.0-beta.3...Dataverse-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Dataverse-v1.0.0-beta.2...Dataverse-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Dataverse-v1.0.0-beta.1...Dataverse-v1.0.0-beta.2
 [1.0.0-beta.1]: https://github.com/joshsmithxrm/ppds-sdk/releases/tag/Dataverse-v1.0.0-beta.1

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.5] - 2026-01-06
+
 ### Added
 
 - **Error report v1.1 with execution context** - Import error reports now include `executionContext` object with CLI/SDK versions, runtime, platform, import mode, and option flags. Enables reproducing and troubleshooting imports after the fact. Version bumped from "1.0" to "1.1". See [ADR-0022](../../docs/adr/0022_IMPORT_DIAGNOSTICS_ARCHITECTURE.md).
@@ -75,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DI integration via `AddDataverseMigration()` extension method
 - Targets: `net8.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.4...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.5...HEAD
+[1.0.0-beta.5]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.4...Migration-v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.3...Migration-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.2...Migration-v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/joshsmithxrm/ppds-sdk/compare/Migration-v1.0.0-beta.1...Migration-v1.0.0-beta.2


### PR DESCRIPTION
## Summary

- Prepare changelogs for release of 4 packages
- Add `ppds interactive` command to CLI help menu (was working but hidden)
- Update CLI README with interactive mode documentation

## Packages

| Package | Version | Key Changes |
|---------|---------|-------------|
| PPDS.Dataverse | 1.0.0-beta.4 | Pool stability, early-bound entities, field-level errors |
| PPDS.Migration | 1.0.0-beta.5 | CMT compatibility, M2M parallelization, bulk deferred fields |
| PPDS.Auth | 1.0.0-beta.5 | Power Platform tokens, profile selection fix |
| PPDS.Cli | 1.0.0-beta.10 | Interactive TUI mode, Phase 1 commands, truncate |

## Changes

- `src/PPDS.Cli/Commands/InteractiveCommand.cs` - New file to register interactive in help
- `src/PPDS.Cli/Program.cs` - Register InteractiveCommand, keep -i/--interactive shortcuts
- `src/PPDS.Cli/README.md` - Add interactive mode section
- `src/PPDS.*/CHANGELOG.md` - Version numbers and dates

## Test plan

- [x] `dotnet build -c Release` succeeds
- [x] `ppds --help` shows `interactive` command
- [x] `ppds -i` still works (TTY check error expected in non-interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)