### PR TITLE
feat(plugins): add unregister command for plugin cleanup

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Plugins/PluginsCommandGroup.cs
@@ -36,7 +36,7 @@ public static class PluginsCommandGroup
     /// </summary>
     public static Command Create()
     {
-        var command = new Command("plugins", "Plugin registration management: extract, deploy, register, diff, list, get, clean, download");
+        var command = new Command("plugins", "Plugin registration management: extract, deploy, register, diff, list, get, clean, download, unregister");
 
         command.Subcommands.Add(ExtractCommand.Create());
         command.Subcommands.Add(DeployCommand.Create());
@@ -46,6 +46,7 @@ public static class PluginsCommandGroup
         command.Subcommands.Add(GetCommand.Create());
         command.Subcommands.Add(CleanCommand.Create());
         command.Subcommands.Add(DownloadCommand.Create());
+        command.Subcommands.Add(UnregisterCommand.Create());
 
         return command;
     }

--- a/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
@@ -1,0 +1,322 @@
+using System.CommandLine;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Plugins.Registration;
+
+namespace PPDS.Cli.Commands.Plugins;
+
+/// <summary>
+/// Unregister plugin entities from Dataverse.
+/// </summary>
+public static class UnregisterCommand
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>
+    /// Valid entity types for unregistration.
+    /// </summary>
+    private static readonly string[] ValidEntityTypes = ["assembly", "package", "type", "step", "image"];
+
+    public static Command Create()
+    {
+        var entityTypeArg = new Argument<string>("type")
+        {
+            Description = "The type of entity to unregister: assembly, package, type, step, image"
+        };
+
+        var nameOrIdArg = new Argument<string>("name-or-id")
+        {
+            Description = "Name or GUID of the entity to unregister"
+        };
+
+        var forceOption = new Option<bool>("--force", "-f")
+        {
+            Description = "Force cascade delete of all child entities",
+            DefaultValueFactory = _ => false
+        };
+
+        var command = new Command("unregister", "Unregister plugin entities from Dataverse")
+        {
+            entityTypeArg,
+            nameOrIdArg,
+            forceOption,
+            PluginsCommandGroup.ProfileOption,
+            PluginsCommandGroup.EnvironmentOption
+        };
+
+        // Add global options including output format
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var entityType = parseResult.GetValue(entityTypeArg)!;
+            var nameOrId = parseResult.GetValue(nameOrIdArg)!;
+            var force = parseResult.GetValue(forceOption);
+            var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
+            var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(entityType, nameOrId, force, profile, environment, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string entityType,
+        string nameOrId,
+        bool force,
+        string? profile,
+        string? environment,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        // Validate entity type
+        var normalizedType = entityType.ToLowerInvariant();
+        if (!ValidEntityTypes.Contains(normalizedType))
+        {
+            writer.WriteError(new StructuredError(
+                ErrorCodes.Validation.InvalidValue,
+                $"Invalid entity type: {entityType}. Valid types are: {string.Join(", ", ValidEntityTypes)}",
+                Target: "type"));
+            return ExitCodes.InvalidArguments;
+        }
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                profile,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var registrationService = serviceProvider.GetRequiredService<IPluginRegistrationService>();
+
+            if (!globalOptions.IsJsonMode)
+            {
+                var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                ConsoleHeader.WriteConnectedAs(connectionInfo);
+                Console.Error.WriteLine();
+            }
+
+            var result = await UnregisterEntityAsync(
+                registrationService,
+                normalizedType,
+                nameOrId,
+                force,
+                cancellationToken);
+
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteSuccess(result);
+            }
+            else
+            {
+                WriteHumanOutput(result);
+            }
+
+            return ExitCodes.Success;
+        }
+        catch (UnregisterException ex)
+        {
+            if (globalOptions.IsJsonMode)
+            {
+                writer.WriteError(new StructuredError(
+                    ex.ErrorCode,
+                    ex.Message,
+                    Target: ex.EntityName));
+            }
+            else
+            {
+                WriteUnregisterError(ex);
+            }
+
+            return ex.ErrorCode switch
+            {
+                "NOT_FOUND" => ExitCodes.NotFound,
+                "MANAGED" => ExitCodes.Forbidden,
+                "HAS_CHILDREN" => ExitCodes.PreconditionFailed,
+                _ => ExitCodes.Error
+            };
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "unregistering plugin", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    private static async Task<UnregisterResult> UnregisterEntityAsync(
+        IPluginRegistrationService service,
+        string entityType,
+        string nameOrId,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        return entityType switch
+        {
+            "image" => await UnregisterImageAsync(service, nameOrId, cancellationToken),
+            "step" => await UnregisterStepAsync(service, nameOrId, force, cancellationToken),
+            "type" => await UnregisterTypeAsync(service, nameOrId, force, cancellationToken),
+            "assembly" => await UnregisterAssemblyAsync(service, nameOrId, force, cancellationToken),
+            "package" => await UnregisterPackageAsync(service, nameOrId, force, cancellationToken),
+            _ => throw new InvalidOperationException($"Unknown entity type: {entityType}")
+        };
+    }
+
+    private static async Task<UnregisterResult> UnregisterImageAsync(
+        IPluginRegistrationService service,
+        string nameOrId,
+        CancellationToken cancellationToken)
+    {
+        var image = await service.GetImageByNameOrIdAsync(nameOrId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Image not found: {nameOrId}",
+                nameOrId,
+                "Image",
+                "NOT_FOUND");
+
+        return await service.UnregisterImageAsync(image.Id, cancellationToken);
+    }
+
+    private static async Task<UnregisterResult> UnregisterStepAsync(
+        IPluginRegistrationService service,
+        string nameOrId,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        var step = await service.GetStepByNameOrIdAsync(nameOrId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Step not found: {nameOrId}",
+                nameOrId,
+                "Step",
+                "NOT_FOUND");
+
+        return await service.UnregisterStepAsync(step.Id, force, cancellationToken);
+    }
+
+    private static async Task<UnregisterResult> UnregisterTypeAsync(
+        IPluginRegistrationService service,
+        string nameOrId,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        var pluginType = await service.GetPluginTypeByNameOrIdAsync(nameOrId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Plugin type not found: {nameOrId}",
+                nameOrId,
+                "Type",
+                "NOT_FOUND");
+
+        return await service.UnregisterPluginTypeAsync(pluginType.Id, force, cancellationToken);
+    }
+
+    private static async Task<UnregisterResult> UnregisterAssemblyAsync(
+        IPluginRegistrationService service,
+        string nameOrId,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        // Try by ID first, then by name
+        if (Guid.TryParse(nameOrId, out var id))
+        {
+            return await service.UnregisterAssemblyAsync(id, force, cancellationToken);
+        }
+
+        var assembly = await service.GetAssemblyByNameAsync(nameOrId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Assembly not found: {nameOrId}",
+                nameOrId,
+                "Assembly",
+                "NOT_FOUND");
+
+        return await service.UnregisterAssemblyAsync(assembly.Id, force, cancellationToken);
+    }
+
+    private static async Task<UnregisterResult> UnregisterPackageAsync(
+        IPluginRegistrationService service,
+        string nameOrId,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        // Try by ID first, then by name
+        if (Guid.TryParse(nameOrId, out var id))
+        {
+            return await service.UnregisterPackageAsync(id, force, cancellationToken);
+        }
+
+        var package = await service.GetPackageByNameAsync(nameOrId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Package not found: {nameOrId}",
+                nameOrId,
+                "Package",
+                "NOT_FOUND");
+
+        return await service.UnregisterPackageAsync(package.Id, force, cancellationToken);
+    }
+
+    private static void WriteHumanOutput(UnregisterResult result)
+    {
+        Console.Error.WriteLine($"Unregistered {result.EntityType.ToLowerInvariant()}: {result.EntityName}");
+
+        // Show cascade summary if applicable
+        var cascadeParts = new List<string>();
+        if (result.TypesDeleted > 0)
+            cascadeParts.Add($"{result.TypesDeleted} plugin type(s)");
+        if (result.StepsDeleted > 0)
+            cascadeParts.Add($"{result.StepsDeleted} step(s)");
+        if (result.ImagesDeleted > 0)
+            cascadeParts.Add($"{result.ImagesDeleted} image(s)");
+
+        if (cascadeParts.Count > 0)
+        {
+            Console.Error.WriteLine($"  Deleted: {string.Join(", ", cascadeParts)}");
+        }
+    }
+
+    private static void WriteUnregisterError(UnregisterException ex)
+    {
+        Console.Error.WriteLine($"Cannot unregister {ex.EntityType.ToLowerInvariant()}: {ex.EntityName}");
+
+        switch (ex.ErrorCode)
+        {
+            case "NOT_FOUND":
+                Console.Error.WriteLine($"  {ex.EntityType} not found in the environment.");
+                break;
+
+            case "MANAGED":
+                Console.Error.WriteLine("  Managed components cannot be deleted in this environment.");
+                break;
+
+            case "HAS_CHILDREN":
+                var childParts = new List<string>();
+                if (ex.TypeCount > 0)
+                    childParts.Add($"{ex.TypeCount} plugin type(s)");
+                if (ex.StepCount > 0)
+                    childParts.Add($"{ex.StepCount} active step(s)");
+                if (ex.ImageCount > 0)
+                    childParts.Add($"{ex.ImageCount} image(s)");
+
+                Console.Error.WriteLine($"  {ex.EntityType} has {string.Join(" with ", childParts)}.");
+                Console.Error.WriteLine("  Use --force to cascade delete all children.");
+                break;
+
+            default:
+                Console.Error.WriteLine($"  {ex.Message}");
+                break;
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
@@ -1,6 +1,4 @@
 using System.CommandLine;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
@@ -14,12 +12,6 @@ namespace PPDS.Cli.Commands.Plugins;
 /// </summary>
 public static class UnregisterCommand
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
-
     /// <summary>
     /// Valid entity types for unregistration.
     /// </summary>
@@ -145,10 +137,10 @@ public static class UnregisterCommand
 
             return ex.ErrorCode switch
             {
-                "NOT_FOUND" => ExitCodes.NotFound,
+                "NOT_FOUND" => ExitCodes.NotFoundError,
                 "MANAGED" => ExitCodes.Forbidden,
                 "HAS_CHILDREN" => ExitCodes.PreconditionFailed,
-                _ => ExitCodes.Error
+                _ => ExitCodes.Failure
             };
         }
         catch (Exception ex)
@@ -303,6 +295,8 @@ public static class UnregisterCommand
 
             case "HAS_CHILDREN":
                 var childParts = new List<string>();
+                if (ex.AssemblyCount > 0)
+                    childParts.Add($"{ex.AssemblyCount} assembly(ies)");
                 if (ex.TypeCount > 0)
                     childParts.Add($"{ex.TypeCount} plugin type(s)");
                 if (ex.StepCount > 0)

--- a/src/PPDS.Cli/Infrastructure/Errors/ExitCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ExitCodes.cs
@@ -31,4 +31,16 @@ public static class ExitCodes
 
     /// <summary>Validation error - incomplete mapping file, schema mismatch, etc.</summary>
     public const int ValidationError = 8;
+
+    /// <summary>Forbidden - action not allowed (e.g., deleting managed component).</summary>
+    public const int Forbidden = 9;
+
+    /// <summary>Precondition failed - operation blocked by current state (e.g., has children).</summary>
+    public const int PreconditionFailed = 10;
+
+    /// <summary>General error code for failure.</summary>
+    public const int Error = 1;
+
+    /// <summary>Not found - resource does not exist.</summary>
+    public const int NotFound = 6;
 }

--- a/src/PPDS.Cli/Infrastructure/Errors/ExitCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ExitCodes.cs
@@ -37,10 +37,4 @@ public static class ExitCodes
 
     /// <summary>Precondition failed - operation blocked by current state (e.g., has children).</summary>
     public const int PreconditionFailed = 10;
-
-    /// <summary>General error code for failure.</summary>
-    public const int Error = 1;
-
-    /// <summary>Not found - resource does not exist.</summary>
-    public const int NotFound = 6;
 }

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -317,6 +317,50 @@ public interface IPluginRegistrationService
     /// <param name="cancellationToken">Cancellation token.</param>
     Task DeletePluginTypeAsync(Guid pluginTypeId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Unregisters a step image by ID.
+    /// </summary>
+    /// <param name="imageId">The image ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the name of the deleted image.</returns>
+    Task<UnregisterResult> UnregisterImageAsync(Guid imageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unregisters a processing step and optionally its images.
+    /// </summary>
+    /// <param name="stepId">The step ID.</param>
+    /// <param name="force">If true, cascade delete all child images. If false, fails when images exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing counts of deleted entities.</returns>
+    Task<UnregisterResult> UnregisterStepAsync(Guid stepId, bool force = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unregisters a plugin type and optionally its steps and images.
+    /// </summary>
+    /// <param name="pluginTypeId">The plugin type ID.</param>
+    /// <param name="force">If true, cascade delete all child steps and images. If false, fails when steps exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing counts of deleted entities.</returns>
+    Task<UnregisterResult> UnregisterPluginTypeAsync(Guid pluginTypeId, bool force = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unregisters an assembly and optionally all its types, steps, and images.
+    /// </summary>
+    /// <param name="assemblyId">The assembly ID.</param>
+    /// <param name="force">If true, cascade delete all child entities. If false, fails when types with steps exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing counts of deleted entities.</returns>
+    Task<UnregisterResult> UnregisterAssemblyAsync(Guid assemblyId, bool force = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Unregisters a plugin package and optionally all its assemblies, types, steps, and images.
+    /// </summary>
+    /// <param name="packageId">The package ID.</param>
+    /// <param name="force">If true, cascade delete all child entities. If false, fails when assemblies exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing counts of deleted entities.</returns>
+    Task<UnregisterResult> UnregisterPackageAsync(Guid packageId, bool force = false, CancellationToken cancellationToken = default);
+
     #endregion
 
     #region Download Operations

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -116,7 +116,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 PluginAssembly.Fields.PublicKeyToken,
                 PluginAssembly.Fields.Culture,
                 PluginAssembly.Fields.IsolationMode,
-                PluginAssembly.Fields.SourceType),
+                PluginAssembly.Fields.SourceType,
+                PluginAssembly.Fields.IsManaged),
             Criteria = new FilterExpression
             {
                 Conditions =
@@ -151,7 +152,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             Name = e.GetAttributeValue<string>(PluginAssembly.Fields.Name) ?? string.Empty,
             Version = e.GetAttributeValue<string>(PluginAssembly.Fields.Version),
             PublicKeyToken = e.GetAttributeValue<string>(PluginAssembly.Fields.PublicKeyToken),
-            IsolationMode = e.GetAttributeValue<OptionSetValue>(PluginAssembly.Fields.IsolationMode)?.Value ?? (int)pluginassembly_isolationmode.Sandbox
+            IsolationMode = e.GetAttributeValue<OptionSetValue>(PluginAssembly.Fields.IsolationMode)?.Value ?? (int)pluginassembly_isolationmode.Sandbox,
+            IsManaged = e.GetAttributeValue<bool?>(PluginAssembly.Fields.IsManaged) ?? false
         }).ToList();
     }
 
@@ -173,7 +175,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             ColumnSet = new ColumnSet(
                 PluginPackage.Fields.Name,
                 PluginPackage.Fields.UniqueName,
-                PluginPackage.Fields.Version),
+                PluginPackage.Fields.Version,
+                PluginPackage.Fields.IsManaged),
             Orders = { new OrderExpression(PluginPackage.Fields.Name, OrderType.Ascending) }
         };
 
