### PR TITLE
fix: distinguish user-provided mapping from auto-created default in summary

### DIFF
--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -294,7 +294,7 @@ public static class ImportCommand
                         ImportMode = importOptions.Mode.ToString(),
                         StripOwnerFields = importOptions.StripOwnerFields,
                         BypassPlugins = importOptions.BypassCustomPlugins != CustomLogicBypass.None,
-                        UserMappingProvided = importOptions.UserMappings != null
+                        UserMappingProvided = userMappingFile != null
                     };
 
                     await outputManager.WriteSummaryAsync(


### PR DESCRIPTION
## Summary
- Check `userMappingFile` (the CLI argument) instead of `importOptions.UserMappings` to determine if the user provided a mapping file
- When `--strip-owner-fields` is used without `--user-mapping`, the code creates an auto-default mapping that should not report `"userMappingProvided": true`

## Test plan
- [x] Build succeeds
- [x] Unit tests pass

Closes #202

🤖 Generated with [Claude Code](https://claude.ai/code)