### PR TITLE
feat(tui): add profile details dialog (who am I)

### DIFF
--- a/src/PPDS.Cli/Tui/Dialogs/ProfileDetailsDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileDetailsDialog.cs
@@ -273,6 +273,7 @@ internal sealed class ProfileDetailsDialog : Dialog
                 _tenantLabel.Text = "-";
                 _authorityLabel.Text = "-";
                 _tokenStatusLabel.Text = "-";
+                _tokenStatusLabel.ColorScheme = TuiColorPalette.Default;
                 _createdLabel.Text = "-";
                 _lastUsedLabel.Text = "-";
                 _environmentLabel.Text = "-";
@@ -358,9 +359,13 @@ internal sealed class ProfileDetailsDialog : Dialog
             {
                 timeRemaining = $"{(int)remaining.TotalHours} hour(s)";
             }
-            else
+            else if (remaining.TotalMinutes >= 1)
             {
                 timeRemaining = $"{(int)remaining.TotalMinutes} minute(s)";
+            }
+            else
+            {
+                timeRemaining = "less than 1 minute";
             }
 
             _tokenStatusLabel.Text = $"Valid (expires in {timeRemaining})";

--- a/src/PPDS.Cli/Tui/Dialogs/ProfileDetailsDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileDetailsDialog.cs
@@ -1,0 +1,398 @@
+using PPDS.Auth.Cloud;
+using PPDS.Auth.Profiles;
+using PPDS.Cli.Tui.Infrastructure;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog for displaying detailed profile information.
+/// Equivalent to the 'ppds auth who' CLI command.
+/// </summary>
+internal sealed class ProfileDetailsDialog : Dialog
+{
+    private readonly InteractiveSession _session;
+    private readonly Label _profileNameLabel;
+    private readonly Label _identityLabel;
+    private readonly Label _authMethodLabel;
+    private readonly Label _cloudLabel;
+    private readonly Label _tenantLabel;
+    private readonly Label _authorityLabel;
+    private readonly Label _tokenStatusLabel;
+    private readonly Label _createdLabel;
+    private readonly Label _lastUsedLabel;
+    private readonly Label _environmentLabel;
+    private readonly Label _environmentUrlLabel;
+
+    /// <summary>
+    /// Creates a new profile details dialog.
+    /// </summary>
+    /// <param name="session">The interactive session for accessing profile data.</param>
+    public ProfileDetailsDialog(InteractiveSession session) : base("Profile Details")
+    {
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+
+        Width = 68;
+        Height = 20;
+        ColorScheme = TuiColorPalette.Default;
+
+        const int labelWidth = 14;
+        const int valueX = 16;
+
+        // Profile name (header)
+        var profileHeaderLabel = new Label("Profile:")
+        {
+            X = 1,
+            Y = 1,
+            Width = labelWidth
+        };
+        _profileNameLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 1,
+            Width = Dim.Fill() - 2
+        };
+
+        // Separator
+        var separator = new Label(new string('─', 64))
+        {
+            X = 1,
+            Y = 2
+        };
+
+        // Identity
+        var identityHeaderLabel = new Label("Identity:")
+        {
+            X = 1,
+            Y = 3,
+            Width = labelWidth
+        };
+        _identityLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 3,
+            Width = Dim.Fill() - 2
+        };
+
+        // Auth Method
+        var authMethodHeaderLabel = new Label("Auth Method:")
+        {
+            X = 1,
+            Y = 4,
+            Width = labelWidth
+        };
+        _authMethodLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 4,
+            Width = Dim.Fill() - 2
+        };
+
+        // Cloud
+        var cloudHeaderLabel = new Label("Cloud:")
+        {
+            X = 1,
+            Y = 5,
+            Width = labelWidth
+        };
+        _cloudLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 5,
+            Width = Dim.Fill() - 2
+        };
+
+        // Tenant
+        var tenantHeaderLabel = new Label("Tenant:")
+        {
+            X = 1,
+            Y = 6,
+            Width = labelWidth
+        };
+        _tenantLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 6,
+            Width = Dim.Fill() - 2
+        };
+
+        // Authority
+        var authorityHeaderLabel = new Label("Authority:")
+        {
+            X = 1,
+            Y = 7,
+            Width = labelWidth
+        };
+        _authorityLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 7,
+            Width = Dim.Fill() - 2
+        };
+
+        // Token Status
+        var tokenHeaderLabel = new Label("Token Status:")
+        {
+            X = 1,
+            Y = 9,
+            Width = labelWidth
+        };
+        _tokenStatusLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 9,
+            Width = Dim.Fill() - 2
+        };
+
+        // Created
+        var createdHeaderLabel = new Label("Created:")
+        {
+            X = 1,
+            Y = 10,
+            Width = labelWidth
+        };
+        _createdLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 10,
+            Width = Dim.Fill() - 2
+        };
+
+        // Last Used
+        var lastUsedHeaderLabel = new Label("Last Used:")
+        {
+            X = 1,
+            Y = 11,
+            Width = labelWidth
+        };
+        _lastUsedLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 11,
+            Width = Dim.Fill() - 2
+        };
+
+        // Environment
+        var envHeaderLabel = new Label("Environment:")
+        {
+            X = 1,
+            Y = 13,
+            Width = labelWidth
+        };
+        _environmentLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 13,
+            Width = Dim.Fill() - 2
+        };
+
+        // URL
+        var urlHeaderLabel = new Label("URL:")
+        {
+            X = 1,
+            Y = 14,
+            Width = labelWidth
+        };
+        _environmentUrlLabel = new Label(string.Empty)
+        {
+            X = valueX,
+            Y = 14,
+            Width = Dim.Fill() - 2
+        };
+
+        // Buttons
+        var refreshButton = new Button("_Refresh")
+        {
+            X = Pos.Center() - 10,
+            Y = Pos.AnchorEnd(1)
+        };
+        refreshButton.Clicked += OnRefreshClicked;
+
+        var closeButton = new Button("_Close")
+        {
+            X = Pos.Center() + 3,
+            Y = Pos.AnchorEnd(1)
+        };
+        closeButton.Clicked += () => Application.RequestStop();
+
+        Add(
+            profileHeaderLabel, _profileNameLabel,
+            separator,
+            identityHeaderLabel, _identityLabel,
+            authMethodHeaderLabel, _authMethodLabel,
+            cloudHeaderLabel, _cloudLabel,
+            tenantHeaderLabel, _tenantLabel,
+            authorityHeaderLabel, _authorityLabel,
+            tokenHeaderLabel, _tokenStatusLabel,
+            createdHeaderLabel, _createdLabel,
+            lastUsedHeaderLabel, _lastUsedLabel,
+            envHeaderLabel, _environmentLabel,
+            urlHeaderLabel, _environmentUrlLabel,
+            refreshButton, closeButton
+        );
+
+        // Handle Escape to close
+        KeyPress += (e) =>
+        {
+            if (e.KeyEvent.Key == Key.Esc)
+            {
+                Application.RequestStop();
+                e.Handled = true;
+            }
+        };
+
+        // Load profile data asynchronously
+#pragma warning disable PPDS013 // Fire-and-forget with explicit error handling via ContinueWith
+        _ = LoadProfileAsync().ContinueWith(t =>
+        {
+            if (t.IsFaulted && t.Exception != null)
+            {
+                Application.MainLoop?.Invoke(() =>
+                {
+                    _profileNameLabel.Text = $"Error: {t.Exception.InnerException?.Message ?? t.Exception.Message}";
+                });
+            }
+        }, TaskScheduler.Default);
+#pragma warning restore PPDS013
+    }
+
+    private async Task LoadProfileAsync()
+    {
+        var store = _session.GetProfileStore();
+        var collection = await store.LoadAsync(CancellationToken.None);
+        var profile = collection.ActiveProfile;
+
+        Application.MainLoop?.Invoke(() =>
+        {
+            if (profile == null)
+            {
+                _profileNameLabel.Text = "(No active profile)";
+                _identityLabel.Text = "-";
+                _authMethodLabel.Text = "-";
+                _cloudLabel.Text = "-";
+                _tenantLabel.Text = "-";
+                _authorityLabel.Text = "-";
+                _tokenStatusLabel.Text = "-";
+                _createdLabel.Text = "-";
+                _lastUsedLabel.Text = "-";
+                _environmentLabel.Text = "-";
+                _environmentUrlLabel.Text = "-";
+                return;
+            }
+
+            UpdateDisplay(profile);
+        });
+    }
+
+    private void UpdateDisplay(AuthProfile profile)
+    {
+        // Profile name
+        _profileNameLabel.Text = profile.DisplayIdentifier;
+
+        // Identity (username or app ID)
+        _identityLabel.Text = profile.IdentityDisplay;
+
+        // Auth method
+        _authMethodLabel.Text = profile.AuthMethod.ToString();
+
+        // Cloud
+        _cloudLabel.Text = profile.Cloud.ToString();
+
+        // Tenant
+        _tenantLabel.Text = profile.TenantId ?? "(not specified)";
+
+        // Authority
+        var authority = profile.Authority ?? CloudEndpoints.GetAuthorityUrl(profile.Cloud, profile.TenantId);
+        _authorityLabel.Text = TruncateUrl(authority, 48);
+
+        // Token status with color
+        UpdateTokenStatus(profile);
+
+        // Created
+        _createdLabel.Text = profile.CreatedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+
+        // Last used
+        _lastUsedLabel.Text = profile.LastUsedAt?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "(never)";
+
+        // Environment
+        if (profile.HasEnvironment)
+        {
+            _environmentLabel.Text = profile.Environment!.DisplayName;
+            _environmentUrlLabel.Text = TruncateUrl(profile.Environment.Url, 48);
+        }
+        else
+        {
+            _environmentLabel.Text = "(no environment selected)";
+            _environmentUrlLabel.Text = "-";
+        }
+    }
+
+    private void UpdateTokenStatus(AuthProfile profile)
+    {
+        if (!profile.TokenExpiresOn.HasValue)
+        {
+            _tokenStatusLabel.Text = "Unknown";
+            _tokenStatusLabel.ColorScheme = TuiColorPalette.Default;
+            return;
+        }
+
+        var expiresOn = profile.TokenExpiresOn.Value;
+        var now = DateTimeOffset.UtcNow;
+
+        if (expiresOn < now)
+        {
+            // Expired
+            _tokenStatusLabel.Text = "Expired";
+            _tokenStatusLabel.ColorScheme = TuiColorPalette.Error;
+        }
+        else
+        {
+            var remaining = expiresOn - now;
+            string timeRemaining;
+
+            if (remaining.TotalDays >= 1)
+            {
+                timeRemaining = $"{(int)remaining.TotalDays} day(s)";
+            }
+            else if (remaining.TotalHours >= 1)
+            {
+                timeRemaining = $"{(int)remaining.TotalHours} hour(s)";
+            }
+            else
+            {
+                timeRemaining = $"{(int)remaining.TotalMinutes} minute(s)";
+            }
+
+            _tokenStatusLabel.Text = $"Valid (expires in {timeRemaining})";
+            _tokenStatusLabel.ColorScheme = TuiColorPalette.Success;
+        }
+    }
+
+    private static string TruncateUrl(string url, int maxLength)
+    {
+        if (string.IsNullOrEmpty(url) || url.Length <= maxLength)
+        {
+            return url;
+        }
+
+        return url.Substring(0, maxLength - 3) + "...";
+    }
+
+    private void OnRefreshClicked()
+    {
+#pragma warning disable PPDS013 // Fire-and-forget with explicit error handling via ContinueWith
+        _ = LoadProfileAsync().ContinueWith(t =>
+        {
+            if (t.IsFaulted && t.Exception != null)
+            {
+                Application.MainLoop?.Invoke(() =>
+                {
+                    MessageBox.ErrorQuery("Refresh Failed",
+                        t.Exception.InnerException?.Message ?? t.Exception.Message,
+                        "OK");
+                });
+            }
+        }, TaskScheduler.Default);
+#pragma warning restore PPDS013
+    }
+}

