### PR TITLE
fix(ship): check against origin/main instead of local main

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -73,11 +73,26 @@ If tests are missing, write them (not stubs).
 
 **Base Branch Check:**
 ```bash
+# Fetch latest from origin
 git fetch origin
-git rev-list --count HEAD..origin/main
+
+# Check how many commits we're behind origin/main
+BEHIND_COUNT=$(git rev-list --count HEAD..origin/main)
+
+if [ "$BEHIND_COUNT" -gt 0 ]; then
+  echo "Branch is $BEHIND_COUNT commits behind origin/main. Rebasing..."
+  git rebase origin/main
+
+  # If rebase fails (conflicts), abort and escalate
+  if [ $? -ne 0 ]; then
+    git rebase --abort
+    echo "ERROR: Rebase failed due to conflicts. Manual resolution required."
+    exit 1
+  fi
+fi
 ```
 
-If behind, rebase onto origin/main.
+**Important:** Always check against `origin/main` (not local `main`) because worktrees may have been created from a stale local main branch.
 
 **Scaffolding Cleanup:**
 ```bash

--- a/.claude/commands/start-work.md
+++ b/.claude/commands/start-work.md
@@ -94,6 +94,26 @@ Branch: feature/import-bugs
 Status: Clean
 ```
 
+### 5b. Check Base Branch Freshness
+
+**Important:** Worktrees may be created from a stale local `main`. Check against `origin/main`:
+
+```bash
+# Fetch latest from origin
+git fetch origin
+
+# Check how many commits we're behind origin/main
+BEHIND_COUNT=$(git rev-list --count HEAD..origin/main)
+
+if [ "$BEHIND_COUNT" -gt 0 ]; then
+  echo "WARNING: Branch is $BEHIND_COUNT commits behind origin/main."
+  echo "Consider rebasing now to avoid conflicts later:"
+  echo "  git rebase origin/main"
+fi
+```
+
+This early warning helps catch stale branches before significant work is done.
+
 ### 6. Display Session Prompt
 
 Output the generated session prompt content.


### PR DESCRIPTION
## Summary

- Expanded the base branch check in `/ship` to explicitly capture the behind count and auto-rebase when needed
- Added step 5b in `/start-work` to warn early when worktree is behind origin/main
- Added note explaining why `origin/main` must be used instead of local `main`

## Test plan

- [x] Changes are markdown documentation only - no code changes
- [ ] Verify /ship correctly rebases when behind origin/main
- [ ] Verify /start-work shows warning when worktree is stale

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)