### PR TITLE
feat: add Ralph Wiggum autonomous iteration loop

### DIFF
--- a/.claude/commands/cancel-ralph.md
+++ b/.claude/commands/cancel-ralph.md
@@ -22,6 +22,7 @@ STATE_FILE="$HOME/.ppds/ralph/${SESSION_ID}.json"
 ```bash
 python -c "
 import json
+import sys
 import os
 from pathlib import Path
 from datetime import datetime
@@ -31,17 +32,17 @@ state_file = Path.home() / '.ppds' / 'ralph' / f'{session_id}.json'
 
 if not state_file.exists():
     print('No active Ralph loop found.')
-    exit(0)
+    sys.exit(0)
 
-state = json.loads(state_file.read_text())
+state = json.loads(state_file.read_text(encoding='utf-8'))
 if not state.get('active'):
     print('Ralph loop already inactive.')
-    exit(0)
+    sys.exit(0)
 
 state['active'] = False
 state['cancelled_at'] = datetime.now().isoformat()
 state['exit_reason'] = 'user_cancelled'
-state_file.write_text(json.dumps(state, indent=2))
+state_file.write_text(json.dumps(state, indent=2), encoding='utf-8')
 
 print(f'Ralph loop cancelled after {state.get(\"current_iteration\", 0)} iterations.')
 "

--- a/.claude/commands/cancel-ralph.md
+++ b/.claude/commands/cancel-ralph.md
@@ -1,0 +1,63 @@
+# Cancel Ralph
+
+Cancel an active Ralph loop. The current iteration will complete, then the session will exit normally.
+
+## Usage
+
+```
+/cancel-ralph
+```
+
+## Process
+
+### 1. Find Active Loop
+
+```bash
+SESSION_ID="${CLAUDE_SESSION_ID:-default}"
+STATE_FILE="$HOME/.ppds/ralph/${SESSION_ID}.json"
+```
+
+### 2. Deactivate Loop
+
+```bash
+python -c "
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+
+session_id = os.environ.get('CLAUDE_SESSION_ID', 'default')
+state_file = Path.home() / '.ppds' / 'ralph' / f'{session_id}.json'
+
+if not state_file.exists():
+    print('No active Ralph loop found.')
+    exit(0)
+
+state = json.loads(state_file.read_text())
+if not state.get('active'):
+    print('Ralph loop already inactive.')
+    exit(0)
+
+state['active'] = False
+state['cancelled_at'] = datetime.now().isoformat()
+state['exit_reason'] = 'user_cancelled'
+state_file.write_text(json.dumps(state, indent=2))
+
+print(f'Ralph loop cancelled after {state.get(\"current_iteration\", 0)} iterations.')
+"
+```
+
+### 3. Confirm
+
+```
+Ralph Loop Cancelled
+====================
+Iterations completed: [N]
+The session will exit normally after current work completes.
+```
+
+## Notes
+
+- Cancellation is graceful - current iteration completes
+- State file is preserved for debugging
+- To restart, use `/ralph-loop` again

--- a/.claude/commands/ralph-loop.md
+++ b/.claude/commands/ralph-loop.md
@@ -47,10 +47,7 @@ Write the ralph loop state file:
 # Get session ID
 SESSION_ID="${CLAUDE_SESSION_ID:-default}"
 
-# Create state directory
-mkdir -p ~/.ppds/ralph
-
-# Write state file
+# Write state file (Python creates directory if needed)
 python -c "
 import json
 import os

--- a/.claude/commands/ralph-loop.md
+++ b/.claude/commands/ralph-loop.md
@@ -1,0 +1,134 @@
+# Ralph Loop
+
+Start an autonomous iteration loop. Claude will work on the task repeatedly until completion or max iterations.
+
+## Usage
+
+```
+/ralph-loop "<task description>" [--max-iterations N] [--completion-promise "SIGNAL"]
+```
+
+## Arguments
+
+- `<task description>` - The task for Claude to work on (required)
+- `--max-iterations N` - Maximum iterations before stopping (default: 20)
+- `--completion-promise "SIGNAL"` - Exact string that signals completion (default: "DONE")
+
+## Examples
+
+```
+/ralph-loop "Fix all TypeScript errors in src/" --max-iterations 10
+/ralph-loop "Implement the login form. Output COMPLETE when done." --completion-promise "COMPLETE"
+/ralph-loop "Get all tests passing" --max-iterations 30 --completion-promise "ALL TESTS PASS"
+```
+
+## How It Works
+
+1. This command writes state to `~/.ppds/ralph/{session}.json`
+2. You start working on the task
+3. When you try to exit, the Stop hook intercepts
+4. If completion signal not found, you continue with the same task
+5. Repeat until done or max iterations reached
+
+## Process
+
+### 1. Parse Arguments
+
+Extract from the user's command:
+- Task description (required)
+- Max iterations (default 20)
+- Completion promise (default "DONE")
+
+### 2. Initialize State
+
+Write the ralph loop state file:
+
+```bash
+# Get session ID
+SESSION_ID="${CLAUDE_SESSION_ID:-default}"
+
+# Create state directory
+mkdir -p ~/.ppds/ralph
+
+# Write state file
+python -c "
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+
+session_id = os.environ.get('CLAUDE_SESSION_ID', 'default')
+state = {
+    'session_id': session_id,
+    'prompt': '''$ARGUMENTS''',
+    'max_iterations': 20,
+    'current_iteration': 0,
+    'completion_promise': 'DONE',
+    'started_at': datetime.now().isoformat(),
+    'active': True
+}
+state_file = Path.home() / '.ppds' / 'ralph' / f'{session_id}.json'
+state_file.parent.mkdir(parents=True, exist_ok=True)
+state_file.write_text(json.dumps(state, indent=2))
+print(f'Ralph loop started: {state_file}')
+"
+```
+
+### 3. Output Task
+
+After initializing, output the task clearly:
+
+```
+Ralph Loop Started
+==================
+Task: [task description]
+Max iterations: [N]
+Completion signal: [SIGNAL]
+
+Starting iteration 1...
+
+---
+
+[task description]
+```
+
+### 4. Begin Work
+
+Now work on the task. When you complete it, include the completion promise in your output.
+
+Example completion:
+```
+All TypeScript errors have been fixed. The build now passes.
+
+DONE
+```
+
+## Cancellation
+
+To cancel an active loop, use `/cancel-ralph`.
+
+## Tips
+
+1. **Clear success criteria** - Include specific, verifiable conditions in your task
+2. **Use completion promises** - Always specify what string signals "done"
+3. **Set reasonable limits** - 20 iterations is usually enough; increase for complex tasks
+4. **Include verification** - Ask Claude to run tests/builds to verify completion
+
+## Example Task Template
+
+```
+/ralph-loop "
+Implement [feature].
+
+Requirements:
+- [ ] Requirement 1
+- [ ] Requirement 2
+- [ ] All tests pass
+
+Verification:
+- Run: dotnet test
+- Check: No errors
+
+When all requirements met and verification passes, output: FEATURE_COMPLETE
+" --max-iterations 25 --completion-promise "FEATURE_COMPLETE"
+```

--- a/.claude/hooks/ralph-hook.py
+++ b/.claude/hooks/ralph-hook.py
@@ -22,6 +22,7 @@ import sys
 import os
 from pathlib import Path
 from datetime import datetime
+from typing import Optional
 
 
 def get_state_dir() -> Path:
@@ -34,7 +35,7 @@ def get_state_file(session_id: str) -> Path:
     return get_state_dir() / f"{session_id}.json"
 
 
-def load_state(session_id: str) -> dict | None:
+def load_state(session_id: str) -> Optional[dict]:
     """Load ralph loop state for a session. Returns None if no active loop."""
     state_file = get_state_file(session_id)
     if not state_file.exists():
@@ -54,7 +55,7 @@ def save_state(session_id: str, state: dict) -> None:
     )
 
 
-def check_completion(transcript_path: str | None, promise: str) -> bool:
+def check_completion(transcript_path: Optional[str], promise: str) -> bool:
     """
     Check if completion promise appears in recent transcript output.
 

--- a/.claude/hooks/ralph-hook.py
+++ b/.claude/hooks/ralph-hook.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Ralph Wiggum Stop Hook - Windows-native autonomous iteration.
+
+This hook intercepts session exits and continues iteration loops
+until completion or max iterations reached.
+
+Usage:
+    1. Run /ralph-loop "your task" --max-iterations 20
+    2. Claude works on the task
+    3. When Claude tries to exit, this hook checks:
+       - Is there an active ralph loop for this session?
+       - Has the completion promise been output?
+       - Have we hit max iterations?
+    4. If not complete, blocks exit and feeds prompt back
+    5. Repeat until done
+
+State is stored in ~/.ppds/ralph/{session_id}.json
+"""
+import json
+import sys
+import os
+from pathlib import Path
+from datetime import datetime
+
+
+def get_state_dir() -> Path:
+    """Get the ralph state directory (~/.ppds/ralph/)."""
+    return Path.home() / ".ppds" / "ralph"
+
+
+def get_state_file(session_id: str) -> Path:
+    """Get the state file for a specific session."""
+    return get_state_dir() / f"{session_id}.json"
+
+
+def load_state(session_id: str) -> dict | None:
+    """Load ralph loop state for a session. Returns None if no active loop."""
+    state_file = get_state_file(session_id)
+    if not state_file.exists():
+        return None
+    try:
+        return json.loads(state_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_state(session_id: str, state: dict) -> None:
+    """Save ralph loop state for a session."""
+    state_dir = get_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    get_state_file(session_id).write_text(
+        json.dumps(state, indent=2), encoding="utf-8"
+    )
+
+
+def check_completion(transcript_path: str | None, promise: str) -> bool:
+    """
+    Check if completion promise appears in recent transcript output.
+
+    Args:
+        transcript_path: Path to the session transcript JSON
+        promise: The exact string to look for (e.g., "DONE")
+
+    Returns:
+        True if promise found in recent assistant messages
+    """
+    if not transcript_path or not promise:
+        return False
+
+    try:
+        transcript_file = Path(transcript_path)
+        if not transcript_file.exists():
+            return False
+
+        transcript = json.loads(transcript_file.read_text(encoding="utf-8"))
+
+        # Look for promise in last 5 assistant messages
+        messages = transcript.get("messages", [])
+        assistant_messages = [
+            m for m in messages
+            if m.get("role") == "assistant"
+        ][-5:]
+
+        for msg in assistant_messages:
+            content = msg.get("content", "")
+            # Handle both string and list content
+            if isinstance(content, list):
+                content = " ".join(
+                    c.get("text", "") for c in content
+                    if isinstance(c, dict) and c.get("type") == "text"
+                )
+            if promise in str(content):
+                return True
+
+        return False
+    except (json.JSONDecodeError, OSError, KeyError):
+        return False
+
+
+def main():
+    """Main hook entry point."""
+    # Read hook input from stdin
+    try:
+        raw_input = sys.stdin.read()
+        hook_input = json.loads(raw_input) if raw_input.strip() else {}
+    except json.JSONDecodeError:
+        hook_input = {}
+
+    # Get session ID - fall back to environment variable or "default"
+    session_id = hook_input.get("session_id")
+    if not session_id:
+        session_id = os.environ.get("CLAUDE_SESSION_ID", "default")
+
+    # Load state for this session
+    state = load_state(session_id)
+
+    # No active loop? Allow exit silently
+    if not state or not state.get("active"):
+        sys.exit(0)
+
+    # Check max iterations
+    current = state.get("current_iteration", 0)
+    max_iter = state.get("max_iterations", 20)
+
+    if current >= max_iter:
+        state["active"] = False
+        state["completed_at"] = datetime.now().isoformat()
+        state["exit_reason"] = "max_iterations_reached"
+        save_state(session_id, state)
+        # Output informational message but allow exit
+        print(json.dumps({
+            "reason": f"Ralph loop complete: max iterations ({max_iter}) reached"
+        }))
+        sys.exit(0)
+
+    # Check completion promise
+    transcript_path = hook_input.get("transcript_path")
+    promise = state.get("completion_promise", "")
+
+    if promise and check_completion(transcript_path, promise):
+        state["active"] = False
+        state["completed_at"] = datetime.now().isoformat()
+        state["exit_reason"] = "completion_promise_found"
+        save_state(session_id, state)
+        print(json.dumps({
+            "reason": f"Ralph loop complete: found '{promise}'"
+        }))
+        sys.exit(0)
+
+    # Continue the loop - increment iteration and block exit
+    state["current_iteration"] = current + 1
+    state["last_iteration_at"] = datetime.now().isoformat()
+    save_state(session_id, state)
+
+    prompt = state.get("prompt", "Continue working on the task.")
+
+    result = {
+        "decision": "block",
+        "reason": f"[Ralph {state['current_iteration']}/{max_iter}] {prompt}"
+    }
+
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/pre-commit-validate.py",
+            "command": "py -3 .claude/hooks/pre-commit-validate.py",
             "timeout": 120
           }
         ]
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/ralph-hook.py"
+            "command": "py -3 .claude/hooks/ralph-hook.py"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,7 +58,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 .claude/hooks/ralph-hook.py"
+            "command": "py -3 .claude/hooks/ralph-hook.py",
+            "timeout": 30
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python .claude/hooks/ralph-hook.py"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a new autonomous iteration feature called "Ralph Wiggum" that allows Claude to work on tasks repeatedly until completion or max iterations:

- `/ralph-loop "<task>" --max-iterations N --completion-promise "SIGNAL"` - Starts an autonomous loop
- `/cancel-ralph` - Gracefully cancels an active loop
- Stop hook (`ralph-hook.py`) intercepts session exits and continues iteration if needed

The hook uses a state file (`~/.ppds/ralph/{session}.json`) to track loop progress and checks for the completion promise in the transcript to determine when to stop.

## Test plan

- [x] Build passes with no warnings
- [x] Unit tests pass (except for a pre-existing flaky test in Dataverse.IntegrationTests)
- [ ] Manual testing: Start a ralph loop, verify it continues until completion promise or max iterations
- [ ] Manual testing: Verify `/cancel-ralph` stops the loop gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)