### PR TITLE
fix(prune): add empty folder cleanup and remove hard-coded paths

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -155,15 +155,17 @@ if ($branch) {
 }
 ```
 
-3. Add statusLine config to `~/.claude/settings.json` with absolute path:
+3. Add statusLine config to `~/.claude/settings.json` using the user's home directory:
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "pwsh -NoProfile -File C:/Users/USERNAME/.claude/statusline.ps1"
+    "command": "pwsh -NoProfile -File ~/.claude/statusline.ps1"
   }
 }
 ```
+
+> **Note:** Use `~` for cross-platform compatibility. On Windows, Claude Code expands `~` to `$env:USERPROFILE`.
 
 ### Step 5: Summary
 

--- a/.claude/workflows/parallel-work.md
+++ b/.claude/workflows/parallel-work.md
@@ -34,7 +34,7 @@ Sessions coordinate via status files in `~/.ppds/sessions/`:
   "status": "working",
   "issue": "#123",
   "branch": "fix/auth-bug",
-  "worktree": "C:/VS/ppds-auth-bug",
+  "worktree": "<repo-parent>/ppds-auth-bug",
   "started": "2025-01-08T10:30:00Z",
   "lastUpdate": "2025-01-08T11:15:00Z",
   "stuck": null

--- a/docs/adr/0030_SESSION_ORCHESTRATION.md
+++ b/docs/adr/0030_SESSION_ORCHESTRATION.md
@@ -77,7 +77,7 @@ All commands require `PPDS_INTERNAL=1` environment variable (automatically set f
   "issueTitle": "Add export button",
   "status": "working",
   "branch": "issue-123",
-  "worktreePath": "C:/VS/ppds-issue-123",
+  "worktreePath": "<repo-parent>/ppds-issue-123",
   "startedAt": "2025-01-08T10:30:00Z",
   "lastHeartbeat": "2025-01-08T11:15:00Z",
   "completedAt": null,

--- a/templates/claude/INSTALL.md
+++ b/templates/claude/INSTALL.md
@@ -22,8 +22,9 @@ cp -r path/to/power-platform-developer-suite/templates/claude/* ~/.claude/ppds/
 # Create PPDS directory in Claude config
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\ppds"
 
-# Copy templates (from SDK repo)
-Copy-Item -Path "C:\path\to\power-platform-developer-suite\templates\claude\*" -Destination "$env:USERPROFILE\.claude\ppds" -Recurse
+# Copy templates (from SDK repo - adjust path to your clone location)
+$sdkPath = "path\to\power-platform-developer-suite"  # <-- Set this to your SDK location
+Copy-Item -Path "$sdkPath\templates\claude\*" -Destination "$env:USERPROFILE\.claude\ppds" -Recurse
 ```
 
 Then in any project's `CLAUDE.md`, add:
@@ -60,7 +61,9 @@ ln -s /path/to/power-platform-developer-suite/templates/claude/CONSUMER_GUIDE.md
 
 **Windows (requires admin):**
 ```powershell
-New-Item -ItemType SymbolicLink -Path ".claude\rules\ppds.md" -Target "C:\path\to\power-platform-developer-suite\templates\claude\CONSUMER_GUIDE.md"
+# Adjust path to your SDK clone location
+$sdkPath = "path\to\power-platform-developer-suite"  # <-- Set this to your SDK location
+New-Item -ItemType SymbolicLink -Path ".claude\rules\ppds.md" -Target "$sdkPath\templates\claude\CONSUMER_GUIDE.md"
 ```
 
 ---

--- a/tests/PPDS.LiveTests/Cli/DataSchemaCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/DataSchemaCommandE2ETests.cs
@@ -202,10 +202,13 @@ public class DataSchemaCommandE2ETests : CliE2ETestBase
     [CliE2EFact]
     public async Task DataSchema_InvalidOutputDirectory_Fails()
     {
+        // Use a guaranteed-nonexistent path in temp directory (cross-platform)
+        var nonexistentPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "schema.xml");
+
         var result = await RunCliAsync(
             "data", "schema",
             "--entities", "account",
-            "--output", @"C:\nonexistent\directory\schema.xml");
+            "--output", nonexistentPath);
 
         result.ExitCode.Should().NotBe(0);
         (result.StdOut + result.StdErr).Should().ContainAny("directory", "does not exist", "Error");


### PR DESCRIPTION
## Summary
- Add Step 5 to `/prune` command to clean up empty/orphaned worktree directories
- Use `.git` type detection: file = worktree (safe to clean), directory = repo (never touch)
- Empty folders auto-deleted; partial-content folders prompt for confirmation
- Remove hard-coded paths from 5 documentation/test files for portability

## Test plan
- [x] Build passes (0 errors, 0 warnings)
- [x] Unit tests pass (6,800+ tests across .NET 8/9/10)
- [ ] Run `/prune` in directory with empty orphan folders
- [ ] Verify full repos (ppds-alm, ppds-docs) are never touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)