@@ -207,7 +210,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             Id = e.Id,
             Name = e.GetAttributeValue<string>(PluginPackage.Fields.Name) ?? string.Empty,
             UniqueName = e.GetAttributeValue<string>(PluginPackage.Fields.UniqueName),
-            Version = e.GetAttributeValue<string>(PluginPackage.Fields.Version)
+            Version = e.GetAttributeValue<string>(PluginPackage.Fields.Version),
+            IsManaged = e.GetAttributeValue<bool?>(PluginPackage.Fields.IsManaged) ?? false
         }).ToList();
     }
 
@@ -228,7 +232,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 PluginAssembly.Fields.PublicKeyToken,
                 PluginAssembly.Fields.Culture,
                 PluginAssembly.Fields.IsolationMode,
-                PluginAssembly.Fields.SourceType),
+                PluginAssembly.Fields.SourceType,
+                PluginAssembly.Fields.IsManaged),
             Criteria = new FilterExpression
             {
                 Conditions =
@@ -248,7 +253,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             Name = e.GetAttributeValue<string>(PluginAssembly.Fields.Name) ?? string.Empty,
             Version = e.GetAttributeValue<string>(PluginAssembly.Fields.Version),
             PublicKeyToken = e.GetAttributeValue<string>(PluginAssembly.Fields.PublicKeyToken),
-            IsolationMode = e.GetAttributeValue<OptionSetValue>(PluginAssembly.Fields.IsolationMode)?.Value ?? (int)pluginassembly_isolationmode.Sandbox
+            IsolationMode = e.GetAttributeValue<OptionSetValue>(PluginAssembly.Fields.IsolationMode)?.Value ?? (int)pluginassembly_isolationmode.Sandbox,
+            IsManaged = e.GetAttributeValue<bool?>(PluginAssembly.Fields.IsManaged) ?? false
         }).ToList();
     }
 
