### PR TITLE
fix(session): inject GitHub owner/repo into worker prompt from git remote

### DIFF
--- a/tests/PPDS.Cli.Tests/Services/Session/SessionServiceGitHubUrlTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Session/SessionServiceGitHubUrlTests.cs
@@ -1,0 +1,131 @@
+using PPDS.Cli.Services.Session;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Session;
+
+/// <summary>
+/// Tests for SessionService.ParseGitHubUrl method.
+/// </summary>
+public class SessionServiceGitHubUrlTests
+{
+    #region HTTPS Format Tests
+
+    [Fact]
+    public void ParseGitHubUrl_HttpsWithGitSuffix_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("https://github.com/joshsmithxrm/power-platform-developer-suite.git");
+
+        Assert.Equal("joshsmithxrm", owner);
+        Assert.Equal("power-platform-developer-suite", repo);
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_HttpsWithoutGitSuffix_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("https://github.com/owner/repo");
+
+        Assert.Equal("owner", owner);
+        Assert.Equal("repo", repo);
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_HttpsWithTrailingSlash_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("https://github.com/owner/repo/");
+
+        Assert.Equal("owner", owner);
+        Assert.Equal("repo", repo);
+    }
+
+    #endregion
+
+    #region SSH Format Tests
+
+    [Fact]
+    public void ParseGitHubUrl_SshWithGitSuffix_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("git@github.com:joshsmithxrm/power-platform-developer-suite.git");
+
+        Assert.Equal("joshsmithxrm", owner);
+        Assert.Equal("power-platform-developer-suite", repo);
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_SshWithoutGitSuffix_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("git@github.com:owner/repo");
+
+        Assert.Equal("owner", owner);
+        Assert.Equal("repo", repo);
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void ParseGitHubUrl_WithWhitespace_TrimsAndParses()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("  https://github.com/owner/repo.git  ");
+
+        Assert.Equal("owner", owner);
+        Assert.Equal("repo", repo);
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_CaseInsensitiveGitSuffix_ReturnsOwnerAndRepo()
+    {
+        var (owner, repo) = SessionService.ParseGitHubUrl("https://github.com/owner/repo.GIT");
+
+        Assert.Equal("owner", owner);
+        Assert.Equal("repo", repo);
+    }
+
+    #endregion
+
+    #region Error Cases
+
+    [Fact]
+    public void ParseGitHubUrl_NullUrl_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl(null!));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_EmptyUrl_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl(""));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_WhitespaceOnly_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl("   "));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_InvalidUrl_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl("https://example.com/owner/repo"));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_GitLabUrl_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl("https://gitlab.com/owner/repo.git"));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_HttpsWithOnlyOwner_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl("https://github.com/owner"));
+    }
+
+    [Fact]
+    public void ParseGitHubUrl_SshWithOnlyOwner_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => SessionService.ParseGitHubUrl("git@github.com:owner"));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Extract GitHub owner/repo from `git remote get-url origin` during session spawn
- Add `ParseGitHubUrl` helper method supporting both HTTPS and SSH URL formats
- Inject "Repository Context" section into worker prompt with explicit owner/repo values
- Provide examples for both `gh` CLI commands and MCP GitHub tool calls

## Problem

Workers were guessing the GitHub repository from the folder name, which failed when the folder name differed from the repo name (e.g., folder `ppds` but repo `power-platform-developer-suite`). This caused:
- `gh issue view` commands to fail
- MCP GitHub tool calls to use wrong repo

## Test Plan

- [x] Unit tests for `ParseGitHubUrl` with HTTPS URLs (with/without .git suffix)
- [x] Unit tests for `ParseGitHubUrl` with SSH URLs (with/without .git suffix)
- [x] Unit tests for edge cases (whitespace, invalid URLs)
- [x] All existing tests pass
- [x] Build succeeds with no warnings

Closes #316
Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)