### PR TITLE
fix(session): replace alarming STALE indicator with informational last-update time

### DIFF
--- a/.claude/start-worker.ps1
+++ b/.claude/start-worker.ps1
@@ -1,4 +1,0 @@
-$env:PPDS_INTERNAL = '1'
-Write-Host 'Worker session for issue #332' -ForegroundColor Cyan
-Write-Host ''
-claude --permission-mode bypassPermissions "Read .claude/session-prompt.md and implement issue #332. Start by understanding the issue, then implement the fix."

--- a/.claude/start-worker.ps1
+++ b/.claude/start-worker.ps1
@@ -1,0 +1,4 @@
+$env:PPDS_INTERNAL = '1'
+Write-Host 'Worker session for issue #332' -ForegroundColor Cyan
+Write-Host ''
+claude --permission-mode bypassPermissions "Read .claude/session-prompt.md and implement issue #332. Start by understanding the issue, then implement the fix."

--- a/src/PPDS.Cli/Commands/Session/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Session/ListCommand.cs
@@ -13,6 +13,11 @@ namespace PPDS.Cli.Commands.Session;
 /// </summary>
 public static class ListCommand
 {
+    /// <summary>
+    /// Threshold in seconds before showing "last update" time for active sessions.
+    /// </summary>
+    private const int LastUpdateDisplayThresholdSeconds = 60;
+
     public static Command Create()
     {
         var command = new Command("list", "List all active worker sessions");
@@ -94,15 +99,11 @@ public static class ListCommand
                         };
 
                         var elapsed = DateTimeOffset.UtcNow - session.StartedAt;
-                        var elapsedStr = elapsed.TotalHours >= 1
-                            ? $"{elapsed.TotalHours:F0}h {elapsed.Minutes}m"
-                            : $"{elapsed.TotalMinutes:F0}m";
+                        var elapsedStr = FormatDuration(elapsed);
 
                         // For active sessions, show time since last update as informational
                         var timeSinceUpdate = DateTimeOffset.UtcNow - session.LastHeartbeat;
-                        var lastUpdateStr = timeSinceUpdate.TotalHours >= 1
-                            ? $"{timeSinceUpdate.TotalHours:F0}h {timeSinceUpdate.Minutes}m"
-                            : $"{timeSinceUpdate.TotalMinutes:F0}m";
+                        var lastUpdateStr = FormatDuration(timeSinceUpdate);
 
                         var isActiveSession = session.Status is SessionStatus.Working
                             or SessionStatus.Planning
@@ -111,7 +112,7 @@ public static class ListCommand
                             or SessionStatus.ReviewsInProgress;
 
                         var statusText = session.Status.ToString();
-                        if (isActiveSession && timeSinceUpdate.TotalSeconds > 60)
+                        if (isActiveSession && timeSinceUpdate.TotalSeconds > LastUpdateDisplayThresholdSeconds)
                         {
                             statusText += $" (last update: {lastUpdateStr} ago)";
                         }
@@ -143,6 +144,19 @@ public static class ListCommand
             writer.WriteError(error);
             return ExceptionMapper.ToExitCode(ex);
         }
+    }
+
+    /// <summary>
+    /// Formats a TimeSpan as a friendly duration string (e.g., "1h 30m" or "45m").
+    /// Uses integer truncation to avoid rounding issues.
+    /// </summary>
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration.TotalHours >= 1)
+        {
+            return $"{(int)duration.TotalHours}h {duration.Minutes}m";
+        }
+        return $"{(int)duration.TotalMinutes}m";
     }
 
     #region Output Models


### PR DESCRIPTION
## Summary

- Show actual session status icons instead of overriding with `[?] STALE` based on time since last update
- Display "last update: Xm ago" as informational text for active sessions (Working, Planning, etc.)
- Only show the elapsed indicator when the update is older than 60 seconds
- Keep JSON `isStale` field for backward compatibility

**Before:**
```
[?] #329 - STALE (no heartbeat) (2m)   ← Worker is actually actively coding
```

**After:**
```
[*] #329 - Working (last update: 2m ago) (2m)   ← Status reflects actual state
```

## Test plan
- [x] Unit tests pass
- [x] Build succeeds with no warnings
- [x] Manual verification: workers in active implementation no longer show as STALE

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)