### PR TITLE
fix(migration): include M2M records in import throughput calculation

### DIFF
--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -402,14 +402,19 @@ namespace PPDS.Migration.Import
                     ? entityResults.Sum(r => r.UpdatedCount ?? 0)
                     : (int?)null;
 
+                // Include M2M relationship failures in total failure count
+                var m2mFailureCount = relationshipResult.FailureCount;
+                var totalFailureCount = recordFailureCount + m2mFailureCount;
+
                 progress?.Complete(new MigrationResult
                 {
                     Success = result.Success,
-                    RecordsProcessed = result.RecordsImported + result.RecordsUpdated + recordFailureCount,
-                    SuccessCount = result.RecordsImported + result.RecordsUpdated,
-                    FailureCount = recordFailureCount,
+                    RecordsProcessed = result.RecordsImported + result.RecordsUpdated + totalFailureCount + relationshipsProcessed,
+                    SuccessCount = result.RecordsImported + result.RecordsUpdated + relationshipsProcessed,
+                    FailureCount = totalFailureCount,
                     CreatedCount = totalCreated,
                     UpdatedCount = totalUpdated,
+                    M2MCount = relationshipsProcessed > 0 ? relationshipsProcessed : null,
                     Duration = result.Duration,
                     Errors = errors.ToArray()
                 });

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -182,7 +182,11 @@ namespace PPDS.Migration.Progress
             Console.ResetColor();
 
             // Summary line: "    42,366 records in 00:00:08 (4,774.5 rec/s)"
-            Console.Error.WriteLine($"    {result.SuccessCount:N0} record(s) in {result.Duration:hh\\:mm\\:ss} ({result.RecordsPerSecond:F1} rec/s)");
+            // Include M2M breakdown if present: "... [42,000 entities + 366 M2M]"
+            var m2mBreakdown = result.M2MCount.HasValue && result.M2MCount.Value > 0
+                ? $" [{result.SuccessCount - result.M2MCount.Value:N0} entities + {result.M2MCount.Value:N0} M2M]"
+                : "";
+            Console.Error.WriteLine($"    {result.SuccessCount:N0} record(s) in {result.Duration:hh\\:mm\\:ss} ({result.RecordsPerSecond:F1} rec/s){m2mBreakdown}");
 
             // Show created/updated breakdown for upsert operations
             if (result.CreatedCount.HasValue && result.UpdatedCount.HasValue)

--- a/src/PPDS.Migration/Progress/MigrationResult.cs
+++ b/src/PPDS.Migration/Progress/MigrationResult.cs
@@ -52,6 +52,12 @@ namespace PPDS.Migration.Progress
         public int? UpdatedCount { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of M2M (many-to-many) relationship records processed.
+        /// Only populated for import operations; null otherwise.
+        /// </summary>
+        public int? M2MCount { get; set; }
+
+        /// <summary>
         /// Gets the average records per second.
         /// </summary>
         public double RecordsPerSecond => Duration.TotalSeconds > 0

--- a/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
@@ -19,6 +19,7 @@ public class MigrationResultTests
         result.Errors.Should().NotBeNull().And.BeEmpty();
         result.CreatedCount.Should().BeNull();
         result.UpdatedCount.Should().BeNull();
+        result.M2MCount.Should().BeNull();
     }
 
     [Fact]
@@ -36,7 +37,8 @@ public class MigrationResultTests
             Duration = duration,
             Errors = errors,
             CreatedCount = 3000,
-            UpdatedCount = 1950
+            UpdatedCount = 1950,
+            M2MCount = 500
         };
 
         result.Success.Should().BeTrue();
@@ -47,6 +49,7 @@ public class MigrationResultTests
         result.Errors.Should().HaveCount(1);
         result.CreatedCount.Should().Be(3000);
         result.UpdatedCount.Should().Be(1950);
+        result.M2MCount.Should().Be(500);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add M2MCount property to MigrationResult to track many-to-many relationship records
- Include relationshipsProcessed in TieredImporter completion statistics 
- Show entity + M2M breakdown in completion message when M2M records are present
- Update MigrationResultTests for new M2MCount property

**Before:**
```
Import succeeded.
    145,348 record(s) in 00:09:05 (266.2 rec/s)
```

**After:**
```
Import succeeded.
    205,762 record(s) in 00:09:05 (377.5 rec/s) [145,348 entities + 60,414 M2M]
```

## Test plan

- [x] Unit tests pass
- [x] MigrationResultTests updated with M2MCount property coverage
- [x] Build succeeds in Release configuration

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)