### PR TITLE
feat(tui): add F2 rename functionality to ProfileSelectorDialog

### DIFF
--- a/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
@@ -218,7 +218,7 @@ internal sealed class ProfileSelectorDialog : Dialog
         var currentName = profile.Name ?? string.Empty;
 
         // Create rename dialog
-        var dialog = new Dialog("Rename Profile")
+        using var dialog = new Dialog("Rename Profile")
         {
             Width = 50,
             Height = 8,
@@ -250,19 +250,19 @@ internal sealed class ProfileSelectorDialog : Dialog
             Y = Pos.AnchorEnd(1)
         };
 
-        var doRename = false;
+        var newName = string.Empty;
 
         okButton.Clicked += () =>
         {
-            var newName = textField.Text?.ToString()?.Trim() ?? string.Empty;
+            var nameFromTextField = textField.Text?.ToString()?.Trim() ?? string.Empty;
 
-            if (string.IsNullOrWhiteSpace(newName))
+            if (string.IsNullOrWhiteSpace(nameFromTextField))
             {
                 MessageBox.ErrorQuery("Validation Error", "Profile name cannot be empty.", "OK");
                 return;
             }
 
-            doRename = true;
+            newName = nameFromTextField;
             Application.RequestStop();
         };
 
@@ -286,9 +286,8 @@ internal sealed class ProfileSelectorDialog : Dialog
 
         Application.Run(dialog);
 
-        if (doRename)
+        if (!string.IsNullOrEmpty(newName))
         {
-            var newName = textField.Text?.ToString()?.Trim() ?? string.Empty;
             PerformRename(profile, newName);
         }
     }
@@ -318,6 +317,13 @@ internal sealed class ProfileSelectorDialog : Dialog
 
         Application.MainLoop?.Invoke(() =>
         {
+            // Re-select the renamed profile to maintain context for the user
+            var renamedProfileIndex = _profiles.ToList().FindIndex(p => p.Name == newName);
+            if (renamedProfileIndex >= 0)
+            {
+                _listView.SelectedItem = renamedProfileIndex;
+            }
+
             _detailLabel.Text = $"Renamed to '{newName}'";
         });
     }


### PR DESCRIPTION
## Summary

- Add F2 keyboard shortcut to rename selected profile in TUI ProfileSelectorDialog
- Show rename dialog with TextField pre-filled with current profile name
- Enter saves, Escape cancels
- Validate name is non-empty (service handles duplicate name validation)
- Refresh profile list after successful rename
- Display confirmation message in detail label

## Test plan

- [x] Unit tests pass
- [x] Build succeeds in Release mode with warnings as errors
- [ ] Manual testing: Launch TUI, select a profile, press F2, rename, verify list updates

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)