--- a/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
@@ -242,14 +242,11 @@ internal sealed class ProfileSelectorDialog : Dialog
             return;
         }
 
-        if (_listView.SelectedItem < 0 || _listView.SelectedItem >= _profiles.Count)
-        {
-            return;
-        }
-
-        // Show the profile details dialog
-        // Note: This shows the active profile details, not the selected list item
-        // (The selected list item would require loading the full AuthProfile)
+        // Show the profile details dialog for the active profile.
+        // Design note: ProfileDetailsDialog shows the active profile because it needs
+        // full AuthProfile data (token expiration, authority, etc.) which is only readily
+        // available for the active profile. Showing details for a non-active profile would
+        // require additional profile loading logic and potentially re-authentication.
         var dialog = new ProfileDetailsDialog(_session);
         Application.Run(dialog);
     }

--- a/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
@@ -11,6 +11,7 @@ namespace PPDS.Cli.Tui.Dialogs;
 internal sealed class ProfileSelectorDialog : Dialog
 {
     private readonly IProfileService _profileService;
+    private readonly InteractiveSession? _session;
     private readonly ListView _listView;
     private readonly Label _detailLabel;
     private readonly Label _hintLabel;
@@ -32,9 +33,12 @@ internal sealed class ProfileSelectorDialog : Dialog
     /// <summary>
     /// Creates a new profile selector dialog.
     /// </summary>
-    public ProfileSelectorDialog(IProfileService profileService) : base("Select Profile")
+    /// <param name="profileService">The profile service for profile operations.</param>
+    /// <param name="session">Optional session for showing profile details dialog.</param>
+    public ProfileSelectorDialog(IProfileService profileService, InteractiveSession? session = null) : base("Select Profile")
     {
         _profileService = profileService ?? throw new ArgumentNullException(nameof(profileService));
+        _session = session;
 
         Width = 60;
         Height = 18;
@@ -79,7 +83,7 @@ internal sealed class ProfileSelectorDialog : Dialog
             Y = Pos.Bottom(_detailLabel),
             Width = Dim.Fill() - 2,
             Height = 1,
-            Text = "F2 to rename | Del to delete",
+            Text = "F2 rename | Del delete | Ctrl+D details",
             ColorScheme = TuiColorPalette.StatusBar_Default
         };
 
@@ -222,6 +226,32 @@ internal sealed class ProfileSelectorDialog : Dialog
             ShowRenameDialog();
             e.Handled = true;
         }
