### PR TITLE
fix(ci): configure Dependabot to surface major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
       fakexrmeasy:
         patterns:
           - "FakeXrmEasy*"
+      # Major version updates grouped separately for manual evaluation
+      major-version-updates:
+        applies-to: version-updates
+        update-types:
+          - "major"
     # Widen version constraints when needed (e.g., 1.1.* -> 1.2.*)
     versioning-strategy: increase
 

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,0 +1,38 @@
+name: Label Dependabot Major Updates
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-major-updates:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Add needs-evaluation label for major updates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = context.payload.pull_request.title;
+            const prBody = context.payload.pull_request.body || '';
+
+            // Check if this is a major version update
+            // Dependabot includes "major" in group name or indicates major bump in body
+            const isMajorUpdate =
+              prTitle.includes('major-version-updates') ||
+              prBody.includes('Update-type: version-update:semver-major');
+
+            if (isMajorUpdate) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['needs-evaluation']
+              });
+              console.log('Added needs-evaluation label to major version update PR');
+            } else {
+              console.log('Not a major version update, skipping label');
+            }

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -2,7 +2,7 @@ name: Label Dependabot Major Updates
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened, synchronize]
 
 permissions:
   pull-requests: write
@@ -16,14 +16,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prTitle = context.payload.pull_request.title;
-            const prBody = context.payload.pull_request.body || '';
+            const prTitle = context.payload.pull_request.title.toLowerCase();
+            const prBody = (context.payload.pull_request.body || '').toLowerCase();
 
             // Check if this is a major version update
-            // Dependabot includes "major" in group name or indicates major bump in body
+            // Dependabot indicates major bumps via:
+            // - Group name in title (e.g., "Bump the major-version-updates group")
+            // - Semver metadata in body (e.g., "update-type: version-update:semver-major")
             const isMajorUpdate =
               prTitle.includes('major-version-updates') ||
-              prBody.includes('Update-type: version-update:semver-major');
+              prBody.includes('semver-major');
 
             if (isMajorUpdate) {
               await github.rest.issues.addLabels({

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ SDK, CLI, TUI, VS Code Extension, and MCP server for Power Platform development.
 | Check `docs/patterns/` before implementing | Canonical patterns exist; cite them in plan |
 | Restate issue understanding in plan | "My Understanding" section catches drift before implementation |
 | Create issues after `/design` plan approval | Enables parallel workers; maintains orchestration visibility |
+| Review `needs-evaluation` Dependabot PRs before merging | Major version updates require manual evaluation |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `major-version-updates` group to Dependabot config with `update-types: ["major"]` to ensure major version bumps create PRs
- Create GitHub Action workflow to auto-label major update PRs with `needs-evaluation`
- Add CLAUDE.md reminder to review `needs-evaluation` PRs before merging

## Problem

Dependabot with `versioning-strategy: increase` doesn't surface major version updates for evaluation. We only discovered Terminal.Gui 2.x exists during a manual review. This leaves us blind to major releases.

## Solution

Configure Dependabot to group major version updates separately and label them for manual evaluation before merge.

## Test plan

- [x] Build passes
- [x] Unit tests pass
- [ ] Verify Dependabot creates PRs for major version updates with `needs-evaluation` label (manual verification when next major version available)

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)