### PR TITLE
feat: logging and observability improvements

### DIFF
--- a/.claude/commands/next-work.md
+++ b/.claude/commands/next-work.md
@@ -1,0 +1,335 @@
+# Next Work
+
+Analyze project state and recommend next parallel workstreams based on milestone, dependencies, and current progress.
+
+## Usage
+
+`/next-work [--milestone <name>] [--count <n>]`
+
+Examples:
+- `/next-work` - Recommend from v1.0 milestone (default)
+- `/next-work --milestone v1.1` - Recommend from v1.1
+- `/next-work --count 2` - Recommend 2 workstreams instead of 3
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--milestone` | `v1.0` | Which milestone to pull work from |
+| `--count` | `3` | Number of parallel workstreams to recommend |
+
+## Process
+
+### 1. Check Current State
+
+**List active worktrees:**
+```bash
+git worktree list
+```
+
+**List open PRs:**
+```bash
+gh pr list --state open --json number,title,headRefName
+```
+
+**Infer in-progress work:**
+- Worktree branches that aren't `main`
+- Match branch names to issues (e.g., `feature/plugin-traces` → #140)
+- Note: Some worktrees may be stale - check last commit date
+
+**Output:**
+```markdown
+## Currently In Progress
+
+| Worktree | Branch | Issues | Last Activity |
+|----------|--------|--------|---------------|
+| sdk-logging-observability | feature/logging-observability | #266-280 | 2 hours ago |
+| sdk-tui-mvp | feature/tui-sql-mvp | #234 | 30 min ago |
+
+Open PRs: 2 (#283, #285)
+```
+
+### 2. Query Available Work
+
+**Fetch milestone issues:**
+```bash
+gh issue list --milestone "<milestone>" --state open --json number,title,labels,body --limit 100
+```
+
+**Parse dependencies from issue bodies:**
+Look for patterns:
+- "Blocked by #X" or "Depends on #X"
+- "After #X"
+- "Requires #X"
+
+Check if blocking issues are closed (batch query to avoid N+1 API calls):
+```bash
+# Collect all unique blocking issue numbers, then check in one GraphQL call
+gh api graphql -f query='
+  query {
+    repository(owner: "{owner}", name: "{repo}") {
+      issues(first: 100, states: [OPEN, CLOSED], filterBy: {}) {
+        nodes { number state }
+      }
+    }
+  }
+' --jq '.data.repository.issues.nodes | map({(.number|tostring): .state}) | add'
+
+# Returns: {"52": "CLOSED", "78": "OPEN", ...}
+# Filter locally to check which blocking issues are resolved
+```
+
+**Categorize issues:**
+```markdown
+## Available Work (v1.0)
+
+### Ready (not blocked, not in progress)
+- #254: Extract IDataMigrationService [area:services]
+- #257: Extract ISolutionService [area:services]
+- #140: Add plugintraces command [area:cli]
+- #281: Build MCP Server [area:mcp]
+...
+
+### Blocked
+- #290: VS Code extension scope (blocked by: TUI MVP not complete)
+
+### Already In Progress
+- #266-280: Logging & Observability (sdk-logging-observability)
+- #234: TUI SQL table abstraction (sdk-tui-mvp)
+```
+
+### 3. Group by Logical Area
+
+Group ready issues by label or inferred area:
+
+```markdown
+## Logical Groupings
+
+### Services (9 issues)
+#254, #257, #259, #260, #261, #262, #263, #264, #265
+- Pattern: ADR-0015 service extraction
+- Enables: TUI panels, MCP tools
+- Effort: Medium each, highly parallelizable within group
+
+### MCP Server (1 issue)
+#281
+- New project: PPDS.Mcp
+- Enables: Claude Code integration
+- Effort: Large, but well-defined phases
+
+### Plugin Traces (2 issues)
+#140, #247
+- New command group: ppds plugintraces
+- Enables: Debugging workflow
+- Effort: Medium
+
+### Web Resources (6 issues)
+#141, #159, #160, #161, #162, #163
+- New command group: ppds webresources
+- Enables: Extension parity
+- Effort: Medium-Large
+
+### SQL DML (1 issue)
+#235
+- Parser enhancement: UPDATE/DELETE/INSERT
+- Enables: Full SQL support
+- Effort: Large (parser changes)
+
+### Bug Fixes (2 issues)
+#200, #202
+- Quick wins, should be prioritized
+- Effort: Small-Medium
+```
+
+### 4. Apply Ranking Heuristics
+
+**Priority order:**
+1. Issues with `v1-blocker` label
+2. Issues with `priority:critical` or `P0-Critical`
+3. Bug fixes (quick wins, user-facing impact)
+4. Enabler work (services that unblock other work)
+5. Issues with `priority:high` or `P1-High`
+6. New features by size (smaller first for momentum)
+
+**Parallelism considerations:**
+- Don't recommend two groups that modify the same files
+- Prefer independent workstreams
+- Balance quick wins with substantial progress
+
+### 5. Generate Recommendations
+
+```markdown
+## Recommended Next Workstreams
+
+Based on v1.0 milestone, current progress, and dependencies:
+
+### 1. Service Extractions (HIGH PRIORITY)
+**Issues:** #254, #257, #259, #260, #261, #262, #263, #264, #265
+**Why:** Enables TUI panels AND MCP tools. Unblocks two other workstreams.
+**Effort:** 9 issues, but mechanical pattern (ADR-0015). Can batch.
+**Branch:** `feature/service-extractions`
+
+### 2. MCP Server (HIGH VALUE)
+**Issues:** #281
+**Why:** Claude Code integration - high visibility, well-defined scope.
+**Effort:** 1 large issue with clear phases. Can start infrastructure now.
+**Branch:** `feature/mcp-server`
+**Note:** Some tools need services from #1, but can build infra in parallel.
+
+### 3. Plugin Traces (QUICK WIN)
+**Issues:** #140, #247
+**Why:** Complete new feature, small scope, useful for debugging.
+**Effort:** 2 issues, straightforward implementation.
+**Branch:** `feature/plugin-traces`
+
+---
+
+**Alternative considerations:**
+- Bug fixes (#200, #202) could be a quick parallel session
+- Web Resources (#141, #159-163) if you want extension parity sooner
+- SQL DML (#235) if you want CLI feature-complete sooner
+
+---
+
+Create these 3 worktrees? (yes / modify / skip)
+```
+
+### 6. Handle User Response
+
+**If "yes" or confirmed:**
+Create worktrees and session prompts using `/plan-work` logic:
+
+```bash
+# For each recommended workstream:
+git worktree add -b <branch> ../<folder> main
+mkdir -p ../<folder>/.claude
+# Generate session-prompt.md with issues, context, first steps
+```
+
+**If "modify":**
+Ask which recommendations to change:
+- Remove a workstream
+- Add a different grouping
+- Change issue grouping within a workstream
+
+**If "skip":**
+Exit without creating anything. User can run `/plan-work` manually with specific issues.
+
+### 7. Output Summary
+
+```markdown
+## Worktrees Created
+
+| Folder | Branch | Issues |
+|--------|--------|--------|
+| sdk-service-extractions | feature/service-extractions | #254, #257, #259-265 |
+| sdk-mcp-server | feature/mcp-server | #281 |
+| sdk-plugin-traces | feature/plugin-traces | #140, #247 |
+
+Session prompts created in each `.claude/session-prompt.md`
+
+To start:
+  cd ../sdk-service-extractions && claude
+  cd ../sdk-mcp-server && claude
+  cd ../sdk-plugin-traces && claude
+
+Then run /start-work in each session.
+```
+
+## Behavior Summary
+
+1. Check active worktrees and PRs to understand current state
+2. Fetch milestone issues and parse dependencies
+3. Categorize: in-progress, blocked, ready
+4. Group ready issues by logical area
+5. Rank and recommend top N workstreams
+6. **STOP for user confirmation**
+7. Create worktrees and session prompts
+8. Output summary with next steps
+
+## Edge Cases
+
+**No issues in milestone:**
+```
+No open issues found in milestone "v1.0".
+Check milestone name or use --milestone to specify a different one.
+```
+
+**All issues blocked or in progress:**
+```
+All v1.0 issues are either in progress or blocked:
+- In progress: 15 issues across 3 worktrees
+- Blocked: 5 issues (waiting on in-progress work)
+
+Consider:
+1. Help complete in-progress work
+2. Check if blocked issues can be unblocked
+3. Pull from v1.1 milestone instead
+```
+
+**Stale worktrees detected:**
+```
+Warning: Worktree 'sdk-old-feature' has no commits in 14 days.
+Consider pruning with: git worktree remove ../sdk-old-feature
+
+Excluding from "in progress" calculation.
+```
+
+**Missing project fields:**
+```
+Note: Some issues missing Priority/Size fields in GitHub Project.
+Recommendations based on labels and dependencies only.
+Run /triage to add project fields for better recommendations.
+```
+
+## Customization
+
+**Grouping preferences:**
+The command uses labels to group issues. Common groupings:
+- `area:*` labels → group by area
+- `phase:*` labels → group by implementation phase
+- `epic:*` labels → group by epic
+
+**Override grouping:**
+If automatic grouping is wrong, user can say "modify" and manually adjust.
+
+## Related Commands
+
+| Command | When to Use |
+|---------|-------------|
+| `/next-work` | "What should I work on?" - Get recommendations |
+| `/plan-work 52 78` | "I know what I want" - Create worktrees for specific issues |
+| `/start-work` | "I'm in a worktree" - Read the session prompt |
+| `/triage` | "Issues need categorization" - Add labels/milestones |
+| `/handoff` | "I'm done for now" - Generate context for next session |
+
+## Example Session
+
+```
+You: /next-work
+
+Claude:
+## Currently In Progress
+- sdk-logging-observability: L&O (#266-280)
+- sdk-tui-mvp: TUI SQL (#234)
+
+## Recommended Next Workstreams
+
+1. **Service Extractions** - #254, #257, #259-265 (enables TUI + MCP)
+2. **MCP Server** - #281 (Claude Code integration)
+3. **Plugin Traces** - #140, #247 (quick win, debugging)
+
+Create these 3 worktrees? (yes / modify / skip)
+
+You: yes
+
+Claude:
+## Worktrees Created
+| Folder | Branch | Issues |
+|--------|--------|--------|
+| sdk-service-extractions | feature/service-extractions | #254, #257, #259-265 |
+| sdk-mcp-server | feature/mcp-server | #281 |
+| sdk-plugin-traces | feature/plugin-traces | #140, #247 |
+
+To start: cd ../sdk-service-extractions && claude
+```

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Eager pool initialization** - `IDataverseConnectionPool.EnsureInitializedAsync()` allows triggering authentication during startup, avoiding surprise browser popups on first query. Idempotent - subsequent calls are no-ops. ([#292](https://github.com/joshsmithxrm/ppds-sdk/issues/292))
+- **Seed initialization result tracking** - `IDataverseConnectionPool.InitializationResults` exposes per-source seed initialization status with failure reason classification (auth, network, service, connection not ready). Enables accurate pool health reporting. ([#287](https://github.com/joshsmithxrm/ppds-sdk/issues/287))
+- **Throttle backoff time tracking** - `IThrottleTracker.TotalBackoffTime` accumulates total backoff duration across all throttle events for observability. ([#273](https://github.com/joshsmithxrm/ppds-sdk/issues/273))
+- **Retry statistics in PoolStatistics** - `PoolStatistics` now includes `TotalBackoffTime`, `RetriesAttempted`, and `RetriesSucceeded` counters for throttle/retry visibility. ([#273](https://github.com/joshsmithxrm/ppds-sdk/issues/273))
+
+### Changed
+
+- **Reduced seed failure log noise** - Per-attempt seed creation failures now log at DEBUG level instead of WARNING. Only the final consolidated error logs at ERROR level with classified failure reason. ([#287](https://github.com/joshsmithxrm/ppds-sdk/issues/287))
+- **Accurate pool initialization status** - Pool now logs "initialized with N degraded source(s)" or "initialization failed" based on actual seed results, instead of always claiming success. ([#287](https://github.com/joshsmithxrm/ppds-sdk/issues/287))
+
 ## [1.0.0-beta.4] - 2026-01-06
 
 ### Added

--- a/src/PPDS.Dataverse/Pooling/DataverseConnectionPool.cs
+++ b/src/PPDS.Dataverse/Pooling/DataverseConnectionPool.cs
@@ -970,7 +970,7 @@ namespace PPDS.Dataverse.Pooling
                 try
                 {
                     // GetSeedClient populates _sourceDop with the server's RecommendedDegreesOfParallelism
-                    var seed = GetSeedClient(source.Name);
+                    GetSeedClient(source.Name);
                     var dop = _sourceDop.TryGetValue(source.Name, out var d) ? d : 4;
 
                     _seedInitResults.Add(new SeedInitializationResult

--- a/src/PPDS.Dataverse/Pooling/IDataverseConnectionPool.cs
+++ b/src/PPDS.Dataverse/Pooling/IDataverseConnectionPool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Xrm.Sdk;
@@ -40,6 +41,21 @@ namespace PPDS.Dataverse.Pooling
         /// Gets pool statistics and health information.
         /// </summary>
         PoolStatistics Statistics { get; }
+
+        /// <summary>
+        /// Gets the results of seed initialization for each connection source.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Use this to check whether all connection sources initialized successfully.
+        /// A source may fail to initialize due to invalid credentials, network issues, etc.
+        /// </para>
+        /// <para>
+        /// Failed sources will use a default DOP of 4 and may fail on first actual request.
+        /// Check this property after pool construction to detect configuration issues early.
+        /// </para>
+        /// </remarks>
+        IReadOnlyList<SeedInitializationResult> InitializationResults { get; }
 
         /// <summary>
         /// Gets a value indicating whether the pool is enabled.
@@ -154,5 +170,14 @@ namespace PPDS.Dataverse.Pooling
         /// </para>
         /// </remarks>
         BatchParallelismCoordinator BatchCoordinator { get; }
+
+        /// <summary>
+        /// Ensures the pool is initialized by warming all seed connections.
+        /// Triggers authentication and DOP discovery.
+        /// Idempotent - subsequent calls are no-ops.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task that completes when initialization is done.</returns>
+        Task EnsureInitializedAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/PPDS.Dataverse/Pooling/PoolStatistics.cs
+++ b/src/PPDS.Dataverse/Pooling/PoolStatistics.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace PPDS.Dataverse.Pooling
@@ -36,6 +37,21 @@ namespace PPDS.Dataverse.Pooling
         /// Gets the total number of throttle events recorded.
         /// </summary>
         public long ThrottleEvents { get; init; }
+
+        /// <summary>
+        /// Gets the total backoff time accumulated from all throttle events.
+        /// </summary>
+        public TimeSpan TotalBackoffTime { get; init; }
+
+        /// <summary>
+        /// Gets the total number of retry attempts made after throttle events.
+        /// </summary>
+        public long RetriesAttempted { get; init; }
+
+        /// <summary>
+        /// Gets the number of retry attempts that succeeded.
+        /// </summary>
+        public long RetriesSucceeded { get; init; }
 
         /// <summary>
         /// Gets the number of connections that were invalidated due to failures.

--- a/src/PPDS.Dataverse/Pooling/SeedInitializationResult.cs
+++ b/src/PPDS.Dataverse/Pooling/SeedInitializationResult.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace PPDS.Dataverse.Pooling
+{
+    /// <summary>
+    /// Result of initializing a seed connection for a pool source.
+    /// </summary>
+    public class SeedInitializationResult
+    {
+        /// <summary>
+        /// Gets the connection source name.
+        /// </summary>
+        public string ConnectionName { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets a value indicating whether the seed was initialized successfully.
+        /// </summary>
+        public bool Success { get; init; }
+
+        /// <summary>
+        /// Gets the discovered DOP (degrees of parallelism) from the server.
+        /// Only populated when <see cref="Success"/> is true.
+        /// </summary>
+        public int? DiscoveredDop { get; init; }
+
+        /// <summary>
+        /// Gets the error message if initialization failed.
+        /// </summary>
+        public string? ErrorMessage { get; init; }
+
+        /// <summary>
+        /// Gets the root cause category of the failure.
+        /// </summary>
+        public SeedFailureReason? FailureReason { get; init; }
+
+        /// <summary>
+        /// Gets the exception that caused the failure, if any.
+        /// </summary>
+        public Exception? Exception { get; init; }
+    }
+
+    /// <summary>
+    /// Categorized reasons for seed initialization failure.
+    /// </summary>
+    public enum SeedFailureReason
+    {
+        /// <summary>
+        /// Authentication failed (invalid credentials, expired token, etc.).
+        /// </summary>
+        AuthenticationFailed,
+
+        /// <summary>
+        /// Network connectivity issue (DNS, timeout, firewall, etc.).
+        /// </summary>
+        NetworkError,
+
+        /// <summary>
+        /// The Dataverse service returned an error.
+        /// </summary>
+        ServiceError,
+
+        /// <summary>
+        /// Connection was established but never became ready.
+        /// </summary>
+        ConnectionNotReady,
+
+        /// <summary>
+        /// Unknown or unclassified error.
+        /// </summary>
+        Unknown
+    }
+}

--- a/src/PPDS.Dataverse/Resilience/IThrottleTracker.cs
+++ b/src/PPDS.Dataverse/Resilience/IThrottleTracker.cs
@@ -42,6 +42,12 @@ namespace PPDS.Dataverse.Resilience
         long TotalThrottleEvents { get; }
 
         /// <summary>
+        /// Gets the total backoff time accumulated from all throttle events.
+        /// This represents the sum of all RetryAfter durations, not actual time spent waiting.
+        /// </summary>
+        TimeSpan TotalBackoffTime { get; }
+
+        /// <summary>
         /// Gets the number of currently throttled connections.
         /// </summary>
         int ThrottledConnectionCount { get; }

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Warnings array in summary.json** - Import warnings (column skipped, bulk not supported, schema mismatch, etc.) are now captured in `ImportResult.Warnings` and serialized to the `warnings` array in summary.json. Enables programmatic consumers to detect non-fatal issues. ([#271](https://github.com/joshsmithxrm/ppds-sdk/issues/271))
+- **Pool statistics in summary.json** - `ImportResult.PoolStatistics` captures throttle/retry metrics (`requestsServed`, `throttleEvents`, `totalBackoffTime`, `retriesAttempted`, `retriesSucceeded`) and serializes to the `poolStatistics` object in summary.json. ([#273](https://github.com/joshsmithxrm/ppds-sdk/issues/273))
+- **IWarningCollector interface** - Thread-safe warning collection during parallel import operations. Used by `TieredImporter` to aggregate warnings from concurrent entity imports. ([#271](https://github.com/joshsmithxrm/ppds-sdk/issues/271))
+- **ImportWarning and ImportWarningCodes** - Structured warning type with standard codes: `BULK_NOT_SUPPORTED`, `COLUMN_SKIPPED`, `SCHEMA_MISMATCH`, `USER_MAPPING_FALLBACK`, `PLUGIN_REENABLE_FAILED`. ([#271](https://github.com/joshsmithxrm/ppds-sdk/issues/271))
+
 ## [1.0.0-beta.5] - 2026-01-06
 
 ### Added

--- a/src/PPDS.Migration/Import/ImportResult.cs
+++ b/src/PPDS.Migration/Import/ImportResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PPDS.Dataverse.Pooling;
 using PPDS.Migration.Progress;
 
 namespace PPDS.Migration.Import
@@ -63,6 +64,16 @@ namespace PPDS.Migration.Import
         /// Gets or sets the results per entity.
         /// </summary>
         public IReadOnlyList<EntityImportResult> EntityResults { get; set; } = Array.Empty<EntityImportResult>();
+
+        /// <summary>
+        /// Gets or sets the connection pool statistics at the end of the import.
+        /// </summary>
+        public PoolStatistics? PoolStatistics { get; set; }
+
+        /// <summary>
+        /// Gets or sets the warnings that occurred during import.
+        /// </summary>
+        public IReadOnlyList<ImportWarning> Warnings { get; set; } = Array.Empty<ImportWarning>();
 
         /// <summary>
         /// Gets the average records per second.

--- a/src/PPDS.Migration/Progress/IWarningCollector.cs
+++ b/src/PPDS.Migration/Progress/IWarningCollector.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace PPDS.Migration.Progress
+{
+    /// <summary>
+    /// Collects warnings during import operations.
+    /// </summary>
+    /// <remarks>
+    /// Implementations must be thread-safe as warnings can be added from parallel operations.
+    /// </remarks>
+    public interface IWarningCollector
+    {
+        /// <summary>
+        /// Adds a warning to the collection.
+        /// </summary>
+        /// <param name="warning">The warning to add.</param>
+        void AddWarning(ImportWarning warning);
+
+        /// <summary>
+        /// Gets all collected warnings.
+        /// </summary>
+        /// <returns>A read-only list of warnings.</returns>
+        IReadOnlyList<ImportWarning> GetWarnings();
+
+        /// <summary>
+        /// Gets the count of collected warnings.
+        /// </summary>
+        int Count { get; }
+    }
+}

--- a/src/PPDS.Migration/Progress/ImportOutputManager.cs
+++ b/src/PPDS.Migration/Progress/ImportOutputManager.cs
@@ -280,6 +280,25 @@ namespace PPDS.Migration.Progress
                         DeferredFields = result.Phase2Duration,
                         Relationships = result.Phase3Duration
                     }
+                    : null,
+                PoolStatistics = result.PoolStatistics != null
+                    ? new PoolStatisticsSummary
+                    {
+                        RequestsServed = result.PoolStatistics.RequestsServed,
+                        ThrottleEvents = result.PoolStatistics.ThrottleEvents,
+                        TotalBackoffTime = result.PoolStatistics.TotalBackoffTime,
+                        RetriesAttempted = result.PoolStatistics.RetriesAttempted,
+                        RetriesSucceeded = result.PoolStatistics.RetriesSucceeded
+                    }
+                    : null,
+                Warnings = result.Warnings.Count > 0
+                    ? result.Warnings.Select(w => new WarningSummary
+                    {
+                        Code = w.Code,
+                        Entity = w.Entity,
+                        Message = w.Message,
+                        Impact = w.Impact
+                    }).ToList()
                     : null
             };
 
@@ -413,6 +432,51 @@ namespace PPDS.Migration.Progress
 
             [JsonPropertyName("phaseTiming")]
             public PhaseTiming? PhaseTiming { get; set; }
+
+            [JsonPropertyName("poolStatistics")]
+            public PoolStatisticsSummary? PoolStatistics { get; set; }
+
+            [JsonPropertyName("warnings")]
+            public List<WarningSummary>? Warnings { get; set; }
+        }
+
+        /// <summary>
+        /// Warning item for summary report.
+        /// </summary>
+        private sealed class WarningSummary
+        {
+            [JsonPropertyName("code")]
+            public string Code { get; set; } = string.Empty;
+
+            [JsonPropertyName("entity")]
+            public string? Entity { get; set; }
+
+            [JsonPropertyName("message")]
+            public string Message { get; set; } = string.Empty;
+
+            [JsonPropertyName("impact")]
+            public string? Impact { get; set; }
+        }
+
+        /// <summary>
+        /// Pool statistics for summary report.
+        /// </summary>
+        private sealed class PoolStatisticsSummary
+        {
+            [JsonPropertyName("requestsServed")]
+            public long RequestsServed { get; set; }
+
+            [JsonPropertyName("throttleEvents")]
+            public long ThrottleEvents { get; set; }
+
+            [JsonPropertyName("totalBackoffTime")]
+            public TimeSpan TotalBackoffTime { get; set; }
+
+            [JsonPropertyName("retriesAttempted")]
+            public long RetriesAttempted { get; set; }
+
+            [JsonPropertyName("retriesSucceeded")]
+            public long RetriesSucceeded { get; set; }
         }
 
         /// <summary>

--- a/src/PPDS.Migration/Progress/ImportWarning.cs
+++ b/src/PPDS.Migration/Progress/ImportWarning.cs
@@ -1,0 +1,60 @@
+namespace PPDS.Migration.Progress
+{
+    /// <summary>
+    /// Represents a warning that occurred during import.
+    /// </summary>
+    public class ImportWarning
+    {
+        /// <summary>
+        /// Gets or sets the warning code.
+        /// </summary>
+        /// <remarks>
+        /// Standard codes:
+        /// <list type="bullet">
+        ///   <item><c>BULK_NOT_SUPPORTED</c> - Entity fell back to individual operations</item>
+        ///   <item><c>COLUMN_SKIPPED</c> - Column in source but not in target</item>
+        ///   <item><c>SCHEMA_MISMATCH</c> - Non-fatal schema differences</item>
+        ///   <item><c>USER_MAPPING_FALLBACK</c> - User reference fell back to current user</item>
+        ///   <item><c>PLUGIN_REENABLE_FAILED</c> - Failed to re-enable plugin steps</item>
+        /// </list>
+        /// </remarks>
+        public string Code { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the human-readable warning message.
+        /// </summary>
+        public string Message { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the affected entity (optional).
+        /// </summary>
+        public string? Entity { get; init; }
+
+        /// <summary>
+        /// Gets or sets the impact assessment (optional).
+        /// </summary>
+        /// <example>"20 records affected", "Reduced throughput"</example>
+        public string? Impact { get; init; }
+    }
+
+    /// <summary>
+    /// Standard warning codes for import operations.
+    /// </summary>
+    public static class ImportWarningCodes
+    {
+        /// <summary>Entity does not support bulk operations, fell back to individual operations.</summary>
+        public const string BulkNotSupported = "BULK_NOT_SUPPORTED";
+
+        /// <summary>Column in source but not in target (skipped).</summary>
+        public const string ColumnSkipped = "COLUMN_SKIPPED";
+
+        /// <summary>Non-fatal schema differences detected.</summary>
+        public const string SchemaMismatch = "SCHEMA_MISMATCH";
+
+        /// <summary>User reference fell back to current user.</summary>
+        public const string UserMappingFallback = "USER_MAPPING_FALLBACK";
+
+        /// <summary>Failed to re-enable plugin steps after import.</summary>
+        public const string PluginReenableFailed = "PLUGIN_REENABLE_FAILED";
+    }
+}

--- a/src/PPDS.Migration/Progress/WarningCollector.cs
+++ b/src/PPDS.Migration/Progress/WarningCollector.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PPDS.Migration.Progress
+{
+    /// <summary>
+    /// Thread-safe implementation of <see cref="IWarningCollector"/>.
+    /// </summary>
+    public class WarningCollector : IWarningCollector
+    {
+        private readonly ConcurrentBag<ImportWarning> _warnings = new();
+
+        /// <inheritdoc />
+        public void AddWarning(ImportWarning warning)
+        {
+            _warnings.Add(warning);
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<ImportWarning> GetWarnings()
+        {
+            return _warnings.ToList().AsReadOnly();
+        }
+
+        /// <inheritdoc />
+        public int Count => _warnings.Count;
+    }
+}

--- a/tests/PPDS.Dataverse.IntegrationTests/Mocks/FakeConnectionPool.cs
+++ b/tests/PPDS.Dataverse.IntegrationTests/Mocks/FakeConnectionPool.cs
@@ -31,6 +31,11 @@ public class FakeConnectionPool : IDataverseConnectionPool
     public bool IsEnabled => true;
     public int SourceCount => 1;
 
+    public IReadOnlyList<SeedInitializationResult> InitializationResults => new List<SeedInitializationResult>
+    {
+        new() { ConnectionName = _connectionName, Success = true, DiscoveredDop = _recommendedParallelism }
+    };
+
     public BatchParallelismCoordinator BatchCoordinator
     {
         get
@@ -97,6 +102,9 @@ public class FakeConnectionPool : IDataverseConnectionPool
     public void RecordAuthFailure() { }
     public void RecordConnectionFailure() { }
     public void InvalidateSeed(string connectionName) { }
+
+    public Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 
     public void Dispose()
     {

--- a/tests/PPDS.Dataverse.Tests/Resilience/ThrottleTrackerTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Resilience/ThrottleTrackerTests.cs
@@ -206,4 +206,45 @@ public class ThrottleTrackerTests
     }
 
     #endregion
+
+    #region TotalBackoffTime Tests
+
+    [Fact]
+    public void TotalBackoffTime_StartsAtZero()
+    {
+        // Assert
+        _tracker.TotalBackoffTime.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void TotalBackoffTime_AccumulatesBackoffDurations()
+    {
+        // Arrange
+        var firstBackoff = TimeSpan.FromMinutes(1);
+        var secondBackoff = TimeSpan.FromMinutes(2);
+
+        // Act
+        _tracker.RecordThrottle("Primary", firstBackoff);
+        _tracker.RecordThrottle("Secondary", secondBackoff);
+
+        // Assert
+        _tracker.TotalBackoffTime.Should().Be(firstBackoff + secondBackoff);
+    }
+
+    [Fact]
+    public void TotalBackoffTime_AccumulatesForSameConnection()
+    {
+        // Arrange
+        var firstBackoff = TimeSpan.FromMinutes(1);
+        var secondBackoff = TimeSpan.FromMinutes(2);
+
+        // Act
+        _tracker.RecordThrottle("Primary", firstBackoff);
+        _tracker.RecordThrottle("Primary", secondBackoff);
+
+        // Assert
+        _tracker.TotalBackoffTime.Should().Be(firstBackoff + secondBackoff);
+    }
+
+    #endregion
 }

--- a/tests/PPDS.Migration.Tests/Progress/WarningCollectorTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/WarningCollectorTests.cs
@@ -1,0 +1,109 @@
+using PPDS.Migration.Progress;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Progress;
+
+public class WarningCollectorTests
+{
+    [Fact]
+    public void AddWarning_SingleWarning_IsCollected()
+    {
+        var collector = new WarningCollector();
+        var warning = new ImportWarning
+        {
+            Code = ImportWarningCodes.BulkNotSupported,
+            Entity = "account",
+            Message = "Entity does not support bulk operations",
+            Impact = "Reduced throughput"
+        };
+
+        collector.AddWarning(warning);
+
+        var warnings = collector.GetWarnings();
+        Assert.Single(warnings);
+        Assert.Equal(warning.Code, warnings[0].Code);
+        Assert.Equal(warning.Entity, warnings[0].Entity);
+        Assert.Equal(warning.Message, warnings[0].Message);
+        Assert.Equal(warning.Impact, warnings[0].Impact);
+    }
+
+    [Fact]
+    public void AddWarning_MultipleWarnings_AllCollected()
+    {
+        var collector = new WarningCollector();
+
+        collector.AddWarning(new ImportWarning
+        {
+            Code = ImportWarningCodes.BulkNotSupported,
+            Entity = "account",
+            Message = "Bulk not supported"
+        });
+        collector.AddWarning(new ImportWarning
+        {
+            Code = ImportWarningCodes.ColumnSkipped,
+            Entity = "contact",
+            Message = "Column skipped"
+        });
+
+        var warnings = collector.GetWarnings();
+        Assert.Equal(2, warnings.Count);
+    }
+
+    [Fact]
+    public void Count_ReturnsNumberOfWarnings()
+    {
+        var collector = new WarningCollector();
+
+        Assert.Equal(0, collector.Count);
+
+        collector.AddWarning(new ImportWarning { Code = "TEST1", Message = "Test 1" });
+        Assert.Equal(1, collector.Count);
+
+        collector.AddWarning(new ImportWarning { Code = "TEST2", Message = "Test 2" });
+        Assert.Equal(2, collector.Count);
+    }
+
+    [Fact]
+    public void GetWarnings_ReturnsReadOnlyList()
+    {
+        var collector = new WarningCollector();
+        collector.AddWarning(new ImportWarning
+        {
+            Code = ImportWarningCodes.SchemaMismatch,
+            Message = "Schema mismatch detected"
+        });
+
+        var warnings = collector.GetWarnings();
+
+        Assert.IsAssignableFrom<IReadOnlyList<ImportWarning>>(warnings);
+    }
+
+    [Fact]
+    public void GetWarnings_EmptyCollector_ReturnsEmptyList()
+    {
+        var collector = new WarningCollector();
+
+        var warnings = collector.GetWarnings();
+
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void AddWarning_ConcurrentAdds_AllCollected()
+    {
+        var collector = new WarningCollector();
+        const int warningCount = 100;
+
+        Parallel.For(0, warningCount, i =>
+        {
+            collector.AddWarning(new ImportWarning
+            {
+                Code = $"TEST_{i}",
+                Message = $"Warning {i}"
+            });
+        });
+
+        Assert.Equal(warningCount, collector.Count);
+        Assert.Equal(warningCount, collector.GetWarnings().Count);
+    }
+}


### PR DESCRIPTION
## Summary

- **#292**: Add `EnsureInitializedAsync()` to trigger pool authentication eagerly, avoiding surprise browser popups on first query
- **#287**: Add seed initialization result tracking with failure classification; reduce seed failure log noise (3+ messages → 1)
- **#273**: Add throttle/retry statistics (`TotalBackoffTime`, `RetriesAttempted`, `RetriesSucceeded`) to `PoolStatistics` and `summary.json`
- **#271**: Add warnings array to `summary.json` for programmatic consumers (column skipped, bulk not supported, etc.)

## New APIs

**PPDS.Dataverse:**
- `IDataverseConnectionPool.EnsureInitializedAsync()` - Eager auth initialization
- `IDataverseConnectionPool.InitializationResults` - Per-source seed status
- `IThrottleTracker.TotalBackoffTime` - Accumulated backoff duration
- `PoolStatistics.TotalBackoffTime/RetriesAttempted/RetriesSucceeded`
- `SeedInitializationResult` class with `SeedFailureReason` enum

**PPDS.Migration:**
- `ImportResult.Warnings` - Collection of import warnings
- `ImportResult.PoolStatistics` - Throttle/retry metrics
- `IWarningCollector` interface + `WarningCollector` implementation
- `ImportWarning` class with `ImportWarningCodes`

## Test plan

- [x] Build passes in Release mode
- [x] All unit tests pass (649 Dataverse, 250 Migration)
- [x] New `ThrottleTrackerTests` for `TotalBackoffTime`
- [x] New `WarningCollectorTests` (6 tests)
- [x] Changelogs updated

Closes #292
Closes #287
Closes #273
Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)