### PR TITLE
fix(session): address bot review feedback

### DIFF
--- a/src/PPDS.Cli/Commands/Session/UpdateCommand.cs
+++ b/src/PPDS.Cli/Commands/Session/UpdateCommand.cs
@@ -131,7 +131,7 @@ public static class UpdateCommand
             SessionStatus.Stuck => "!",
             SessionStatus.Paused => "-",
             SessionStatus.Complete => "+",
-            _ => "-"
+            _ => "?"
         };
 
         var prNumber = SessionService.ExtractPrNumber(prUrl);


### PR DESCRIPTION
## Summary

- Use `?` for unknown status icon in UpdateCommand (matches ListCommand)
- Only set CompletionReason on first transition to Complete status  
- Default CompletionReason to "Completed" if no reason provided
- Simplify CancelAllAsync condition to `is not SessionStatus.Complete`

## Test plan

- [x] Unit tests pass
- [x] Build passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)