### PR TITLE
feat(cli): add ppds backlog command for project health dashboard

### DIFF
--- a/.claude/commands/backlog.md
+++ b/.claude/commands/backlog.md
@@ -1,0 +1,94 @@
+# Backlog
+
+View current bugs, ready work, and project health. Use as a dashboard or to start planning sessions.
+
+## Usage
+
+`/backlog [options]`
+
+Examples:
+- `/backlog` - Summary view of current repo
+- `/backlog --full` - Detailed listing with all issues
+- `/backlog --plan` - Start a planning session with backlog context
+- `/backlog --all` - Cross-repo ecosystem view
+
+## Arguments
+
+`$ARGUMENTS` - Options (see below)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--full` | Show all issues in each category, not just top 5 |
+| `--plan` | After showing summary, start planning conversation |
+| `--all` | Cross-repo view of all PPDS repositories |
+| `--bugs` | Show only bugs |
+| `--ready` | Show only ready-for-work items |
+
+## Process
+
+### 1. Fetch Backlog Data
+
+Run the CLI command to get backlog data:
+
+```bash
+ppds backlog $ARGUMENTS
+```
+
+The CLI handles:
+- GitHub API calls (GraphQL for project fields, REST for PRs)
+- Caching (5-minute TTL in ~/.ppds/cache/backlog.json)
+- Cross-repo aggregation (single project tracks all repos)
+- Session integration (shows active worker sessions)
+
+Display the CLI output to the user.
+
+### 2. Planning Conversation (--plan only)
+
+If `--plan` was specified, after showing the summary, continue to a planning conversation:
+
+```
+Based on the backlog, what would you like to focus on?
+
+Options:
+1. Start with critical bugs first
+2. Pick up some quick wins (small, ready items)
+3. Work on specific issues (provide numbers)
+4. Run /triage first to process untriaged items
+5. Something else
+
+What's your priority?
+```
+
+**STOP for user input.**
+
+Based on their response, chain to the appropriate next command:
+- Specific issues: `/plan-work <issue numbers>`
+- Triage: `/triage`
+- Continue planning conversation
+
+## Integration with Other Commands
+
+| After /backlog | Next Command | Purpose |
+|----------------|--------------|---------|
+| See bugs | `/plan-work 199 200` | Plan bug fixes |
+| See untriaged | `/triage` | Process new issues |
+| See ready work | `/plan-work --batch <name>` | Plan a batch |
+| Use --plan | Natural conversation | Discuss priorities |
+
+## When to Use
+
+- **Daily standup** - Quick view of project state
+- **Sprint planning** - See what's ready to work on
+- **Prioritization** - Compare bugs vs features
+- **Start of session** - "What should I work on?"
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/triage` | Process untriaged issues |
+| `/plan-work` | Create worktrees for issues |
+| `/design` | Start design conversation |
+| `/orchestrate` | Dispatch parallel workers |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ MinVer tags: `{Package}-v{version}` (e.g., `Cli-v1.0.0-beta.11`)
 
 | Command | Purpose |
 |---------|---------|
+| `/backlog` | View bugs, ready work, and start planning sessions |
 | `/design` | Design conversation for new feature |
 | `/design-ui` | Reference-driven UI design with wireframes |
 | `/orchestrate` | Orchestrate parallel work sessions |

