### PR TITLE
refactor(plugins): convert InvalidOperationException to PpdsException per ADR-0026

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
@@ -211,8 +211,7 @@ public static class DownloadCommand
 
             return ExitCodes.Success;
         }
-        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent
-                                    || ex.ErrorCode == ErrorCodes.Plugin.ImageNotSupported)
+        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent)
         {
             writer.WriteError(new StructuredError(
                 ex.ErrorCode,
@@ -334,8 +333,7 @@ public static class DownloadCommand
 
             return ExitCodes.Success;
         }
-        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent
-                                    || ex.ErrorCode == ErrorCodes.Plugin.ImageNotSupported)
+        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent)
         {
             writer.WriteError(new StructuredError(
                 ex.ErrorCode,

--- a/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DownloadCommand.cs
@@ -211,11 +211,12 @@ public static class DownloadCommand
 
             return ExitCodes.Success;
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("has no content"))
+        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent
+                                    || ex.ErrorCode == ErrorCodes.Plugin.ImageNotSupported)
         {
             writer.WriteError(new StructuredError(
-                ErrorCodes.Validation.InvalidValue,
-                ex.Message,
+                ex.ErrorCode,
+                ex.UserMessage,
                 Target: nameOrId));
             return ExitCodes.InvalidArguments;
         }
@@ -333,11 +334,12 @@ public static class DownloadCommand
 
             return ExitCodes.Success;
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("has no content"))
+        catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Plugin.NoContent
+                                    || ex.ErrorCode == ErrorCodes.Plugin.ImageNotSupported)
         {
             writer.WriteError(new StructuredError(
-                ErrorCodes.Validation.InvalidValue,
-                ex.Message,
+                ex.ErrorCode,
+                ex.UserMessage,
                 Target: nameOrId));
             return ExitCodes.InvalidArguments;
         }

--- a/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
@@ -137,9 +137,9 @@ public static class UnregisterCommand
 
             return ex.ErrorCode switch
             {
-                "NOT_FOUND" => ExitCodes.NotFoundError,
-                "MANAGED" => ExitCodes.Forbidden,
-                "HAS_CHILDREN" => ExitCodes.PreconditionFailed,
+                ErrorCodes.Plugin.NotFound => ExitCodes.NotFoundError,
+                ErrorCodes.Plugin.ManagedComponent => ExitCodes.Forbidden,
+                ErrorCodes.Plugin.HasChildren => ExitCodes.PreconditionFailed,
                 _ => ExitCodes.Failure
             };
         }

--- a/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/UnregisterCommand.cs
@@ -179,7 +179,7 @@ public static class UnregisterCommand
                 $"Image not found: {nameOrId}",
                 nameOrId,
                 "Image",
-                "NOT_FOUND");
+                ErrorCodes.Plugin.NotFound);
 
         return await service.UnregisterImageAsync(image.Id, cancellationToken);
     }
@@ -195,7 +195,7 @@ public static class UnregisterCommand
                 $"Step not found: {nameOrId}",
                 nameOrId,
                 "Step",
-                "NOT_FOUND");
+                ErrorCodes.Plugin.NotFound);
 
         return await service.UnregisterStepAsync(step.Id, force, cancellationToken);
     }
@@ -211,7 +211,7 @@ public static class UnregisterCommand
                 $"Plugin type not found: {nameOrId}",
                 nameOrId,
                 "Type",
-                "NOT_FOUND");
+                ErrorCodes.Plugin.NotFound);
 
         return await service.UnregisterPluginTypeAsync(pluginType.Id, force, cancellationToken);
     }
@@ -233,7 +233,7 @@ public static class UnregisterCommand
                 $"Assembly not found: {nameOrId}",
                 nameOrId,
                 "Assembly",
-                "NOT_FOUND");
+                ErrorCodes.Plugin.NotFound);
 
         return await service.UnregisterAssemblyAsync(assembly.Id, force, cancellationToken);
     }
@@ -255,7 +255,7 @@ public static class UnregisterCommand
                 $"Package not found: {nameOrId}",
                 nameOrId,
                 "Package",
-                "NOT_FOUND");
+                ErrorCodes.Plugin.NotFound);
 
         return await service.UnregisterPackageAsync(package.Id, force, cancellationToken);
     }
@@ -285,15 +285,15 @@ public static class UnregisterCommand
 
         switch (ex.ErrorCode)
         {
-            case "NOT_FOUND":
+            case ErrorCodes.Plugin.NotFound:
                 Console.Error.WriteLine($"  {ex.EntityType} not found in the environment.");
                 break;
 
-            case "MANAGED":
+            case ErrorCodes.Plugin.ManagedComponent:
                 Console.Error.WriteLine("  Managed components cannot be deleted in this environment.");
                 break;
 
-            case "HAS_CHILDREN":
+            case ErrorCodes.Plugin.HasChildren:
                 var childParts = new List<string>();
                 if (ex.AssemblyCount > 0)
                     childParts.Add($"{ex.AssemblyCount} assembly(ies)");

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -196,4 +196,25 @@ public static class ErrorCodes
         /// <summary>The requested solution was not found.</summary>
         public const string NotFound = "Solution.NotFound";
     }