@@ -287,7 +293,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             ColumnSet = new ColumnSet(
                 PluginType.Fields.TypeName,
                 PluginType.Fields.FriendlyName,
-                PluginType.Fields.Name),
+                PluginType.Fields.Name,
+                PluginType.Fields.IsManaged),
             Criteria = new FilterExpression
             {
                 Conditions =
@@ -305,7 +312,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         {
             Id = e.Id,
             TypeName = e.GetAttributeValue<string>(PluginType.Fields.TypeName) ?? string.Empty,
-            FriendlyName = e.GetAttributeValue<string>(PluginType.Fields.FriendlyName)
+            FriendlyName = e.GetAttributeValue<string>(PluginType.Fields.FriendlyName),
+            IsManaged = e.GetAttributeValue<bool?>(PluginType.Fields.IsManaged) ?? false
         }).ToList();
     }
 
@@ -335,7 +343,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 SdkMessageProcessingStep.Fields.Description,
                 SdkMessageProcessingStep.Fields.SupportedDeployment,
                 SdkMessageProcessingStep.Fields.ImpersonatingUserId,
-                SdkMessageProcessingStep.Fields.AsyncAutoDelete),
+                SdkMessageProcessingStep.Fields.AsyncAutoDelete,
+                SdkMessageProcessingStep.Fields.IsManaged),
             Criteria = new FilterExpression
             {
                 Conditions =
@@ -396,7 +405,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 Deployment = MapDeploymentFromValue(e.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStep.Fields.SupportedDeployment)?.Value ?? 0),
                 ImpersonatingUserId = impersonatingUserRef?.Id,
                 ImpersonatingUserName = impersonatingUserName,