+        else if (e.KeyEvent.Key == (Key.CtrlMask | Key.D))
+        {
+            ShowProfileDetailsDialog();
+            e.Handled = true;
+        }
+    }
+
+    private void ShowProfileDetailsDialog()
+    {
+        if (_session == null)
+        {
+            // Session not available - show simple message
+            MessageBox.Query("Details", "Profile details require session context.", "OK");
+            return;
+        }
+
+        if (_listView.SelectedItem < 0 || _listView.SelectedItem >= _profiles.Count)
+        {
+            return;
+        }
+
+        // Show the profile details dialog
+        // Note: This shows the active profile details, not the selected list item
+        // (The selected list item would require loading the full AuthProfile)
+        var dialog = new ProfileDetailsDialog(_session);
+        Application.Run(dialog);
     }
 
     private void ShowRenameDialog()

--- a/src/PPDS.Cli/Tui/MainWindow.cs
+++ b/src/PPDS.Cli/Tui/MainWindow.cs
@@ -70,6 +70,7 @@ internal sealed class MainWindow : Window
                 new("", "", () => {}, null, null, Key.Null), // Separator
                 new("Switch _Profile...", "Select a different authentication profile", () => ShowProfileSelector()),
                 new("Switch _Environment...", "Select a different environment", () => ShowEnvironmentSelector()),
