### PR TITLE
feat(tui): add environment details dialog with multiple access methods

### DIFF
--- a/src/PPDS.Cli/Tui/MainWindow.cs
+++ b/src/PPDS.Cli/Tui/MainWindow.cs
@@ -232,7 +232,7 @@ internal sealed class MainWindow : Window
             return;
         }
 
-        var dialog = new EnvironmentDetailsDialog(_session, _environmentUrl, _environmentName);
+        using var dialog = new EnvironmentDetailsDialog(_session, _environmentUrl, _environmentName);
         Application.Run(dialog);
     }
 


### PR DESCRIPTION
## Summary

- Add `EnvironmentDetailsDialog` showing org/environment info (equivalent to `ppds env who`)
- Status bar click opens dialog (converted from `Label` to `Button`)
- `Ctrl+E` shortcut from main window
- Environment menu with "View Details..." menu item
- Refresh button re-queries WhoAmI
- Environment type shown with appropriate color styling

## Information Displayed

- Environment display name
- URL
- Unique name
- Type (Production, Sandbox, Developer, Trial)
- Region
- Dataverse version
- Organization ID
- User ID (current user)
- Business Unit ID
- Connected identity

## Test plan

- [x] Build passes (`dotnet build -c Release --warnaserror`)
- [x] Unit tests pass (`dotnet test --filter "Category!=Integration"`)
- [ ] Manual: Click status bar to open dialog
- [ ] Manual: Press Ctrl+E to open dialog
- [ ] Manual: Use Environment → View Details menu
- [ ] Manual: Click Refresh button in dialog

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)