### PR TITLE
feat(session): auto-cleanup orphaned session records in session list

### DIFF
--- a/.claude/start-worker.ps1
+++ b/.claude/start-worker.ps1
@@ -1,0 +1,4 @@
+$env:PPDS_INTERNAL = '1'
+Write-Host 'Worker session for issue #328' -ForegroundColor Cyan
+Write-Host ''
+claude --permission-mode bypassPermissions "Read .claude/session-prompt.md and implement issue #328. Start by understanding the issue, then implement the fix."

--- a/.claude/start-worker.ps1
+++ b/.claude/start-worker.ps1
@@ -1,4 +1,0 @@
-$env:PPDS_INTERNAL = '1'
-Write-Host 'Worker session for issue #328' -ForegroundColor Cyan
-Write-Host ''
-claude --permission-mode bypassPermissions "Read .claude/session-prompt.md and implement issue #328. Start by understanding the issue, then implement the fix."

--- a/src/PPDS.Cli/Services/Session/ISessionService.cs
+++ b/src/PPDS.Cli/Services/Session/ISessionService.cs
@@ -36,7 +36,23 @@ public interface ISessionService
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of session states.</returns>
+    /// <remarks>
+    /// This method also performs lazy cleanup of orphaned sessions (where the worktree
+    /// no longer exists). Use <see cref="ListWithCleanupInfoAsync"/> if you need to
+    /// report which sessions were cleaned up.
+    /// </remarks>
     Task<IReadOnlyList<SessionState>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists all active and recently completed sessions, with information about cleaned up sessions.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing sessions and any cleaned up issue numbers.</returns>
+    /// <remarks>
+    /// Orphaned sessions (where the worktree no longer exists) are automatically cleaned up.
+    /// The result includes the issue numbers of any sessions that were removed.
+    /// </remarks>
+    Task<SessionListResult> ListWithCleanupInfoAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets detailed state for a specific session.

--- a/src/PPDS.Cli/Services/Session/SessionState.cs
+++ b/src/PPDS.Cli/Services/Session/SessionState.cs
@@ -167,3 +167,12 @@ public sealed record WorktreeStatus
     /// </summary>
     public IReadOnlyList<string> ChangedFiles { get; init; } = [];
 }
+
+/// <summary>
+/// Result of listing sessions with cleanup information.
+/// </summary>
+/// <param name="Sessions">Active sessions after cleanup.</param>
+/// <param name="CleanedIssueNumbers">Issue numbers of sessions that were cleaned up because their worktrees no longer exist.</param>
+public sealed record SessionListResult(
+    IReadOnlyList<SessionState> Sessions,
+    IReadOnlyList<int> CleanedIssueNumbers);

