### PR TITLE
feat(session): add dynamic terminal tab titles and simplify status enum

### DIFF
--- a/src/PPDS.Cli/Commands/Session/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Session/ListCommand.cs
@@ -100,17 +100,12 @@ public static class ListCommand
                         // active implementation is normal
                         var statusIcon = session.Status switch
                         {
-                            SessionStatus.Registered => "[ ]",
                             SessionStatus.Planning => "[~]",
-                            SessionStatus.PlanningComplete => "[P]",
                             SessionStatus.Working => "[*]",
                             SessionStatus.Shipping => "[^]",
-                            SessionStatus.ReviewsInProgress => "[R]",
-                            SessionStatus.PrReady => "[+]",
                             SessionStatus.Stuck => "[!]",
                             SessionStatus.Paused => "[-]",
                             SessionStatus.Complete => "[+]",
-                            SessionStatus.Cancelled => "[x]",
                             _ => "[?]"
                         };
 
@@ -123,9 +118,7 @@ public static class ListCommand
 
                         var isActiveSession = session.Status is SessionStatus.Working
                             or SessionStatus.Planning
-                            or SessionStatus.PlanningComplete
-                            or SessionStatus.Shipping
-                            or SessionStatus.ReviewsInProgress;
+                            or SessionStatus.Shipping;
 
                         var statusText = session.Status.ToString();
                         if (isActiveSession && timeSinceUpdate.TotalSeconds > LastUpdateDisplayThresholdSeconds)

--- a/src/PPDS.Cli/Services/Session/ISessionService.cs
+++ b/src/PPDS.Cli/Services/Session/ISessionService.cs
@@ -82,7 +82,8 @@ public interface ISessionService
     /// <param name="reason">Reason for status change (required for Stuck).</param>
     /// <param name="prUrl">Pull request URL (for Complete status).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task UpdateAsync(
+    /// <returns>The updated session state.</returns>
+    Task<SessionState> UpdateAsync(
         string sessionId,
         SessionStatus status,
         string? reason = null,

--- a/src/PPDS.Cli/Services/Session/SessionState.cs
+++ b/src/PPDS.Cli/Services/Session/SessionState.cs
@@ -61,6 +61,17 @@ public sealed record SessionState
     public string? PullRequestUrl { get; init; }
 
     /// <summary>
+    /// When the session completed (null if not yet complete).
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>
+    /// Reason for completion (e.g., "PR merged", "Cancelled by user").
+    /// Only set when status is Complete.
+    /// </summary>
+    public string? CompletionReason { get; init; }
+
+    /// <summary>
     /// Git status summary for the worktree.
     /// </summary>
     public WorktreeStatus? WorktreeStatus { get; init; }
@@ -68,23 +79,15 @@ public sealed record SessionState
 
 /// <summary>
 /// Session lifecycle status.
+/// Simplified to 6 core states for clarity.
 /// </summary>
 public enum SessionStatus
 {
     /// <summary>
-    /// Worktree created, worker starting up.
-    /// </summary>
-    Registered,
-
-    /// <summary>
     /// Worker is exploring codebase and creating plan.
+    /// Encompasses: registered, exploring, plan written.
     /// </summary>
     Planning,
-
-    /// <summary>
-    /// Worker has written plan, continuing to implementation.
-    /// </summary>
-    PlanningComplete,
 
     /// <summary>
     /// Worker actively implementing.
@@ -92,19 +95,9 @@ public enum SessionStatus
     Working,
 
     /// <summary>
-    /// PR created, waiting for required CI checks.
+    /// PR created, in review pipeline (CI, bot review, ready for human).
     /// </summary>
     Shipping,
-
-    /// <summary>
-    /// CI passed, addressing bot review comments.
-    /// </summary>
-    ReviewsInProgress,
-
-    /// <summary>
-    /// All bot comments addressed, PR ready for human review.
-    /// </summary>
-    PrReady,
 
     /// <summary>
     /// Worker hit a domain gate or repeated failure, needs human guidance.
@@ -117,14 +110,10 @@ public enum SessionStatus
     Paused,
 
     /// <summary>
-    /// PR created and CI passed.
+    /// Terminal state - work done or cancelled.
+    /// Check CompletionReason for details.
     /// </summary>
-    Complete,
-
-    /// <summary>
-    /// Human cancelled the session.
-    /// </summary>
-    Cancelled
+    Complete
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- **Dynamic terminal tab titles** - Windows Terminal tab titles now update dynamically when workers report status via `ppds session update`, showing status icons and PR numbers at a glance
- **Simplified status enum** - Reduced from 11 to 6 states (Planning, Working, Shipping, Stuck, Paused, Complete) to reduce cognitive load while orchestrating
- **Completion tracking** - Added `CompletedAt` timestamp and `CompletionReason` properties for better auditing
- **Backward compatible** - Custom JSON converter automatically migrates old session files with deprecated status values

### Tab Title Format

| Status | Example |
|--------|---------|
| Planning | `~ #329` |
| Working | `* #329` |
| Shipping | `^ #329` |
| Complete with PR | `+ #329 -> PR #330` |

## Test plan

- [x] Build succeeds with no warnings
- [x] All 1293 CLI unit tests pass
- [x] All other test suites pass
- [ ] Manual verification: spawn a session and observe tab title updates through status transitions

## Files changed

- `SessionState.cs` - Simplified enum, added CompletedAt/CompletionReason
- `ISessionService.cs` - UpdateAsync now returns SessionState
- `SessionService.cs` - Tab title emission, CompletedAt tracking, JSON migration converter
- `UpdateCommand.cs` - FormatTabTitle and EmitTabTitleUpdate helpers
- `ListCommand.cs` - Updated icon mapping
- `docs/adr/0030_SESSION_ORCHESTRATION.md` - Documented changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)