### PR TITLE
feat: add git branch to status line display

### DIFF
--- a/.claude/commands/setup-ecosystem.md
+++ b/.claude/commands/setup-ecosystem.md
@@ -121,8 +121,7 @@ Read existing settings.json first, merge the hooks section, then write back.
 1. Create status line script at `~/.claude/statusline.ps1`:
 ```powershell
 # PPDS Claude status line - shows directory and git branch
-$json = [Console]::In.ReadToEnd()
-$data = $json | ConvertFrom-Json
+$data = $input | ConvertFrom-Json
 $dir = Split-Path $data.workspace.current_dir -Leaf
 $branch = ""
 try {
@@ -131,7 +130,7 @@ try {
     if ($LASTEXITCODE -eq 0 -and $b) { $branch = " ($b)" }
     Pop-Location
 } catch {}
-Write-Host "$dir$branch"
+Write-Output "$dir$branch"
 ```
 
 2. Add statusLine config to `~/.claude/settings.json`:


### PR DESCRIPTION
## Summary
- Update status line script to show `dir (branch)` format instead of `[model] dir`
- Update `/setup-ecosystem` command with the improved script so future setups get git branch support

## Test plan
- [x] Restart Claude Code and verify status line shows `sdk (feature/statusline-git-branch)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)