-                AsyncAutoDelete = e.GetAttributeValue<bool?>(SdkMessageProcessingStep.Fields.AsyncAutoDelete) ?? false
+                AsyncAutoDelete = e.GetAttributeValue<bool?>(SdkMessageProcessingStep.Fields.AsyncAutoDelete) ?? false,
+                IsManaged = e.GetAttributeValue<bool?>(SdkMessageProcessingStep.Fields.IsManaged) ?? false
             };
         }).ToList();
     }
@@ -416,7 +426,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 SdkMessageProcessingStepImage.Fields.Name,
                 SdkMessageProcessingStepImage.Fields.EntityAlias,
                 SdkMessageProcessingStepImage.Fields.ImageType,
-                SdkMessageProcessingStepImage.Fields.Attributes1),
+                SdkMessageProcessingStepImage.Fields.Attributes1,
+                SdkMessageProcessingStepImage.Fields.IsManaged),
             Criteria = new FilterExpression
             {
                 Conditions =
@@ -436,7 +447,8 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             Name = e.GetAttributeValue<string>(SdkMessageProcessingStepImage.Fields.Name) ?? string.Empty,
             EntityAlias = e.GetAttributeValue<string>(SdkMessageProcessingStepImage.Fields.EntityAlias),
             ImageType = MapImageTypeFromValue(e.GetAttributeValue<OptionSetValue>(SdkMessageProcessingStepImage.Fields.ImageType)?.Value ?? 0),
-            Attributes = e.GetAttributeValue<string>(SdkMessageProcessingStepImage.Fields.Attributes1)
+            Attributes = e.GetAttributeValue<string>(SdkMessageProcessingStepImage.Fields.Attributes1),
+            IsManaged = e.GetAttributeValue<bool?>(SdkMessageProcessingStepImage.Fields.IsManaged) ?? false
         }).ToList();
     }
 