--- a/src/PPDS.Cli/Commands/Backlog/BacklogCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Backlog/BacklogCommandGroup.cs
@@ -1,0 +1,390 @@
+using System.CommandLine;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Services.Backlog;
+using PPDS.Cli.Services.Session;
+using Spectre.Console;
+
+namespace PPDS.Cli.Commands.Backlog;
+
+/// <summary>
+/// Command group for backlog operations.
+/// </summary>
+public static class BacklogCommandGroup
+{
+    public static Command Create()
+    {
+        var fullOption = new Option<bool>("--full")
+        {
+            Description = "Show all issues in each category, not just top 5"
+        };
+
+        var bugsOption = new Option<bool>("--bugs")
+        {
+            Description = "Show only bugs"
+        };
+
+        var readyOption = new Option<bool>("--ready")
+        {
+            Description = "Show only ready-for-work items"
+        };
+
+        var allOption = new Option<bool>("--all")
+        {
+            Description = "Cross-repo ecosystem view"
+        };
+
+        var repoOption = new Option<string?>("--repo")
+        {
+            Description = "Override repository (owner/repo format)"
+        };
+
+        var noCacheOption = new Option<bool>("--no-cache")
+        {
+            Description = "Bypass cache and fetch fresh data"
+        };
+
+        var command = new Command("backlog", "View project backlog: bugs, ready work, and project health")
+        {
+            fullOption,
+            bugsOption,
+            readyOption,
+            allOption,
+            repoOption,
+            noCacheOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+            var full = parseResult.GetValue(fullOption);
+            var bugsOnly = parseResult.GetValue(bugsOption);
+            var readyOnly = parseResult.GetValue(readyOption);
+            var allRepos = parseResult.GetValue(allOption);
+            var repo = parseResult.GetValue(repoOption);
+            var noCache = parseResult.GetValue(noCacheOption);
+
+            return await ExecuteAsync(
+                globalOptions,
+                full,
+                bugsOnly,
+                readyOnly,
+                allRepos,
+                repo,
+                noCache,
+                cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        GlobalOptionValues globalOptions,
+        bool full,
+        bool bugsOnly,
+        bool readyOnly,
+        bool allRepos,
+        string? repo,
+        bool noCache,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            // Create service with optional session integration
+            ISessionService? sessionService = null;
+            try
+            {
+                var spawner = new WindowsTerminalWorkerSpawner();
+                var sessionLogger = NullLogger<SessionService>.Instance;
+                sessionService = new SessionService(spawner, sessionLogger);
+            }
+            catch
+            {
+                // Session service not available, continue without it
+            }
+
+            var logger = NullLogger<BacklogService>.Instance;
+            var service = new BacklogService(sessionService, logger);
+
+            // Parse repo option if provided
+            string? owner = null;
+            string? repoName = null;
+            if (!string.IsNullOrEmpty(repo))
+            {
+                var parts = repo.Split('/');
+                if (parts.Length == 2)
+                {
+                    owner = parts[0];
+                    repoName = parts[1];
+                }
+            }
+
+            if (allRepos)
+            {
+                var ecosystem = await service.GetEcosystemBacklogAsync(noCache, cancellationToken);
+
+                if (globalOptions.IsJsonMode)
+                {
+                    writer.WriteSuccess(ecosystem);
+                }
+                else
+                {
+                    RenderEcosystemBacklog(ecosystem, full, bugsOnly, readyOnly);
+                }
+            }
+            else
+            {
+                var backlog = await service.GetBacklogAsync(owner, repoName, noCache, cancellationToken);
+
+                if (globalOptions.IsJsonMode)
+                {
+                    writer.WriteSuccess(backlog);
+                }
+                else
+                {
+                    RenderBacklog(backlog, full, bugsOnly, readyOnly);
+                }
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "fetching backlog", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static void RenderBacklog(BacklogData backlog, bool full, bool bugsOnly, bool readyOnly)
+    {
+        var rule = new Rule($"[bold blue]BACKLOG: {backlog.Repo}[/]")
+        {
+            Justification = Justify.Left
+        };
+        AnsiConsole.Write(rule);
+
+        if (backlog.FromCache)
+        {
+            var age = (int)(DateTimeOffset.UtcNow - backlog.FetchedAt).TotalMinutes;
+            Console.Error.WriteLine($"(cached {age}m ago)");
+        }
+
+        Console.WriteLine();
+
+        // Health metrics
+        if (!bugsOnly && !readyOnly)
+        {
+            RenderHealthMetrics(backlog.Health);
+            Console.WriteLine();
+        }
+
+        // Bugs
+        if (!readyOnly)
+        {
+            RenderCategory("BUGS", backlog.Bugs, full, item =>
+                $"[red]#{item.Number}[/] [[{EscapeMarkup(item.Priority ?? "?")}]] {EscapeMarkup(item.Title)} [dim]({item.AgeInDays}d)[/]" +
+                (item.ActiveSessionId != null ? $" [yellow][[{item.ActiveSessionStatus}]][/]" : ""));
+        }
+
+        // In Progress
+        if (!bugsOnly && !readyOnly)
+        {
+            RenderCategory("IN PROGRESS", backlog.InProgress, full, item =>
+            {
+                var assignee = item.Assignee != null ? $"@{item.Assignee}" : "unassigned";
+                return $"[yellow]#{item.Number}[/] [[{EscapeMarkup(item.Size ?? "?")}]] {EscapeMarkup(item.Title)} [dim]{assignee} ({item.AgeInDays}d)[/]" +
+                       (item.ActiveSessionId != null ? $" [green][[{item.ActiveSessionStatus}]][/]" : "");
+            });
+        }
+
+        // Blocked
+        if (!bugsOnly && !readyOnly)
+        {
+            RenderCategory("BLOCKED", backlog.Blocked, full, item =>
+                $"[grey]#{item.Number}[/] [[{EscapeMarkup(item.Size ?? "?")}]] {EscapeMarkup(item.Title)} [dim]({item.AgeInDays}d)[/]");
+        }
+
+        // Ready
+        if (!bugsOnly)
+        {
+            RenderCategory("READY FOR WORK", backlog.Ready, full, item =>
+                $"[green]#{item.Number}[/] [[{EscapeMarkup(item.Priority ?? "?")}, {EscapeMarkup(item.Size ?? "?")}]] {EscapeMarkup(item.Title)}" +
+                (item.ActiveSessionId != null ? $" [yellow][[{item.ActiveSessionStatus}]][/]" : ""));
+        }
+
+        // Untriaged
+        if (!bugsOnly && !readyOnly)
+        {
+            if (backlog.Untriaged.Count > 0)
+            {
+                Console.WriteLine($"[dim]UNTRIAGED ({backlog.Untriaged.Count})[/]");
+                Console.WriteLine($"  {backlog.Untriaged.Count} issues need triage (missing Size or Target)");
+                Console.WriteLine("  Run: /triage");
+                Console.WriteLine();
+            }
+        }
+
+        // PRs
+        if (!bugsOnly && !readyOnly && backlog.PullRequests.Count > 0)
+        {
+            AnsiConsole.MarkupLine($"[blue]OPEN PRs ({backlog.PullRequests.Count})[/]");
+            var prsToShow = full ? backlog.PullRequests : backlog.PullRequests.Take(5).ToList();
+            foreach (var pr in prsToShow)
+            {
+                var status = pr.IsDraft ? "[dim](Draft)[/]" : "[green](Review)[/]";
+                AnsiConsole.MarkupLine($"  #{pr.Number} {EscapeMarkup(pr.Title)} @{pr.Author} {status}");
+            }
+            if (!full && backlog.PullRequests.Count > 5)
+            {
+                Console.WriteLine($"  ... +{backlog.PullRequests.Count - 5} more (use --full to see all)");
+            }
+            Console.WriteLine();
+        }
+
+        // Tip
+        AnsiConsole.MarkupLine("[dim]TIP: Use ppds backlog --help to see all options[/]");
+    }
+
+    private static void RenderEcosystemBacklog(EcosystemBacklog ecosystem, bool full, bool bugsOnly, bool readyOnly)
+    {
+        var rule = new Rule("[bold blue]BACKLOG: PPDS Ecosystem[/]")
+        {
+            Justification = Justify.Left
+        };
+        AnsiConsole.Write(rule);
+        Console.WriteLine();
+
+        // Summary table
+        var table = new Table();
+        table.AddColumn("Repository");
+        table.AddColumn("Open", c => c.RightAligned());
+        table.AddColumn("Bugs", c => c.RightAligned());
+        table.AddColumn("In Progress", c => c.RightAligned());
+        table.AddColumn("Ready", c => c.RightAligned());
+
+        foreach (var repo in ecosystem.Repos)
+        {
+            table.AddRow(
+                repo.Repo,
+                repo.Health.OpenIssues.ToString(),
+                repo.Health.TotalBugs.ToString(),
+                repo.Health.InProgressCount.ToString(),
+                repo.Health.ReadyCount.ToString());
+        }
+
+        table.AddRow(
+            "[bold]TOTAL[/]",
+            $"[bold]{ecosystem.Health.OpenIssues}[/]",
+            $"[bold]{ecosystem.Health.TotalBugs}[/]",
+            $"[bold]{ecosystem.Health.InProgressCount}[/]",
+            $"[bold]{ecosystem.Health.ReadyCount}[/]");
+
+        AnsiConsole.Write(table);
+        Console.WriteLine();
+
+        // Aggregate bugs across repos
+        if (!readyOnly)
+        {
+            var allBugs = ecosystem.Repos.SelectMany(r => r.Bugs).OrderBy(b => GetPriorityOrder(b.Priority)).ToList();
+            RenderCategory("ALL BUGS", allBugs, full, item =>
+                $"[dim][[{GetRepoShortName(item.Repository)}]][/] [red]#{item.Number}[/] [[{EscapeMarkup(item.Priority ?? "?")}]] {EscapeMarkup(item.Title)}");
+        }
+
+        // Aggregate ready items
+        if (!bugsOnly)
+        {
+            var allReady = ecosystem.Repos.SelectMany(r => r.Ready).OrderBy(r => GetPriorityOrder(r.Priority)).ToList();
+            RenderCategory("TOP READY ITEMS", allReady, full, item =>
+                $"[dim][[{GetRepoShortName(item.Repository)}]][/] [green]#{item.Number}[/] [[{EscapeMarkup(item.Priority ?? "?")}, {EscapeMarkup(item.Size ?? "?")}]] {EscapeMarkup(item.Title)}");
+        }
+    }
+
+    private static void RenderHealthMetrics(HealthMetrics health)
+    {
+        AnsiConsole.MarkupLine("[bold]PROJECT HEALTH[/]");
+
+        var grid = new Grid();
+        grid.AddColumn();
+        grid.AddColumn();
+        grid.AddColumn();
+
+        grid.AddRow(
+            $"Open Issues: [bold]{health.OpenIssues}[/]",
+            $"In Progress: [bold]{health.InProgressCount}[/]",
+            $"PRs Open: [bold]{health.OpenPrs}[/]");
+
+        var bugColor = health.CriticalBugs > 0 ? "red" : (health.HighPriorityBugs > 0 ? "yellow" : "green");
+        var bugDetail = health.CriticalBugs > 0 ? $"({health.CriticalBugs} critical)" : "";
+
+        grid.AddRow(
+            $"Bugs: [{bugColor}]{health.TotalBugs}[/] {bugDetail}",
+            $"Ready: [bold]{health.ReadyCount}[/]",
+            $"Blocked: [bold]{health.BlockedCount}[/]");
+
+        AnsiConsole.Write(grid);
+    }
+
+    private static void RenderCategory(string title, IReadOnlyList<BacklogItem> items, bool full, Func<BacklogItem, string> formatter)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        AnsiConsole.MarkupLine($"[bold]{title} ({items.Count})[/]");
+
+        var itemsToShow = full ? items : items.Take(5).ToList();
+        foreach (var item in itemsToShow)
+        {
+            AnsiConsole.MarkupLine($"  {formatter(item)}");
+        }
+
+        if (!full && items.Count > 5)
+        {
+            Console.WriteLine($"  ... +{items.Count - 5} more (use --full to see all)");
+        }
+
+        Console.WriteLine();
+    }
+
+    private static string EscapeMarkup(string text)
+    {
+        return text.Replace("[", "[[").Replace("]", "]]");
+    }
+
+    private static int GetPriorityOrder(string? priority)
+    {
+        return priority?.ToUpperInvariant() switch
+        {
+            "P0-CRITICAL" or "P0" => 0,
+            "P1-HIGH" or "P1" => 1,
+            "P2-MEDIUM" or "P2" => 2,
+            "P3-LOW" or "P3" => 3,
+            _ => 99
+        };
+    }
+
+    private static string GetRepoShortName(string repository)
+    {
+        // "joshsmithxrm/power-platform-developer-suite" -> "ppds"
+        // "joshsmithxrm/ppds-docs" -> "docs"
+        var name = repository.Split('/').LastOrDefault() ?? repository;
+        if (name == "power-platform-developer-suite")
+        {
+            return "ppds";
+        }
+        if (name.StartsWith("ppds-"))
+        {
+            return name["ppds-".Length..];
+        }
+        return name;
+    }
+}

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -172,4 +172,19 @@ public static class ErrorCodes
         /// <summary>Invalid session status transition.</summary>
         public const string InvalidTransition = "Session.InvalidTransition";
     }
+
+    /// <summary>
+    /// External service errors.
+    /// </summary>
+    public static class External
+    {
+        /// <summary>GitHub API call failed.</summary>
+        public const string GitHubApiError = "External.GitHubApiError";
+
+        /// <summary>GitHub authentication failed.</summary>
+        public const string GitHubAuthError = "External.GitHubAuthError";
+
+        /// <summary>External service is unavailable.</summary>
+        public const string ServiceUnavailable = "External.ServiceUnavailable";
+    }
 }

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using PPDS.Cli.Commands.Auth;
+using PPDS.Cli.Commands.Backlog;
 using PPDS.Cli.Commands.Connections;
 using PPDS.Cli.Commands.ConnectionReferences;
 using PPDS.Cli.Commands.Data;
@@ -60,6 +61,7 @@ public static class Program
 
         // Add command groups
         rootCommand.Subcommands.Add(AuthCommandGroup.Create());
+        rootCommand.Subcommands.Add(BacklogCommandGroup.Create());
         rootCommand.Subcommands.Add(EnvCommandGroup.Create());
         rootCommand.Subcommands.Add(EnvCommandGroup.CreateOrgAlias()); // 'org' alias for 'env'
         rootCommand.Subcommands.Add(DataCommandGroup.Create());

--- a/src/PPDS.Cli/Services/Backlog/BacklogData.cs
+++ b/src/PPDS.Cli/Services/Backlog/BacklogData.cs
@@ -1,0 +1,351 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.Backlog;
+
+/// <summary>
+/// Backlog summary data for a repository or ecosystem.
+/// </summary>
+public sealed record BacklogData
+{
+    /// <summary>
+    /// Repository owner (e.g., "joshsmithxrm").
+    /// </summary>
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+
+    /// <summary>
+    /// Repository name (e.g., "power-platform-developer-suite").
+    /// </summary>
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    /// <summary>
+    /// When this data was fetched.
+    /// </summary>
+    [JsonPropertyName("fetchedAt")]
+    public required DateTimeOffset FetchedAt { get; init; }
+
+    /// <summary>
+    /// Whether this data came from cache.
+    /// </summary>
+    [JsonPropertyName("fromCache")]
+    public bool FromCache { get; init; }
+
+    /// <summary>
+    /// Project health metrics.
+    /// </summary>
+    [JsonPropertyName("health")]
+    public required HealthMetrics Health { get; init; }
+
+    /// <summary>
+    /// Active milestone progress (null if no active milestone).
+    /// </summary>
+    [JsonPropertyName("activeMilestone")]
+    public MilestoneProgress? ActiveMilestone { get; init; }
+
+    /// <summary>
+    /// Bug issues sorted by priority then age.
+    /// </summary>
+    [JsonPropertyName("bugs")]
+    public required IReadOnlyList<BacklogItem> Bugs { get; init; }
+
+    /// <summary>
+    /// Issues currently in progress.
+    /// </summary>
+    [JsonPropertyName("inProgress")]
+    public required IReadOnlyList<BacklogItem> InProgress { get; init; }
+
+    /// <summary>
+    /// Blocked issues.
+    /// </summary>
+    [JsonPropertyName("blocked")]
+    public required IReadOnlyList<BacklogItem> Blocked { get; init; }
+
+    /// <summary>
+    /// Ready-for-work issues (have Size and Target set).
+    /// </summary>
+    [JsonPropertyName("ready")]
+    public required IReadOnlyList<BacklogItem> Ready { get; init; }
+
+    /// <summary>
+    /// Issues missing Size or Target fields.
+    /// </summary>
+    [JsonPropertyName("untriaged")]
+    public required IReadOnlyList<BacklogItem> Untriaged { get; init; }
+
+    /// <summary>
+    /// Open pull requests.
+    /// </summary>
+    [JsonPropertyName("pullRequests")]
+    public required IReadOnlyList<OpenPullRequest> PullRequests { get; init; }
+}
+
+/// <summary>
+/// Cross-repo backlog aggregation.
+/// </summary>
+public sealed record EcosystemBacklog
+{
+    /// <summary>
+    /// Per-repo backlog data.
+    /// </summary>
+    [JsonPropertyName("repos")]
+    public required IReadOnlyList<BacklogData> Repos { get; init; }
+
+    /// <summary>
+    /// When this data was fetched.
+    /// </summary>
+    [JsonPropertyName("fetchedAt")]
+    public required DateTimeOffset FetchedAt { get; init; }
+
+    /// <summary>
+    /// Aggregated health metrics.
+    /// </summary>
+    [JsonPropertyName("health")]
+    public required HealthMetrics Health { get; init; }
+}
+
+/// <summary>
+/// Project health metrics.
+/// </summary>
+public sealed record HealthMetrics
+{
+    /// <summary>
+    /// Total open issues.
+    /// </summary>
+    [JsonPropertyName("openIssues")]
+    public int OpenIssues { get; init; }
+
+    /// <summary>
+    /// Number of open PRs.
+    /// </summary>
+    [JsonPropertyName("openPrs")]
+    public int OpenPrs { get; init; }
+
+    /// <summary>
+    /// Total bugs.
+    /// </summary>
+    [JsonPropertyName("totalBugs")]
+    public int TotalBugs { get; init; }
+
+    /// <summary>
+    /// Number of critical (P0) bugs.
+    /// </summary>
+    [JsonPropertyName("criticalBugs")]
+    public int CriticalBugs { get; init; }
+
+    /// <summary>
+    /// Number of high priority (P1) bugs.
+    /// </summary>
+    [JsonPropertyName("highPriorityBugs")]
+    public int HighPriorityBugs { get; init; }
+
+    /// <summary>
+    /// Issues in progress.
+    /// </summary>
+    [JsonPropertyName("inProgressCount")]
+    public int InProgressCount { get; init; }
+
+    /// <summary>
+    /// Ready-for-work issues.
+    /// </summary>
+    [JsonPropertyName("readyCount")]
+    public int ReadyCount { get; init; }
+
+    /// <summary>
+    /// Blocked issues.
+    /// </summary>
+    [JsonPropertyName("blockedCount")]
+    public int BlockedCount { get; init; }
+
+    /// <summary>
+    /// Untriaged issues.
+    /// </summary>
+    [JsonPropertyName("untriagedCount")]
+    public int UntriagedCount { get; init; }
+}
+
+/// <summary>
+/// Milestone progress information.
+/// </summary>
+public sealed record MilestoneProgress
+{
+    /// <summary>
+    /// Milestone title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Completed issues in milestone.
+    /// </summary>
+    [JsonPropertyName("completedCount")]
+    public int CompletedCount { get; init; }
+
+    /// <summary>
+    /// Total issues in milestone.
+    /// </summary>
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Target date (if set).
+    /// </summary>
+    [JsonPropertyName("dueOn")]
+    public DateTimeOffset? DueOn { get; init; }
+
+    /// <summary>
+    /// Completion percentage.
+    /// </summary>
+    [JsonPropertyName("percentComplete")]
+    public int PercentComplete => TotalCount > 0 ? (int)((CompletedCount * 100.0) / TotalCount) : 0;
+}
+
+/// <summary>
+/// A single backlog item (issue).
+/// </summary>
+public sealed record BacklogItem
+{
+    /// <summary>
+    /// GitHub issue number.
+    /// </summary>
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    /// <summary>
+    /// Issue title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Repository identifier (e.g., "joshsmithxrm/power-platform-developer-suite").
+    /// </summary>
+    [JsonPropertyName("repository")]
+    public required string Repository { get; init; }
+
+    /// <summary>
+    /// Project type field value (bug, feature, enhancement, etc.).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// Project priority field value (P0-Critical, P1-High, P2-Medium, P3-Low).
+    /// </summary>
+    [JsonPropertyName("priority")]
+    public string? Priority { get; init; }
+
+    /// <summary>
+    /// Project size field value (XS, S, M, L, XL).
+    /// </summary>
+    [JsonPropertyName("size")]
+    public string? Size { get; init; }
+
+    /// <summary>
+    /// Project status field value (Todo, In Progress, Blocked, Done).
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Project target field value (milestone/sprint).
+    /// </summary>
+    [JsonPropertyName("target")]
+    public string? Target { get; init; }
+
+    /// <summary>
+    /// Primary assignee login (null if unassigned).
+    /// </summary>
+    [JsonPropertyName("assignee")]
+    public string? Assignee { get; init; }
+
+    /// <summary>
+    /// Milestone title (if assigned to a milestone).
+    /// </summary>
+    [JsonPropertyName("milestone")]
+    public string? Milestone { get; init; }
+
+    /// <summary>
+    /// Issue labels.
+    /// </summary>
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<string> Labels { get; init; } = [];
+
+    /// <summary>
+    /// When the issue was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Age in days since creation.
+    /// </summary>
+    [JsonPropertyName("ageInDays")]
+    public int AgeInDays => (int)(DateTimeOffset.UtcNow - CreatedAt).TotalDays;
+
+    /// <summary>
+    /// Active worker session ID for this issue (null if no active session).
+    /// </summary>
+    [JsonPropertyName("activeSessionId")]
+    public string? ActiveSessionId { get; init; }
+
+    /// <summary>
+    /// Active worker session status (null if no active session).
+    /// </summary>
+    [JsonPropertyName("activeSessionStatus")]
+    public string? ActiveSessionStatus { get; init; }
+}
+
+/// <summary>
+/// An open pull request.
+/// </summary>
+public sealed record OpenPullRequest
+{
+    /// <summary>
+    /// PR number.
+    /// </summary>
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    /// <summary>
+    /// PR title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Repository identifier.
+    /// </summary>
+    [JsonPropertyName("repository")]
+    public required string Repository { get; init; }
+
+    /// <summary>
+    /// Head branch name.
+    /// </summary>
+    [JsonPropertyName("headBranch")]
+    public required string HeadBranch { get; init; }
+
+    /// <summary>
+    /// Author login.
+    /// </summary>
+    [JsonPropertyName("author")]
+    public required string Author { get; init; }
+
+    /// <summary>
+    /// When the PR was created.
+    /// </summary>
+    [JsonPropertyName("createdAt")]
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>
+    /// Whether this is a draft PR.
+    /// </summary>
+    [JsonPropertyName("isDraft")]
+    public bool IsDraft { get; init; }
+
+    /// <summary>
+    /// Associated issue number (if PR references an issue).
+    /// </summary>
+    [JsonPropertyName("linkedIssue")]
+    public int? LinkedIssue { get; init; }
+}

--- a/src/PPDS.Cli/Services/Backlog/BacklogService.cs
+++ b/src/PPDS.Cli/Services/Backlog/BacklogService.cs
@@ -1,0 +1,791 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.Session;
+
+namespace PPDS.Cli.Services.Backlog;
+
+/// <summary>
+/// Service for fetching and categorizing GitHub project backlog.
+/// </summary>
+public sealed class BacklogService : IBacklogService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    /// <summary>
+    /// GitHub Project ID for the PPDS project (tracks all repos).
+    /// </summary>
+    private const string ProjectId = "PVT_kwHOAGk32c4BLj-0";
+
+    /// <summary>
+    /// Default cache TTL in minutes.
+    /// </summary>
+    private const int DefaultCacheTtlMinutes = 5;
+
+    /// <summary>
+    /// Default owner when not detected from git.
+    /// </summary>
+    private const string DefaultOwner = "joshsmithxrm";
+
+    /// <summary>
+    /// Default repo when not detected from git.
+    /// </summary>
+    private const string DefaultRepo = "power-platform-developer-suite";
+
+    private readonly ISessionService? _sessionService;
+    private readonly ILogger<BacklogService> _logger;
+    private readonly string _cacheDir;
+    private readonly string _repoRoot;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BacklogService"/> class.
+    /// </summary>
+    public BacklogService(ISessionService? sessionService, ILogger<BacklogService> logger)
+    {
+        _sessionService = sessionService;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var userProfile = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        _cacheDir = Path.Combine(userProfile, ".ppds", "cache");
+        Directory.CreateDirectory(_cacheDir);
+
+        // Try to find repo root, but don't fail if not in a repo
+        _repoRoot = FindRepoRoot(Directory.GetCurrentDirectory()) ?? Directory.GetCurrentDirectory();
+    }
+
+    /// <inheritdoc />
+    public async Task<BacklogData> GetBacklogAsync(
+        string? owner = null,
+        string? repo = null,
+        bool noCache = false,
+        CancellationToken cancellationToken = default)
+    {
+        // Resolve owner/repo
+        var (resolvedOwner, resolvedRepo) = await ResolveOwnerRepoAsync(owner, repo, cancellationToken);
+        var repoFilter = $"{resolvedOwner}/{resolvedRepo}";
+
+        // Check cache
+        var cacheFile = GetCacheFilePath();
+        if (!noCache && TryReadCache(cacheFile, out var cachedData))
+        {
+            // Filter to requested repo and mark as from cache
+            return FilterToRepo(cachedData!, repoFilter, fromCache: true);
+        }
+
+        // Fetch fresh data from GitHub
+        var allData = await FetchProjectDataAsync(cancellationToken);
+
+        // Cache the full data
+        WriteCache(cacheFile, allData);
+
+        // Filter to requested repo
+        return FilterToRepo(allData, repoFilter, fromCache: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<EcosystemBacklog> GetEcosystemBacklogAsync(
+        bool noCache = false,
+        CancellationToken cancellationToken = default)
+    {
+        // Check cache
+        var cacheFile = GetCacheFilePath();
+        if (!noCache && TryReadCache(cacheFile, out var cachedData))
+        {
+            return CreateEcosystemBacklog(cachedData!, fromCache: true);
+        }
+
+        // Fetch fresh data
+        var allData = await FetchProjectDataAsync(cancellationToken);
+
+        // Cache the data
+        WriteCache(cacheFile, allData);
+
+        return CreateEcosystemBacklog(allData, fromCache: false);
+    }
+
+    /// <inheritdoc />
+    public void InvalidateCache()
+    {
+        var cacheFile = GetCacheFilePath();
+        if (File.Exists(cacheFile))
+        {
+            File.Delete(cacheFile);
+            _logger.LogDebug("Backlog cache invalidated");
+        }
+    }
+
+    private string GetCacheFilePath() => Path.Combine(_cacheDir, "backlog.json");
+
+    private bool TryReadCache(string cacheFile, out CachedBacklogData? data)
+    {
+        data = null;
+
+        if (!File.Exists(cacheFile))
+        {
+            return false;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(cacheFile);
+            var cached = JsonSerializer.Deserialize<CachedBacklogData>(json, JsonOptions);
+
+            if (cached == null)
+            {
+                return false;
+            }
+
+            // Check TTL
+            var age = DateTimeOffset.UtcNow - cached.FetchedAt;
+            if (age.TotalMinutes > DefaultCacheTtlMinutes)
+            {
+                _logger.LogDebug("Backlog cache expired ({Age} minutes old)", (int)age.TotalMinutes);
+                return false;
+            }
+
+            data = cached;
+            _logger.LogDebug("Using cached backlog data ({Age} minutes old)", (int)age.TotalMinutes);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read backlog cache");
+            return false;
+        }
+    }
+
+    private void WriteCache(string cacheFile, CachedBacklogData data)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(data, JsonOptions);
+            File.WriteAllText(cacheFile, json);
+            _logger.LogDebug("Backlog data cached");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write backlog cache");
+        }
+    }
+
+    private async Task<CachedBacklogData> FetchProjectDataAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Fetching project data from GitHub...");
+
+        var allItems = new List<ProjectItem>();
+        string? cursor = null;
+
+        // Paginate through all project items
+        do
+        {
+            var (items, nextCursor) = await FetchProjectPageAsync(cursor, cancellationToken);
+            allItems.AddRange(items);
+            cursor = nextCursor;
+        }
+        while (cursor != null);
+
+        _logger.LogDebug("Fetched {Count} project items", allItems.Count);
+
+        // Get active sessions for correlation
+        var sessionsByIssue = await GetActiveSessionsAsync(cancellationToken);
+
+        // Convert to BacklogItems and categorize
+        var now = DateTimeOffset.UtcNow;
+        var bugs = new List<BacklogItem>();
+        var inProgress = new List<BacklogItem>();
+        var blocked = new List<BacklogItem>();
+        var ready = new List<BacklogItem>();
+        var untriaged = new List<BacklogItem>();
+
+        foreach (var item in allItems)
+        {
+            // Skip closed issues
+            if (item.State != "OPEN")
+            {
+                continue;
+            }
+
+            var backlogItem = ToBacklogItem(item, sessionsByIssue);
+
+            // Categorize based on type, status, and fields
+            if (IsBug(backlogItem))
+            {
+                bugs.Add(backlogItem);
+            }
+            else if (backlogItem.Status?.Equals("In Progress", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                inProgress.Add(backlogItem);
+            }
+            else if (backlogItem.Status?.Equals("Blocked", StringComparison.OrdinalIgnoreCase) == true ||
+                     backlogItem.Labels.Any(l => l.Equals("blocked", StringComparison.OrdinalIgnoreCase)))
+            {
+                blocked.Add(backlogItem);
+            }
+            else if (!string.IsNullOrEmpty(backlogItem.Size) && !string.IsNullOrEmpty(backlogItem.Target))
+            {
+                ready.Add(backlogItem);
+            }
+            else
+            {
+                untriaged.Add(backlogItem);
+            }
+        }
+
+        // Sort categories
+        bugs = bugs.OrderBy(b => GetPriorityOrder(b.Priority)).ThenByDescending(b => b.AgeInDays).ToList();
+        inProgress = inProgress.OrderByDescending(i => i.AgeInDays).ToList();
+        blocked = blocked.OrderByDescending(b => b.AgeInDays).ToList();
+        ready = ready.OrderBy(r => GetPriorityOrder(r.Priority)).ThenBy(r => GetSizeOrder(r.Size)).ToList();
+        untriaged = untriaged.OrderByDescending(u => u.AgeInDays).ToList();
+
+        // Fetch PRs separately
+        var prs = await FetchOpenPullRequestsAsync(cancellationToken);
+
+        return new CachedBacklogData
+        {
+            FetchedAt = now,
+            Bugs = bugs,
+            InProgress = inProgress,
+            Blocked = blocked,
+            Ready = ready,
+            Untriaged = untriaged,
+            PullRequests = prs
+        };
+    }
+
+    private async Task<(List<ProjectItem> Items, string? NextCursor)> FetchProjectPageAsync(
+        string? cursor,
+        CancellationToken cancellationToken)
+    {
+        // Build GraphQL query
+        var afterClause = cursor != null ? $", after: \"{cursor}\"" : "";
+        var query = $$"""
+            query {
+              node(id: "{{ProjectId}}") {
+                ... on ProjectV2 {
+                  items(first: 100{{afterClause}}) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      content {
+                        ... on Issue {
+                          number
+                          state
+                          title
+                          createdAt
+                          repository { nameWithOwner }
+                          labels(first: 10) { nodes { name } }
+                          assignees(first: 3) { nodes { login } }
+                          milestone { title }
+                        }
+                      }
+                      fieldValues(first: 10) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { name } }
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            Arguments = "api graphql -f query=\"" + query.Replace("\"", "\\\"").Replace("\n", " ").Replace("\r", "") + "\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = _repoRoot
+        };
+
+        using var process = Process.Start(startInfo)
+            ?? throw new PpdsException(ErrorCodes.External.GitHubApiError, "Failed to start gh process");
+
+        var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        var output = await outputTask;
+        var error = await errorTask;
+
+        if (process.ExitCode != 0)
+        {
+            _logger.LogError("GitHub API error: {Error}", error);
+            throw new PpdsException(
+                ErrorCodes.External.GitHubApiError,
+                $"Failed to fetch project data from GitHub: {error}");
+        }
+
+        // Parse response
+        var items = new List<ProjectItem>();
+        string? nextCursor = null;
+
+        try
+        {
+            var json = JsonNode.Parse(output);
+            var projectNode = json?["data"]?["node"]?["items"];
+
+            if (projectNode == null)
+            {
+                _logger.LogWarning("Unexpected GraphQL response structure");
+                return (items, null);
+            }
+
+            var pageInfo = projectNode["pageInfo"];
+            var hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+            nextCursor = hasNextPage ? pageInfo?["endCursor"]?.GetValue<string>() : null;
+
+            var nodes = projectNode["nodes"]?.AsArray();
+            if (nodes == null)
+            {
+                return (items, nextCursor);
+            }
+
+            foreach (var node in nodes)
+            {
+                var content = node?["content"];
+                if (content == null || content.GetValueKind() == JsonValueKind.Null)
+                {
+                    continue; // Skip non-issue items (draft issues, etc.)
+                }
+
+                var item = new ProjectItem
+                {
+                    Number = content["number"]?.GetValue<int>() ?? 0,
+                    State = content["state"]?.GetValue<string>() ?? "OPEN",
+                    Title = content["title"]?.GetValue<string>() ?? "",
+                    CreatedAt = DateTimeOffset.TryParse(
+                        content["createdAt"]?.GetValue<string>(),
+                        out var created) ? created : DateTimeOffset.UtcNow,
+                    Repository = content["repository"]?["nameWithOwner"]?.GetValue<string>() ?? "",
+                    Labels = content["labels"]?["nodes"]?.AsArray()?
+                        .Select(l => l?["name"]?.GetValue<string>() ?? "")
+                        .Where(l => !string.IsNullOrEmpty(l))
+                        .ToList() ?? [],
+                    Assignee = content["assignees"]?["nodes"]?.AsArray()?
+                        .FirstOrDefault()?["login"]?.GetValue<string>(),
+                    Milestone = content["milestone"]?["title"]?.GetValue<string>()
+                };
+
+                // Parse field values
+                if (node?["fieldValues"]?["nodes"]?.AsArray() is { } fieldValues)
+                {
+                    foreach (var fv in fieldValues)
+                    {
+                        var fieldName = fv?["field"]?["name"]?.GetValue<string>();
+                        var value = fv?["name"]?.GetValue<string>();
+
+                        if (string.IsNullOrEmpty(fieldName) || string.IsNullOrEmpty(value))
+                        {
+                            continue;
+                        }
+
+                        switch (fieldName.ToLowerInvariant())
+                        {
+                            case "status":
+                                item.Status = value;
+                                break;
+                            case "type":
+                                item.Type = value;
+                                break;
+                            case "priority":
+                                item.Priority = value;
+                                break;
+                            case "size":
+                                item.Size = value;
+                                break;
+                            case "target":
+                                item.Target = value;
+                                break;
+                        }
+                    }
+                }
+
+                items.Add(item);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse GraphQL response");
+            throw new PpdsException(
+                ErrorCodes.External.GitHubApiError,
+                "Failed to parse GitHub project data");
+        }
+
+        return (items, nextCursor);
+    }
+
+    private async Task<List<OpenPullRequest>> FetchOpenPullRequestsAsync(CancellationToken cancellationToken)
+    {
+        var prs = new List<OpenPullRequest>();
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            Arguments = "pr list --state open --json number,title,headRefName,author,createdAt,isDraft,repository --limit 50",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = _repoRoot
+        };
+
+        using var process = Process.Start(startInfo);
+        if (process == null)
+        {
+            return prs;
+        }
+
+        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+        {
+            _logger.LogWarning("Failed to fetch PRs");
+            return prs;
+        }
+
+        try
+        {
+            var nodes = JsonNode.Parse(output)?.AsArray();
+            if (nodes == null)
+            {
+                return prs;
+            }
+
+            foreach (var node in nodes)
+            {
+                prs.Add(new OpenPullRequest
+                {
+                    Number = node?["number"]?.GetValue<int>() ?? 0,
+                    Title = node?["title"]?.GetValue<string>() ?? "",
+                    Repository = node?["repository"]?["nameWithOwner"]?.GetValue<string>() ?? "",
+                    HeadBranch = node?["headRefName"]?.GetValue<string>() ?? "",
+                    Author = node?["author"]?["login"]?.GetValue<string>() ?? "",
+                    CreatedAt = DateTimeOffset.TryParse(
+                        node?["createdAt"]?.GetValue<string>(),
+                        out var created) ? created : DateTimeOffset.UtcNow,
+                    IsDraft = node?["isDraft"]?.GetValue<bool>() ?? false,
+                    LinkedIssue = ExtractLinkedIssue(node?["headRefName"]?.GetValue<string>())
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse PR response");
+        }
+
+        return prs;
+    }
+
+    private async Task<Dictionary<int, SessionState>> GetActiveSessionsAsync(CancellationToken cancellationToken)
+    {
+        if (_sessionService == null)
+        {
+            return [];
+        }
+
+        try
+        {
+            var sessions = await _sessionService.ListAsync(cancellationToken);
+            return sessions
+                .Where(s => s.Status is not SessionStatus.Complete)
+                .ToDictionary(s => s.IssueNumber);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get active sessions");
+            return [];
+        }
+    }
+
+    private BacklogItem ToBacklogItem(ProjectItem item, Dictionary<int, SessionState> sessions)
+    {
+        sessions.TryGetValue(item.Number, out var session);
+
+        return new BacklogItem
+        {
+            Number = item.Number,
+            Title = item.Title,
+            Repository = item.Repository,
+            Type = item.Type,
+            Priority = item.Priority,
+            Size = item.Size,
+            Status = item.Status,
+            Target = item.Target,
+            Assignee = item.Assignee,
+            Milestone = item.Milestone,
+            Labels = item.Labels,
+            CreatedAt = item.CreatedAt,
+            ActiveSessionId = session?.Id,
+            ActiveSessionStatus = session?.Status.ToString()
+        };
+    }
+
+    private static bool IsBug(BacklogItem item)
+    {
+        if (item.Type?.Equals("bug", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return true;
+        }
+
+        return item.Labels.Any(l => l.Equals("bug", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static int GetPriorityOrder(string? priority)
+    {
+        return priority?.ToUpperInvariant() switch
+        {
+            "P0-CRITICAL" or "P0" => 0,
+            "P1-HIGH" or "P1" => 1,
+            "P2-MEDIUM" or "P2" => 2,
+            "P3-LOW" or "P3" => 3,
+            _ => 99
+        };
+    }
+
+    private static int GetSizeOrder(string? size)
+    {
+        return size?.ToUpperInvariant() switch
+        {
+            "XS" => 0,
+            "S" => 1,
+            "M" => 2,
+            "L" => 3,
+            "XL" => 4,
+            _ => 99
+        };
+    }
+
+    private static int? ExtractLinkedIssue(string? branchName)
+    {
+        if (string.IsNullOrEmpty(branchName))
+        {
+            return null;
+        }
+
+        // Match patterns like "issue-123" or "123-feature-name"
+        var match = System.Text.RegularExpressions.Regex.Match(branchName, @"(?:issue-)?(\d+)");
+        if (match.Success && int.TryParse(match.Groups[1].Value, out var issueNumber))
+        {
+            return issueNumber;
+        }
+
+        return null;
+    }
+
+    private BacklogData FilterToRepo(CachedBacklogData data, string repoFilter, bool fromCache)
+    {
+        bool MatchesRepo(BacklogItem item) =>
+            item.Repository.Equals(repoFilter, StringComparison.OrdinalIgnoreCase);
+
+        bool MatchesPrRepo(OpenPullRequest pr) =>
+            string.IsNullOrEmpty(pr.Repository) || pr.Repository.Equals(repoFilter, StringComparison.OrdinalIgnoreCase);
+
+        var bugs = data.Bugs.Where(MatchesRepo).ToList();
+        var inProgress = data.InProgress.Where(MatchesRepo).ToList();
+        var blocked = data.Blocked.Where(MatchesRepo).ToList();
+        var ready = data.Ready.Where(MatchesRepo).ToList();
+        var untriaged = data.Untriaged.Where(MatchesRepo).ToList();
+        var prs = data.PullRequests.Where(MatchesPrRepo).ToList();
+
+        var parts = repoFilter.Split('/');
+        var owner = parts.Length > 0 ? parts[0] : DefaultOwner;
+        var repo = parts.Length > 1 ? parts[1] : DefaultRepo;
+
+        return new BacklogData
+        {
+            Owner = owner,
+            Repo = repo,
+            FetchedAt = data.FetchedAt,
+            FromCache = fromCache,
+            Health = new HealthMetrics
+            {
+                OpenIssues = bugs.Count + inProgress.Count + blocked.Count + ready.Count + untriaged.Count,
+                OpenPrs = prs.Count,
+                TotalBugs = bugs.Count,
+                CriticalBugs = bugs.Count(b => b.Priority?.Contains("P0", StringComparison.OrdinalIgnoreCase) == true),
+                HighPriorityBugs = bugs.Count(b => b.Priority?.Contains("P1", StringComparison.OrdinalIgnoreCase) == true),
+                InProgressCount = inProgress.Count,
+                ReadyCount = ready.Count,
+                BlockedCount = blocked.Count,
+                UntriagedCount = untriaged.Count
+            },
+            Bugs = bugs,
+            InProgress = inProgress,
+            Blocked = blocked,
+            Ready = ready,
+            Untriaged = untriaged,
+            PullRequests = prs
+        };
+    }
+
+    private EcosystemBacklog CreateEcosystemBacklog(CachedBacklogData data, bool fromCache)
+    {
+        // Group by repo
+        var repos = data.Bugs.Concat(data.InProgress).Concat(data.Blocked).Concat(data.Ready).Concat(data.Untriaged)
+            .Select(i => i.Repository)
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct()
+            .ToList();
+
+        var repoBacklogs = repos.Select(r => FilterToRepo(data, r, fromCache)).ToList();
+
+        return new EcosystemBacklog
+        {
+            Repos = repoBacklogs,
+            FetchedAt = data.FetchedAt,
+            Health = new HealthMetrics
+            {
+                OpenIssues = data.Bugs.Count + data.InProgress.Count + data.Blocked.Count + data.Ready.Count + data.Untriaged.Count,
+                OpenPrs = data.PullRequests.Count,
+                TotalBugs = data.Bugs.Count,
+                CriticalBugs = data.Bugs.Count(b => b.Priority?.Contains("P0", StringComparison.OrdinalIgnoreCase) == true),
+                HighPriorityBugs = data.Bugs.Count(b => b.Priority?.Contains("P1", StringComparison.OrdinalIgnoreCase) == true),
+                InProgressCount = data.InProgress.Count,
+                ReadyCount = data.Ready.Count,
+                BlockedCount = data.Blocked.Count,
+                UntriagedCount = data.Untriaged.Count
+            }
+        };
+    }
+
+    private async Task<(string Owner, string Repo)> ResolveOwnerRepoAsync(
+        string? owner,
+        string? repo,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
+        {
+            return (owner, repo);
+        }
+
+        // Try to detect from git remote
+        try
+        {
+            var remoteUrl = await GetGitHubRemoteAsync(cancellationToken);
+            return ParseGitHubUrl(remoteUrl);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not detect repo from git remote, using defaults");
+            return (DefaultOwner, DefaultRepo);
+        }
+    }
+
+    private async Task<string> GetGitHubRemoteAsync(CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = "remote get-url origin",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = _repoRoot
+        };
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git process");
+
+        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException("Failed to get git remote URL");
+        }
+
+        return output.Trim();
+    }
+
+    private static (string Owner, string Repo) ParseGitHubUrl(string remoteUrl)
+    {
+        var url = remoteUrl.Trim();
+        if (url.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            url = url[..^4];
+        }
+
+        string? path = null;
+        if (url.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
+        {
+            path = url["https://github.com/".Length..];
+        }
+        else if (url.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+        {
+            path = url["git@github.com:".Length..];
+        }
+
+        if (path != null)
+        {
+            var parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2)
+            {
+                return (parts[0], parts[1]);
+            }
+        }
+
+        throw new ArgumentException($"Cannot parse GitHub URL: {remoteUrl}");
+    }
+
+    private static string? FindRepoRoot(string startPath)
+    {
+        var dir = new DirectoryInfo(startPath);
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    #region Internal Types
+
+    private sealed class ProjectItem
+    {
+        public int Number { get; set; }
+        public string State { get; set; } = "OPEN";
+        public string Title { get; set; } = "";
+        public DateTimeOffset CreatedAt { get; set; }
+        public string Repository { get; set; } = "";
+        public List<string> Labels { get; set; } = [];
+        public string? Assignee { get; set; }
+        public string? Milestone { get; set; }
+        public string? Status { get; set; }
+        public string? Type { get; set; }
+        public string? Priority { get; set; }
+        public string? Size { get; set; }
+        public string? Target { get; set; }
+    }
+
+    private sealed class CachedBacklogData
+    {
+        public DateTimeOffset FetchedAt { get; set; }
+        public List<BacklogItem> Bugs { get; set; } = [];
+        public List<BacklogItem> InProgress { get; set; } = [];
+        public List<BacklogItem> Blocked { get; set; } = [];
+        public List<BacklogItem> Ready { get; set; } = [];
+        public List<BacklogItem> Untriaged { get; set; } = [];
+        public List<OpenPullRequest> PullRequests { get; set; } = [];
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Services/Backlog/IBacklogService.cs
+++ b/src/PPDS.Cli/Services/Backlog/IBacklogService.cs
@@ -1,0 +1,55 @@
+namespace PPDS.Cli.Services.Backlog;
+
+/// <summary>
+/// Application service for fetching and categorizing GitHub project backlog.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This service fetches issues from GitHub Projects v2 and categorizes them
+/// by type, status, priority, and readiness. Results are cached to avoid
+/// repeated API calls.
+/// </para>
+/// <para>
+/// The service integrates with <see cref="Session.ISessionService"/> to show
+/// which issues have active worker sessions.
+/// </para>
+/// </remarks>
+public interface IBacklogService
+{
+    /// <summary>
+    /// Gets the backlog for a specific repository.
+    /// </summary>
+    /// <param name="owner">Repository owner (optional, detected from git remote).</param>
+    /// <param name="repo">Repository name (optional, detected from git remote).</param>
+    /// <param name="noCache">If true, bypass cache and fetch fresh data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Categorized backlog data.</returns>
+    /// <remarks>
+    /// If owner/repo are not specified, they are detected from the current git remote.
+    /// Data is cached for 5 minutes unless noCache is true.
+    /// </remarks>
+    Task<BacklogData> GetBacklogAsync(
+        string? owner = null,
+        string? repo = null,
+        bool noCache = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the backlog aggregated across all PPDS ecosystem repositories.
+    /// </summary>
+    /// <param name="noCache">If true, bypass cache and fetch fresh data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Aggregated backlog across all repos.</returns>
+    /// <remarks>
+    /// Since the GitHub Project tracks all repos, this returns data from a single
+    /// project query, filtered and grouped by repository.
+    /// </remarks>
+    Task<EcosystemBacklog> GetEcosystemBacklogAsync(
+        bool noCache = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invalidates the backlog cache.
+    /// </summary>
+    void InvalidateCache();
+}

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -4,6 +4,7 @@ using PPDS.Auth.Credentials;
 using PPDS.Auth.Profiles;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Plugins.Registration;
+using PPDS.Cli.Services.Backlog;
 using PPDS.Cli.Services.Environment;
 using PPDS.Cli.Services.Export;
 using PPDS.Cli.Services.History;
@@ -58,6 +59,9 @@ public static class ServiceRegistration
         // Session orchestration services
         services.AddSingleton<IWorkerSpawner, WindowsTerminalWorkerSpawner>();
         services.AddSingleton<ISessionService, SessionService>();
+
+        // Backlog service - depends on session service for worker correlation
+        services.AddTransient<IBacklogService, BacklogService>();
 
         // Connection service - requires profile-based token provider and environment ID
         // Registered as factory because it needs runtime values from ResolvedConnectionInfo


### PR DESCRIPTION
## Summary

- Add `ppds backlog` CLI command for viewing project health and backlog status
- Fetch and categorize issues from GitHub Projects v2 (Bugs, In Progress, Blocked, Ready, Untriaged)
- Add cross-repo ecosystem view (`--all`) using shared GitHub Project
- Implement 5-minute caching in `~/.ppds/cache/backlog.json`
- Integrate with session service to show active worker sessions
- Support JSON output mode (`--output-format json`) for piping
- Add `External` error code category for GitHub API errors

## Changes

| File | Change |
|------|--------|
| `src/PPDS.Cli/Commands/Backlog/BacklogCommandGroup.cs` | CLI command with Spectre.Console output |
| `src/PPDS.Cli/Services/Backlog/IBacklogService.cs` | Service interface |
| `src/PPDS.Cli/Services/Backlog/BacklogService.cs` | Implementation with gh CLI wrapper, caching |
| `src/PPDS.Cli/Services/Backlog/BacklogData.cs` | Domain models |
| `.claude/commands/backlog.md` | Simplified command spec (357→95 lines) |

## Test plan

- [x] Unit tests pass (1293 tests)
- [x] `ppds backlog` shows categorized issues
- [x] `ppds backlog --all` shows cross-repo ecosystem view
- [x] `ppds backlog --output-format json` outputs valid JSON
- [x] Caching works (shows "cached Xm ago")

🤖 Generated with [Claude Code](https://claude.com/claude-code)