--- a/tests/PPDS.Cli.Tests/Services/Session/SessionServiceCleanupTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Session/SessionServiceCleanupTests.cs
@@ -1,0 +1,162 @@
+using PPDS.Cli.Services.Session;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Session;
+
+/// <summary>
+/// Tests for SessionService orphaned session cleanup logic.
+/// </summary>
+public class SessionServiceCleanupTests : IDisposable
+{
+    private readonly List<string> _tempDirectories = [];
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirectories)
+        {
+            if (Directory.Exists(dir))
+            {
+                try { Directory.Delete(dir, recursive: true); }
+                catch { /* best effort cleanup */ }
+            }
+        }
+    }
+
+    private string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        _tempDirectories.Add(path);
+        return path;
+    }
+
+    private static SessionState CreateSession(int issueNumber, string worktreePath)
+    {
+        return new SessionState
+        {
+            Id = issueNumber.ToString(),
+            IssueNumber = issueNumber,
+            IssueTitle = $"Test issue #{issueNumber}",
+            Status = SessionStatus.Working,
+            Branch = $"issue-{issueNumber}",
+            WorktreePath = worktreePath,
+            StartedAt = DateTimeOffset.UtcNow.AddHours(-1),
+            LastHeartbeat = DateTimeOffset.UtcNow
+        };
+    }
+
+    #region FindOrphanedSessions Tests
+
+    [Fact]
+    public void FindOrphanedSessions_WithExistingWorktree_ReturnsEmpty()
+    {
+        // Arrange
+        var existingPath = CreateTempDirectory();
+        var sessions = new[] { CreateSession(123, existingPath) };
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert
+        Assert.Empty(orphaned);
+    }
+
+    [Fact]
+    public void FindOrphanedSessions_WithNonExistentWorktree_ReturnsSession()
+    {
+        // Arrange
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}");
+        var sessions = new[] { CreateSession(456, nonExistentPath) };
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert
+        Assert.Single(orphaned);
+        Assert.Equal(456, orphaned[0].IssueNumber);
+    }
+
+    [Fact]
+    public void FindOrphanedSessions_WithMixedSessions_ReturnsOnlyOrphaned()
+    {
+        // Arrange
+        var existingPath = CreateTempDirectory();
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}");
+
+        var sessions = new[]
+        {
+            CreateSession(100, existingPath),         // exists - should NOT be in result
+            CreateSession(200, nonExistentPath),      // missing - should be in result
+            CreateSession(300, existingPath),         // exists - should NOT be in result
+        };
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert
+        Assert.Single(orphaned);
+        Assert.Equal(200, orphaned[0].IssueNumber);
+    }
+
+    [Fact]
+    public void FindOrphanedSessions_WithAllOrphaned_ReturnsAll()
+    {
+        // Arrange
+        var nonExistent1 = Path.Combine(Path.GetTempPath(), $"missing-1-{Guid.NewGuid():N}");
+        var nonExistent2 = Path.Combine(Path.GetTempPath(), $"missing-2-{Guid.NewGuid():N}");
+
+        var sessions = new[]
+        {
+            CreateSession(10, nonExistent1),
+            CreateSession(20, nonExistent2),
+        };
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert
+        Assert.Equal(2, orphaned.Count);
+        Assert.Contains(orphaned, s => s.IssueNumber == 10);
+        Assert.Contains(orphaned, s => s.IssueNumber == 20);
+    }
+
+    [Fact]
+    public void FindOrphanedSessions_WithEmptyInput_ReturnsEmpty()
+    {
+        // Arrange
+        var sessions = Array.Empty<SessionState>();
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert
+        Assert.Empty(orphaned);
+    }
+
+    [Fact]
+    public void FindOrphanedSessions_PreservesStaleSessionsWithExistingWorktree()
+    {
+        // Arrange - a "stale" session with no heartbeat but worktree exists
+        var existingPath = CreateTempDirectory();
+        var staleSession = new SessionState
+        {
+            Id = "789",
+            IssueNumber = 789,
+            IssueTitle = "Stale session",
+            Status = SessionStatus.Working,
+            Branch = "issue-789",
+            WorktreePath = existingPath,
+            StartedAt = DateTimeOffset.UtcNow.AddHours(-5),
+            LastHeartbeat = DateTimeOffset.UtcNow.AddHours(-3) // Very old heartbeat
+        };
+        var sessions = new[] { staleSession };
+
+        // Act
+        var orphaned = SessionService.FindOrphanedSessions(sessions);
+
+        // Assert - stale sessions with existing worktrees should NOT be cleaned up
+        Assert.Empty(orphaned);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add lazy cleanup of orphaned session records when listing sessions
- If a session's worktree path no longer exists (e.g., after `/prune`), the session record is automatically removed
- Report cleaned sessions to the user in both CLI and JSON output
- Sessions with existing worktrees are preserved even if stale (work may be recoverable)

## Implementation
- `SessionService.CleanOrphanedSessions()` - identifies and removes orphaned sessions
- `SessionService.ListWithCleanupInfoAsync()` - returns sessions + cleanup info
- `ListCommand` - reports cleanup to stderr and includes in JSON output
- `SessionService.FindOrphanedSessions()` - static testable helper

## Test plan
- [x] Unit tests for `FindOrphanedSessions` logic
- [x] Tests cover: existing worktree kept, missing worktree removed, mixed sessions, stale sessions with existing worktrees preserved
- [x] All unit tests pass

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)