@@ -1405,6 +1417,295 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
 
     #endregion
 
+    #region Unregister Operations
+
+    /// <summary>
+    /// Unregisters a step image by ID.
+    /// </summary>
+    public async Task<UnregisterResult> UnregisterImageAsync(Guid imageId, CancellationToken cancellationToken = default)
+    {
+        // Get image info first
+        var query = new QueryExpression(SdkMessageProcessingStepImage.EntityLogicalName)
+        {
+            ColumnSet = new ColumnSet(
+                SdkMessageProcessingStepImage.Fields.Name,
+                SdkMessageProcessingStepImage.Fields.IsManaged)
+        };
+        query.Criteria.AddCondition(SdkMessageProcessingStepImage.Fields.SdkMessageProcessingStepImageId, ConditionOperator.Equal, imageId);
+
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        var results = await RetrieveMultipleAsync(query, client, cancellationToken);
+        var entity = results.Entities.FirstOrDefault()
+            ?? throw new UnregisterException(
+                $"Image with ID {imageId} not found.",
+                imageId.ToString(),
+                "Image",
+                "NOT_FOUND");
+
+        var name = entity.GetAttributeValue<string>(SdkMessageProcessingStepImage.Fields.Name) ?? string.Empty;
+        var isManaged = entity.GetAttributeValue<bool?>(SdkMessageProcessingStepImage.Fields.IsManaged) ?? false;
+
+        if (isManaged)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister: {name} is managed. Managed components cannot be deleted in this environment.",
+                name,
+                "Image",
+                "MANAGED");
+        }
+
+        await DeleteAsync(SdkMessageProcessingStepImage.EntityLogicalName, imageId, client, cancellationToken);
+
+        return new UnregisterResult
+        {
+            EntityName = name,
+            EntityType = "Image",
+            ImagesDeleted = 1
+        };
+    }
+
+    /// <summary>
+    /// Unregisters a processing step and optionally its images.
+    /// </summary>
+    public async Task<UnregisterResult> UnregisterStepAsync(Guid stepId, bool force = false, CancellationToken cancellationToken = default)
+    {
+        // Get step info
+        var step = await GetStepByNameOrIdAsync(stepId.ToString(), cancellationToken)
+            ?? throw new UnregisterException(
+                $"Step with ID {stepId} not found.",
+                stepId.ToString(),
+                "Step",
+                "NOT_FOUND");
+
+        if (step.IsManaged)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister: {step.Name} is managed. Managed components cannot be deleted in this environment.",
+                step.Name,
+                "Step",
+                "MANAGED");
+        }
+
+        // Check for images
+        var images = await ListImagesForStepAsync(stepId, cancellationToken);
+
+        if (images.Count > 0 && !force)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister step: {step.Name}. Step has {images.Count} image(s). Use --force to cascade delete all images.",
+                step.Name,
+                "Step",
+                "HAS_CHILDREN",
+                imageCount: images.Count);
+        }
+
+        var result = new UnregisterResult
+        {
+            EntityName = step.Name,
+            EntityType = "Step"
+        };
+
+        // Delete images in parallel if force
+        if (images.Count > 0)
+        {
+            var parallelism = _pool.GetTotalRecommendedParallelism();
+            await Parallel.ForEachAsync(
+                images,
+                new ParallelOptions { MaxDegreeOfParallelism = parallelism, CancellationToken = cancellationToken },
+                async (image, ct) =>
+                {
+                    await using var imageClient = await _pool.GetClientAsync(cancellationToken: ct);
+                    await DeleteAsync(SdkMessageProcessingStepImage.EntityLogicalName, image.Id, imageClient, ct);
+                });
+            result.ImagesDeleted = images.Count;
+        }
+
+        // Delete step
+        await using var stepClient = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        await DeleteAsync(SdkMessageProcessingStep.EntityLogicalName, stepId, stepClient, cancellationToken);
+        result.StepsDeleted = 1;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Unregisters a plugin type and optionally its steps and images.
+    /// </summary>
+    public async Task<UnregisterResult> UnregisterPluginTypeAsync(Guid pluginTypeId, bool force = false, CancellationToken cancellationToken = default)
+    {
+        // Get type info
+        var pluginType = await GetPluginTypeByNameOrIdAsync(pluginTypeId.ToString(), cancellationToken)
+            ?? throw new UnregisterException(
+                $"Plugin type with ID {pluginTypeId} not found.",
+                pluginTypeId.ToString(),
+                "Type",
+                "NOT_FOUND");
+
+        if (pluginType.IsManaged)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister: {pluginType.TypeName} is managed. Managed components cannot be deleted in this environment.",
+                pluginType.TypeName,
+                "Type",
+                "MANAGED");
+        }
+
+        // Check for steps
+        var steps = await ListStepsForTypeAsync(pluginTypeId, options: null, cancellationToken);
+
+        if (steps.Count > 0 && !force)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister plugin type: {pluginType.TypeName}. Type has {steps.Count} active step(s). Use --force to cascade delete all steps and images.",
+                pluginType.TypeName,
+                "Type",
+                "HAS_CHILDREN",
+                stepCount: steps.Count);
+        }
+
+        var result = new UnregisterResult
+        {
+            EntityName = pluginType.TypeName,
+            EntityType = "Type"
+        };
+
+        // Delete steps (and their images) in parallel if force
+        foreach (var step in steps)
+        {
+            var stepResult = await UnregisterStepAsync(step.Id, force: true, cancellationToken);
+            result += stepResult;
+        }
+
+        // Delete type
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        await DeleteAsync(PluginType.EntityLogicalName, pluginTypeId, client, cancellationToken);
+        result.TypesDeleted = 1;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Unregisters an assembly and optionally all its types, steps, and images.
+    /// </summary>
+    public async Task<UnregisterResult> UnregisterAssemblyAsync(Guid assemblyId, bool force = false, CancellationToken cancellationToken = default)
+    {
+        // Get assembly info
+        var assembly = await GetAssemblyByIdAsync(assemblyId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Assembly with ID {assemblyId} not found.",
+                assemblyId.ToString(),
+                "Assembly",
+                "NOT_FOUND");
+
+        if (assembly.IsManaged)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister: {assembly.Name} is managed. Managed components cannot be deleted in this environment.",
+                assembly.Name,
+                "Assembly",
+                "MANAGED");
+        }
+
+        // Get types and their steps
+        var types = await ListTypesForAssemblyAsync(assemblyId, cancellationToken);
+        var totalSteps = 0;
+
+        foreach (var type in types)
+        {
+            var steps = await ListStepsForTypeAsync(type.Id, options: null, cancellationToken);
+            totalSteps += steps.Count;
+        }
+
+        if (totalSteps > 0 && !force)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister assembly: {assembly.Name}. Assembly has {types.Count} plugin type(s) with {totalSteps} active step(s). Use --force to cascade delete all children.",
+                assembly.Name,
+                "Assembly",
+                "HAS_CHILDREN",
+                typeCount: types.Count,
+                stepCount: totalSteps);
+        }
+
+        var result = new UnregisterResult
+        {
+            EntityName = assembly.Name,
+            EntityType = "Assembly"
+        };
+
+        // Delete types (and their steps/images) in sequence
+        foreach (var type in types)
+        {
+            var typeResult = await UnregisterPluginTypeAsync(type.Id, force: true, cancellationToken);
+            result += typeResult;
+        }
+
+        // Delete assembly
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        await DeleteAsync(PluginAssembly.EntityLogicalName, assemblyId, client, cancellationToken);
+        result.AssembliesDeleted = 1;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Unregisters a plugin package and optionally all its assemblies, types, steps, and images.
+    /// </summary>
+    public async Task<UnregisterResult> UnregisterPackageAsync(Guid packageId, bool force = false, CancellationToken cancellationToken = default)
+    {
+        // Get package info
+        var package = await GetPackageByIdAsync(packageId, cancellationToken)
+            ?? throw new UnregisterException(
+                $"Package with ID {packageId} not found.",
+                packageId.ToString(),
+                "Package",
+                "NOT_FOUND");
+
+        if (package.IsManaged)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister: {package.Name} is managed. Managed components cannot be deleted in this environment.",
+                package.Name,
+                "Package",
+                "MANAGED");
+        }
+
+        // Get assemblies
+        var assemblies = await ListAssembliesForPackageAsync(packageId, cancellationToken);
+
+        if (assemblies.Count > 0 && !force)
+        {
+            throw new UnregisterException(
+                $"Cannot unregister package: {package.Name}. Package has {assemblies.Count} assembly(ies). Use --force to cascade delete all children.",
+                package.Name,
+                "Package",
+                "HAS_CHILDREN",
+                typeCount: assemblies.Count);
+        }
+
+        var result = new UnregisterResult
+        {
+            EntityName = package.Name,
+            EntityType = "Package"
+        };
+
+        // Delete assemblies (and their types/steps/images) in sequence
+        foreach (var assembly in assemblies)
+        {
+            var assemblyResult = await UnregisterAssemblyAsync(assembly.Id, force: true, cancellationToken);
+            result += assemblyResult;
+        }
+
+        // Delete package
+        await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
+        await DeleteAsync(PluginPackage.EntityLogicalName, packageId, client, cancellationToken);
+        result.PackagesDeleted = 1;
+
+        return result;
+    }
+
+    #endregion
+
     #region Solution Operations
 
     /// <summary>