+                new("View Profile _Details...", "Show profile details (who am I)", () => ShowProfileDetails(), shortcut: Key.CtrlMask | Key.I),
                 new("", "", () => {}, null, null, Key.Null), // Separator
                 new("_Quit", "Exit the application", () => RequestStop(), shortcut: Key.CtrlMask | Key.Q)
             }),
@@ -145,6 +146,10 @@ internal sealed class MainWindow : Window
                     e.Handled = true;
                     break;
                 // F3 disabled - Data Migration coming soon
+                case Key.CtrlMask | Key.I:
+                    ShowProfileDetails();
+                    e.Handled = true;
+                    break;
             }
         };
     }
@@ -211,7 +216,7 @@ internal sealed class MainWindow : Window
     private void ShowProfileSelector()
     {
         var service = _session.GetProfileService();
-        var dialog = new ProfileSelectorDialog(service);
+        var dialog = new ProfileSelectorDialog(service, _session);
 
         Application.Run(dialog);
 
@@ -284,6 +289,12 @@ internal sealed class MainWindow : Window
             }, TaskScheduler.Default);
 #pragma warning restore PPDS013
         }
+    }
+
+    private void ShowProfileDetails()
+    {
+        var dialog = new ProfileDetailsDialog(_session);
+        Application.Run(dialog);
     }
 
     private void ShowEnvironmentSelector()
@@ -361,6 +372,7 @@ internal sealed class MainWindow : Window
         MessageBox.Query("Keyboard Shortcuts",
             "Global Shortcuts:\n" +
             "  F2       - SQL Query\n" +
+            "  Ctrl+I   - Profile Details\n" +
             "  Ctrl+Q   - Quit\n\n" +
             "Table Navigation:\n" +
             "  Arrows   - Navigate cells\n" +


### PR DESCRIPTION
## Summary

Add ProfileDetailsDialog to show full profile information in TUI, equivalent to `ppds auth who` CLI command.

**Features:**
- Display profile name, identity, auth method, cloud, tenant, and authority URL
- Token status with color-coded display (valid=green, expired=red)
- Created and last used timestamps
- Current environment name and URL
- Refresh button to reload profile data

**Access methods:**
- `Ctrl+I` from anywhere in TUI
- Menu: File > View Profile Details
- `Ctrl+D` from Profile Selector dialog

## Test plan

- [x] Build passes (Release configuration, warnings as errors)
- [x] Unit tests pass (1293 tests)
- [ ] Manual: Launch TUI, press Ctrl+I, verify all fields display correctly
- [ ] Manual: Check token status color coding (green for valid, red for expired)
- [ ] Manual: Test from ProfileSelectorDialog with Ctrl+D
- [ ] Manual: Test from menu: File > View Profile Details

## Files changed

| File | Description |
|------|-------------|
| `src/PPDS.Cli/Tui/Dialogs/ProfileDetailsDialog.cs` | New dialog showing profile details |
| `src/PPDS.Cli/Tui/MainWindow.cs` | Add Ctrl+I handler, menu item, ShowProfileDetails method |
| `src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs` | Add Ctrl+D handler, update hint label |

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)