### PR TITLE
chore: slim CLAUDE.md and consolidate ecosystem commands

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,109 @@
+# Create Issue
+
+Create a GitHub issue in any PPDS ecosystem repository.
+
+## Usage
+
+`/create-issue [repo]`
+
+Where `[repo]` is one of:
+- `extension` - power-platform-developer-suite
+- `sdk` - ppds-sdk
+- `tools` - ppds-tools
+- `alm` - ppds-alm
+- `demo` - ppds-demo
+
+## Process
+
+### 1. Gather Information
+Ask user for:
+- Issue type: `feat`, `fix`, `chore`, `docs`
+- Title (concise, imperative)
+- Description (problem, solution, context)
+- Labels (if known)
+
+### 2. Format Issue
+
+```markdown
+## Summary
+
+[1-3 sentence description of what this issue addresses]
+
+## Background
+
+[Context, why this matters, related issues]
+
+## Tasks
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+---
+
+Related: [links to related issues if any]
+```
+
+### 3. Create Issue
+
+```bash
+gh issue create --repo joshsmithxrm/[repo-name] --title "[type]: [title]" --body "[body]"
+```
+
+### 4. Link Cross-Repo Issues
+
+If this issue relates to issues in other repos:
+- Add "Related:" links in body
+- Comment on related issues with link to new issue
+
+## Repository Mapping
+
+| Shorthand | Full Repo Name |
+|-----------|----------------|
+| `extension` | `joshsmithxrm/power-platform-developer-suite` |
+| `sdk` | `joshsmithxrm/ppds-sdk` |
+| `tools` | `joshsmithxrm/ppds-tools` |
+| `alm` | `joshsmithxrm/ppds-alm` |
+| `demo` | `joshsmithxrm/ppds-demo` |
+
+## Labels by Type
+
+| Type | Labels to Add |
+|------|---------------|
+| Feature | `enhancement` |
+| Bug | `bug` |
+| Tech Debt | `tech-debt` |
+| Documentation | `documentation` |
+| Cross-repo | `cross-repo` |
+
+## Example
+
+```
+User: /create-issue sdk
+
+Claude: What type of issue?
+- feat (new feature)
+- fix (bug fix)
+- chore (maintenance)
+- docs (documentation)
+
+User: feat
+
+Claude: Title? (imperative, concise)
+
+User: Add interactive plugin registration CLI commands
+
+Claude: Description? (problem, solution, context)
+
+User: [provides description]
+
+Claude: Creating issue...
+[Creates issue with gh CLI]
+
+Created: https://github.com/joshsmithxrm/ppds-sdk/issues/70
+```