@@ -1721,6 +2022,7 @@ public sealed class PluginTypeInfo
     public string? FriendlyName { get; set; }
     public Guid? AssemblyId { get; set; }
     public string? AssemblyName { get; set; }
+    public bool IsManaged { get; set; }
     public DateTime? CreatedOn { get; set; }
     public DateTime? ModifiedOn { get; set; }
 }
@@ -1748,6 +2050,7 @@ public sealed class PluginStepInfo
     public bool AsyncAutoDelete { get; set; }
     public Guid? PluginTypeId { get; set; }
     public string? PluginTypeName { get; set; }
+    public bool IsManaged { get; set; }
     public DateTime? CreatedOn { get; set; }
     public DateTime? ModifiedOn { get; set; }
 }
@@ -1765,8 +2068,126 @@ public sealed class PluginImageInfo
     public string? MessagePropertyName { get; set; }
     public Guid? StepId { get; set; }
     public string? StepName { get; set; }
+    public bool IsManaged { get; set; }
     public DateTime? CreatedOn { get; set; }
     public DateTime? ModifiedOn { get; set; }
+}
+
+/// <summary>
+/// Result of an unregister operation.
+/// </summary>
+public sealed class UnregisterResult
+{
+    /// <summary>
+    /// Name of the deleted entity.
+    /// </summary>
+    public string EntityName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Type of entity that was deleted (Package, Assembly, Type, Step, Image).
+    /// </summary>
+    public string EntityType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Number of packages deleted (for cascade operations).
+    /// </summary>
+    public int PackagesDeleted { get; set; }
+
+    /// <summary>
+    /// Number of assemblies deleted (for cascade operations).
+    /// </summary>
+    public int AssembliesDeleted { get; set; }
+
+    /// <summary>
+    /// Number of plugin types deleted (for cascade operations).
+    /// </summary>
+    public int TypesDeleted { get; set; }
+
+    /// <summary>
+    /// Number of steps deleted (for cascade operations).
+    /// </summary>
+    public int StepsDeleted { get; set; }
+
+    /// <summary>
+    /// Number of images deleted (for cascade operations).
+    /// </summary>
+    public int ImagesDeleted { get; set; }
+
+    /// <summary>
+    /// Gets the total number of entities deleted.
+    /// </summary>
+    public int TotalDeleted => PackagesDeleted + AssembliesDeleted + TypesDeleted + StepsDeleted + ImagesDeleted;
+
+    /// <summary>
+    /// Combines two unregister results.
+    /// </summary>
+    public static UnregisterResult operator +(UnregisterResult a, UnregisterResult b)
+    {
+        return new UnregisterResult
+        {
+            EntityName = a.EntityName,
+            EntityType = a.EntityType,
+            PackagesDeleted = a.PackagesDeleted + b.PackagesDeleted,
+            AssembliesDeleted = a.AssembliesDeleted + b.AssembliesDeleted,
+            TypesDeleted = a.TypesDeleted + b.TypesDeleted,
+            StepsDeleted = a.StepsDeleted + b.StepsDeleted,
+            ImagesDeleted = a.ImagesDeleted + b.ImagesDeleted
+        };
+    }
+}
+
+/// <summary>
+/// Exception thrown when an unregister operation cannot proceed.
+/// </summary>
+public sealed class UnregisterException : Exception
+{
+    /// <summary>
+    /// The name of the entity that could not be unregistered.
+    /// </summary>
+    public string EntityName { get; }
+
+    /// <summary>
+    /// The type of entity (Assembly, Package, Type, Step).
+    /// </summary>
+    public string EntityType { get; }
+
+    /// <summary>
+    /// Error code for programmatic handling.
+    /// </summary>
+    public string ErrorCode { get; }
+
+    /// <summary>
+    /// Number of child types that exist (for assembly/package).
+    /// </summary>
+    public int TypeCount { get; }
+
+    /// <summary>
+    /// Number of child steps that exist (for type/assembly/package).
+    /// </summary>
+    public int StepCount { get; }
+
+    /// <summary>
+    /// Number of child images that exist (for step).
+    /// </summary>
+    public int ImageCount { get; }
+
+    public UnregisterException(
+        string message,
+        string entityName,
+        string entityType,
+        string errorCode,
+        int typeCount = 0,
+        int stepCount = 0,
+        int imageCount = 0)
+        : base(message)
+    {
+        EntityName = entityName;
+        EntityType = entityType;
+        ErrorCode = errorCode;
+        TypeCount = typeCount;
+        StepCount = stepCount;
+        ImageCount = imageCount;
+    }
 }
 
 #endregion

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -1569,7 +1569,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
             EntityType = "Type"
         };
 
