### PR TITLE
feat(rpc): add solutions/* RPC methods

### DIFF
--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -187,4 +187,13 @@ public static class ErrorCodes
         /// <summary>External service is unavailable.</summary>
         public const string ServiceUnavailable = "External.ServiceUnavailable";
     }
+
+    /// <summary>
+    /// Solution-related errors.
+    /// </summary>
+    public static class Solution
+    {
+        /// <summary>The requested solution was not found.</summary>
+        public const string NotFound = "Solution.NotFound";
+    }
 }


### PR DESCRIPTION
## Summary

- Add `solutions/list` RPC method to list solutions with optional filter and includeManaged flag
- Add `solutions/components` RPC method to get solution components grouped by type
- Add `Solution.NotFound` error code for structured error handling
- Add response DTOs: `SolutionsListResponse`, `SolutionInfoDto`, `SolutionComponentsResponse`, `SolutionComponentInfoDto`

## Test plan

- [x] Build succeeds
- [x] Unit tests pass
- [ ] Integration testing (requires live Dataverse)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)