### PR TITLE
feat(plugins): add `ppds plugins register` command for imperative registration

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
@@ -36,10 +36,11 @@ public static class PluginsCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("plugins", "Plugin registration management: extract, deploy, diff, list, get, clean, download");
+        var command = new Command("plugins", "Plugin registration management: extract, deploy, register, diff, list, get, clean, download");
 
         command.Subcommands.Add(ExtractCommand.Create());
         command.Subcommands.Add(DeployCommand.Create());
+        command.Subcommands.Add(RegisterCommand.Create());
         command.Subcommands.Add(DiffCommand.Create());
         command.Subcommands.Add(ListCommand.Create());
         command.Subcommands.Add(GetCommand.Create());

--- a/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
@@ -41,19 +41,12 @@ public static class RegisterCommand
             Description = "Path to the plugin assembly DLL file"
         }.AcceptExistingOnly();
 
-        var isolationOption = new Option<IsolationMode>("--isolation")
-        {
-            Description = "Isolation mode for the assembly",
-            DefaultValueFactory = _ => IsolationMode.Sandbox
-        };
-
         var command = new Command("assembly", "Register a plugin assembly (DLL)")
         {
             pathArgument,
             PluginsCommandGroup.ProfileOption,
             PluginsCommandGroup.EnvironmentOption,
-            PluginsCommandGroup.SolutionOption,
-            isolationOption
+            PluginsCommandGroup.SolutionOption
         };
 
         GlobalOptions.AddToCommand(command);
@@ -64,10 +57,9 @@ public static class RegisterCommand
             var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
             var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
             var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
-            var isolation = parseResult.GetValue(isolationOption);
             var globalOptions = GlobalOptions.GetValues(parseResult);
 
-            return await ExecuteAssemblyAsync(path, profile, environment, solution, isolation, globalOptions, cancellationToken);
+            return await ExecuteAssemblyAsync(path, profile, environment, solution, globalOptions, cancellationToken);
         });
 
         return command;
@@ -78,7 +70,6 @@ public static class RegisterCommand
         string? profile,
         string? environment,
         string? solution,
-        IsolationMode isolation,
         GlobalOptionValues globalOptions,
         CancellationToken cancellationToken)
     {
@@ -902,16 +893,4 @@ public static class RegisterCommand
     }
 
     #endregion
-}
-
-/// <summary>
-/// Plugin assembly isolation mode.
-/// </summary>
-public enum IsolationMode
-{
-    /// <summary>Sandbox isolation (recommended for cloud).</summary>
-    Sandbox,
-
-    /// <summary>No isolation (on-premises only).</summary>
-    None
 }

