### PR TITLE
fix(workflow): design sessions should create issues, not implement directly

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -164,10 +164,10 @@ Design Session Flow:
 
 Before proposing new work, design sessions MUST complete this checklist:
 
-- [ ] **Check existing milestone** - Run `gh issue list --milestone "<milestone>" --state all` to see existing work
+- [ ] **Check existing milestone** - Find the current milestone with `gh milestone list --state open`, then run `gh issue list --milestone "<milestone>" --state all` to see existing work
 - [ ] **Search for duplicates** - Run `gh issue list --search "<feature-keywords>" --limit 20`
 - [ ] **Scope alignment** - Explicitly confirm if TUI/Extension/CLI should have feature parity
-- [ ] **Platform-specific vs shared** - Identify features unique to one interface (e.g., notebooks are VS Code-only)
+- [ ] **Platform-specific vs shared** - Identify features unique to one UI layer (e.g., notebooks are VS Code-only)
 - [ ] **Design for orchestration** - Plan wave labels and include query patterns for worker dispatch
 - [ ] **Integrate existing backlog** - Consider labeling existing open issues into wave structure
 - [ ] **Session boundary clarity** - Be explicit: what happens THIS session vs FUTURE worker sessions

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -138,7 +138,39 @@ Now engage in the design conversation:
 - Explore options with the user
 - Consider tradeoffs
 - Create artifacts as needed
-- File issues when design is complete
+- Complete the design plan
+
+### 6. After Plan Approval
+
+**STOP. Do not implement directly.**
+
+Design sessions produce **plans and issues**, not code. After the user approves your design plan:
+
+1. **Create GitHub issues** for each implementation phase using `/create-issue`
+2. **Add wave labels** (`wave:1`, `wave:2`) for parallel execution
+3. **Offer to dispatch workers** via `/orchestrate`
+4. **End the design session** - implementation happens in worker sessions
+
+```
+Design Session Flow:
+  Explore → Analyze → Plan → [GATE] → Create Issues → Dispatch Workers
+                               ↑
+                        You are here after plan approval
+```
+
+**Exception:** Trivial fixes (typos, single-line changes) may be implemented directly with explicit user approval.
+
+## Scoping Session Checklist
+
+Before proposing new work, design sessions MUST complete this checklist:
+
+- [ ] **Check existing milestone** - Run `gh issue list --milestone "<milestone>" --state all` to see existing work
+- [ ] **Search for duplicates** - Run `gh issue list --search "<feature-keywords>" --limit 20`
+- [ ] **Scope alignment** - Explicitly confirm if TUI/Extension/CLI should have feature parity
+- [ ] **Platform-specific vs shared** - Identify features unique to one interface (e.g., notebooks are VS Code-only)
+- [ ] **Design for orchestration** - Plan wave labels and include query patterns for worker dispatch
+- [ ] **Integrate existing backlog** - Consider labeling existing open issues into wave structure
+- [ ] **Session boundary clarity** - Be explicit: what happens THIS session vs FUTURE worker sessions
 
 ## When to Use
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivi
 | File issues in wrong repo | Issues belong in target repo (ppds-docs issues in ppds-docs, not ppds) |
 | Start implementation without plan citations | Cite `docs/patterns/` or ADRs in plan's "Patterns I'll Follow" section |
 | Omit "What I'm NOT Doing" from plans | Explicit boundaries prevent scope creep; required for approval |
+| Implement in design sessions | Design sessions produce plans and issues; workers implement |
 
 ## ALWAYS
 
@@ -45,6 +46,7 @@ NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivi
 | Wait for required CI checks only in /ship | `Integration Tests` requires live Dataverse (ADR-0029) |
 | Check `docs/patterns/` before implementing | Canonical patterns exist; cite them in plan |
 | Restate issue understanding in plan | "My Understanding" section catches drift before implementation |
+| Create issues after `/design` plan approval | Enables parallel workers; maintains orchestration visibility |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add explicit gate after plan approval in `/design` skill that prevents direct implementation
- Add scoping session checklist to validate scope before proposing work
- Add CLAUDE.md rules to enforce design/implementation separation

## Changes

### `.claude/commands/design.md`
- Added "After Plan Approval" section (step 6) with explicit STOP instruction
- Design sessions now create GitHub issues using `/create-issue` instead of implementing directly
- Added "Scoping Session Checklist" with 7 validation items before proposing new work

### `CLAUDE.md`
- Added NEVER rule: "Implement in design sessions"
- Added ALWAYS rule: "Create issues after `/design` plan approval"

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [ ] Manual testing: Run `/design` and verify it stops after plan approval

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)