### PR TITLE
feat(ship): wait 10 minutes before first CI check

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -143,7 +143,7 @@ After PR creation, poll only REQUIRED checks (don't wait for optional ones).
 **Timing:**
 - **Initial wait:** 10 minutes (600 seconds) before first check - CI typically takes 5-8 minutes
 - **Subsequent checks:** 3 minutes (180 seconds) between each check if still running
-- **Timeout:** 15 minutes total - if required checks don't complete, continue to bot review phase
+- **Timeout:** 20 minutes total - if required checks don't complete, continue to bot review phase
 
 **Required checks (must pass):**
 - `build` or `build-status`
@@ -171,7 +171,7 @@ gh api repos/{owner}/{repo}/commits/$SHA/check-runs \
         | {name: .name, status: .status, conclusion: .conclusion}'
 
 # If any required checks still running, wait 3 minutes and check again
-# Repeat until all complete or 15-minute timeout reached
+# Repeat until all complete or 20-minute timeout reached
 ```
 
 **Important:** Do NOT use `gh pr checks --watch` - it waits for ALL checks including optional ones.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -138,7 +138,12 @@ EOF
 
 ### 5. Wait for Required CI Checks
 
-After PR creation, poll only REQUIRED checks (don't wait for optional ones):
+After PR creation, poll only REQUIRED checks (don't wait for optional ones).
+
+**Timing:**
+- **Initial wait:** 10 minutes (600 seconds) before first check - CI typically takes 5-8 minutes
+- **Subsequent checks:** 3 minutes (180 seconds) between each check if still running
+- **Timeout:** 15 minutes total - if required checks don't complete, continue to bot review phase
 
 **Required checks (must pass):**
 - `build` or `build-status`
@@ -157,15 +162,19 @@ After PR creation, poll only REQUIRED checks (don't wait for optional ones):
 # Get SHA of PR head commit
 SHA=$(gh pr view {pr} --json headRefOid --jq '.headRefOid')
 
-# Poll required checks every 30 seconds until all complete
+# Wait 10 minutes before first check (CI typically takes 5-8 minutes)
+sleep 600
+
+# Check required CI status
 gh api repos/{owner}/{repo}/commits/$SHA/check-runs \
   --jq '.check_runs[] | select(.name | test("^(build|test|extension|Analyze|CodeQL|dependency)"))
         | {name: .name, status: .status, conclusion: .conclusion}'
+
+# If any required checks still running, wait 3 minutes and check again
+# Repeat until all complete or 15-minute timeout reached
 ```
 
 **Important:** Do NOT use `gh pr checks --watch` - it waits for ALL checks including optional ones.
-
-**Timeout:** If required checks don't complete within 15 minutes, update session status to `Shipping` and continue to bot review phase.
 
 ### 5b. Wait for Bot Reviews (parallel to CI)
 


### PR DESCRIPTION
## Summary

- Updates `/ship` command CI polling to wait 10 minutes before first check instead of polling repeatedly with increasing intervals (60s, 90s, 120s...)
- Reduces API calls and output verbosity since CI typically takes 5-8 minutes anyway
- Uses 3-minute intervals for subsequent checks if CI is still running

## Test plan

- [ ] Manual verification: Run `/ship` and observe it waits 10 minutes before first CI check
- [ ] Subsequent checks use 3-minute intervals if CI still running

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)