### PR TITLE
feat(plugins): add download command for assembly and package binaries

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Infrastructure;
@@ -14,12 +13,6 @@ namespace PPDS.Cli.Commands.Plugins;
 /// </summary>
 public static class DownloadCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
-
     public static Command Create()
     {
         var command = new Command("download", "Download plugin assembly or package binary from Dataverse");

--- a/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
@@ -1,0 +1,462 @@
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Plugins.Registration;
+
+namespace PPDS.Cli.Commands.Plugins;
+
+/// <summary>
+/// Download plugin assembly or package binary content from Dataverse.
+/// </summary>
+public static class DownloadCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static Command Create()
+    {
+        var command = new Command("download", "Download plugin assembly or package binary from Dataverse");
+
+        command.Subcommands.Add(CreateAssemblySubcommand());
+        command.Subcommands.Add(CreatePackageSubcommand());
+
+        return command;
+    }
+
+    private static Command CreateAssemblySubcommand()
+    {
+        var nameArgument = new Argument<string>("name-or-id")
+        {
+            Description = "Assembly name or GUID"
+        };
+
+        var outputOption = new Option<string>("--output", "-o")
+        {
+            Description = "Output file path or directory",
+            Required = true
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Overwrite existing file"
+        };
+
+        var command = new Command("assembly", "Download a plugin assembly DLL")
+        {
+            nameArgument,
+            outputOption,
+            forceOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var nameOrId = parseResult.GetValue(nameArgument)!;
+            var output = parseResult.GetValue(outputOption)!;
+            var force = parseResult.GetValue(forceOption);
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAssemblyAsync(nameOrId, output, force, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static Command CreatePackageSubcommand()
+    {
+        var nameArgument = new Argument<string>("name-or-id")
+        {
+            Description = "Package name, unique name, or GUID"
+        };
+
+        var outputOption = new Option<string>("--output", "-o")
+        {
+            Description = "Output file path or directory",
+            Required = true
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Overwrite existing file"
+        };
+
+        var command = new Command("package", "Download a plugin package (nupkg)")
+        {
+            nameArgument,
+            outputOption,
+            forceOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var nameOrId = parseResult.GetValue(nameArgument)!;
+            var output = parseResult.GetValue(outputOption)!;
+            var force = parseResult.GetValue(forceOption);
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecutePackageAsync(nameOrId, output, force, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAssemblyAsync(
+        string nameOrId,
+        string output,
+        bool force,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            // Resolve name to ID if needed
+            Guid assemblyId;
+            string assemblyName;
+
+            if (Guid.TryParse(nameOrId, out assemblyId))
+            {
+                // User provided a GUID directly - we'll get the name from the download
+                assemblyName = nameOrId;
+            }
+            else
+            {
+                // Look up by name
+                var assembly = await registrationService.GetAssemblyByNameAsync(nameOrId, cancellationToken);
+                if (assembly == null)
+                {
+                    writer.WriteError(new StructuredError(
+                        ErrorCodes.Operation.NotFound,
+                        $"Assembly not found: {nameOrId}",
+                        Target: nameOrId));
+                    return ExitCodes.NotFoundError;
+                }
+                assemblyId = assembly.Id;
+                assemblyName = assembly.Name;
+            }
+
+            if (!globalOptions.IsJsonMode)
+            {
+                Console.Error.WriteLine($"Downloading assembly: {assemblyName}");
+            }
+
+            var (content, fileName) = await registrationService.DownloadAssemblyAsync(assemblyId, cancellationToken);
+
+            // If user passed GUID, update the assemblyName to actual name from download
+            if (Guid.TryParse(nameOrId, out _))
+            {
+                assemblyName = Path.GetFileNameWithoutExtension(fileName);
+            }
+
+            // Determine output path
+            var outputPath = ResolveOutputPath(output, fileName, force, globalOptions, writer, out var pathError);
+            if (outputPath == null)
+            {
+                return pathError;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                // JSON mode: output metadata only, no file written
+                writer.WriteSuccess(new DownloadMetadata
+                {
+                    Name = assemblyName,
+                    Id = assemblyId,
+                    ContentSize = content.Length,
+                    FileName = fileName
+                });
+            }
+            else
+            {
+                // Write file
+                await File.WriteAllBytesAsync(outputPath, content, cancellationToken);
+
+                var sizeKb = content.Length / 1024.0;
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Downloaded: {fileName} ({sizeKb:F1} KB)");
+                Console.Error.WriteLine($"  Source: {assemblyName} ({assemblyId})");
+                Console.Error.WriteLine($"  Output: {Path.GetFullPath(outputPath)}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("has no content"))
+        {
+            writer.WriteError(new StructuredError(
+                ErrorCodes.Validation.InvalidValue,
+                ex.Message,
+                Target: nameOrId));
+            return ExitCodes.InvalidArguments;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "downloading assembly", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static async Task<int> ExecutePackageAsync(
+        string nameOrId,
+        string output,
+        bool force,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            // Resolve name to ID if needed
+            Guid packageId;
+            string packageName;
+            string? packageVersion = null;
+
+            if (Guid.TryParse(nameOrId, out packageId))
+            {
+                // User provided a GUID directly
+                packageName = nameOrId;
+            }
+            else
+            {
+                // Look up by name or unique name
+                var package = await registrationService.GetPackageByNameAsync(nameOrId, cancellationToken);
+                if (package == null)
+                {
+                    writer.WriteError(new StructuredError(
+                        ErrorCodes.Operation.NotFound,
+                        $"Package not found: {nameOrId}",
+                        Target: nameOrId));
+                    return ExitCodes.NotFoundError;
+                }
+                packageId = package.Id;
+                packageName = package.Name;
+                packageVersion = package.Version;
+            }
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var versionSuffix = !string.IsNullOrEmpty(packageVersion) ? $" v{packageVersion}" : "";
+                Console.Error.WriteLine($"Downloading package: {packageName}{versionSuffix}");
+            }
+
+            var (content, fileName) = await registrationService.DownloadPackageAsync(packageId, cancellationToken);
+
+            // If user passed GUID, parse name from fileName
+            if (Guid.TryParse(nameOrId, out _))
+            {
+                // fileName format: PackageName.Version.nupkg
+                var nameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
+                packageName = nameWithoutExt;
+            }
+
+            // Determine output path
+            var outputPath = ResolveOutputPath(output, fileName, force, globalOptions, writer, out var pathError);
+            if (outputPath == null)
+            {
+                return pathError;
+            }
+
+            if (globalOptions.IsJsonMode)
+            {
+                // JSON mode: output metadata only, no file written
+                writer.WriteSuccess(new DownloadMetadata
+                {
+                    Name = packageName,
+                    Id = packageId,
+                    ContentSize = content.Length,
+                    Version = packageVersion,
+                    FileName = fileName
+                });
+            }
+            else
+            {
+                // Write file
+                await File.WriteAllBytesAsync(outputPath, content, cancellationToken);
+
+                var sizeKb = content.Length / 1024.0;
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Downloaded: {fileName} ({sizeKb:F1} KB)");
+                Console.Error.WriteLine($"  Source: {packageName} ({packageId})");
+                Console.Error.WriteLine($"  Output: {Path.GetFullPath(outputPath)}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("has no content"))
+        {
+            writer.WriteError(new StructuredError(
+                ErrorCodes.Validation.InvalidValue,
+                ex.Message,
+                Target: nameOrId));
+            return ExitCodes.InvalidArguments;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "downloading package", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the output path, handling both file and directory cases.
+    /// Returns null if path validation fails.
+    /// </summary>
+    private static string? ResolveOutputPath(
+        string output,
+        string defaultFileName,
+        bool force,
+        GlobalOptionValues globalOptions,
+        IOutputWriter writer,
+        out int errorCode)
+    {
+        errorCode = ExitCodes.Success;
+        string outputPath;
+
+        // Check if output is a directory (ends with separator or exists as directory)
+        var isDirectory = output.EndsWith(Path.DirectorySeparatorChar) ||
+                         output.EndsWith(Path.AltDirectorySeparatorChar) ||
+                         Directory.Exists(output);
+
+        if (isDirectory)
+        {
+            // Ensure directory exists
+            if (!Directory.Exists(output))
+            {
+                try
+                {
+                    Directory.CreateDirectory(output);
+                }
+                catch (Exception ex)
+                {
+                    writer.WriteError(new StructuredError(
+                        ErrorCodes.Validation.DirectoryNotFound,
+                        $"Cannot create directory: {output}",
+                        Details: ex.Message,
+                        Target: output));
+                    errorCode = ExitCodes.Failure;
+                    return null;
+                }
+            }
+
+            outputPath = Path.Combine(output, defaultFileName);
+        }
+        else
+        {
+            outputPath = output;
+
+            // Ensure parent directory exists
+            var directory = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(directory);
+                }
+                catch (Exception ex)
+                {
+                    writer.WriteError(new StructuredError(
+                        ErrorCodes.Validation.DirectoryNotFound,
+                        $"Cannot create directory: {directory}",
+                        Details: ex.Message,
+                        Target: directory));
+                    errorCode = ExitCodes.Failure;
+                    return null;
+                }
+            }
+        }
+
+        // Check if file exists (skip in JSON mode since we don't write files)
+        if (!globalOptions.IsJsonMode && File.Exists(outputPath) && !force)
+        {
+            writer.WriteError(new StructuredError(
+                ErrorCodes.Validation.InvalidValue,
+                $"Output file already exists. Use --force to overwrite.",
+                Target: outputPath));
+            errorCode = ExitCodes.Failure;
+            return null;
+        }
+
+        return outputPath;
+    }
+
+    #region Output Models
+
+    private sealed class DownloadMetadata
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("contentSize")]
+        public int ContentSize { get; set; }
+
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
+
+        [JsonPropertyName("fileName")]
+        public string FileName { get; set; } = string.Empty;
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
@@ -36,13 +36,14 @@ public static class PluginsCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("plugins", "Plugin registration management: extract, deploy, diff, list, clean");
+        var command = new Command("plugins", "Plugin registration management: extract, deploy, diff, list, clean, download");
 
         command.Subcommands.Add(ExtractCommand.Create());
         command.Subcommands.Add(DeployCommand.Create());
         command.Subcommands.Add(DiffCommand.Create());
         command.Subcommands.Add(ListCommand.Create());
         command.Subcommands.Add(CleanCommand.Create());
+        command.Subcommands.Add(DownloadCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -256,6 +256,32 @@ public interface IPluginRegistrationService
 
     #endregion
 
+    #region Download Operations
+
+    /// <summary>
+    /// Downloads the binary content of a plugin assembly.
+    /// </summary>
+    /// <param name="assemblyId">The assembly ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Tuple containing the binary content and assembly name with .dll extension.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when assembly has no content (e.g., source type is Disk or GAC).</exception>
+    Task<(byte[] Content, string FileName)> DownloadAssemblyAsync(
+        Guid assemblyId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Downloads the binary content of a plugin package.
+    /// </summary>
+    /// <param name="packageId">The package ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Tuple containing the binary content and package name with .nupkg extension.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when package has no content.</exception>
+    Task<(byte[] Content, string FileName)> DownloadPackageAsync(
+        Guid packageId,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+
     #region Solution Operations
 
     /// <summary>

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DownloadCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DownloadCommandTests.cs
@@ -1,0 +1,249 @@
+using System.CommandLine;
+using PPDS.Cli.Commands.Plugins;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Plugins;
+
+public class DownloadCommandTests
+{
+    private readonly Command _command;
+
+    public DownloadCommandTests()
+    {
+        _command = DownloadCommand.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("download", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("Download", _command.Description);
+    }
+
+    [Fact]
+    public void Create_HasAssemblySubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "assembly");
+        Assert.NotNull(subcommand);
+        Assert.Contains("DLL", subcommand.Description);
+    }
+
+    [Fact]
+    public void Create_HasPackageSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "package");
+        Assert.NotNull(subcommand);
+        Assert.Contains("nupkg", subcommand.Description);
+    }
+
+    #endregion
+
+    #region Assembly Subcommand Tests
+
+    [Fact]
+    public void AssemblySubcommand_HasNameOrIdArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "name-or-id");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_HasRequiredOutputOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--output");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_HasOptionalForceOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--force");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_HasOptionalProfileOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_HasOptionalEnvironmentOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithRequiredOptions_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("MyPlugin --output ./recovered/");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithForce_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("MyPlugin --output ./MyPlugin.dll --force");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithGuid_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("12345678-1234-1234-1234-123456789abc --output ./recovered/");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithProfile_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("MyPlugin --output ./recovered/ --profile dev");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithJsonOutput_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("MyPlugin --output ./recovered/ --output-format Json");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_Parse_WithoutOutput_HasErrors()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var result = subcommand.Parse("MyPlugin");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Package Subcommand Tests
+
+    [Fact]
+    public void PackageSubcommand_HasNameOrIdArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "name-or-id");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void PackageSubcommand_HasRequiredOutputOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--output");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void PackageSubcommand_HasOptionalForceOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--force");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void PackageSubcommand_Parse_WithRequiredOptions_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var result = subcommand.Parse("MyPlugin.Plugins --output ./recovered/");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void PackageSubcommand_Parse_WithForce_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var result = subcommand.Parse("MyPlugin.Plugins --output ./MyPlugin.1.0.0.nupkg --force");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void PackageSubcommand_Parse_WithGuid_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var result = subcommand.Parse("12345678-1234-1234-1234-123456789abc --output ./recovered/");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void PackageSubcommand_Parse_WithJsonOutput_Succeeds()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var result = subcommand.Parse("MyPackage --output ./recovered/ --output-format Json");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void PackageSubcommand_Parse_WithoutOutput_HasErrors()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var result = subcommand.Parse("MyPackage");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Alias Tests
+
+    [Fact]
+    public void AssemblySubcommand_OutputOption_HasShortAlias()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.First(o => o.Name == "--output");
+        Assert.Contains("-o", option.Aliases);
+    }
+
+    [Fact]
+    public void AssemblySubcommand_ForceOption_HasShortAlias()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.First(o => o.Name == "--force");
+        Assert.Contains("-f", option.Aliases);
+    }
+
+    [Fact]
+    public void PackageSubcommand_OutputOption_HasShortAlias()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var option = subcommand.Options.First(o => o.Name == "--output");
+        Assert.Contains("-o", option.Aliases);
+    }
+
+    [Fact]
+    public void PackageSubcommand_ForceOption_HasShortAlias()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var option = subcommand.Options.First(o => o.Name == "--force");
+        Assert.Contains("-f", option.Aliases);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
@@ -63,9 +63,16 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
-    public void Create_HasFiveSubcommands()
+    public void Create_HasDownloadSubcommand()
     {
-        Assert.Equal(5, _command.Subcommands.Count);
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "download");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasSixSubcommands()
+    {
+        Assert.Equal(6, _command.Subcommands.Count);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Add `ppds plugins download assembly <name> --output <path>` to download DLL binaries from Dataverse
- Add `ppds plugins download package <name> --output <path>` to download nupkg binaries from Dataverse
- Add `DownloadAssemblyAsync` and `DownloadPackageAsync` methods to `IPluginRegistrationService`
- Support lookup by name or GUID
- Auto-generate filename when output is a directory
- Handle Disk/GAC source types with clear error messages

## Test plan
- [x] Unit tests for command structure and parsing
- [x] Unit tests for all subcommand options
- [x] All existing tests pass
- [ ] Integration test (requires live Dataverse - manual)

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)