--- a/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
@@ -1,0 +1,917 @@
+using System.CommandLine;
+using System.IO.Compression;
+using System.Text.Json.Serialization;
+using System.Xml.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
+
+namespace PPDS.Cli.Commands.Plugins;
+
+/// <summary>
+/// Register plugin components imperatively without a configuration file.
+/// </summary>
+public static class RegisterCommand
+{
+    /// <summary>
+    /// Creates the 'register' command with all subcommands.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("register", "Register plugin components: assembly, package, type, step, image");
+
+        command.Subcommands.Add(CreateAssemblyCommand());
+        command.Subcommands.Add(CreatePackageCommand());
+        command.Subcommands.Add(CreateTypeCommand());
+        command.Subcommands.Add(CreateStepCommand());
+        command.Subcommands.Add(CreateImageCommand());
+
+        return command;
+    }
+
+    #region Assembly Subcommand
+
+    private static Command CreateAssemblyCommand()
+    {
+        var pathArgument = new Argument<FileInfo>("path")
+        {
+            Description = "Path to the plugin assembly DLL file"
+        }.AcceptExistingOnly();
+
+        var isolationOption = new Option<IsolationMode>("--isolation")
+        {
+            Description = "Isolation mode for the assembly",
+            DefaultValueFactory = _ => IsolationMode.Sandbox
+        };
+
+        var command = new Command("assembly", "Register a plugin assembly (DLL)")
+        {
+            pathArgument,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption,
+            PluginsCommandGroup.SolutionOption,
+            isolationOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var path = parseResult.GetValue(pathArgument)!;
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
+            var isolation = parseResult.GetValue(isolationOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAssemblyAsync(path, profile, environment, solution, isolation, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAssemblyAsync(
+        FileInfo assemblyFile,
+        string? profile,
+        string? environment,
+        string? solution,
+        IsolationMode isolation,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            var assemblyName = Path.GetFileNameWithoutExtension(assemblyFile.Name);
+            var assemblyBytes = await File.ReadAllBytesAsync(assemblyFile.FullName, cancellationToken);
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Registering assembly: {assemblyName}");
+            }
+
+            var assemblyId = await registrationService.UpsertAssemblyAsync(assemblyName, assemblyBytes, solution, cancellationToken);
+
+            // Count discovered types
+            var types = await registrationService.ListTypesForAssemblyAsync(assemblyId, cancellationToken);
+
+            var result = new RegisterAssemblyResult
+            {
+                Success = true,
+                Operation = "register-assembly",
+                Id = assemblyId,
+                Name = assemblyName,
+                PluginTypesDiscovered = types.Count,
+                Solution = solution
+            };
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                Console.Error.WriteLine($"  Assembly registered: {assemblyId}");
+                Console.Error.WriteLine($"  Plugin types discovered: {types.Count}");
+                if (!string.IsNullOrEmpty(solution))
+                    Console.Error.WriteLine($"  Solution: {solution}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "registering assembly", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #endregion
+
+    #region Package Subcommand
+
+    private static Command CreatePackageCommand()
+    {
+        var pathArgument = new Argument<FileInfo>("path")
+        {
+            Description = "Path to the plugin package (.nupkg) file"
+        }.AcceptExistingOnly();
+
+        var command = new Command("package", "Register a plugin package (NuGet)")
+        {
+            pathArgument,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption,
+            PluginsCommandGroup.SolutionOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var path = parseResult.GetValue(pathArgument)!;
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecutePackageAsync(path, profile, environment, solution, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecutePackageAsync(
+        FileInfo packageFile,
+        string? profile,
+        string? environment,
+        string? solution,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            var packageName = GetPackageIdFromNupkg(packageFile.FullName);
+            var packageBytes = await File.ReadAllBytesAsync(packageFile.FullName, cancellationToken);
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Registering package: {packageName}");
+            }
+
+            var packageId = await registrationService.UpsertPackageAsync(packageName, packageBytes, solution, cancellationToken);
+
+            // Count discovered types
+            var types = await registrationService.ListTypesForPackageAsync(packageId, cancellationToken);
+
+            var result = new RegisterPackageResult
+            {
+                Success = true,
+                Operation = "register-package",
+                Id = packageId,
+                Name = packageName,
+                PluginTypesDiscovered = types.Count,
+                Solution = solution
+            };
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                Console.Error.WriteLine($"  Package registered: {packageId}");
+                Console.Error.WriteLine($"  Plugin types discovered: {types.Count}");
+                if (!string.IsNullOrEmpty(solution))
+                    Console.Error.WriteLine($"  Solution: {solution}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "registering package", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #endregion
+
+    #region Type Subcommand
+
+    private static Command CreateTypeCommand()
+    {
+        var assemblyArgument = new Argument<string>("assembly")
+        {
+            Description = "Assembly name containing the plugin type"
+        };
+
+        var typenameOption = new Option<string>("--typename")
+        {
+            Description = "Fully qualified type name (namespace.classname)",
+            Required = true
+        };
+
+        var command = new Command("type", "Register a plugin type within an assembly")
+        {
+            assemblyArgument,
+            typenameOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption,
+            PluginsCommandGroup.SolutionOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var assembly = parseResult.GetValue(assemblyArgument)!;
+            var typename = parseResult.GetValue(typenameOption)!;
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteTypeAsync(assembly, typename, profile, environment, solution, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteTypeAsync(
+        string assemblyName,
+        string typeName,
+        string? profile,
+        string? environment,
+        string? solution,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Registering type: {typeName}");
+            }
+
+            // Find the assembly
+            var assembly = await registrationService.GetAssemblyByNameAsync(assemblyName, cancellationToken);
+            if (assembly == null)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"Assembly not found: {assemblyName}",
+                    Target: assemblyName));
+                return ExitCodes.NotFoundError;
+            }
+
+            var typeId = await registrationService.UpsertPluginTypeAsync(assembly.Id, typeName, solution, cancellationToken);
+
+            var result = new RegisterTypeResult
+            {
+                Success = true,
+                Operation = "register-type",
+                Id = typeId,
+                TypeName = typeName,
+                AssemblyName = assemblyName,
+                Solution = solution
+            };
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                Console.Error.WriteLine($"  Type registered: {typeId}");
+                Console.Error.WriteLine($"  Assembly: {assemblyName}");
+                if (!string.IsNullOrEmpty(solution))
+                    Console.Error.WriteLine($"  Solution: {solution}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "registering type", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #endregion
+
+    #region Step Subcommand
+
+    private static Command CreateStepCommand()
+    {
+        var typeArgument = new Argument<string>("type")
+        {
+            Description = "Plugin type name (fully qualified)"
+        };
+
+        var messageOption = new Option<string>("--message")
+        {
+            Description = "SDK message name (Create, Update, Delete, etc.)",
+            Required = true
+        };
+
+        var entityOption = new Option<string>("--entity")
+        {
+            Description = "Primary entity logical name",
+            Required = true
+        };
+
+        var stageOption = new Option<string>("--stage")
+        {
+            Description = "Pipeline stage: PreValidation, PreOperation, or PostOperation",
+            Required = true
+        };
+
+        var modeOption = new Option<string>("--mode")
+        {
+            Description = "Execution mode: Sync or Async",
+            DefaultValueFactory = _ => "Sync"
+        };
+
+        var rankOption = new Option<int>("--rank")
+        {
+            Description = "Execution order (1-999999)",
+            DefaultValueFactory = _ => 1
+        };
+
+        var filteringAttributesOption = new Option<string?>("--filtering-attributes")
+        {
+            Description = "Comma-separated list of attributes that trigger this step (for Update message)"
+        };
+
+        var nameOption = new Option<string?>("--name")
+        {
+            Description = "Step display name (auto-generated if not specified)"
+        };
+
+        var command = new Command("step", "Register a processing step for a plugin type")
+        {
+            typeArgument,
+            messageOption,
+            entityOption,
+            stageOption,
+            modeOption,
+            rankOption,
+            filteringAttributesOption,
+            nameOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption,
+            PluginsCommandGroup.SolutionOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var typeName = parseResult.GetValue(typeArgument)!;
+            var message = parseResult.GetValue(messageOption)!;
+            var entity = parseResult.GetValue(entityOption)!;
+            var stage = parseResult.GetValue(stageOption)!;
+            var mode = parseResult.GetValue(modeOption)!;
+            var rank = parseResult.GetValue(rankOption);
+            var filteringAttributes = parseResult.GetValue(filteringAttributesOption);
+            var name = parseResult.GetValue(nameOption);
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteStepAsync(typeName, message, entity, stage, mode, rank, filteringAttributes, name, profile, environment, solution, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteStepAsync(
+        string typeName,
+        string message,
+        string entity,
+        string stage,
+        string mode,
+        int rank,
+        string? filteringAttributes,
+        string? name,
+        string? profile,
+        string? environment,
+        string? solution,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            // Normalize mode
+            var normalizedMode = mode.ToLowerInvariant() switch
+            {
+                "sync" => "Synchronous",
+                "async" => "Asynchronous",
+                _ => mode
+            };
+
+            // Auto-generate step name if not specified
+            var stepName = name ?? $"{typeName}: {message} of {entity}";
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Registering step: {stepName}");
+            }
+
+            // Find the plugin type
+            var pluginType = await registrationService.GetPluginTypeByNameAsync(typeName, cancellationToken);
+            if (pluginType == null)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"Plugin type not found: {typeName}",
+                    Target: typeName));
+                return ExitCodes.NotFoundError;
+            }
+
+            // Get message ID
+            var messageId = await registrationService.GetSdkMessageIdAsync(message, cancellationToken);
+            if (messageId == null)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"SDK message not found: {message}",
+                    Target: message));
+                return ExitCodes.NotFoundError;
+            }
+
+            // Get message filter ID
+            var filterId = await registrationService.GetSdkMessageFilterIdAsync(messageId.Value, entity, null, cancellationToken);
+
+            // Build step config
+            var stepConfig = new PluginStepConfig
+            {
+                Name = stepName,
+                Message = message,
+                Entity = entity,
+                Stage = stage,
+                Mode = normalizedMode,
+                ExecutionOrder = rank,
+                FilteringAttributes = filteringAttributes
+            };
+
+            var stepId = await registrationService.UpsertStepAsync(pluginType.Id, stepConfig, messageId.Value, filterId, solution, cancellationToken);
+
+            var result = new RegisterStepResult
+            {
+                Success = true,
+                Operation = "register-step",
+                Id = stepId,
+                Name = stepName,
+                TypeName = typeName,
+                Message = message,
+                Entity = entity,
+                Stage = stage,
+                Mode = normalizedMode,
+                Rank = rank,
+                Solution = solution
+            };
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                Console.Error.WriteLine($"  Step registered: {stepId}");
+                Console.Error.WriteLine($"  Message: {message}, Entity: {entity}, Stage: {stage}");
+                if (!string.IsNullOrEmpty(solution))
+                    Console.Error.WriteLine($"  Solution: {solution}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "registering step", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #endregion
+
+    #region Image Subcommand
+
+    private static Command CreateImageCommand()
+    {
+        var stepArgument = new Argument<string>("step")
+        {
+            Description = "Step name to attach the image to"
+        };
+
+        var nameOption = new Option<string>("--name")
+        {
+            Description = "Image name",
+            Required = true
+        };
+
+        var typeOption = new Option<string>("--type")
+        {
+            Description = "Image type: pre, post, or both",
+            Required = true
+        };
+
+        var attributesOption = new Option<string?>("--attributes")
+        {
+            Description = "Comma-separated list of attributes to include (all if not specified)"
+        };
+
+        var command = new Command("image", "Register an image for a processing step")
+        {
+            stepArgument,
+            nameOption,
+            typeOption,
+            attributesOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption,
+            PluginsCommandGroup.SolutionOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var stepName = parseResult.GetValue(stepArgument)!;
+            var name = parseResult.GetValue(nameOption)!;
+            var type = parseResult.GetValue(typeOption)!;
+            var attributes = parseResult.GetValue(attributesOption);
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var solution = parseResult.GetValue(PluginsCommandGroup.SolutionOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteImageAsync(stepName, name, type, attributes, profile, environment, solution, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteImageAsync(
+        string stepName,
+        string imageName,
+        string imageType,
+        string? attributes,
+        string? profile,
+        string? environment,
+        string? solution,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            // Normalize image type
+            var normalizedImageType = imageType.ToLowerInvariant() switch
+            {
+                "pre" => "PreImage",
+                "post" => "PostImage",
+                "both" => "Both",
+                _ => imageType
+            };
+
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine($"Registering image: {imageName} on step: {stepName}");
+            }
+
+            // Find the step
+            var step = await registrationService.GetStepByNameAsync(stepName, cancellationToken);
+            if (step == null)
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Operation.NotFound,
+                    $"Processing step not found: {stepName}",
+                    Target: stepName));
+                return ExitCodes.NotFoundError;
+            }
+
+            // Build image config
+            var imageConfig = new PluginImageConfig
+            {
+                Name = imageName,
+                ImageType = normalizedImageType,
+                Attributes = attributes
+            };
+
+            var imageId = await registrationService.UpsertImageAsync(step.Id, imageConfig, step.Message, cancellationToken);
+
+            var result = new RegisterImageResult
+            {
+                Success = true,
+                Operation = "register-image",
+                Id = imageId,
+                Name = imageName,
+                ImageType = normalizedImageType,
+                StepName = stepName,
+                Attributes = attributes
+            };
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                Console.Error.WriteLine($"  Image registered: {imageId}");
+                Console.Error.WriteLine($"  Type: {normalizedImageType}");
+                if (!string.IsNullOrEmpty(attributes))
+                    Console.Error.WriteLine($"  Attributes: {attributes}");
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "registering image", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Extracts the package ID from the .nuspec file inside a .nupkg.
+    /// </summary>
+    private static string GetPackageIdFromNupkg(string nupkgPath)
+    {
+        using var archive = ZipFile.OpenRead(nupkgPath);
+
+        var nuspecEntry = archive.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase) &&
+            !e.FullName.Contains('/'));
+
+        if (nuspecEntry == null)
+        {
+            throw new InvalidOperationException($"No .nuspec file found in package: {nupkgPath}");
+        }
+
+        using var stream = nuspecEntry.Open();
+        var doc = XDocument.Load(stream);
+
+        var ns = doc.Root?.GetDefaultNamespace() ?? XNamespace.None;
+        var id = doc.Root?.Element(ns + "metadata")?.Element(ns + "id")?.Value;
+
+        if (string.IsNullOrEmpty(id))
+        {
+            throw new InvalidOperationException($"No <id> element found in nuspec: {nupkgPath}");
+        }
+
+        return id;
+    }
+
+    #endregion
+
+    #region Result Models
+
+    private sealed class RegisterAssemblyResult
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("operation")]
+        public string Operation { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("pluginTypesDiscovered")]
+        public int PluginTypesDiscovered { get; set; }
+
+        [JsonPropertyName("solution")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Solution { get; set; }
+    }
+
+    private sealed class RegisterPackageResult
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("operation")]
+        public string Operation { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("pluginTypesDiscovered")]
+        public int PluginTypesDiscovered { get; set; }
+
+        [JsonPropertyName("solution")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Solution { get; set; }
+    }
+
+    private sealed class RegisterTypeResult
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("operation")]
+        public string Operation { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("typeName")]
+        public string TypeName { get; set; } = string.Empty;
+
+        [JsonPropertyName("assemblyName")]
+        public string AssemblyName { get; set; } = string.Empty;
+
+        [JsonPropertyName("solution")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Solution { get; set; }
+    }
+
+    private sealed class RegisterStepResult
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("operation")]
+        public string Operation { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("typeName")]
+        public string TypeName { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+
+        [JsonPropertyName("entity")]
+        public string Entity { get; set; } = string.Empty;
+
+        [JsonPropertyName("stage")]
+        public string Stage { get; set; } = string.Empty;
+
+        [JsonPropertyName("mode")]
+        public string Mode { get; set; } = string.Empty;
+
+        [JsonPropertyName("rank")]
+        public int Rank { get; set; }
+
+        [JsonPropertyName("solution")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Solution { get; set; }
+    }
+
+    private sealed class RegisterImageResult
+    {
+        [JsonPropertyName("success")]
+        public bool Success { get; set; }
+
+        [JsonPropertyName("operation")]
+        public string Operation { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("imageType")]
+        public string ImageType { get; set; } = string.Empty;
+
+        [JsonPropertyName("stepName")]
+        public string StepName { get; set; } = string.Empty;
+
+        [JsonPropertyName("attributes")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Attributes { get; set; }
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Plugin assembly isolation mode.
+/// </summary>
+public enum IsolationMode
+{
+    /// <summary>Sandbox isolation (recommended for cloud).</summary>
+    Sandbox,
+
+    /// <summary>No isolation (on-premises only).</summary>
+    None
+}

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -198,6 +198,24 @@ public interface IPluginRegistrationService
         string assemblyName,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets a plugin type by its fully qualified type name.
+    /// </summary>
+    /// <param name="typeName">The fully qualified type name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PluginTypeInfo?> GetPluginTypeByNameAsync(
+        string typeName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a processing step by its display name.
+    /// </summary>
+    /// <param name="stepName">The step display name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<PluginStepInfo?> GetStepByNameAsync(
+        string stepName,
+        CancellationToken cancellationToken = default);
+
     #endregion
 
     #region Create/Update Operations

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -965,9 +965,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         {
             ColumnSet = new ColumnSet(
                 PluginType.Fields.TypeName,
-                PluginType.Fields.FriendlyName,
-                PluginType.Fields.Name,
-                PluginType.Fields.PluginAssemblyId),
+                PluginType.Fields.FriendlyName),
             Criteria = new FilterExpression
             {
                 Conditions =

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -953,6 +953,116 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
     }
 
     /// <summary>
+    /// Gets a plugin type by its fully qualified type name.
+    /// </summary>
+    /// <param name="typeName">The fully qualified type name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<PluginTypeInfo?> GetPluginTypeByNameAsync(
+        string typeName,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new QueryExpression(PluginType.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                PluginType.Fields.TypeName,
+                PluginType.Fields.FriendlyName,
+                PluginType.Fields.Name,
+                PluginType.Fields.PluginAssemblyId),
+            Criteria = new FilterExpression
+            {
+                Conditions =
+                {
+                    new ConditionExpression(PluginType.Fields.TypeName, ConditionOperator.Equal, typeName)
+                }
+            }
+        };
+
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        var results = await RetrieveMultipleAsync(query, client, cancellationToken);
+        var entity = results.Entities.FirstOrDefault();
+
+        if (entity == null)
+            return null;
+
+        return new PluginTypeInfo
+        {
+            Id = entity.Id,
+            TypeName = entity.GetAttributeValue<string>(PluginType.Fields.TypeName) ?? string.Empty,
+            FriendlyName = entity.GetAttributeValue<string>(PluginType.Fields.FriendlyName)
+        };
+    }
+
+    /// <summary>
+    /// Gets a processing step by its display name.
+    /// </summary>
+    /// <param name="stepName">The step display name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<PluginStepInfo?> GetStepByNameAsync(
+        string stepName,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new QueryExpression(SdkMessageProcessingStep.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                SdkMessageProcessingStep.Fields.Name,
+                SdkMessageProcessingStep.Fields.Stage,
+                SdkMessageProcessingStep.Fields.Mode,
+                SdkMessageProcessingStep.Fields.Rank,
+                SdkMessageProcessingStep.Fields.FilteringAttributes,
+                SdkMessageProcessingStep.Fields.Configuration,
+                SdkMessageProcessingStep.Fields.StateCode,
+                SdkMessageProcessingStep.Fields.Description,
+                SdkMessageProcessingStep.Fields.SupportedDeployment,
+                SdkMessageProcessingStep.Fields.AsyncAutoDelete),
+            Criteria = new FilterExpression
+            {
+                Conditions =
+                {
+                    new ConditionExpression(SdkMessageProcessingStep.Fields.Name, ConditionOperator.Equal, stepName)
+                }
+            },
+            LinkEntities =
+            {
+                new LinkEntity(SdkMessageProcessingStep.EntityLogicalName, SdkMessage.EntityLogicalName, SdkMessageProcessingStep.Fields.SdkMessageId, SdkMessage.Fields.SdkMessageId, JoinOperator.Inner)
+                {
+                    Columns = new ColumnSet(SdkMessage.Fields.Name),
+                    EntityAlias = "message"
+                },
+                new LinkEntity(SdkMessageProcessingStep.EntityLogicalName, SdkMessageFilter.EntityLogicalName, SdkMessageProcessingStep.Fields.SdkMessageFilterId, SdkMessageFilter.Fields.SdkMessageFilterId, JoinOperator.LeftOuter)
+                {
+                    Columns = new ColumnSet(SdkMessageFilter.Fields.PrimaryObjectTypeCode, SdkMessageFilter.Fields.SecondaryObjectTypeCode),
+                    EntityAlias = "filter"
+                }
+            }
+        };
+
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        var results = await RetrieveMultipleAsync(query, client, cancellationToken);
+        var entity = results.Entities.FirstOrDefault();
+
+        if (entity == null)
+            return null;
+
+        return new PluginStepInfo
+        {
+            Id = entity.Id,
+            Name = entity.GetAttributeValue<string>(SdkMessageProcessingStep.Fields.Name) ?? string.Empty,
+            Message = entity.GetAttributeValue<AliasedValue>($"message.{SdkMessage.Fields.Name}")?.Value?.ToString() ?? string.Empty,
+            PrimaryEntity = entity.GetAttributeValue<AliasedValue>($"filter.{SdkMessageFilter.Fields.PrimaryObjectTypeCode}")?.Value?.ToString() ?? "none",
+            SecondaryEntity = entity.GetAttributeValue<AliasedValue>($"filter.{SdkMessageFilter.Fields.SecondaryObjectTypeCode}")?.Value?.ToString(),
+            Stage = MapStageFromValue(entity.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStep.Fields.Stage)?.Value ?? StagePostOperation),
+            Mode = MapModeFromValue(entity.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStep.Fields.Mode)?.Value ?? 0),
+            ExecutionOrder = entity.GetAttributeValue<int>(SdkMessageProcessingStep.Fields.Rank),
+            FilteringAttributes = entity.GetAttributeValue<string>(SdkMessageProcessingStep.Fields.FilteringAttributes),
+            Configuration = entity.GetAttributeValue<string>(SdkMessageProcessingStep.Fields.Configuration),
+            IsEnabled = entity.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStep.Fields.StateCode)?.Value == (int)sdkmessageprocessingstep_statecode.Enabled,
+            Description = entity.GetAttributeValue<string>(SdkMessageProcessingStep.Fields.Description),
+            Deployment = MapDeploymentFromValue(entity.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStep.Fields.SupportedDeployment)?.Value ?? 0),
+            AsyncAutoDelete = entity.GetAttributeValue<bool?>(SdkMessageProcessingStep.Fields.AsyncAutoDelete) ?? false
+        };
+    }
+
+    /// <summary>
     /// Creates or updates a plugin type.
     /// </summary>
     /// <param name="assemblyId">The assembly ID.</param>

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
@@ -70,6 +70,13 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
+    public void Create_HasRegisterSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "register");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
     public void Create_HasDownloadSubcommand()
     {
         var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "download");