-        // Delete steps (and their images) in parallel if force
+        // Delete steps (and their images) in sequence
         foreach (var step in steps)
         {
             var stepResult = await UnregisterStepAsync(step.Id, force: true, cancellationToken);
@@ -1680,7 +1680,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
                 package.Name,
                 "Package",
                 "HAS_CHILDREN",
-                typeCount: assemblies.Count);
+                assemblyCount: assemblies.Count);
         }
 
         var result = new UnregisterResult
@@ -2157,6 +2157,11 @@ public sealed class UnregisterException : Exception
     public string ErrorCode { get; }
 
     /// <summary>
+    /// Number of child assemblies that exist (for package).
+    /// </summary>
+    public int AssemblyCount { get; }
+
+    /// <summary>
     /// Number of child types that exist (for assembly/package).
     /// </summary>
     public int TypeCount { get; }
@@ -2176,6 +2181,7 @@ public sealed class UnregisterException : Exception
         string entityName,
         string entityType,
         string errorCode,
+        int assemblyCount = 0,
         int typeCount = 0,
         int stepCount = 0,
         int imageCount = 0)
@@ -2184,6 +2190,7 @@ public sealed class UnregisterException : Exception
         EntityName = entityName;
         EntityType = entityType;
         ErrorCode = errorCode;
