### PR TITLE
feat(cli): add ppds query history command

### DIFF
--- a/src/PPDS.Cli/Commands/Query/History/ClearCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ClearCommand.cs
@@ -1,0 +1,124 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.History;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// Clear all query history for an environment.
+/// </summary>
+public static class ClearCommand
+{
+    /// <summary>
+    /// Creates the 'clear' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Skip confirmation prompt"
+        };
+
+        var command = new Command("clear", "Clear all query history for the current environment")
+        {
+            HistoryCommandGroup.ProfileOption,
+            HistoryCommandGroup.EnvironmentOption,
+            forceOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var profile = parseResult.GetValue(HistoryCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(HistoryCommandGroup.EnvironmentOption);
+            var force = parseResult.GetValue(forceOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(profile, environment, force, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string? profile,
+        string? environment,
+        bool force,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var historyService = serviceProvider.GetRequiredService<IQueryHistoryService>();
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var environmentUrl = connectionInfo.EnvironmentUrl;
+            var envDisplayName = connectionInfo.EnvironmentDisplayName ?? environmentUrl;
+
+            // Confirm unless --force is specified
+            if (!force && !globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"This will clear all query history for environment: {envDisplayName}");
+                Console.Error.Write("Are you sure? [y/N] ");
+
+                var response = Console.ReadLine();
+                if (!string.Equals(response, "y", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(response, "yes", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.Error.WriteLine("Cancelled.");
+                    return ExitCodes.Success;
+                }
+            }
+
+            await historyService.ClearHistoryAsync(environmentUrl, cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(new ClearOutput
+                {
+                    Environment = envDisplayName,
+                    Cleared = true
+                });
+            }
+            else
+            {
+                Console.Error.WriteLine($"Cleared query history for: {envDisplayName}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "clearing query history", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #region Output Models
+
+    private sealed class ClearOutput
+    {
+        [JsonPropertyName("environment")]
+        public string Environment { get; set; } = "";
+
+        [JsonPropertyName("cleared")]
+        public bool Cleared { get; set; }
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/Query/History/DeleteCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/DeleteCommand.cs
@@ -1,0 +1,120 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.History;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// Delete a specific query history entry.
+/// </summary>
+public static class DeleteCommand
+{
+    /// <summary>
+    /// Creates the 'delete' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var idArgument = new Argument<string>("id")
+        {
+            Description = "The history entry ID to delete"
+        };
+
+        var command = new Command("delete", "Delete a query history entry")
+        {
+            idArgument,
+            HistoryCommandGroup.ProfileOption,
+            HistoryCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idArgument)!;
+            var profile = parseResult.GetValue(HistoryCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(HistoryCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(id, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string id,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var historyService = serviceProvider.GetRequiredService<IQueryHistoryService>();
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var environmentUrl = connectionInfo.EnvironmentUrl;
+
+            var deleted = await historyService.DeleteEntryAsync(environmentUrl, id, cancellationToken);
+
+            if (!deleted)
+            {
+                var error = new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"History entry '{id}' not found.",
+                    null,
+                    "id");
+
+                writer.WriteError(error);
+                return ExitCodes.NotFoundError;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(new DeleteOutput
+                {
+                    Id = id,
+                    Deleted = true
+                });
+            }
+            else
+            {
+                Console.Error.WriteLine($"Deleted history entry: {id}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "deleting query history entry", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #region Output Models
+
+    private sealed class DeleteOutput
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("deleted")]
+        public bool Deleted { get; set; }
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
@@ -154,7 +154,7 @@ public static class ExecuteCommand
 
         if (result.MoreRecords)
         {
-            Console.Error.WriteLine("More records available (use --page or --paging-cookie for continuation)");
+            Console.Error.WriteLine("More records available (use 'ppds query sql' with --page for continuation)");
         }
 
         Console.Error.WriteLine($"Execution Time: {result.ExecutionTimeMs}ms");
@@ -201,7 +201,7 @@ public static class ExecuteCommand
         if (result.MoreRecords && !string.IsNullOrEmpty(result.PagingCookie))
         {
             Console.Error.WriteLine();
-            Console.Error.WriteLine("Paging cookie (for continuation):");
+            Console.Error.WriteLine("Paging cookie (use with 'ppds query sql --paging-cookie' for continuation):");
             Console.Error.WriteLine(result.PagingCookie);
         }
     }

--- a/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
@@ -1,0 +1,254 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.History;
+using PPDS.Cli.Services.Query;
+using PPDS.Dataverse.Query;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// Re-execute a query from history.
+/// </summary>
+public static class ExecuteCommand
+{
+    /// <summary>
+    /// Creates the 'execute' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var idArgument = new Argument<string>("id")
+        {
+            Description = "The history entry ID to execute"
+        };
+
+        var topOption = new Option<int?>("--top", "-t")
+        {
+            Description = "Limit the number of results returned (overrides query TOP)"
+        };
+
+        var command = new Command("execute", "Re-execute a query from history")
+        {
+            idArgument,
+            HistoryCommandGroup.ProfileOption,
+            HistoryCommandGroup.EnvironmentOption,
+            topOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idArgument)!;
+            var profile = parseResult.GetValue(HistoryCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(HistoryCommandGroup.EnvironmentOption);
+            var top = parseResult.GetValue(topOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(id, profile, environment, top, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string id,
+        string? profile,
+        string? environment,
+        int? top,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var historyService = serviceProvider.GetRequiredService<IQueryHistoryService>();
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var environmentUrl = connectionInfo.EnvironmentUrl;
+
+            // Get the history entry
+            var entry = await historyService.GetEntryByIdAsync(environmentUrl, id, cancellationToken);
+
+            if (entry == null)
+            {
+                var error = new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"History entry '{id}' not found.",
+                    null,
+                    "id");
+
+                writer.WriteError(error);
+                return ExitCodes.NotFoundError;
+            }
+
+            // Execute the query
+            if (!globalOptions.IsJsonMode)
+            {
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Executing query from history: {id}");
+                Console.Error.WriteLine();
+            }
+
+            var sqlQueryService = serviceProvider.GetRequiredService<ISqlQueryService>();
+
+            var request = new SqlQueryRequest
+            {
+                Sql = entry.Sql,
+                TopOverride = top
+            };
+
+            var queryResult = await sqlQueryService.ExecuteAsync(request, cancellationToken);
+
+            switch (globalOptions.OutputFormat)
+            {
+                case Commands.OutputFormat.Json:
+                    writer.WriteSuccess(queryResult.Result);
+                    break;
+                case Commands.OutputFormat.Csv:
+                    WriteCsvOutput(queryResult.Result);
+                    break;
+                default:
+                    WriteTableOutput(queryResult.Result, globalOptions.Verbose);
+                    break;
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "executing query from history", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static void WriteTableOutput(QueryResult result, bool verbose)
+    {
+        Console.Error.WriteLine();
+
+        if (result.Count == 0)
+        {
+            Console.Error.WriteLine("No records found.");
+            return;
+        }
+
+        Console.Error.WriteLine($"Entity: {result.EntityLogicalName}");
+        Console.Error.WriteLine($"Records: {result.Count}");
+
+        if (result.TotalCount.HasValue)
+        {
+            Console.Error.WriteLine($"Total Count: {result.TotalCount}");
+        }
+
+        if (result.MoreRecords)
+        {
+            Console.Error.WriteLine("More records available (use --page or --paging-cookie for continuation)");
+        }
+
+        Console.Error.WriteLine($"Execution Time: {result.ExecutionTimeMs}ms");
+        Console.Error.WriteLine();
+
+        // Print table header
+        var columns = result.Columns;
+        var columnWidths = new int[columns.Count];
+
+        for (var i = 0; i < columns.Count; i++)
+        {
+            columnWidths[i] = Math.Max(
+                columns[i].Alias?.Length ?? columns[i].LogicalName.Length,
+                20);
+        }
+
+        // Header row
+        var header = string.Join(" | ", columns.Select((c, i) =>
+            (c.Alias ?? c.LogicalName).PadRight(columnWidths[i])));
+        Console.WriteLine(header);
+        Console.WriteLine(new string('-', header.Length));
+
+        // Data rows
+        foreach (var record in result.Records)
+        {
+            var row = new List<string>();
+            for (var i = 0; i < columns.Count; i++)
+            {
+                var columnName = columns[i].Alias ?? columns[i].LogicalName;
+                if (record.TryGetValue(columnName, out var queryValue) && queryValue != null)
+                {
+                    var displayValue = queryValue.FormattedValue ?? queryValue.Value?.ToString() ?? "";
+                    row.Add(TruncateValue(displayValue, columnWidths[i]));
+                }
+                else
+                {
+                    row.Add("".PadRight(columnWidths[i]));
+                }
+            }
+
+            Console.WriteLine(string.Join(" | ", row));
+        }
+
+        if (result.MoreRecords && !string.IsNullOrEmpty(result.PagingCookie))
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Paging cookie (for continuation):");
+            Console.Error.WriteLine(result.PagingCookie);
+        }
+    }
+
+    private static string TruncateValue(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value.PadRight(maxLength);
+        }
+
+        return value[..(maxLength - 3)] + "...";
+    }
+
+    private static void WriteCsvOutput(QueryResult result)
+    {
+        if (result.Count == 0)
+        {
+            return;
+        }
+
+        // Header row
+        var headers = result.Columns.Select(c => EscapeCsvField(c.Alias ?? c.LogicalName));
+        Console.WriteLine(string.Join(",", headers));
+
+        // Data rows
+        foreach (var record in result.Records)
+        {
+            var values = result.Columns.Select(c =>
+            {
+                var key = c.Alias ?? c.LogicalName;
+                if (record.TryGetValue(key, out var qv) && qv != null)
+                {
+                    return EscapeCsvField(qv.FormattedValue ?? qv.Value?.ToString() ?? "");
+                }
+                return "";
+            });
+            Console.WriteLine(string.Join(",", values));
+        }
+    }
+
+    private static string EscapeCsvField(string value)
+    {
+        if (value.Contains(',') || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+        return value;
+    }
+}

--- a/src/PPDS.Cli/Commands/Query/History/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/GetCommand.cs
@@ -1,0 +1,160 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.History;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// Get a specific query history entry by ID.
+/// </summary>
+public static class GetCommand
+{
+    /// <summary>
+    /// Creates the 'get' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var idArgument = new Argument<string>("id")
+        {
+            Description = "The history entry ID to retrieve"
+        };
+
+        var command = new Command("get", "Get a specific query history entry")
+        {
+            idArgument,
+            HistoryCommandGroup.ProfileOption,
+            HistoryCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var id = parseResult.GetValue(idArgument)!;
+            var profile = parseResult.GetValue(HistoryCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(HistoryCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(id, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string id,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var historyService = serviceProvider.GetRequiredService<IQueryHistoryService>();
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var environmentUrl = connectionInfo.EnvironmentUrl;
+
+            var entry = await historyService.GetEntryByIdAsync(environmentUrl, id, cancellationToken);
+
+            if (entry == null)
+            {
+                var error = new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"History entry '{id}' not found.",
+                    null,
+                    "id");
+
+                writer.WriteError(error);
+                return ExitCodes.NotFoundError;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                var output = new HistoryEntryOutput
+                {
+                    Id = entry.Id,
+                    Sql = entry.Sql,
+                    ExecutedAt = entry.ExecutedAt,
+                    RowCount = entry.RowCount,
+                    ExecutionTimeMs = entry.ExecutionTimeMs,
+                    Success = entry.Success,
+                    ErrorMessage = entry.ErrorMessage
+                };
+                writer.WriteSuccess(output);
+            }
+            else
+            {
+                WriteTextOutput(entry);
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "getting query history entry", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static void WriteTextOutput(QueryHistoryEntry entry)
+    {
+        Console.Error.WriteLine($"ID:           {entry.Id}");
+        Console.Error.WriteLine($"Executed At:  {entry.ExecutedAt.LocalDateTime:yyyy-MM-dd HH:mm:ss}");
+        Console.Error.WriteLine($"Row Count:    {entry.RowCount?.ToString() ?? "-"}");
+        Console.Error.WriteLine($"Duration:     {(entry.ExecutionTimeMs.HasValue ? $"{entry.ExecutionTimeMs}ms" : "-")}");
+        Console.Error.WriteLine($"Success:      {entry.Success}");
+
+        if (!string.IsNullOrEmpty(entry.ErrorMessage))
+        {
+            Console.Error.WriteLine($"Error:        {entry.ErrorMessage}");
+        }
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("SQL:");
+        Console.Error.WriteLine(new string('-', 40));
+        Console.WriteLine(entry.Sql);
+    }
+
+    #region Output Models
+
+    private sealed class HistoryEntryOutput
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("sql")]
+        public string Sql { get; set; } = "";
+
+        [JsonPropertyName("executedAt")]
+        public DateTimeOffset ExecutedAt { get; set; }
+
+        [JsonPropertyName("rowCount")]
+        public int? RowCount { get; set; }
+
+        [JsonPropertyName("executionTimeMs")]
+        public long? ExecutionTimeMs { get; set; }
+
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/Query/History/HistoryCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Query/History/HistoryCommandGroup.cs
@@ -1,0 +1,41 @@
+using System.CommandLine;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// History command group for managing SQL query history.
+/// </summary>
+public static class HistoryCommandGroup
+{
+    /// <summary>
+    /// Profile option for authentication.
+    /// </summary>
+    public static readonly Option<string?> ProfileOption = new("--profile", "-p")
+    {
+        Description = "Authentication profile name"
+    };
+
+    /// <summary>
+    /// Environment option for target environment.
+    /// </summary>
+    public static readonly Option<string?> EnvironmentOption = new("--environment", "-env")
+    {
+        Description = "Override the environment URL. Takes precedence over profile's bound environment."
+    };
+
+    /// <summary>
+    /// Creates the 'history' command group with all subcommands.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("history", "Manage SQL query history: list, get, execute, delete, clear");
+
+        command.Subcommands.Add(ListCommand.Create());
+        command.Subcommands.Add(GetCommand.Create());
+        command.Subcommands.Add(ExecuteCommand.Create());
+        command.Subcommands.Add(DeleteCommand.Create());
+        command.Subcommands.Add(ClearCommand.Create());
+
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
@@ -83,15 +83,9 @@ public static class ListCommand
                 Console.Error.WriteLine();
             }
 
-            IReadOnlyList<QueryHistoryEntry> entries;
-            if (string.IsNullOrWhiteSpace(filter))
-            {
-                entries = await historyService.GetHistoryAsync(environmentUrl, limit, cancellationToken);
-            }
-            else
-            {
-                entries = await historyService.SearchHistoryAsync(environmentUrl, filter, limit, cancellationToken);
-            }
+            var entries = string.IsNullOrWhiteSpace(filter)
+                ? await historyService.GetHistoryAsync(environmentUrl, limit, cancellationToken)
+                : await historyService.SearchHistoryAsync(environmentUrl, filter, limit, cancellationToken);
 
             if (entries.Count == 0)
             {
@@ -160,13 +154,8 @@ public static class ListCommand
 
     private static string GetQueryPreview(string sql, int maxLength)
     {
-        var normalized = sql.Replace('\n', ' ').Replace('\r', ' ').Replace('\t', ' ');
-        // Collapse multiple spaces
-        while (normalized.Contains("  "))
-        {
-            normalized = normalized.Replace("  ", " ");
-        }
-        normalized = normalized.Trim();
+        // Efficiently collapse all whitespace to single spaces using regex
+        var normalized = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ").Trim();
 
         if (normalized.Length <= maxLength)
         {

--- a/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
@@ -1,0 +1,212 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.History;
+
+namespace PPDS.Cli.Commands.Query.History;
+
+/// <summary>
+/// List query history entries with optional filtering.
+/// </summary>
+public static class ListCommand
+{
+    /// <summary>
+    /// Creates the 'list' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var limitOption = new Option<int>("--limit", "-l")
+        {
+            Description = "Maximum number of entries to return",
+            DefaultValueFactory = _ => 20
+        };
+
+        var filterOption = new Option<string?>("--filter")
+        {
+            Description = "Filter queries by substring match (case-insensitive)"
+        };
+
+        var command = new Command("list", "List recent query history entries")
+        {
+            HistoryCommandGroup.ProfileOption,
+            HistoryCommandGroup.EnvironmentOption,
+            limitOption,
+            filterOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var profile = parseResult.GetValue(HistoryCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(HistoryCommandGroup.EnvironmentOption);
+            var limit = parseResult.GetValue(limitOption);
+            var filter = parseResult.GetValue(filterOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(profile, environment, limit, filter, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string? profile,
+        string? environment,
+        int limit,
+        string? filter,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken);
+
+            var historyService = serviceProvider.GetRequiredService<IQueryHistoryService>();
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var environmentUrl = connectionInfo.EnvironmentUrl;
+
+            if (!globalOptions.IsJsonMode)
+            {
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            IReadOnlyList<QueryHistoryEntry> entries;
+            if (string.IsNullOrWhiteSpace(filter))
+            {
+                entries = await historyService.GetHistoryAsync(environmentUrl, limit, cancellationToken);
+            }
+            else
+            {
+                entries = await historyService.SearchHistoryAsync(environmentUrl, filter, limit, cancellationToken);
+            }
+
+            if (entries.Count == 0)
+            {
+                if (globalOptions.IsJsonMode)
+                {
+                    writer.WriteSuccess(new ListOutput { Entries = [] });
+                }
+                else
+                {
+                    Console.Error.WriteLine("No query history found.");
+                }
+                return ExitCodes.Success;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                var output = new ListOutput
+                {
+                    Entries = entries.Select(e => new HistoryEntryOutput
+                    {
+                        Id = e.Id,
+                        Sql = e.Sql,
+                        ExecutedAt = e.ExecutedAt,
+                        RowCount = e.RowCount,
+                        ExecutionTimeMs = e.ExecutionTimeMs,
+                        Success = e.Success,
+                        ErrorMessage = e.ErrorMessage
+                    }).ToList()
+                };
+                writer.WriteSuccess(output);
+            }
+            else
+            {
+                WriteTextOutput(entries);
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "listing query history", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static void WriteTextOutput(IReadOnlyList<QueryHistoryEntry> entries)
+    {
+        Console.Error.WriteLine($"{"ID",-14} {"Executed",-18} {"Rows",-8} {"Time",-10} {"Query Preview",-40}");
+        Console.Error.WriteLine(new string('-', 95));
+
+        foreach (var entry in entries)
+        {
+            var id = entry.Id;
+            var executed = entry.ExecutedAt.LocalDateTime.ToString("MM/dd/yy HH:mm:ss");
+            var rows = entry.RowCount?.ToString() ?? "-";
+            var time = entry.ExecutionTimeMs.HasValue ? $"{entry.ExecutionTimeMs}ms" : "-";
+            var preview = GetQueryPreview(entry.Sql, 40);
+
+            Console.Error.WriteLine($"{id,-14} {executed,-18} {rows,-8} {time,-10} {preview,-40}");
+        }
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Total: {entries.Count} entries");
+    }
+
+    private static string GetQueryPreview(string sql, int maxLength)
+    {
+        var normalized = sql.Replace('\n', ' ').Replace('\r', ' ').Replace('\t', ' ');
+        // Collapse multiple spaces
+        while (normalized.Contains("  "))
+        {
+            normalized = normalized.Replace("  ", " ");
+        }
+        normalized = normalized.Trim();
+
+        if (normalized.Length <= maxLength)
+        {
+            return normalized;
+        }
+
+        return normalized[..(maxLength - 3)] + "...";
+    }
+
+    #region Output Models
+
+    private sealed class ListOutput
+    {
+        [JsonPropertyName("entries")]
+        public List<HistoryEntryOutput> Entries { get; set; } = [];
+    }
+
+    private sealed class HistoryEntryOutput
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("sql")]
+        public string Sql { get; set; } = "";
+
+        [JsonPropertyName("executedAt")]
+        public DateTimeOffset ExecutedAt { get; set; }
+
+        [JsonPropertyName("rowCount")]
+        public int? RowCount { get; set; }
+
+        [JsonPropertyName("executionTimeMs")]
+        public long? ExecutionTimeMs { get; set; }
+
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("errorMessage")]
+        public string? ErrorMessage { get; set; }
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/Query/QueryCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Query/QueryCommandGroup.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using PPDS.Cli.Commands.Query.History;
 
 namespace PPDS.Cli.Commands.Query;
 
@@ -64,6 +65,7 @@ public static class QueryCommandGroup
 
         command.Subcommands.Add(FetchCommand.Create());
         command.Subcommands.Add(SqlCommand.Create());
+        command.Subcommands.Add(HistoryCommandGroup.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Services/History/IQueryHistoryService.cs
+++ b/src/PPDS.Cli/Services/History/IQueryHistoryService.cs
@@ -53,6 +53,18 @@ public interface IQueryHistoryService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets a specific history entry by ID.
+    /// </summary>
+    /// <param name="environmentUrl">The environment URL.</param>
+    /// <param name="entryId">The entry ID to retrieve.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The history entry, or null if not found.</returns>
+    Task<QueryHistoryEntry?> GetEntryByIdAsync(
+        string environmentUrl,
+        string entryId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes a specific history entry.
     /// </summary>
     /// <param name="environmentUrl">The environment URL.</param>

--- a/src/PPDS.Cli/Services/History/QueryHistoryService.cs
+++ b/src/PPDS.Cli/Services/History/QueryHistoryService.cs
@@ -118,6 +118,16 @@ public sealed class QueryHistoryService : IQueryHistoryService
     }
 
     /// <inheritdoc />
+    public async Task<QueryHistoryEntry?> GetEntryByIdAsync(
+        string environmentUrl,
+        string entryId,
+        CancellationToken cancellationToken = default)
+    {
+        var history = await LoadHistoryAsync(environmentUrl, cancellationToken);
+        return history.FirstOrDefault(e => e.Id == entryId);
+    }
+
+    /// <inheritdoc />
     public async Task<bool> DeleteEntryAsync(
         string environmentUrl,
         string entryId,

--- a/tests/PPDS.Cli.Tests/Mocks/FakeQueryHistoryService.cs
+++ b/tests/PPDS.Cli.Tests/Mocks/FakeQueryHistoryService.cs
@@ -64,6 +64,16 @@ public sealed class FakeQueryHistoryService : IQueryHistoryService
     }
 
     /// <inheritdoc />
+    public Task<QueryHistoryEntry?> GetEntryByIdAsync(
+        string environmentUrl,
+        string entryId,
+        CancellationToken cancellationToken = default)
+    {
+        var entry = _entries.FirstOrDefault(e => e.Id == entryId);
+        return Task.FromResult(entry);
+    }
+
+    /// <inheritdoc />
     public Task<bool> DeleteEntryAsync(
         string environmentUrl,
         string entryId,


### PR DESCRIPTION
## Summary

- Add `ppds query history list` - List recent queries with optional filter and limit
- Add `ppds query history get <id>` - Retrieve a specific query by ID
- Add `ppds query history execute <id>` - Re-execute a saved query with optional --top override
- Add `ppds query history delete <id>` - Delete a query from history
- Add `ppds query history clear` - Clear all history (with --force to skip confirmation)
- All commands support `--json` output format for scripting
- Added `GetEntryByIdAsync` method to `IQueryHistoryService` interface

## Test plan

- [x] Build passes (Release with --warnaserror)
- [x] All unit tests pass
- [x] Manual verification of `ppds query history --help` and subcommand help

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)