### PR TITLE
feat: complete service extraction verification and IPluginRegistrationService

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,111 @@
+# Ship
+
+Commit, push, and create PR in one command.
+
+## Usage
+
+`/ship` - Commit all changes, push, and create PR
+`/ship --amend` - Amend last commit, force push, update PR
+
+## Workflow
+
+### 1. Check Current State
+
+```bash
+git status
+git log --oneline -3
+```
+
+Determine what needs to happen:
+- Uncommitted changes? -> Commit them
+- Unpushed commits? -> Push them
+- No PR exists? -> Create one
+
+### 2. Commit (if needed)
+
+If there are uncommitted changes:
+
+1. Stage all changes: `git add -A`
+2. Generate commit message from changes:
+   - Use conventional commit format: `type(scope): description`
+   - Types: feat, fix, docs, refactor, test, chore
+   - Reference related issues with `Closes #N` (one per line)
+3. Commit with the message
+
+### 3. Push (if needed)
+
+```bash
+# Check if branch has upstream
+git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null
+
+# Push with upstream tracking
+git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+```
+
+If `--amend` was used and commits were amended:
+```bash
+git push --force-with-lease
+```
+
+### 4. Create PR (if none exists)
+
+Check for existing PR:
+```bash
+gh pr view --json number 2>/dev/null
+```
+
+If no PR exists, create one:
+
+```bash
+gh pr create --title "PR title from commit" --body "$(cat <<'EOF'
+## Summary
+<bullet points summarizing changes>
+
+## Test plan
+- [ ] Unit tests pass
+- [ ] Manual testing completed
+
+Closes #N
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 5. Report Result
+
+```
+Ship Complete
+=============
+[✓] Committed: feat(plugins): add IPluginRegistrationService interface
+[✓] Pushed: feature/service-extractions -> origin
+[✓] PR: https://github.com/owner/repo/pull/123
+
+Ready for review!
+```
+
+## Behavior
+
+- **Smart detection**: Only performs steps that are needed
+- **Safe defaults**: Never force pushes unless `--amend` specified
+- **Issue linking**: Extracts issue numbers from branch name or prompts
+- **Draft option**: Add `--draft` to create as draft PR
+
+## Examples
+
+```bash
+# Standard ship - commit, push, create PR
+/ship
+
+# Amend and update existing PR
+/ship --amend
+
+# Create as draft PR
+/ship --draft
+```
+
+## When to Use
+
+- After completing a feature or fix
+- After `/pre-pr` passes all checks
+- When you want to stop typing `git add && git commit && git push && gh pr create`

--- a/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
@@ -2,13 +2,11 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
-using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Cli.Commands.Plugins;
 
@@ -104,9 +102,7 @@ public static class CleanCommand
                 ProfileServiceFactory.DefaultDeviceCodeCallback,
                 cancellationToken);
 
-            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
-            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
-            var registrationService = new PluginRegistrationService(pool, logger);
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
 
             if (!globalOptions.IsJsonMode)
             {
@@ -173,7 +169,7 @@ public static class CleanCommand
     }
 
     private static async Task<CleanResult> CleanAssemblyAsync(
-        PluginRegistrationService service,
+        IPluginRegistrationService service,
         PluginAssemblyConfig assemblyConfig,
         bool dryRun,
         GlobalOptionValues globalOptions,

--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -4,13 +4,11 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
-using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Cli.Commands.Plugins;
 
@@ -118,9 +116,7 @@ public static class DeployCommand
                 ProfileServiceFactory.DefaultDeviceCodeCallback,
                 cancellationToken);
 
-            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
-            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
-            var registrationService = new PluginRegistrationService(pool, logger);
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
 
             if (!globalOptions.IsJsonMode)
             {
@@ -178,7 +174,7 @@ public static class DeployCommand
     }
 
     private static async Task<DeploymentResult> DeployAssemblyAsync(
-        PluginRegistrationService service,
+        IPluginRegistrationService service,
         PluginAssemblyConfig assemblyConfig,
         string configDir,
         string? solutionOverride,

--- a/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
@@ -2,13 +2,11 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
-using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Cli.Commands.Plugins;
 
@@ -95,9 +93,7 @@ public static class DiffCommand
                 ProfileServiceFactory.DefaultDeviceCodeCallback,
                 cancellationToken);
 
-            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
-            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
-            var registrationService = new PluginRegistrationService(pool, logger);
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
 
             if (!globalOptions.IsJsonMode)
             {
@@ -198,7 +194,7 @@ public static class DiffCommand
     }
 
     private static async Task<AssemblyDrift> ComputeDriftAsync(
-        PluginRegistrationService service,
+        IPluginRegistrationService service,
         PluginAssemblyConfig config)
     {
         var drift = new AssemblyDrift

--- a/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
@@ -2,12 +2,10 @@ using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
 using PPDS.Cli.Plugins.Registration;
-using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Cli.Commands.Plugins;
 
@@ -79,9 +77,7 @@ public static class ListCommand
                 ProfileServiceFactory.DefaultDeviceCodeCallback,
                 cancellationToken);
 
-            var pool = serviceProvider.GetRequiredService<IDataverseConnectionPool>();
-            var logger = serviceProvider.GetRequiredService<ILogger<PluginRegistrationService>>();
-            var registrationService = new PluginRegistrationService(pool, logger);
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
 
             if (!globalOptions.IsJsonMode)
             {
@@ -228,7 +224,7 @@ public static class ListCommand
     }
 
     private static async Task PopulateTypesAsync(
-        PluginRegistrationService registrationService,
+        IPluginRegistrationService registrationService,
         List<PluginTypeInfo> types,
         List<TypeOutput> typeOutputs)
     {

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -1,0 +1,259 @@
+using PPDS.Cli.Plugins.Models;
+
+namespace PPDS.Cli.Plugins.Registration;
+
+/// <summary>
+/// Service for managing plugin registrations in Dataverse.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service provides operations for querying, creating, updating, and deleting
+/// plugin assemblies, packages, types, steps, and images in Dataverse.
+/// </para>
+/// <para>
+/// See ADR-0002 and ADR-0005 for pool architecture details.
+/// See ADR-0015 for application service layer pattern.
+/// </para>
+/// </remarks>
+public interface IPluginRegistrationService
+{
+    #region Query Operations
+
+    /// <summary>
+    /// Lists all plugin assemblies in the environment.
+    /// </summary>
+    /// <param name="assemblyNameFilter">Optional filter by assembly name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginAssemblyInfo>> ListAssembliesAsync(
+        string? assemblyNameFilter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all plugin packages in the environment.
+    /// </summary>
+    /// <param name="packageNameFilter">Optional filter by package name or unique name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginPackageInfo>> ListPackagesAsync(
+        string? packageNameFilter = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all assemblies contained in a plugin package.
+    /// </summary>
+    /// <param name="packageId">The package ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginAssemblyInfo>> ListAssembliesForPackageAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all plugin types for a package by querying through the package's assemblies.
+    /// </summary>
+    /// <param name="packageId">The package ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginTypeInfo>> ListTypesForPackageAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all plugin types for an assembly.
+    /// </summary>
+    /// <param name="assemblyId">The assembly ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginTypeInfo>> ListTypesForAssemblyAsync(
+        Guid assemblyId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all processing steps for a plugin type.
+    /// </summary>
+    /// <param name="pluginTypeId">The plugin type ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginStepInfo>> ListStepsForTypeAsync(
+        Guid pluginTypeId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all images for a processing step.
+    /// </summary>
+    /// <param name="stepId">The step ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<List<PluginImageInfo>> ListImagesForStepAsync(
+        Guid stepId,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Lookup Operations
+
+    /// <summary>
+    /// Gets an assembly by name.
+    /// </summary>
+    /// <param name="name">The assembly name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PluginAssemblyInfo?> GetAssemblyByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a plugin package by name or unique name.
+    /// </summary>
+    /// <param name="name">The package name or unique name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PluginPackageInfo?> GetPackageByNameAsync(
+        string name,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the SDK message ID for a message name.
+    /// </summary>
+    /// <param name="messageName">The message name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid?> GetSdkMessageIdAsync(
+        string messageName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the SDK message filter ID for a message and entity combination.
+    /// </summary>
+    /// <param name="messageId">The message ID.</param>
+    /// <param name="primaryEntity">The primary entity logical name.</param>
+    /// <param name="secondaryEntity">Optional secondary entity logical name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid?> GetSdkMessageFilterIdAsync(
+        Guid messageId,
+        string primaryEntity,
+        string? secondaryEntity = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the assembly ID for an assembly that is part of a plugin package.
+    /// </summary>
+    /// <param name="packageId">The package ID.</param>
+    /// <param name="assemblyName">The assembly name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid?> GetAssemblyIdForPackageAsync(
+        Guid packageId,
+        string assemblyName,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Create/Update Operations
+
+    /// <summary>
+    /// Creates or updates a plugin assembly (for classic DLL assemblies only).
+    /// For NuGet packages, use <see cref="UpsertPackageAsync"/> instead.
+    /// </summary>
+    /// <param name="name">The assembly name.</param>
+    /// <param name="content">The assembly DLL content.</param>
+    /// <param name="solutionName">Optional solution to add the assembly to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid> UpsertAssemblyAsync(
+        string name,
+        byte[] content,
+        string? solutionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or updates a plugin package (for NuGet packages).
+    /// </summary>
+    /// <param name="packageName">The package name from .nuspec.</param>
+    /// <param name="nupkgContent">The raw .nupkg file content.</param>
+    /// <param name="solutionName">Solution to add the package to.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The package ID.</returns>
+    Task<Guid> UpsertPackageAsync(
+        string packageName,
+        byte[] nupkgContent,
+        string? solutionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or updates a plugin type.
+    /// </summary>
+    /// <param name="assemblyId">The assembly ID.</param>
+    /// <param name="typeName">The type name.</param>
+    /// <param name="solutionName">Optional solution name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid> UpsertPluginTypeAsync(
+        Guid assemblyId,
+        string typeName,
+        string? solutionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or updates a processing step.
+    /// </summary>
+    /// <param name="pluginTypeId">The plugin type ID.</param>
+    /// <param name="stepConfig">The step configuration.</param>
+    /// <param name="messageId">The SDK message ID.</param>
+    /// <param name="filterId">Optional SDK message filter ID.</param>
+    /// <param name="solutionName">Optional solution name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Guid> UpsertStepAsync(
+        Guid pluginTypeId,
+        PluginStepConfig stepConfig,
+        Guid messageId,
+        Guid? filterId,
+        string? solutionName = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates or updates a step image.
+    /// </summary>
+    /// <param name="stepId">The step ID.</param>
+    /// <param name="imageConfig">The image configuration.</param>
+    /// <param name="messageName">The SDK message name (e.g., "Create", "Update", "SetState").</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the message does not support images.</exception>
+    Task<Guid> UpsertImageAsync(
+        Guid stepId,
+        PluginImageConfig imageConfig,
+        string messageName,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Delete Operations
+
+    /// <summary>
+    /// Deletes a step image.
+    /// </summary>
+    /// <param name="imageId">The image ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteImageAsync(Guid imageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a processing step (also deletes child images in parallel).
+    /// </summary>
+    /// <param name="stepId">The step ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteStepAsync(Guid stepId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a plugin type (only if it has no steps).
+    /// </summary>
+    /// <param name="pluginTypeId">The plugin type ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeletePluginTypeAsync(Guid pluginTypeId, CancellationToken cancellationToken = default);
+
+    #endregion
+
+    #region Solution Operations
+
+    /// <summary>
+    /// Adds a component to a solution.
+    /// </summary>
+    /// <param name="componentId">The component ID.</param>
+    /// <param name="componentType">The component type code.</param>
+    /// <param name="solutionName">The solution unique name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AddToSolutionAsync(
+        Guid componentId,
+        int componentType,
+        string solutionName,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+}

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -901,9 +901,13 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
             await ExecuteAsync(request, client, cancellationToken);
         }
-        catch (Exception ex) when (ex.Message.Contains("already exists"))
+        catch (FaultException<OrganizationServiceFault> ex) when (ex.Detail?.ErrorCode == -2147159998)
         {
-            // Component already in solution, ignore
+            // Error code 0x80048542: Component already exists in the solution
+            // This is expected when re-deploying - not an error
+            _logger.LogDebug(
+                "Component {ComponentId} already exists in solution {SolutionName}, skipping",
+                componentId, solutionName);
         }
     }
 

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -21,7 +21,7 @@ namespace PPDS.Cli.Plugins.Registration;
 /// Each method acquires its own client from the pool, enabling DOP-based parallelism.
 /// See ADR-0002 and ADR-0005 for pool architecture details.
 /// </remarks>
-public sealed class PluginRegistrationService
+public sealed class PluginRegistrationService : IPluginRegistrationService
 {
     private readonly IDataverseConnectionPool _pool;
     private readonly ILogger<PluginRegistrationService> _logger;

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Logging;
 using PPDS.Auth.Credentials;
 using PPDS.Auth.Profiles;
 using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Plugins.Registration;
 using PPDS.Cli.Services.Query;
+using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Cli.Services;
 
@@ -26,6 +28,14 @@ public static class ServiceRegistration
     {
         // Query services
         services.AddTransient<ISqlQueryService, SqlQueryService>();
+
+        // Plugin registration service - requires connection pool
+        services.AddTransient<IPluginRegistrationService>(sp =>
+        {
+            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
+            var logger = sp.GetRequiredService<ILogger<PluginRegistrationService>>();
+            return new PluginRegistrationService(pool, logger);
+        });
 
         // Connection service - requires profile-based token provider and environment ID
         // Registered as factory because it needs runtime values from ResolvedConnectionInfo


### PR DESCRIPTION
## Summary
- Extract `IPluginRegistrationService` interface from `PluginRegistrationService` for DI consumption
- Register service in `AddCliApplicationServices()` per ADR-0015 application service layer pattern
- Update all Plugins commands (list, deploy, diff, clean) to resolve service from DI
- Add `/ship` command for streamlined commit-push-pr workflow

## Service Extraction Verification

Verified all 12 service extraction issues (#254-265):

| Issue | Service | Status |
|-------|---------|--------|
| #254 | IDataMigrationService | Closed - alternative design (IExporter/IImporter) |
| #255 | IPluginService | **Implemented in this PR** |
| #256 | IPluginTraceService | Closed - already exists |
| #257 | ISolutionService | Closed - already exists |
| #258 | IMetadataService | Closed - already exists |
| #259 | IUserService | Closed - already exists |
| #260 | IRoleService | Closed - already exists |
| #261 | IFlowService | Closed - already exists |
| #262 | IImportJobService | Closed - already exists |
| #263 | IConnectionReferenceService | Closed - already exists |
| #264 | IDeploymentSettingsService | Closed - already exists |
| #265 | IEnvironmentVariableService | Closed - already exists |

## Test plan
- [x] Build passes with warnings as errors
- [x] All 3,500+ unit tests pass
- [x] XML documentation complete on new interface

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)