### PR TITLE
docs: add GitHub repository info to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivi
 
 | Property | Value |
 |----------|-------|
-| Owner | joshsmithxrm |
-| Repo | power-platform-developer-suite |
+| Owner | `joshsmithxrm` |
+| Repo | `power-platform-developer-suite` |
 
 ## NEVER
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 NuGet packages & CLI for Power Platform: plugin attributes, Dataverse connectivity, migration tooling.
 
+## Repository
+
+| Property | Value |
+|----------|-------|
+| Owner | joshsmithxrm |
+| Repo | power-platform-developer-suite |
+
 ## NEVER
 
 | Rule | Why |


### PR DESCRIPTION
## Summary
- Add Repository section to CLAUDE.md with owner (`joshsmithxrm`) and repo (`power-platform-developer-suite`)
- Provides explicit repo info so Claude doesn't have to guess when using GitHub MCP tools

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Verify CLAUDE.md renders correctly in GitHub

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)