### PR TITLE
fix: distinguish user-provided mapping from auto-created default in summary

### DIFF
--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -294,7 +294,7 @@ public static class ImportCommand
                         ImportMode = importOptions.Mode.ToString(),
                         StripOwnerFields = importOptions.StripOwnerFields,
                         BypassPlugins = importOptions.BypassCustomPlugins != CustomLogicBypass.None,
-                        UserMappingProvided = importOptions.UserMappings != null
+                        UserMappingProvided = userMappingFile != null
                     };
 
                     await outputManager.WriteSummaryAsync(


### PR DESCRIPTION
## Summary
- Fix `userMappingProvided` reporting: check `userMappingFile` (CLI argument) instead of `importOptions.UserMappings` to correctly distinguish user-provided mapping from auto-created default
- Add dynamic repo context detection for multi-repo orchestration (`.claude/lib/repo-context.md`)
- Improve `/commit` and `/ship` workflow documentation with user confirmation step and rebase-first flow
- Add upstream remote fallback for worktrees/forks robustness

## Test plan
- [x] Build succeeds
- [x] Unit tests pass
- [x] CI checks pass

Closes #202

🤖 Generated with [Claude Code](https://claude.ai/code)