+
+    /// <summary>
+    /// Plugin-related errors.
+    /// </summary>
+    public static class Plugin
+    {
+        /// <summary>Plugin entity not found.</summary>
+        public const string NotFound = "Plugin.NotFound";
+
+        /// <summary>Assembly or package has no binary content.</summary>
+        public const string NoContent = "Plugin.NoContent";
+
+        /// <summary>Message does not support plugin images.</summary>
+        public const string ImageNotSupported = "Plugin.ImageNotSupported";
+
+        /// <summary>Cannot modify managed component.</summary>
+        public const string ManagedComponent = "Plugin.ManagedComponent";
+
+        /// <summary>Entity has child components that must be removed first.</summary>
+        public const string HasChildren = "Plugin.HasChildren";
+    }
 }

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -1,3 +1,4 @@
+using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Plugins.Models;
 
 namespace PPDS.Cli.Plugins.Registration;
@@ -285,7 +286,7 @@ public interface IPluginRegistrationService
     /// <param name="imageConfig">The image configuration.</param>
     /// <param name="messageName">The SDK message name (e.g., "Create", "Update", "SetState").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <exception cref="InvalidOperationException">Thrown when the message does not support images.</exception>
+    /// <exception cref="PpdsException">Thrown when the message does not support images.</exception>
     Task<Guid> UpsertImageAsync(
         Guid stepId,
         PluginImageConfig imageConfig,
@@ -371,7 +372,7 @@ public interface IPluginRegistrationService
     /// <param name="assemblyId">The assembly ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Tuple containing the binary content and assembly name with .dll extension.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when assembly has no content (e.g., source type is Disk or GAC).</exception>
+    /// <exception cref="PpdsException">Thrown when assembly has no content (e.g., source type is Disk or GAC).</exception>
     Task<(byte[] Content, string FileName)> DownloadAssemblyAsync(
         Guid assemblyId,
         CancellationToken cancellationToken = default);
@@ -382,7 +383,7 @@ public interface IPluginRegistrationService
     /// <param name="packageId">The package ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Tuple containing the binary content and package name with .nupkg extension.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when package has no content.</exception>
+    /// <exception cref="PpdsException">Thrown when package has no content.</exception>
     Task<(byte[] Content, string FileName)> DownloadPackageAsync(
         Guid packageId,
         CancellationToken cancellationToken = default);

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using Moq;
+using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Cli.Plugins.Registration;
 using PPDS.Dataverse.Client;
@@ -510,7 +511,7 @@ public class PluginRegistrationServiceTests
     [InlineData("Retrieve")]
     [InlineData("RetrieveMultiple")]
     [InlineData("CustomAction")]
-    public async Task UpsertImageAsync_ThrowsInvalidOperationException_ForUnsupportedMessages(string messageName)
+    public async Task UpsertImageAsync_ThrowsPpdsException_ForUnsupportedMessages(string messageName)
     {
         // Arrange
         var imageConfig = new PluginImageConfig
@@ -520,11 +521,12 @@ public class PluginRegistrationServiceTests
         };
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<PpdsException>(
             () => _sut.UpsertImageAsync(Guid.NewGuid(), imageConfig, messageName));
 
-        Assert.Contains(messageName, exception.Message);
-        Assert.Contains("does not support images", exception.Message);
+        Assert.Equal(ErrorCodes.Plugin.ImageNotSupported, exception.ErrorCode);
+        Assert.Contains(messageName, exception.UserMessage);
+        Assert.Contains("does not support plugin images", exception.UserMessage);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Add `ErrorCodes.Plugin` category with 5 new error codes for plugin operations
- Update `ExceptionMapper` to handle `PpdsException` (preserves structured error codes)
- Convert `UnregisterException` to inherit from `PpdsException` (was `Exception`)
- Convert 3 `InvalidOperationException` throws in `PluginRegistrationService` to `PpdsException`
- Update `DownloadCommand.cs` to catch `PpdsException` with error code matching (replaces fragile message filtering)
- Update `UnregisterCommand.cs` to use `ErrorCodes.Plugin.*` constants

## Test plan

- [x] Unit tests pass (1464 tests)
- [x] Build succeeds with warnings as errors
- [x] Updated existing test to expect `PpdsException` instead of `InvalidOperationException`

## Files Changed

| File | Changes |
|------|---------|
| `ErrorCodes.cs` | Added `Plugin` category (5 codes) |
| `ExceptionMapper.cs` | Handle `PpdsException` in `ToExitCode()` and `MapExceptionToCode()` |
| `PluginRegistrationService.cs` | Convert exceptions, inherit `UnregisterException` from `PpdsException` |
| `IPluginRegistrationService.cs` | Update XML docs |
| `DownloadCommand.cs` | Catch `PpdsException` instead of message filtering |
| `UnregisterCommand.cs` | Use `ErrorCodes.Plugin.*` constants |
| `PluginRegistrationServiceTests.cs` | Update test to expect `PpdsException` |

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)