+        AssemblyCount = assemblyCount;
         TypeCount = typeCount;
         StepCount = stepCount;
         ImageCount = imageCount;

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/PluginsCommandGroupTests.cs
@@ -42,6 +42,13 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
+    public void Create_HasRegisterSubcommand()
+    {
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "register");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
     public void Create_HasDiffSubcommand()
     {
         var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "diff");
@@ -56,13 +63,6 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
-    public void Create_HasCleanSubcommand()
-    {
-        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "clean");
-        Assert.NotNull(subcommand);
-    }
-
-    [Fact]
     public void Create_HasGetSubcommand()
     {
         var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "get");
@@ -70,9 +70,9 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
-    public void Create_HasRegisterSubcommand()
+    public void Create_HasCleanSubcommand()
     {
-        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "register");
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "clean");
         Assert.NotNull(subcommand);
     }
 
@@ -84,9 +84,16 @@ public class PluginsCommandGroupTests
     }
 
     [Fact]
-    public void Create_HasEightSubcommands()
+    public void Create_HasUnregisterSubcommand()
     {
-        Assert.Equal(8, _command.Subcommands.Count);
+        var subcommand = _command.Subcommands.FirstOrDefault(c => c.Name == "unregister");
+        Assert.NotNull(subcommand);
+    }
+
+    [Fact]
+    public void Create_HasNineSubcommands()
+    {
+        Assert.Equal(9, _command.Subcommands.Count);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/UnregisterCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/UnregisterCommandTests.cs
@@ -1,0 +1,164 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using PPDS.Cli.Commands.Plugins;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Plugins;
+
+public class UnregisterCommandTests
+{
+    private readonly Command _command;
+
+    public UnregisterCommandTests()
+    {
+        _command = UnregisterCommand.Create();
+    }
+
+    #region Command Structure Tests
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("unregister", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.Contains("Unregister", _command.Description);
+    }
+
+    [Fact]
+    public void Create_HasTypeArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "type");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Create_HasNameOrIdArgument()
+    {
+        var argument = _command.Arguments.FirstOrDefault(a => a.Name == "name-or-id");
+        Assert.NotNull(argument);
+    }
+
+    [Fact]
+    public void Create_HasOptionalForceOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--force");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+        Assert.Contains("-f", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasOptionalProfileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--profile");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasOptionalEnvironmentOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    [Fact]
+    public void Create_HasOptionalOutputFormatOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--output-format");
+        Assert.NotNull(option);
+        Assert.False(option.Required);
+    }
+
+    #endregion
+
+    #region Argument Parsing Tests
+
+    [Theory]
+    [InlineData("assembly", "MyPlugin")]
+    [InlineData("package", "MyPlugin.Plugins")]
+    [InlineData("type", "MyNamespace.CreateHandler")]
+    [InlineData("step", "MyPlugin: Create of account")]
+    [InlineData("image", "MyPlugin: Create PreImage")]
+    public void Parse_WithValidTypeAndName_Succeeds(string entityType, string nameOrId)
+    {
+        var result = _command.Parse($"{entityType} \"{nameOrId}\"");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithGuid_Succeeds()
+    {
+        var guid = Guid.NewGuid();
+        var result = _command.Parse($"step {guid}");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithForceOption_Succeeds()
+    {
+        var result = _command.Parse("assembly MyPlugin --force");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithForceShortAlias_Succeeds()
+    {
+        var result = _command.Parse("assembly MyPlugin -f");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_MissingArguments_HasError()
+    {
+        var result = _command.Parse("");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_MissingNameOrId_HasError()
+    {
+        var result = _command.Parse("assembly");
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithOptionalProfile_Succeeds()
+    {
+        var result = _command.Parse("assembly MyPlugin --profile dev");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithOptionalEnvironment_Succeeds()
+    {
+        var result = _command.Parse("assembly MyPlugin --environment https://org.crm.dynamics.com");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithOptionalJson_Succeeds()
+    {
+        var result = _command.Parse("assembly MyPlugin --output-format Json");
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Parse_WithAllOptions_Succeeds()
+    {
+        var result = _command.Parse(
+            "assembly MyPlugin " +
+            "--force " +
+            "--profile dev " +
+            "--environment https://org.crm.dynamics.com " +
+            "--output-format Json");
+        Assert.Empty(result.Errors);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `ppds plugins unregister <type> <name-or-id>` command to remove plugin entities from Dataverse
- Support for all plugin entity types: assembly, package, type, step, image
- Validate managed state (prevents deletion of managed components)
- Support `--force` flag for cascade delete of child entities
- Proper error codes and exit statuses for programmatic handling

## Test plan

- [x] Unit tests for command structure and argument parsing
- [x] Tests for all entity type arguments
- [x] Build passes with no warnings
- [ ] Manual testing against Dataverse environment

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)