@@ -77,9 +84,9 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
-    public void Create_HasSevenSubcommands()
+    public void Create_HasEightSubcommands()
     {
-        Assert.Equal(7, _command.Subcommands.Count);
+        Assert.Equal(8, _command.Subcommands.Count);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/RegisterCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/RegisterCommandTests.cs
@@ -114,13 +114,6 @@ public class RegisterCommandTests : IDisposable
         Assert.NotNull(argument);
     }
 
-    [Fact]
-    public void Assembly_HasIsolationOption()
-    {
-        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
-        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--isolation");
-        Assert.NotNull(option);
-    }
 
     [Fact]
     public void Assembly_HasProfileOption()
@@ -148,7 +141,7 @@ public class RegisterCommandTests : IDisposable
     [Fact]
     public void Assembly_Parse_WithAllOptions_Succeeds()
     {
-        var result = _command.Parse($"assembly \"{_tempDllFile}\" --profile dev --solution MySolution --isolation Sandbox");
+        var result = _command.Parse($"assembly \"{_tempDllFile}\" --profile dev --solution MySolution");
         Assert.Empty(result.Errors);
     }
 

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/RegisterCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/RegisterCommandTests.cs
@@ -1,0 +1,437 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Plugins;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Plugins;
+
+public class RegisterCommandTests : IDisposable
+{
+    private readonly Command _command;
+    private readonly string _tempDllFile;
+    private readonly string _tempNupkgFile;
+    private readonly string _originalDir;
+
+    public RegisterCommandTests()
+    {
+        _command = RegisterCommand.Create();
+
+        // Create temp files for parsing tests
+        _tempDllFile = Path.Combine(Path.GetTempPath(), $"TestPlugin-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(_tempDllFile, [0x4D, 0x5A]); // MZ header for valid DLL
+
+        // Create a minimal nupkg (zip with .nuspec)
+        _tempNupkgFile = Path.Combine(Path.GetTempPath(), $"TestPlugin-{Guid.NewGuid()}.nupkg");
+        CreateMinimalNupkg(_tempNupkgFile);
+
+        _originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(Path.GetTempPath());
+    }
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalDir);
+        if (File.Exists(_tempDllFile))
+            File.Delete(_tempDllFile);
+        if (File.Exists(_tempNupkgFile))
+            File.Delete(_tempNupkgFile);
+    }
+
+    private static void CreateMinimalNupkg(string path)
+    {
+        using var archive = System.IO.Compression.ZipFile.Open(path, System.IO.Compression.ZipArchiveMode.Create);
+        var entry = archive.CreateEntry("test.nuspec");
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write("""
+            <?xml version="1.0"?>
+            <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+              <metadata>
+                <id>TestPlugin</id>
+                <version>1.0.0</version>
+              </metadata>
+            </package>
+            """);
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("register", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("Register", _command.Description);
+    }
+
+    [Fact]
+    public void Create_HasAssemblySubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "assembly");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasPackageSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "package");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasTypeSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "type");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasStepSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "step");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasImageSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "image");
+        Assert.NotNull(subcommand);
+    }
+
+    #endregion
+
+    #region Assembly Subcommand Tests
+
+    [Fact]
+    public void Assembly_HasPathArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "path");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Assembly_HasIsolationOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--isolation");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Assembly_HasProfileOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Assembly_HasSolutionOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "assembly");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--solution");
+        Assert.NotNull(option);
+    }
+
+    [Fact]
+    public void Assembly_Parse_WithPath_Succeeds()
+    {
+        var result = _command.Parse($"assembly \"{_tempDllFile}\"");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Assembly_Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse($"assembly \"{_tempDllFile}\" --profile dev --solution MySolution --isolation Sandbox");
+        Assert.Empty(result.Errors);
+    }
+
+    #endregion
+
+    #region Package Subcommand Tests
+
+    [Fact]
+    public void Package_HasPathArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "package");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "path");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Package_Parse_WithPath_Succeeds()
+    {
+        var result = _command.Parse($"package \"{_tempNupkgFile}\"");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Package_Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse($"package \"{_tempNupkgFile}\" --profile dev --solution MySolution");
+        Assert.Empty(result.Errors);
+    }
+
+    #endregion
+
+    #region Type Subcommand Tests
+
+    [Fact]
+    public void Type_HasAssemblyArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "type");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "assembly");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Type_HasTypenameOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "type");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--typename");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Type_Parse_WithRequiredOptions_Succeeds()
+    {
+        var result = _command.Parse("type MyAssembly --typename MyNamespace.MyPlugin");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Type_Parse_MissingTypename_HasError()
+    {
+        var result = _command.Parse("type MyAssembly");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Step Subcommand Tests
+
+    [Fact]
+    public void Step_HasTypeArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "type");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Step_HasRequiredMessageOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--message");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasRequiredEntityOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--entity");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasRequiredStageOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--stage");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasOptionalModeOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--mode");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasOptionalRankOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--rank");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasOptionalFilteringAttributesOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--filtering-attributes");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Step_HasOptionalNameOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "step");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--name");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Step_Parse_WithRequiredOptions_Succeeds()
+    {
+        var result = _command.Parse("step MyNamespace.MyPlugin --message Create --entity account --stage PostOperation");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Step_Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse(
+            "step MyNamespace.MyPlugin " +
+            "--message Update " +
+            "--entity account " +
+            "--stage PreOperation " +
+            "--mode Sync " +
+            "--rank 10 " +
+            "--filtering-attributes \"name,telephone1\" " +
+            "--name \"MyPlugin: Update of account\" " +
+            "--solution MySolution");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Step_Parse_MissingMessage_HasError()
+    {
+        var result = _command.Parse("step MyPlugin --entity account --stage PostOperation");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Step_Parse_MissingEntity_HasError()
+    {
+        var result = _command.Parse("step MyPlugin --message Create --stage PostOperation");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Step_Parse_MissingStage_HasError()
+    {
+        var result = _command.Parse("step MyPlugin --message Create --entity account");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Image Subcommand Tests
+
+    [Fact]
+    public void Image_HasStepArgument()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "image");
+        var argument = subcommand.Arguments.FirstOrDefault(a => a.Name == "step");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Image_HasRequiredNameOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "image");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--name");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Image_HasRequiredTypeOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "image");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--type");
+        Assert.NotNull(option);
+        Assert.True(option.Required);
+    }
+
+    [Fact]
+    public void Image_HasOptionalAttributesOption()
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == "image");
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--attributes");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Image_Parse_WithRequiredOptions_Succeeds()
+    {
+        var result = _command.Parse("image \"MyPlugin: Create of account\" --name PreImage --type pre");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Image_Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse(
+            "image \"MyPlugin: Update of account\" " +
+            "--name PreImage " +
+            "--type pre " +
+            "--attributes \"name,accountnumber,statecode\"");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Image_Parse_MissingName_HasError()
+    {
+        var result = _command.Parse("image \"MyPlugin: Create of account\" --type pre");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Image_Parse_MissingType_HasError()
+    {
+        var result = _command.Parse("image \"MyPlugin: Create of account\" --name PreImage");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    #endregion
+
+    #region Global Options Tests
+
+    [Theory]
+    [InlineData("assembly")]
+    [InlineData("package")]
+    [InlineData("type")]
+    [InlineData("step")]
+    [InlineData("image")]
+    public void Subcommand_HasOutputFormatOption(string subcommandName)
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == subcommandName);
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--output-format");
+        Assert.NotNull(option);
+    }
+
+    [Theory]
+    [InlineData("assembly")]
+    [InlineData("package")]
+    [InlineData("type")]
+    [InlineData("step")]
+    [InlineData("image")]
+    public void Subcommand_HasVerboseOption(string subcommandName)
+    {
+        var subcommand = _command.Subcommands.First(c => c.Name == subcommandName);
+        var option = subcommand.Options.FirstOrDefault(o => o.Name == "--verbose");
+        Assert.NotNull(option);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Add new `ppds plugins register` command group with 5 subcommands:
- `register assembly` - Register a plugin assembly (DLL) directly to Dataverse
- `register package` - Register a NuGet plugin package
- `register type` - Register a plugin type within an assembly
- `register step` - Register a processing step for a plugin type
- `register image` - Register an image for a processing step

This enables direct imperative registration of plugin components without requiring a `registrations.json` configuration file, complementing the existing `ppds plugins deploy` workflow.

### Changes

- Add `GetPluginTypeByNameAsync` and `GetStepByNameAsync` lookup methods to `IPluginRegistrationService`
- Create `RegisterCommand.cs` with 5 subcommands following existing CLI patterns
- Add `RegisterCommand` to `PluginsCommandGroup`
- Add comprehensive unit tests for command structure and argument parsing

### Example Usage

```bash
# Register an assembly
ppds plugins register assembly MyPlugin.dll --solution MySolution

# Register a NuGet package
ppds plugins register package MyPlugin.1.0.0.nupkg --solution MySolution

# Register a plugin type
ppds plugins register type MyAssembly --typename MyNamespace.MyPlugin

# Register a step
ppds plugins register step MyNamespace.MyPlugin \
  --message Create --entity account --stage PostOperation

# Register an image
ppds plugins register image "MyPlugin: Create of account" \
  --name PreImage --type pre --attributes "name,accountnumber"
```

## Test plan

- [x] Unit tests pass (1378 tests across all frameworks)
- [x] Command structure tests verify options and arguments
- [x] Argument parsing tests verify all required/optional options
- [x] Build succeeds on net8.0, net9.0, net10.0

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)