### PR TITLE
docs: add ADR-0016 file format policy and ADR-0017 git branching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivi
 | Include ErrorCode in `PpdsException` | Enables programmatic handling (retry, re-auth) (ADR-0026) |
 | Make new user data accessible via `ppds serve` | VS Code extension needs same data as CLI/TUI |
 | Link related issues in PR body | Use "Closes #123" or "Relates to #456" |
+| Use JSON for config files, JSONL for streaming | No YAML; consistency with CLI output (ADR-0016) |
 
 ---
 

--- a/docs/adr/0016_FILE_FORMAT_POLICY.md
+++ b/docs/adr/0016_FILE_FORMAT_POLICY.md
@@ -1,0 +1,77 @@
+# ADR-0016: File Format Policy
+
+**Status:** Accepted
+**Date:** 2026-01-07
+**Authors:** Josh, Claude
+
+## Context
+
+The CLI produces and consumes various file formats. Without a clear policy, we risk:
+- Format inconsistency (some JSON, some YAML, some XML)
+- User confusion about what format to use
+- Dependency bloat from supporting multiple formats
+
+Related decisions:
+- ADR-0008: CLI output architecture (stdout=JSON for data)
+- ADR-0020: Import error reporting (JSON error reports)
+
+## Decision
+
+### Format by Use Case
+
+| Use Case | Format | Extension | Example |
+|----------|--------|-----------|---------|
+| CLI stdout output | JSON | (piped) | `ppds data export --output-format json` |
+| User config files | JSON | `.json` | `registrations.json`, `mapping.json` |
+| Streaming structured data | JSON Lines | `.jsonl` | `import.errors.jsonl` |
+| Human-readable logs | Plain text | `.log` | `import.progress.log` |
+| Summary reports | JSON | `.json` | `import.summary.json` |
+| Tabular data export | CSV | `.csv` | `ppds data export --output-format csv` |
+| Query input files | Native | `.fetchxml`, `.sql` | Domain-specific formats |
+
+### JSON for Config Files
+
+All user-authored configuration files use JSON:
+- `registrations.json` - Plugin registration
+- `mapping.json` - CSV column mappings
+- `deployment-settings.json` - PAC-compatible settings
+- Filter files - Query filters
+
+**YAML is explicitly not supported.** Rationale:
+- Consistency with CLI output format
+- No additional dependencies (YamlDotNet)
+- JSON Schema provides IDE autocomplete/validation
+- Single format to document and support
+
+Mitigations for lack of comments:
+1. JSON Schema files (`schemas/*.schema.json`) for IDE support
+2. `_`-prefixed metadata fields in generated files
+3. Example snippets in CLI help
+
+### JSON Lines for Streaming
+
+Use JSONL (one JSON object per line) for streaming structured data:
+- Append-only writes (safe during crashes)
+- Line-by-line parsing (memory efficient)
+- Easy to grep/tail
+
+Example: `import.errors.jsonl`
+```
+{"recordId":"abc","entity":"account","error":"Duplicate key"}
+{"recordId":"def","entity":"contact","error":"Missing reference"}
+```
+
+## Consequences
+
+### Positive
+- Clear guidance for all file format decisions
+- Consistency across the CLI
+- No YAML dependency
+- JSON Schema ecosystem for config validation
+
+### Negative
+- Users cannot add comments to config files
+- Must use JSON syntax (quotes, commas)
+
+### Neutral
+- Can revisit YAML support if users request it

--- a/docs/adr/0017_GIT_BRANCHING_STRATEGY.md
+++ b/docs/adr/0017_GIT_BRANCHING_STRATEGY.md
@@ -1,0 +1,94 @@
+# ADR-0017: Git Branching Strategy
+
+**Status:** Accepted
+**Date:** 2026-01-07
+**Authors:** Josh, Claude
+
+## Context
+
+The ppds-sdk repository uses git worktrees for parallel development. Without documented conventions:
+- Branch names are inconsistent
+- Worktree locations vary
+- Unclear when to create worktrees vs branches
+- PR workflow not standardized
+
+## Decision
+
+### Branch Naming
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `feature/` | New functionality | `feature/plugin-traces` |
+| `fix/` | Bug fixes | `fix/bypass-plugins` |
+| `docs/` | Documentation only | `docs/file-format-policy` |
+| `chore/` | Maintenance, refactoring | `chore/pre-pr-cleanup` |
+| `release/` | Release preparation | `release/v1.0.0` |
+
+### Worktree Strategy
+
+Use worktrees for parallel, isolated work. Each worktree is a separate directory with its own branch.
+
+**Location:** `C:\VS\ppds\sdk-{branch-suffix}`
+
+```
+C:\VS\ppds\
+├── sdk/                    # Main repo (main or current work)
+├── sdk-plugin-traces/      # feature/plugin-traces
+├── sdk-tui-enhancements/   # feature/tui-enhancements
+└── sdk-file-format-adr/    # docs/file-format-policy
+```
+
+**When to use worktrees:**
+- Work spans multiple sessions
+- Need to context-switch between features
+- Large feature requiring isolation
+
+**When to use simple branches:**
+- Quick fixes (< 1 hour)
+- Single-session work
+- No need to switch away
+
+### Worktree Lifecycle
+
+```bash
+# Create worktree from main
+git worktree add ../sdk-{name} main
+cd ../sdk-{name}
+git checkout -b feature/{name}
+
+# Work, commit, push
+git push -u origin feature/{name}
+gh pr create
+
+# After PR merges, clean up
+git worktree remove ../sdk-{name}
+```
+
+### Main Branch Protection
+
+- `main` is protected; direct commits blocked
+- All changes require PR with passing CI
+- Squash merge preferred for clean history
+
+### PR Conventions
+
+1. **Title:** `type: description` (e.g., `feat: add plugin traces CLI`)
+2. **Body:** Include "Closes #123" for linked issues
+3. **CI:** All checks must pass
+4. **Review:** Required for non-docs changes
+
+## Consequences
+
+### Positive
+- Consistent branch naming aids navigation
+- Worktrees enable true parallel development
+- Clear lifecycle prevents orphaned worktrees
+- Protected main ensures stability
+
+### Negative
+- More disk space for multiple worktrees
+- Must remember to clean up after merge
+
+### Neutral
+- Existing workflows unchanged
+- Optional adoption of worktree pattern


### PR DESCRIPTION
## Summary

Adds two ADRs establishing project conventions:

### ADR-0016: File Format Policy

| Use Case | Format |
|----------|--------|
| CLI stdout output | JSON |
| User config files | JSON |
| Streaming structured data | JSONL |
| Human-readable logs | Plain text |
| Tabular export | CSV |

**YAML explicitly not supported** - consistency, no extra dependencies.

### ADR-0017: Git Branching Strategy

- Branch naming: `feature/`, `fix/`, `docs/`, `chore/`
- Worktree locations: `C:\VS\ppds\sdk-{name}`
- Worktree lifecycle: create → work → PR → cleanup
- Main branch protection

## Changes

- `docs/adr/0016_FILE_FORMAT_POLICY.md` - New ADR
- `docs/adr/0017_GIT_BRANCHING_STRATEGY.md` - New ADR
- `CLAUDE.md` - Added file format rule to ALWAYS table

## Test plan

- [x] ADRs follow existing format
- [x] CLAUDE.md renders correctly
- [x] No duplicate ADR numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)