--- a/.claude/commands/design-session.md
+++ b/.claude/commands/design-session.md
@@ -1,0 +1,238 @@
+# Design Session
+
+Prepare a structured design session with mandatory discovery of existing patterns and ADRs.
+
+## Usage
+
+`/design-session [feature-name]`
+
+Examples:
+- `/design-session plugin-traces` - Design CLI commands for plugin traces
+- `/design-session web-resources` - Design web resource management
+- `/design-session connection-refs` - Design connection reference workflow
+
+## Arguments
+
+`$ARGUMENTS` - Feature or epic name (optional, will prompt if not provided)
+
+## Process
+
+### 1. Discovery Phase (MANDATORY)
+
+Before any design work, search for existing context:
+
+**Search for ADRs:**
+```bash
+# Find all ADRs in the target repo
+find . -path "*/docs/adr/*.md" -type f | head -20
+```
+
+**Search for existing patterns in CLAUDE.md:**
+```bash
+# Look for relevant sections
+grep -i "<feature-keyword>" CLAUDE.md
+```
+
+**Search for related issues:**
+```bash
+gh issue list --search "<feature-name>" --limit 10
+```
+
+**Report findings:**
+```
+## Discovery Results
+
+### Relevant ADRs
+- [ADR-000X](link) - Summary
+- (none found)
+
+### Related Patterns in CLAUDE.md
+- [Section name] - Summary
+- (none found)
+
+### Related Issues
+- #N - Title
+- (none found)
+
+### Existing Implementations
+- [file path] - What it does
+- (none found)
+```
+
+### 2. Context Gathering
+
+If user hasn't provided a feature inventory, request one:
+
+```
+Before designing, please provide a feature inventory:
+
+For each feature/panel/command, document:
+- Current capabilities (what it does)
+- UI elements (if applicable)
+- Data considerations (large fields, relationships)
+- Open questions
+
+See docs/AGENTIC_WORKFLOW.md "Feature Inventory Pattern" for template.
+```
+
+Identify:
+- Constraints from existing architecture
+- Dependencies on other features
+- Existing implementations to reference
+
+### 3. Scope Confirmation
+
+Present findings and confirm scope:
+
+```
+## Design Session Scope
+
+**Feature:** [name]
+
+**Context Found:**
+- [ADRs, patterns, issues discovered]
+
+**Proposed Scope:**
+- [What will be designed in this session]
+
+**Questions to Resolve:**
+1. [Key question]
+2. [Key question]
+
+**Session Split Recommendation:**
+- Single session (proceed) | Split into N sessions (why)
+
+Confirm scope before proceeding?
+```
+
+**STOP for user confirmation.**
+
+### 4. Generate Design Prompt
+
+After confirmation, create `.claude/design-session.md`:
+
+```markdown
+# Design Session: [Feature Name]
+
+## Problem Statement
+[What we're designing and why]
+
+## Existing Context
+
+### Relevant ADRs
+- [ADR-000X](path) - [summary]
+
+### Related Patterns
+- [pattern from CLAUDE.md or existing code]
+
+### Related Issues
+- #N - [title]
+
+## Feature Inventory
+[User-provided breakdown or link to source]
+
+## Key Questions to Resolve
+1. [Question from scope confirmation]
+2. [Question from scope confirmation]
+
+## Deliverables Checklist
+- [ ] ROADMAP.md update (if multi-phase)
+- [ ] ADR for [decision] (if architectural)
+- [ ] Design session prompts for follow-up (if splitting)
+- [ ] GitHub issues for implementation
+- [ ] CLAUDE.md update (if new patterns)
+
+## References
+- `docs/adr/` - Existing ADRs
+- `CLAUDE.md` - Project conventions
+- [Relevant code paths - relative references only]
+
+## Session Start Instructions
+1. Read this prompt and referenced materials
+2. Explore existing patterns before proposing new ones
+3. Ask clarifying questions before finalizing design
+4. Create ADRs for architectural decisions
+5. File issues with consistent format
+```
+
+### 5. Output Summary
+
+```
+## Design Session Prepared
+
+**Feature:** [name]
+**Prompt:** .claude/design-session.md
+
+### Discovery Summary
+- [N] ADRs reviewed
+- [N] related issues found
+- [Key patterns identified]
+
+### Recommended Next Steps
+1. Read the generated prompt
+2. Start design conversation (no agents for design phase)
+3. Create artifacts per checklist
+
+### Session Split
+- [Single session] | [Split into N sessions - prompts needed for...]
+
+To begin: Read .claude/design-session.md and start designing.
+```
+
+## Behavior Summary
+
+1. **Always search first** - Never skip discovery
+2. Parse feature name from arguments or prompt for it
+3. Search for ADRs, patterns, and issues
+4. Report what was found
+5. Request feature inventory if not provided
+6. Confirm scope with user
+7. **STOP for confirmation**
+8. Generate design prompt file
+9. Output summary with next steps
+
+## Edge Cases
+
+**No ADRs found:**
+```
+No existing ADRs found in docs/adr/.
+This may be the first architectural decision for this area.
+```
+
+**No CLAUDE.md patterns found:**
+```
+No related patterns found in CLAUDE.md.
+Consider documenting patterns discovered during design.
+```
+
+**Feature already has issues:**
+```
+Found existing issues:
+- #N - [title] (status)
+
+Should this session:
+1. Design implementation for existing issues?
+2. Create new scope beyond existing issues?
+```
+
+## When to Use
+
+- Starting feature parity work (CLI ↔ extension)
+- Designing new command groups
+- Planning multi-phase epics
+- Before filing implementation issues
+- When architectural decisions are needed
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/plan-work` | Triage existing issues into worktrees |
+| `/retrospective` | Analyze completed sessions |
+| `/handoff` | Generate context for next session |
+
+## Notes
+
+- `.claude/design-session.md` is gitignored (ephemeral)
+- Use relative paths in prompts (not hardcoded absolute paths)
+- Reference AGENTIC_WORKFLOW.md for patterns

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,81 @@
+# Session Handoff
+
+Generate a context summary for handoff between Claude Code sessions.
+
+## Usage
+
+`/handoff`
+
+## Output
+
+Creates a handoff summary with:
+
+### 1. Current State
+- Which repo(s) you're working in
+- Branch name and status (`git status`)
+- Recent commits (`git log --oneline -5`)
+- Uncommitted changes summary
+
+### 2. Work Completed This Session
+- Features/fixes implemented
+- Issues created or updated
+- Files created or significantly modified
+- Decisions made
+
+### 3. Work In Progress
+- Current task (if incomplete)
+- Blockers or open questions
+- Decisions deferred to user
+
+### 4. Next Steps
+- Immediate next actions
+- Which repo to work in next
+- Pending items from todo list
+- Suggested priority order
+
+### 5. Key Context
+- Important decisions made
+- Cross-repo implications
+- Related issues/PRs created
+
+## Format
+
+Output as markdown that can be:
+1. Copied to a new session's first message
+2. Saved to `docs/work/handoff-[date].md` (if requested)
+
+## Example Output
+
+```markdown
+## Session Handoff - 2025-01-15
+
+### Repos Touched
+- sdk/ (feature/plugin-registration-cli)
+- extension/ (main)
+
+### Completed
+- Created CLI commands issue (sdk#70)
+- Created extension migration issue (extension#95)
+- Updated workspace settings for issue permissions
+
+### In Progress
+- Documentation cleanup discussion ongoing
+
+### Blockers
+- None
+
+### Next Steps
+1. Decide on extension .claude cleanup
+2. Start SDK CLI commands implementation
+3. Update extension to use CLI backend
+
+### Key Decisions
+- Using process invocation (not daemon) for plugin registration
+- Extension becomes UI shell, SDK has logic
+```
+
+## Notes
+
+- Run before `/clear` or ending a session
+- Captures context that would otherwise be lost
+- Especially useful for cross-repo work where state spans multiple folders

--- a/.claude/commands/install-cli.md
+++ b/.claude/commands/install-cli.md
@@ -20,6 +20,15 @@ This script:
 3. Uninstalls any existing version
 4. Installs the new version globally
 
+## If Installation Fails
+
+**Stop and prompt the user.** Installation failures often occur because:
+- TUI is running in another terminal session (file lock)
+- Another CLI process is active
+- Antivirus is blocking the operation
+
+The user may not realize another process has the CLI locked.
+
 ## After Installation
 
 Verify with:
@@ -31,4 +40,5 @@ ppds --version
 
 - After making changes to PPDS.Cli or its dependencies
 - When testing CLI behavior locally
-- Before running integration tests that use the CLI
+
+**Alternative:** The terminal profile's `ppds` function runs CLI directly from the worktree without global installation. Run `/setup-terminal` to install the profile.

--- a/.claude/commands/ppds-help.md
+++ b/.claude/commands/ppds-help.md
@@ -1,0 +1,74 @@
+---
+description: Show PPDS CLI quick reference
+---
+
+# PPDS CLI Commands
+
+## Authentication
+
+| Command | Description |
+|---------|-------------|
+| `ppds auth create` | Create authentication profile |
+| `ppds auth list` | List saved profiles |
+| `ppds auth select` | Set active profile |
+| `ppds auth who` | Show current identity |
+| `ppds auth delete` | Remove a profile |
+
+## Environment
+
+| Command | Description |
+|---------|-------------|
+| `ppds env list` | List available environments |
+| `ppds env select` | Select active environment |
+| `ppds env who` | Show environment details |
+
+## Data Operations
+
+| Command | Description |
+|---------|-------------|
+| `ppds data schema` | Generate schema from Dataverse |
+| `ppds data export` | Export data to zip |
+| `ppds data import` | Import data from zip |
+| `ppds data load` | Load CSV data into entity |
+| `ppds data copy` | Copy data between environments |
+| `ppds data users` | Generate user mapping file |
+
+## Plugins
+
+| Command | Description |
+|---------|-------------|
+| `ppds plugins extract` | Extract registrations from assembly |
+| `ppds plugins deploy` | Deploy to Dataverse |
+| `ppds plugins diff` | Compare config vs environment |
+| `ppds plugins list` | List registered plugins |
+| `ppds plugins clean` | Remove orphaned registrations |
+
+## Querying
+
+| Command | Description |
+|---------|-------------|
+| `ppds query sql` | Execute SQL query |
+| `ppds query fetch` | Execute FetchXML |
+
+## Metadata
+
+| Command | Description |
+|---------|-------------|
+| `ppds metadata entities` | List entities |
+| `ppds metadata entity <name>` | Get entity details |
+| `ppds metadata attributes <entity>` | List attributes |
+| `ppds metadata relationships <entity>` | List relationships |
+| `ppds metadata keys <entity>` | List alternate keys |
+| `ppds metadata optionsets` | List global option sets |
+| `ppds metadata optionset <name>` | Get option set values |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-f json` | JSON output format |
+| `-f csv` | CSV output format (query only) |
+| `-v` / `--verbose` | Verbose output |
+| `--debug` | Debug output |
+| `-q` / `--quiet` | Suppress status messages |
+| `--dry-run` | Preview without applying |

--- a/.claude/commands/prune.md
+++ b/.claude/commands/prune.md
@@ -1,0 +1,91 @@
+# Prune Local Branches
+
+Clean up local branches and worktrees that no longer have remote tracking branches.
+
+## Usage
+
+`/prune`
+
+## Steps
+
+### 1. Fetch and Prune Remote References
+
+```bash
+git fetch --prune
+```
+
+### 2. Identify Branches to Clean
+
+List all branches with their tracking status:
+
+```bash
+git branch -vv
+```
+
+Branches marked with `: gone]` have had their remote deleted (typically after PR merge).
+
+### 3. List Current Worktrees
+
+```bash
+git worktree list
+```
+
+### 4. Remove Worktrees for Gone Branches
+
+For each worktree whose branch shows `: gone]`:
+
+```bash
+git worktree remove "<path>" --force
+```
+
+If removal fails due to permissions, run `git worktree prune` to clean metadata.
+
+### 5. Delete Gone Branches
+
+Delete all branches whose remote tracking branch is gone:
+
+```bash
+git branch -D <branch-name>
+```
+
+### 6. Verify Final State
+
+```bash
+git branch -vv
+git worktree list
+```
+
+## Output
+
+Report a summary table:
+
+```
+Pruned Branches
+===============
+| Deleted Branch | Last Commit |
+|----------------|-------------|
+| feature/foo    | abc1234     |
+| fix/bar        | def5678     |
+
+Remaining Branches (have remotes):
+- main
+- feature/active-work
+
+Note: If any worktree directories couldn't be deleted due to permissions,
+list them so user can manually delete.
+```
+
+## Behavior
+
+1. Fetch with prune to update remote tracking info
+2. Identify branches marked as "gone"
+3. Remove worktrees first (branches with worktrees can't be deleted)
+4. Delete the branches
+5. Report what was cleaned up and what remains
+6. Note any directories that need manual cleanup
+
+## When to Use
+
+- After merging multiple PRs
+- Periodic cleanup of stale branches
+- Before starting new work to reduce clutter

--- a/.claude/commands/retrospective.md
+++ b/.claude/commands/retrospective.md
@@ -1,0 +1,293 @@
+# Session Retrospective
+
+Analyze a specific Claude Code session to extract learnings and improve workflows.
+
+## Usage
+
+`/retrospective [project-path]`
+
+Examples:
+- `/retrospective` - Analyze current project's most recent session
+- `/retrospective C:\VS\.claude-worktrees\sdk\optimistic-almeida` - Specific worktree
+- `/retrospective sdk` - Shorthand for ppds/sdk
+
+## Philosophy
+
+**Iterate on sessions, not ecosystems.** Analyzing one session deeply is more actionable than synthesizing 30 days of cross-repo data. Do retrospectives after significant sessions, extract learnings, implement improvements immediately.
+
+## Critical Behaviors
+
+### Be Direct
+- Give honest feedback on what went wrong
+- Don't soften criticism - the goal is improvement
+- "The AI went off-track here because X was missing from CLAUDE.md" is appropriate
+
+### This Is a Discussion
+- Present findings, discuss implications together
+- User provides context you don't have
+- Track insights that emerge
+- Decide together what to change
+
+---
+
+## Phase 1: Locate Session Logs
+
+### Session Log Location
+
+Claude Code stores session logs at:
+```
+C:\Users\[username]\.claude\projects\[encoded-path]\
+```
+
+**Path encoding:** `C:\path\to\project` → `C--path-to-project`
+
+### Find the Session
+
+```powershell
+# List recent sessions for a project
+$projectPath = "C--VS--claude-worktrees-sdk-optimistic-almeida"
+Get-ChildItem "C:\Users\$env:USERNAME\.claude\projects\$projectPath" -Filter "*.jsonl" |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object Name, Length, LastWriteTime -First 5
+```
+
+### Session File Structure
+
+| File | Purpose |
+|------|---------|
+| `[UUID].jsonl` | Main conversation log (largest file) |
+| `agent-*.jsonl` | Subagent task logs |
+| `[UUID]/tool-results/` | Cached tool outputs |
+
+---
+
+## Phase 2: Analyze Session
+
+Read the main session log and analyze for:
+
+### 2.1 Friction Detection
+
+Search for signals of problems:
+
+| Signal | What to Look For |
+|--------|------------------|
+| User corrections | "no", "wrong", "not what I meant", "stop" |
+| Repeated instructions | Same thing said twice |
+| User frustration | Short responses after long outputs |
+| Missing context | User provides info mid-task that should have been asked |
+| Apologies | Claude apologizing indicates something went wrong |
+
+**Extract specific examples** - not just counts.
+
+### 2.2 Workflow Analysis
+
+- **Phases:** When did plan mode start/end? What were the transitions?
+- **Commits:** How often? After logical phases or random?
+- **Tool usage:** Effective? Parallelized? Right tools for the job?
+- **Questions:** Did Claude ask the right questions upfront?
+
+### 2.3 Positive Patterns
+
+What went RIGHT that should be reinforced:
+- Smooth approvals ("lgtm", "proceed", "yes")
+- Good question-asking before implementation
+- Effective use of agents/exploration
+- Clean commit cadence
+
+### 2.4 Session Metrics
+
+| Metric | Value |
+|--------|-------|
+| User messages | [count] |
+| Tool uses | [count] |
+| Files modified | [count] |
+| Commits made | [count] |
+| Friction incidents | [count] |
+| User corrections ("no/wrong") | [count] |
+
+---
+
+## Phase 3: Cross-Reference Artifacts
+
+### Git History
+
+```bash
+git log --oneline --since="[session-date]"
+git diff --stat [first-commit]..[last-commit]
+```
+
+- Match conversation flow to commit timing
+- Evaluate commit granularity
+- Assess commit message quality
+
+### Documentation Created
+
+- ADRs created?
+- CHANGELOG updated?
+- CLAUDE.md updated?
+- Other docs?
+
+### PR Created
+
+```bash
+gh pr view [PR#]
+```
+
+- Description quality
+- Issue links
+- Any review feedback?
+
+---
+
+## Phase 4: Identify Improvements
+
+**This is the critical phase.** For each finding, determine the actionable fix.
+
+### 4.1 CLAUDE.md Updates
+
+| Repo | Update Needed | Why |
+|------|---------------|-----|
+| [repo] | Add rule: "..." | Prevented mistake X |
+| [repo] | Add to NEVER: "..." | AI did Y which was wrong |
+
+Questions to ask:
+- Did the AI make a mistake that a CLAUDE.md rule would prevent?
+- Is there tribal knowledge that should be documented?
+- Are there patterns that should be in ALWAYS/NEVER?
+
+### 4.2 Slash Commands
+
+| Action | Command | Purpose |
+|--------|---------|---------|
+| Create | `/[name]` | [what it does] |
+| Update | `/[name]` | [what to add/change] |
+
+Questions to ask:
+- Was there a repeated manual process that should be a command?
+- Did an existing command miss a step (like `/pre-pr` missing push)?
+- Would a command have prevented an error?
+
+### 4.3 Workspace Documentation
+
+| Document | Update |
+|----------|--------|
+| `AGENTIC_WORKFLOW.md` | Add section on X |
+| `[other].md` | Update Y |
+
+Questions to ask:
+- Did we discover a new pattern that should be documented?
+- Is there process guidance that was improvised but should be formalized?
+- Are there templates or checklists that would help?
+
+### 4.4 Repo-Level Documentation
+
+| Repo | Document | Update |
+|------|----------|--------|
+| [repo] | `docs/[file].md` | [change] |
+
+---
+
+## Phase 5: Create Retrospective Report
+
+Store in `docs/retrospectives/YYYY-MM-DD_BRIEF_DESCRIPTION.md`:
+
+```markdown
+# Session Retrospective: [Title]
+
+**Date:** YYYY-MM-DD
+**Project:** [path or repo]
+**Branch:** [branch-name]
+**Duration:** [if known]
+**Outcome:** [PR #, files changed, key deliverables]
+
+---
+
+## Summary
+
+[1-3 sentences on what was accomplished]
+
+---
+
+## What Went Well
+
+| Pattern | Why It Worked |
+|---------|---------------|
+| [pattern] | [explanation] |
+
+---
+
+## Friction Points
+
+### [Issue Title]
+- **Issue:** What happened
+- **Impact:** How it affected the session
+- **Root Cause:** Why it happened
+- **Fix:** What we're changing to prevent recurrence
+
+---
+
+## Improvements Identified
+
+### CLAUDE.md Updates
+- [ ] [repo]: [update]
+
+### Slash Commands
+- [ ] [action]: [command] - [purpose]
+
+### Workspace Documentation
+- [ ] [document]: [update]
+
+### Repo Documentation
+- [ ] [repo]/[document]: [update]
+
+---
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| User messages | |
+| Files modified | |
+| Commits | |
+| Friction incidents | |
+| User corrections | |
+
+---
+
+## Action Items
+
+- [ ] Implement CLAUDE.md updates
+- [ ] Implement slash command changes
+- [ ] Update documentation
+- [ ] Commit and push changes
+```
+
+---
+
+## Phase 6: Implement Improvements
+
+After discussing findings with user, implement the approved changes:
+
+1. **CLAUDE.md updates** - Add rules to appropriate repos
+2. **Slash commands** - Create or update commands
+3. **Documentation** - Update workspace and repo docs
+4. **Commit** - Group related changes, clear commit messages
+
+---
+
+## When to Run
+
+- After significant sessions (10+ files, architectural changes)
+- When friction was encountered
+- When new patterns emerged
+- Periodically for high-activity projects
+
+**Don't wait for monthly reviews.** Iterate after each meaningful session.
+
+---
+
+## Related
+
+- `/handoff` - Generate context for next session
+- `/create-issue` - Create issue for follow-up work
+- `docs/AGENTIC_WORKFLOW.md` - Process documentation

--- a/.claude/commands/setup-ecosystem.md
+++ b/.claude/commands/setup-ecosystem.md
@@ -1,0 +1,132 @@
+# Setup PPDS Ecosystem
+
+Set up PPDS repositories on a new machine or update an existing setup.
+
+## Usage
+
+`/setup-ecosystem`
+
+## What It Does
+
+Interactive wizard to clone PPDS repositories and configure the development environment.
+
+## Flow
+
+### 1. Choose Base Path
+
+Ask user where to put repos:
+- Default: `C:\VS\ppds` (Windows) or `~/dev/ppds` (macOS/Linux)
+- User can specify any path
+
+```
+Where do you want the PPDS repos? [default: C:\VS\ppds]
+```
+
+### 2. Select Repositories
+
+Ask which repos to clone (use AskUserQuestion with multiSelect):
+- `sdk` - NuGet packages & CLI (core)
+- `extension` - VS Code extension
+- `tools` - PowerShell module
+- `alm` - CI/CD templates
+- `demo` - Reference implementation
+
+### 3. VS Code Workspace
+
+Ask if they want a VS Code workspace file created.
+
+### 4. Execute Setup
+
+For each selected repo:
+1. Check if folder exists
+2. If exists, verify it's a git repo and pull latest
+3. If not, clone from GitHub
+
+```bash
+# Clone pattern
+git clone https://github.com/joshsmithxrm/ppds-sdk.git {base}/sdk
+git clone https://github.com/joshsmithxrm/power-platform-developer-suite.git {base}/extension
+git clone https://github.com/joshsmithxrm/ppds-tools.git {base}/tools
+git clone https://github.com/joshsmithxrm/ppds-alm.git {base}/alm
+git clone https://github.com/joshsmithxrm/ppds-demo.git {base}/demo
+```
+
+### 5. Create Workspace File (if requested)
+
+Generate `{base}/ppds.code-workspace`:
+
+```json
+{
+    "folders": [
+        { "path": "sdk" },
+        { "path": "extension" },
+        { "path": "tools" },
+        { "path": "alm" },
+        { "path": "demo" }
+    ],
+    "settings": {}
+}
+```
+
+Only include folders that were cloned.
+
+### 6. Recommend Terminal Setup
+
+After setup, suggest running `/setup-terminal` to install the PowerShell profile with the `ppds` function (runs CLI from worktree without global install).
+
+## Idempotent Behavior
+
+| Scenario | Action |
+|----------|--------|
+| Folder doesn't exist | Clone repo |
+| Folder exists, is git repo | `git pull` to update |
+| Folder exists, not git repo | Warn and skip |
+| Workspace file exists | Ask to overwrite or skip |
+
+## Example Session
+
+```
+User: /setup-ecosystem
+
+Claude: Where do you want the PPDS repos?
+[Uses AskUserQuestion with text input option]
+
+User: D:\Projects\ppds
+
+Claude: Which repos do you need?
+[Uses AskUserQuestion with multiSelect]
+- sdk (NuGet packages & CLI)
+- extension (VS Code extension)
+- tools (PowerShell module)
+- alm (CI/CD templates)
+- demo (Reference implementation)
+
+User: [selects sdk, extension]
+
+Claude: Create VS Code workspace file?
+[Uses AskUserQuestion]
+
+User: Yes
+
+Claude: Setting up D:\Projects\ppds...
+
+Creating directory...
+Cloning sdk... done
+Cloning extension... done
+Creating ppds.code-workspace... done
+
+Setup complete!
+
+To set up terminal helpers, run: /setup-terminal
+To open in VS Code: code D:\Projects\ppds\ppds.code-workspace
+```
+
+## Repository URLs
+
+| Shorthand | GitHub URL |
+|-----------|------------|
+| `sdk` | `https://github.com/joshsmithxrm/ppds-sdk.git` |
+| `extension` | `https://github.com/joshsmithxrm/power-platform-developer-suite.git` |
+| `tools` | `https://github.com/joshsmithxrm/ppds-tools.git` |
+| `alm` | `https://github.com/joshsmithxrm/ppds-alm.git` |
+| `demo` | `https://github.com/joshsmithxrm/ppds-demo.git` |

--- a/.claude/commands/setup-terminal.md
+++ b/.claude/commands/setup-terminal.md
@@ -1,0 +1,61 @@
+# Setup PPDS Terminal Profile
+
+Install or update the PPDS terminal profile on this machine.
+
+## What This Does
+
+Installs PowerShell functions for parallel PPDS development:
+
+| Command | Purpose |
+|---------|---------|
+| `ppds` | Runs CLI from current worktree (no reinstalling!) |
+| `goto` | Quick navigation to worktrees with tab completion |
+| `ppdsw` | Open new terminal tabs/panes per worktree |
+| (prompt) | Shows `[worktree:branch]` so you know where you are |
+
+## Instructions
+
+Run the installer script from the SDK:
+
+```powershell
+& C:\VS\ppds\sdk\scripts\Install-PpdsTerminalProfile.ps1
+```
+
+If reinstalling/updating, add `-Force`:
+
+```powershell
+& C:\VS\ppds\sdk\scripts\Install-PpdsTerminalProfile.ps1 -Force
+```
+
+After installation, restart PowerShell or reload the profile:
+
+```powershell
+. $PROFILE
+```
+
+## Custom Base Path
+
+If your PPDS repos are not in `C:\VS\ppds`, specify the path:
+
+```powershell
+& C:\VS\ppds\sdk\scripts\Install-PpdsTerminalProfile.ps1 -PpdsBasePath "D:\Projects\ppds"
+```
+
+## Verification
+
+After installation, test the commands:
+
+```powershell
+# Check ppds runs from worktree
+cd C:\VS\ppds\sdk
+ppds --version
+# Should show: [ppds: sdk] followed by version
+
+# Test goto picker
+goto
+# Should show numbered list of worktrees
+
+# Test workspace launcher
+ppdsw sdk -Split
+# Should open a split pane in sdk directory
+```

--- a/.claude/commands/test-cli.md
+++ b/.claude/commands/test-cli.md
@@ -1,6 +1,6 @@
 # CLI Smoke Test
 
-Installs and tests the local CLI to verify changes work correctly.
+Tests the local CLI to verify changes work correctly.
 
 ## When to Use
 
@@ -24,18 +24,14 @@ Installs and tests the local CLI to verify changes work correctly.
 - Identify which commands/features need testing
 - If unclear what to test, ask the user
 
-### 2. Install Latest
-```powershell
-pwsh -ExecutionPolicy Bypass -File ./scripts/Install-LocalCli.ps1
-```
-
-### 3. Verify Version
+### 2. Verify Version
 ```bash
 ppds --version
 ```
 - Confirm version includes expected commit hash from `git rev-parse --short HEAD`
+- If CLI is not available, prompt user to run `/install-cli` or use terminal profile's `ppds` function
 
-### 4. Run Tests
+### 3. Run Tests
 
 **CRITICAL**: Run each command INDIVIDUALLY.
 
@@ -85,7 +81,7 @@ Use the `cli-test` profile:
 - If `cli-test` doesn't exist, SKIP auth tests and note it
 - Never run destructive commands
 
-### 5. Report Results
+### 4. Report Results
 
 After running all tests, provide a summary:
 
@@ -114,8 +110,8 @@ Summary: 9/9 passed
 
 | Situation | Action |
 |-----------|--------|
+| CLI not found | Prompt to run `/install-cli` or use terminal profile |
 | Test failure | Report which failed, show output, continue |
-| Install failure | Stop and report |
 | Version mismatch | Warn but continue |
 | Profile missing | Skip auth tests with note |
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,8 @@
       "Bash(git mv:*)",
       "Bash(git worktree list:*)",
       "Bash(git worktree prune:*)",
+      "Bash(git worktree add:*)",
+      "Bash(git worktree remove:*)",
       "Bash(git describe:*)",
       "Bash(git tag:*)",
       "Bash(git -C:*)",
@@ -94,6 +96,9 @@
       "Bash(gh release list:*)",
       "Bash(gh release view:*)",
       "Bash(gh issue create:*)",
+      "Bash(gh label list:*)",
+      "Bash(gh project item-add:*)",
+      "Bash(gh project item-edit:*)",
       "WebSearch"
     ],
     "deny": [
@@ -125,8 +130,6 @@
       "Bash(git revert:*)",
       "Bash(git apply:*)",
       "Bash(git am:*)",
-      "Bash(git worktree add:*)",
-      "Bash(git worktree remove:*)",
       "Bash(git branch -D:*)",
       "Bash(git branch -d:*)",
       "Bash(git tag -d:*)",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,50 +3,32 @@ name: Build
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Detect which files changed to conditionally run jobs
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**'
-              - '!src/**/*.md'
-              - 'tests/**'
-              - '!tests/**/*.md'
-              - '**/*.csproj'
-              - '*.sln'
-              - 'Directory.Build.props'
-              - '.github/workflows/**'
-
   # Dependency review for PRs - checks for vulnerabilities in dependency changes
   dependency-review:
     runs-on: ubuntu-latest
-    needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout
@@ -60,8 +42,6 @@ jobs:
           deny-licenses: ''
 
   build:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
 
     steps:
@@ -118,22 +98,3 @@ jobs:
           src/PPDS.Plugins/bin/Release/*.nupkg
           src/PPDS.Plugins/bin/Release/*.snupkg
         if-no-files-found: warn
-
-  # Gate job for branch protection - always runs, reports success when build passes or is skipped
-  build-status:
-    runs-on: ubuntu-latest
-    needs: [changes, build]
-    if: always()
-    steps:
-      - name: Check build status
-        run: |
-          if [[ "${{ needs.changes.outputs.code }}" != "true" ]]; then
-            echo "No code changes - build skipped (OK)"
-            exit 0
-          elif [[ "${{ needs.build.result }}" == "success" ]]; then
-            echo "Build passed"
-            exit 0
-          else
-            echo "Build failed: ${{ needs.build.result }}"
-            exit 1
-          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,3 +98,19 @@ jobs:
           src/PPDS.Plugins/bin/Release/*.nupkg
           src/PPDS.Plugins/bin/Release/*.snupkg
         if-no-files-found: warn
+
+  # Gate job for branch protection
+  build-status:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Check build status
+        run: |
+          if [[ "${{ needs.build.result }}" == "success" ]]; then
+            echo "Build passed"
+            exit 0
+          else
+            echo "Build failed: ${{ needs.build.result }}"
+            exit 1
+          fi

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,43 @@
+name: CI Gate
+
+# Always runs - provides status checks for branch protection when other workflows are skipped
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**.cs'
+              - '**.csproj'
+              - '**.sln'
+              - 'Directory.Build.props'
+              - 'Directory.Packages.props'
+              - 'nuget.config'
+
+  # These jobs satisfy branch protection when code workflows are skipped
+  build-status:
+    runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.code != 'true'
+    steps:
+      - run: echo "No code changes - build not required"
+
+  test-status:
+    runs-on: ubuntu-latest
+    needs: check-changes
+    if: needs.check-changes.outputs.code != 'true'
+    steps:
+      - run: echo "No code changes - tests not required"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,18 +3,22 @@ name: Integration Tests
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,48 +3,29 @@ name: Test
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.claude/**'
-      - '*.md'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**.cs'
+      - '**.csproj'
+      - '**.sln'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'nuget.config'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Detect which files changed to conditionally run jobs
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**'
-              - '!src/**/*.md'
-              - 'tests/**'
-              - '!tests/**/*.md'
-              - '**/*.csproj'
-              - '*.sln'
-              - 'Directory.Build.props'
-              - '.github/workflows/**'
-
   test:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
 
     steps:
@@ -77,22 +58,3 @@ jobs:
         flags: unittests
         fail_ci_if_error: false  # Don't fail build if upload fails
         verbose: true
-
-  # Gate job for branch protection - always runs, reports success when test passes or is skipped
-  test-status:
-    runs-on: ubuntu-latest
-    needs: [changes, test]
-    if: always()
-    steps:
-      - name: Check test status
-        run: |
-          if [[ "${{ needs.changes.outputs.code }}" != "true" ]]; then
-            echo "No code changes - test skipped (OK)"
-            exit 0
-          elif [[ "${{ needs.test.result }}" == "success" ]]; then
-            echo "Tests passed"
-            exit 0
-          else
-            echo "Tests failed: ${{ needs.test.result }}"
-            exit 1
-          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,19 @@ jobs:
         flags: unittests
         fail_ci_if_error: false  # Don't fail build if upload fails
         verbose: true
+
+  # Gate job for branch protection
+  test-status:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check test status
+        run: |
+          if [[ "${{ needs.test.result }}" == "success" ]]; then
+            echo "Tests passed"
+            exit 0
+          else
+            echo "Tests failed: ${{ needs.test.result }}"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,304 +1,68 @@
 # CLAUDE.md - ppds-sdk
 
-**NuGet packages for Power Platform development: plugin attributes, Dataverse connectivity, and migration tooling.**
+NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivity, migration tooling.
 
-**Part of the PPDS Ecosystem** - See `C:\VS\ppds\CLAUDE.md` for cross-project context.
-
----
-
-## 🚫 NEVER
+## NEVER
 
 | Rule | Why |
 |------|-----|
-| Commit directly to `main` | Branch is protected; all changes require PR |
-| Regenerate `PPDS.Plugins.snk` | Breaks strong naming; existing assemblies won't load |
-| Skip XML documentation on public APIs | Consumers need IntelliSense documentation |
-| Commit with failing tests | All tests must pass before merge |
-| Create new ServiceClient per request | 42,000x slower than Clone/pool pattern |
-| Guess parallelism values | Use `RecommendedDegreesOfParallelism` from server |
-| Hold single pooled client for multiple queries | Defeats pool parallelism; see `.claude/rules/DATAVERSE_PATTERNS.md` |
-| Use magic strings for generated entities | Use `EntityLogicalName` and `Fields.*` constants |
-| Use late-bound `Entity` for generated entity types | Use early-bound classes; compile-time safety |
-| Write CLI status messages to stdout | Use `Console.Error.WriteLine` for status; stdout is for data |
+| Regenerate `PPDS.Plugins.snk` | Breaks strong naming |
+| Create new ServiceClient per request | 42,000x slower than pool |
+| Hold single pooled client for multiple queries | Defeats pool parallelism |
+| Use magic strings for generated entities | Use `EntityLogicalName` and `Fields.*` |
+| Write CLI status messages to stdout | stdout = data, stderr = status |
 
----
-
-## ✅ ALWAYS
+## ALWAYS
 
 | Rule | Why |
 |------|-----|
-| Strong name all assemblies | Required for Dataverse plugin sandbox |
-| XML documentation for public APIs | IntelliSense support for consumers |
-| Run `dotnet test` before PR | Ensures no regressions |
-| Update `CHANGELOG.md` for user-facing changes | Skip internal refactoring |
 | Use connection pool for multi-request scenarios | See `.claude/rules/DATAVERSE_PATTERNS.md` |
-| Dispose pooled clients with `await using` | Returns connections to pool |
 | Use bulk APIs (`CreateMultiple`, `UpdateMultiple`) | 5x faster than `ExecuteMultiple` |
-| Use early-bound classes for generated entities | Type safety, IntelliSense support |
-| Read ADRs 0002/0005 before Dataverse multi-record code | Pool patterns are non-obvious |
 | Add new services to `RegisterDataverseServices()` | Keeps CLI and library DI in sync |
 
----
-
-## 💻 Tech Stack
-
-| Technology | Version | Purpose |
-|------------|---------|---------|
-| .NET | 4.6.2, 8.0, 9.0, 10.0 | Plugins: 4.6.2 only; libraries/CLI: 8.0+ |
-| C# | Latest (LangVersion) | Primary language |
-| Strong Naming | .snk file | Required for Dataverse plugin assemblies |
-
----
-
-## 📁 Project Structure
+## Structure
 
 ```
-ppds-sdk/
-├── src/
-│   ├── PPDS.Plugins/        # Plugin attributes (PluginStep, PluginImage)
-│   ├── PPDS.Dataverse/      # Connection pool, bulk operations, metadata
-│   │   └── Generated/       # Early-bound entity classes (DO NOT edit)
-│   ├── PPDS.Migration/      # Migration engine library
-│   ├── PPDS.Auth/           # Authentication profiles
-│   └── PPDS.Cli/            # CLI tool (ppds command)
-├── tests/                   # Unit, integration, and live tests
-├── docs/adr/                # Architecture Decision Records
-└── CHANGELOG.md
+src/
+├── PPDS.Plugins/     # Plugin attributes (PluginStep, PluginImage)
+├── PPDS.Dataverse/   # Connection pool, bulk operations
+│   └── Generated/    # Early-bound entities (DO NOT edit)
+├── PPDS.Migration/   # Migration engine
+├── PPDS.Auth/        # Auth profiles
+└── PPDS.Cli/         # CLI (ppds command)
 ```
 
----
+## Generated Entities
 
-## 🏗️ Generated Entities
+Early-bound in `src/PPDS.Dataverse/Generated/`. Use `EntityLogicalName` and `Fields.*` constants.
 
-Early-bound classes in `src/PPDS.Dataverse/Generated/` provide type safety.
+Late-bound only when: entity type is runtime-determined, or no generated class exists.
 
-**Available:** `PluginAssembly`, `PluginPackage`, `PluginType`, `SdkMessage`, `SdkMessageFilter`, `SdkMessageProcessingStep`, `SdkMessageProcessingStepImage`, `Solution`, `SolutionComponent`, `AsyncOperation`, `ImportJob`, `SystemUser`, `Role`, `Publisher`, `EnvironmentVariableDefinition`, `EnvironmentVariableValue`, `Workflow`, `ConnectionReference`
+Regenerate: `.\scripts\Generate-EarlyBoundModels.ps1 -Force`
 
-```csharp
-// ✅ Correct - Early-bound with constants
-var query = new QueryExpression(PluginAssembly.EntityLogicalName)
-{
-    ColumnSet = new ColumnSet(PluginAssembly.Fields.Name)
-};
+## Dataverse Performance
 
-// ❌ Wrong - Magic strings
-var query = new QueryExpression("pluginassembly");
-```
+**Read ADRs 0002/0005 before any multi-record code.** Reference: `BulkOperationExecutor.cs`
 
-**Late-bound is acceptable only when:** Entity type is determined at runtime (migration), building generic tooling, or entity has no generated class.
+Key: Get client INSIDE parallel loops. Use `pool.GetTotalRecommendedParallelism()` as DOP ceiling.
 
-**Regenerating:** `.\scripts\Generate-EarlyBoundModels.ps1 -Force` (requires `pac auth`)
+## Versioning
 
----
+MinVer tags: `{Package}-v{version}` (e.g., `Cli-v1.0.0-beta.11`)
 
-## 🛠️ Common Commands
-
-```powershell
-dotnet build                    # Debug build
-dotnet build -c Release         # Release build
-dotnet test                     # Run all tests
-dotnet pack -c Release -o ./nupkgs
-```
-
----
-
-## 🔄 Development Workflow
-
-1. Create feature branch from `main`
-2. Make changes + **add tests for new classes**
-3. Update `CHANGELOG.md` (same commit)
-4. Run `/pre-pr` before committing
-5. Create PR to `main`
-6. Run `/review-bot-comments` after bots comment
-
-### Plan Mode Checklist
-
-- [ ] **Shared utilities identified** - Will logic be needed in multiple files?
-- [ ] **Constants centralized** - Magic numbers/strings that should be shared?
-- [ ] **Existing patterns checked** - Similar functionality to extend?
-
-**Anti-pattern:** Planning WHAT without WHERE. Always consider where shared logic should live to avoid expensive refactoring.
-
-### Code Conventions
-
-- Use nullable reference types (`string?` not `string`)
-- XML documentation on public APIs
-- Comments explain WHY, not WHAT
-- Namespaces: `PPDS.{Package}.{Area}` (e.g., `PPDS.Auth.Credentials`)
-
----
-
-## 📦 Version Management
-
-Each package has independent versioning using MinVer:
-
-| Package | Tag Format |
-|---------|------------|
-| PPDS.Plugins | `Plugins-v{version}` |
-| PPDS.Dataverse | `Dataverse-v{version}` |
-| PPDS.Migration | `Migration-v{version}` |
-| PPDS.Auth | `Auth-v{version}` |
-| PPDS.Cli | `Cli-v{version}` |
-
-Pre-release: `-alpha.N`, `-beta.N`, `-rc.N` suffix
-
----
-
-## 🔀 Git Strategy
-
-| Branch | Purpose |
-|--------|---------|
-| `main` | Protected, always releasable |
-| `feature/*` | New features |
-| `fix/*` | Bug fixes |
-
-**Merge:** Squash merge to main. Pre-release = fix pattern issues now, don't defer.
-
----
-
-## 🚀 Release Process
-
-1. Update per-package `CHANGELOG.md` (in `src/{package}/`)
-2. Merge to `main`
-3. Create GitHub Release with package-specific tag
-4. `publish-nuget.yml` workflow publishes to NuGet.org
-
----
-
-## ⚡ Dataverse Performance
-
-**See `.claude/rules/DATAVERSE_PATTERNS.md` for pool usage patterns, DOP parallelism, and code examples.**
-
-Key points:
-- Get client INSIDE parallel loops (not outside)
-- Use `pool.GetTotalRecommendedParallelism()` as DOP ceiling
-- Reference impl: `BulkOperationExecutor.cs`
-
-### Architecture Decision Records
-
-| ADR | Summary |
-|-----|---------|
-| [0001](docs/adr/0001_DISABLE_AFFINITY_COOKIE.md) | Disable affinity cookie for 10x throughput |
-| [0002](docs/adr/0002_MULTI_CONNECTION_POOLING.md) | Multiple Application Users multiply API quota |
-| [0003](docs/adr/0003_THROTTLE_AWARE_SELECTION.md) | Route away from throttled connections |
-| [0004](docs/adr/0004_THROTTLE_RECOVERY_STRATEGY.md) | Transparent throttle waiting |
-| [0005](docs/adr/0005_DOP_BASED_PARALLELISM.md) | DOP-based parallelism |
-| [0006](docs/adr/0006_CONNECTION_SOURCE_ABSTRACTION.md) | IConnectionSource for custom auth |
-| [0007](docs/adr/0007_UNIFIED_CLI_AND_AUTH.md) | Unified CLI and auth profiles |
-| [0008](docs/adr/0008_CLI_OUTPUT_ARCHITECTURE.md) | CLI stdout/stderr separation |
-| [0009](docs/adr/0009_CLI_COMMAND_TAXONOMY.md) | CLI command taxonomy |
-| [0010](docs/adr/0010_PUBLISHED_UNPUBLISHED_DEFAULT.md) | Default to published content |
-| [0011](docs/adr/0011_DEPLOYMENT_SETTINGS_FORMAT.md) | Deployment settings format |
-| [0012](docs/adr/0012_HYBRID_FILTER_DESIGN.md) | Hybrid filter design |
-| [0013](docs/adr/0013_CLI_DRY_RUN_CONVENTION.md) | CLI --dry-run convention |
-| [0014](docs/adr/0014_CSV_MAPPING_SCHEMA.md) | CSV mapping schema |
-| [0015](docs/adr/0015_APPLICATION_SERVICE_LAYER.md) | Application service layer for CLI/TUI/Daemon |
-| [0019](docs/adr/0019_POOL_MANAGED_CONCURRENCY.md) | Pool-managed concurrency |
-| [0020](docs/adr/0020_IMPORT_ERROR_REPORTING.md) | Import error reporting |
-| [0021](docs/adr/0021_TRUNCATE_COMMAND.md) | Truncate command |
-| [0022](docs/adr/0022_IMPORT_DIAGNOSTICS_ARCHITECTURE.md) | Import diagnostics architecture |
-
----
-
-## 🖥️ CLI (PPDS.Cli)
-
-See [CLI README](src/PPDS.Cli/README.md) for full documentation.
-
-Quick start:
-```bash
-ppds auth create --name dev    # Create profile
-ppds env select                # Select environment
-ppds data export --schema schema.xml --output data.zip
-```
-
-**Output conventions:** stdout = data, stderr = status messages.
-
----
-
-## 🔌 DI Registration
-
-Two DI paths must stay synchronized:
-- **Library:** `AddDataverseConnectionPool(config)`
-- **CLI:** `ProfileServiceFactory.CreateFromProfileAsync()`
-
-Both call `RegisterDataverseServices()` to register shared services. When adding a service, add it there (not to individual paths).
-
----
-
-## 🧪 Testing
-
-**See `.claude/rules/TESTING.md` for test categories, CI behavior, and local setup.**
-
-Key rules:
-- New public class → must have test class
-- Run `/run-integration-local` for live tests
-- CI: Unit tests on commits, full tests on PRs
-
----
-
-## 🤖 Bot Review Handling
-
-PRs reviewed by Copilot, Gemini, CodeQL. Not all findings are valid.
-
-| Finding Type | Action |
-|--------------|--------|
-| Unused code, resource leaks | Usually valid - fix |
-| Style suggestions | Often preference - dismiss with reason |
-| Logic errors | Verify manually |
-
-Run `/review-bot-comments [PR#]` to triage.
-
----
-
-## 🗺️ Issue Triage
-
-Issues are tracked in the [PPDS Roadmap](https://github.com/users/joshsmithxrm/projects/3) project.
-
-### Triage Command
-
-`/triage` - Systematically categorize GitHub issues with project fields and labels
-
-### Project Fields
-
-| Field | Values | Purpose |
-|-------|--------|---------|
-| **Type** | feature, bug, chore, docs, refactor | Work category |
-| **Priority** | P0-Critical, P1-High, P2-Medium, P3-Low | Urgency/importance |
-| **Size** | XS, S, M, L, XL | Effort estimate |
-| **Status** | Todo, In Progress, Done | Current state |
-| **Target** | This Week, Next, Q1 2026, CLI v1.0.0, Blocked | Sequencing |
-| **Parent Issue** | Link to epic/parent | Issue hierarchy |
-
-### Label Strategy
-
-**Use labels for:**
-- **Epics**: epic:cli-daemon, epic:testing, epic:data-migration
-- **Phases**: phase:1-core, phase:2-connections, phase:3-traces, phase:4-webresources, phase:5-migration
-- **Areas**: area:plugins, area:data, area:auth, area:cli, area:tui, area:pooling, area:daemon
-- **Special**: foundation, blocked, performance
-- **Type hints** (optional): bug, enhancement, documentation
-
-**Don't use labels for:** Priority, Size, Status, Target (use project fields instead)
-
-See [docs/ROADMAP.md](docs/ROADMAP.md) for detailed guidelines.
-
----
-
-## 🛠️ Claude Commands
+## Commands
 
 | Command | Purpose |
 |---------|---------|
-| `/triage [options] [issues...]` | Batch triage issues in PPDS Roadmap project |
-| `/plan-work <issues...>` | Triage issues, create worktrees |
 | `/pre-pr` | Validate before PR |
-| `/review-bot-comments [PR#]` | Triage bot findings |
-| `/run-integration-local [filter]` | Run integration tests |
-| `/debug-ci-failure [run-id]` | Analyze CI failure |
+| `/triage` | Batch triage issues |
+| `/ppds-help` | CLI quick reference |
+| `/setup-ecosystem` | Set up PPDS repos on new machine |
 
-**Hook:** `pre-commit-validate.py` - Build + unit tests on commit (~10s)
+Hook: `pre-commit-validate.py` runs build + unit tests on commit (~10s)
 
----
+## Rules
 
-## 📦 Consumer Templates
-
-Projects using PPDS: see `templates/claude/` for Claude Code integration.
+- `.claude/rules/DATAVERSE_PATTERNS.md` - Pool usage, parallelism
+- `.claude/rules/TESTING.md` - Test categories, CI behavior
+- `docs/adr/` - Architecture decisions

--- a/scripts/Install-PpdsTerminalProfile.ps1
+++ b/scripts/Install-PpdsTerminalProfile.ps1
@@ -241,17 +241,20 @@ function Start-PpdsWorkspace {
         return
     }
 
-    # Build Windows Terminal command
+    # Build Windows Terminal command arguments
+    `$wtArgs = @('-w', '0')
     if (`$Split) {
-        wt -w 0 split-pane -d `$worktreePath --title `$Worktree
+        `$wtArgs += 'split-pane', '-d', `$worktreePath, '--title', `$Worktree
     } else {
-        wt -w 0 new-tab -d `$worktreePath --title `$Worktree
+        `$wtArgs += 'new-tab', '-d', `$worktreePath, '--title', `$Worktree
     }
 
     if (`$WithClaude) {
-        Start-Sleep -Milliseconds 500
-        wt -w 0 split-pane -d `$worktreePath --title "`$Worktree (Claude)" pwsh -NoExit -Command "claude"
+        `$wtArgs += ';', 'split-pane', '-d', `$worktreePath, '--title', "`$Worktree (Claude)", 'pwsh', '-NoExit', '-Command', 'claude'
     }
+
+    # Execute wt with all arguments at once
+    & wt @`$wtArgs
 }
 
 Set-Alias ppdsw Start-PpdsWorkspace

--- a/scripts/Install-PpdsTerminalProfile.ps1
+++ b/scripts/Install-PpdsTerminalProfile.ps1
@@ -1,0 +1,337 @@
+<#
+.SYNOPSIS
+    Installs or updates the PPDS terminal profile for parallel worktree development.
+
+.DESCRIPTION
+    Sets up PowerShell with:
+    - Dynamic `ppds` command that runs the CLI from your current worktree
+    - `goto` command for quick navigation between worktrees
+    - `ppdsw` (Start-PpdsWorkspace) to launch new terminal tabs/panes
+    - Visual prompt showing current worktree and branch
+
+.PARAMETER Force
+    Overwrite existing profile without prompting.
+
+.PARAMETER PpdsBasePath
+    Base path where PPDS repos are located. Defaults to C:\VS\ppds.
+
+.EXAMPLE
+    .\Install-PpdsTerminalProfile.ps1
+
+.EXAMPLE
+    .\Install-PpdsTerminalProfile.ps1 -Force -PpdsBasePath "D:\Projects\ppds"
+#>
+[CmdletBinding()]
+param(
+    [switch]$Force,
+    [string]$PpdsBasePath = "C:\VS\ppds"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Determine profile paths for both Windows PowerShell and PowerShell Core
+$windowsPowerShellProfile = Join-Path ([Environment]::GetFolderPath('MyDocuments')) "WindowsPowerShell\profile.ps1"
+$powerShellCoreProfile = Join-Path ([Environment]::GetFolderPath('MyDocuments')) "PowerShell\Microsoft.PowerShell_profile.ps1"
+
+# Use current shell's profile as primary
+$profilePath = $PROFILE.CurrentUserAllHosts
+if (-not $profilePath) {
+    $profilePath = $PROFILE
+}
+
+Write-Host "PPDS Terminal Profile Installer" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Profile locations:"
+Write-Host "  Windows PowerShell: $windowsPowerShellProfile"
+Write-Host "  PowerShell Core:    $powerShellCoreProfile"
+Write-Host "PPDS base path:       $PpdsBasePath"
+Write-Host ""
+
+# Check if profile already exists in either location
+$alreadyInstalled = $false
+foreach ($prof in @($windowsPowerShellProfile, $powerShellCoreProfile)) {
+    if (Test-Path $prof) {
+        $existingContent = Get-Content $prof -Raw
+        if ($existingContent -match "# PPDS Terminal Profile") {
+            $alreadyInstalled = $true
+        } elseif (-not $Force) {
+            # Backup existing non-PPDS profile
+            $backupPath = "$prof.backup-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+            Copy-Item $prof $backupPath
+            Write-Host "Backed up existing profile to: $backupPath" -ForegroundColor Green
+        }
+    }
+}
+
+if ($alreadyInstalled -and -not $Force) {
+    Write-Host "PPDS profile already installed. Use -Force to reinstall." -ForegroundColor Yellow
+    return
+}
+
+if ($alreadyInstalled) {
+    Write-Host "Reinstalling PPDS profile..." -ForegroundColor Yellow
+}
+
+# Ensure profile directory exists
+$profileDir = Split-Path $profilePath -Parent
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+    Write-Host "Created profile directory: $profileDir" -ForegroundColor Green
+}
+
+# Profile content
+$profileContent = @"
+# PPDS Terminal Profile
+# Installed by Install-PpdsTerminalProfile.ps1
+# https://github.com/joshsmithxrm/ppds-sdk
+
+`$script:PpdsBasePath = "$PpdsBasePath"
+
+#region Dynamic ppds Command
+<#
+.SYNOPSIS
+    Runs the ppds CLI from your current worktree automatically.
+.DESCRIPTION
+    When you're in a PPDS SDK worktree (sdk/, sdk-tui-ux/, etc.), this runs
+    that worktree's CLI via 'dotnet run'. Outside worktrees, uses the global tool.
+#>
+function ppds {
+    # Walk up from current directory looking for PPDS.Cli
+    `$dir = `$PWD.Path
+    while (`$dir) {
+        `$cliProject = Join-Path `$dir "src\PPDS.Cli\PPDS.Cli.csproj"
+        if (Test-Path `$cliProject) {
+            # Found it - run this worktree's CLI
+            `$worktreeName = Split-Path `$dir -Leaf
+            Write-Host "[ppds: `$worktreeName]" -ForegroundColor DarkGray
+            dotnet run --project `$cliProject --framework net8.0 --no-launch-profile -- @args
+            return
+        }
+        `$parent = Split-Path `$dir -Parent
+        if (-not `$parent -or `$parent -eq `$dir) { break }
+        `$dir = `$parent
+    }
+
+    # Not in a worktree - use global tool
+    `$globalPpds = Get-Command ppds -CommandType Application -ErrorAction SilentlyContinue
+    if (`$globalPpds) {
+        & `$globalPpds @args
+    } else {
+        Write-Error "Not in a PPDS worktree and no global ppds tool installed"
+    }
+}
+#endregion
+
+#region Quick Navigation
+<#
+.SYNOPSIS
+    Quickly navigate to PPDS worktrees.
+.DESCRIPTION
+    Without arguments, shows an interactive picker of all worktrees.
+    With an argument, jumps directly to that worktree.
+.EXAMPLE
+    goto           # Interactive picker
+    goto sdk-tui   # Jump to sdk-tui-ux (partial match)
+#>
+function goto {
+    param([string]`$Worktree)
+
+    if (-not (Test-Path `$script:PpdsBasePath)) {
+        Write-Error "PPDS base path not found: `$script:PpdsBasePath"
+        return
+    }
+
+    # Get all valid worktrees (has .git or src/PPDS.Cli)
+    `$worktrees = Get-ChildItem `$script:PpdsBasePath -Directory | Where-Object {
+        (Test-Path (Join-Path `$_.FullName ".git")) -or
+        (Test-Path (Join-Path `$_.FullName "src\PPDS.Cli"))
+    } | Select-Object -ExpandProperty Name
+
+    if (-not `$Worktree) {
+        # Interactive picker
+        Write-Host "PPDS Worktrees:" -ForegroundColor Cyan
+        for (`$i = 0; `$i -lt `$worktrees.Count; `$i++) {
+            `$wt = `$worktrees[`$i]
+            `$wtPath = Join-Path `$script:PpdsBasePath `$wt
+            `$branch = git -C `$wtPath branch --show-current 2>`$null
+            Write-Host "  [`$i] " -NoNewline -ForegroundColor DarkGray
+            Write-Host `$wt -NoNewline -ForegroundColor Yellow
+            if (`$branch) {
+                Write-Host " (`$branch)" -ForegroundColor DarkGray
+            } else {
+                Write-Host ""
+            }
+        }
+        Write-Host ""
+        `$selection = Read-Host "Select (number or name)"
+
+        if (`$selection -match '^\d+$' -and [int]`$selection -lt `$worktrees.Count) {
+            `$Worktree = `$worktrees[[int]`$selection]
+        } else {
+            `$Worktree = `$selection
+        }
+    }
+
+    # Support partial matching
+    `$match = `$worktrees | Where-Object { `$_ -like "`$Worktree*" } | Select-Object -First 1
+    if (`$match) {
+        `$Worktree = `$match
+    }
+
+    `$targetPath = Join-Path `$script:PpdsBasePath `$Worktree
+    if (Test-Path `$targetPath) {
+        Set-Location `$targetPath
+        `$host.UI.RawUI.WindowTitle = "PPDS: `$Worktree"
+    } else {
+        Write-Error "Worktree not found: `$Worktree"
+    }
+}
+
+# Tab completion for goto
+Register-ArgumentCompleter -CommandName goto -ParameterName Worktree -ScriptBlock {
+    param(`$commandName, `$parameterName, `$wordToComplete, `$commandAst, `$fakeBoundParameters)
+
+    if (Test-Path `$script:PpdsBasePath) {
+        Get-ChildItem `$script:PpdsBasePath -Directory |
+            Where-Object { `$_.Name -like "`$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    `$_.Name,
+                    `$_.Name,
+                    'ParameterValue',
+                    `$_.Name
+                )
+            }
+    }
+}
+#endregion
+
+#region Workspace Launcher
+<#
+.SYNOPSIS
+    Opens a new terminal tab/pane in a PPDS worktree.
+.DESCRIPTION
+    Launches Windows Terminal with a new tab or split pane in the specified worktree.
+    Optionally launches Claude Code alongside.
+.PARAMETER Worktree
+    Name of the worktree folder (e.g., sdk-tui-ux)
+.PARAMETER WithClaude
+    Also launch Claude Code in a split pane
+.PARAMETER Split
+    Add as split pane instead of new tab
+.EXAMPLE
+    Start-PpdsWorkspace sdk-tui-ux
+    ppdsw sdk-tui-ux -WithClaude -Split
+#>
+function Start-PpdsWorkspace {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]`$Worktree,
+
+        [switch]`$WithClaude,
+        [switch]`$Split
+    )
+
+    `$worktreePath = Join-Path `$script:PpdsBasePath `$Worktree
+
+    if (-not (Test-Path `$worktreePath)) {
+        Write-Error "Worktree not found: `$worktreePath"
+        return
+    }
+
+    # Build Windows Terminal command
+    if (`$Split) {
+        wt -w 0 split-pane -d `$worktreePath --title `$Worktree
+    } else {
+        wt -w 0 new-tab -d `$worktreePath --title `$Worktree
+    }
+
+    if (`$WithClaude) {
+        Start-Sleep -Milliseconds 500
+        wt -w 0 split-pane -d `$worktreePath --title "`$Worktree (Claude)" pwsh -NoExit -Command "claude"
+    }
+}
+
+Set-Alias ppdsw Start-PpdsWorkspace
+
+# Tab completion for Start-PpdsWorkspace
+Register-ArgumentCompleter -CommandName Start-PpdsWorkspace -ParameterName Worktree -ScriptBlock {
+    param(`$commandName, `$parameterName, `$wordToComplete, `$commandAst, `$fakeBoundParameters)
+
+    if (Test-Path `$script:PpdsBasePath) {
+        Get-ChildItem `$script:PpdsBasePath -Directory |
+            Where-Object { `$_.Name -like "`$wordToComplete*" } |
+            ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    `$_.Name,
+                    `$_.Name,
+                    'ParameterValue',
+                    `$_.Name
+                )
+            }
+    }
+}
+#endregion
+
+#region Visual Prompt
+function Get-PpdsPromptInfo {
+    `$dir = `$PWD.Path
+    if (`$dir -like "`$script:PpdsBasePath\*") {
+        `$relative = `$dir.Substring(`$script:PpdsBasePath.Length + 1)
+        `$worktree = (`$relative -split '\\')[0]
+        `$branch = git branch --show-current 2>`$null
+        if (`$branch) {
+            return "[`${worktree}:`${branch}]"
+        }
+        return "[`$worktree]"
+    }
+    return `$null
+}
+
+function prompt {
+    `$ppdsInfo = Get-PpdsPromptInfo
+    if (`$ppdsInfo) {
+        Write-Host `$ppdsInfo -NoNewline -ForegroundColor Magenta
+        Write-Host " " -NoNewline
+    }
+
+    # Shortened path display
+    `$shortPath = `$PWD.Path
+    if (`$shortPath.Length -gt 50) {
+        `$parts = `$shortPath -split '\\'
+        if (`$parts.Count -gt 3) {
+            `$shortPath = `$parts[0] + "\...\" + (`$parts[-2..-1] -join '\')
+        }
+    }
+
+    Write-Host `$shortPath -NoNewline -ForegroundColor Blue
+    return "> "
+}
+#endregion
+
+Write-Host "[PPDS] Terminal profile loaded. Commands: ppds, goto, ppdsw" -ForegroundColor DarkGray
+"@
+
+# Write to both profile locations
+$profilesToWrite = @($windowsPowerShellProfile, $powerShellCoreProfile) | Select-Object -Unique
+
+foreach ($prof in $profilesToWrite) {
+    $profDir = Split-Path $prof -Parent
+    if (-not (Test-Path $profDir)) {
+        New-Item -ItemType Directory -Path $profDir -Force | Out-Null
+    }
+    Set-Content -Path $prof -Value $profileContent -Encoding UTF8
+    Write-Host "Wrote profile to: $prof" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "PPDS terminal profile installed successfully!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Available commands:" -ForegroundColor Cyan
+Write-Host "  ppds     - Runs CLI from current worktree automatically"
+Write-Host "  goto     - Quick navigation to worktrees (with tab completion)"
+Write-Host "  ppdsw    - Open new terminal tab/pane in a worktree"
+Write-Host ""
+Write-Host "Restart PowerShell or run: . `$PROFILE" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

- Reduce CLAUDE.md from 305 to ~70 lines (keep only non-obvious rules)
- Migrate 7 slash commands from ppds/.claude/ to sdk/.claude/
- Add `/setup-ecosystem` command for new machine onboarding
- Add `/setup-terminal` command with `Install-PpdsTerminalProfile.ps1`
- Fix `/test-cli` to not auto-install CLI (prompts user instead)
- Add failure guidance to `/install-cli` for TUI conflicts

## Context

SDK is now the main repo. Parent `ppds/` folder becomes a plain container (workspace repo archived to `ppds/workspace/`).

## New Commands

| Command | Purpose |
|---------|---------|
| `/setup-ecosystem` | Clone repos, configure folder structure, create VS Code workspace |
| `/setup-terminal` | Install PowerShell profile with `ppds` function |

## Test plan

- [ ] Verify slim CLAUDE.md has essential rules
- [ ] Test `/ppds-help` shows CLI reference
- [ ] Test `/setup-terminal` instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)