### PR TITLE
fix(auth): check PPDS_TEST_CLIENT_SECRET for credential store bypass

### DIFF
--- a/src/PPDS.Auth/Credentials/CredentialProviderFactory.cs
+++ b/src/PPDS.Auth/Credentials/CredentialProviderFactory.cs
@@ -23,6 +23,20 @@ public static class CredentialProviderFactory
     public const string TestClientSecretEnvVar = "PPDS_TEST_CLIENT_SECRET";
 
     /// <summary>
+    /// Gets the SPN secret from environment variables, checking both production and test variables.
+    /// Returns null if neither is set.
+    /// </summary>
+    public static string? GetSpnSecretFromEnvironment() =>
+        Environment.GetEnvironmentVariable(SpnSecretEnvVar)
+        ?? Environment.GetEnvironmentVariable(TestClientSecretEnvVar);
+
+    /// <summary>
+    /// Returns true if credential store should be bypassed (SPN secret is available via environment).
+    /// </summary>
+    public static bool ShouldBypassCredentialStore() =>
+        !string.IsNullOrWhiteSpace(GetSpnSecretFromEnvironment());
+
+    /// <summary>
     /// Creates a credential provider for the specified auth profile.
     /// </summary>
     /// <param name="profile">The auth profile.</param>
@@ -43,9 +57,7 @@ public static class CredentialProviderFactory
             throw new ArgumentNullException(nameof(profile));
 
         // Check for environment variable override for SPN secret
-        // PPDS_SPN_SECRET takes precedence, PPDS_TEST_CLIENT_SECRET is fallback for test scenarios
-        var envSecret = Environment.GetEnvironmentVariable(SpnSecretEnvVar)
-            ?? Environment.GetEnvironmentVariable(TestClientSecretEnvVar);
+        var envSecret = GetSpnSecretFromEnvironment();
 
         return profile.AuthMethod switch
         {
@@ -89,9 +101,7 @@ public static class CredentialProviderFactory
             throw new ArgumentNullException(nameof(profile));
 
         // Check for environment variable override for SPN secret
-        // PPDS_SPN_SECRET takes precedence, PPDS_TEST_CLIENT_SECRET is fallback for test scenarios
-        var envSecret = Environment.GetEnvironmentVariable(SpnSecretEnvVar)
-            ?? Environment.GetEnvironmentVariable(TestClientSecretEnvVar);
+        var envSecret = GetSpnSecretFromEnvironment();
 
         return profile.AuthMethod switch
         {

--- a/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
@@ -209,8 +209,7 @@ public static class AuthCommandGroup
     {
         // Check if secret is provided via environment variable (CI/automation scenario).
         // If so, skip secure credential store entirely - secrets will be provided at runtime.
-        var envSpnSecret = Environment.GetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar);
-        var bypassCredentialStore = !string.IsNullOrWhiteSpace(envSpnSecret);
+        var bypassCredentialStore = CredentialProviderFactory.ShouldBypassCredentialStore();
 
         // Store secrets in secure credential store (not in profile), unless bypassed
         // Declared outside try block so finally can dispose it

--- a/src/PPDS.Cli/Services/Profile/ProfileService.cs
+++ b/src/PPDS.Cli/Services/Profile/ProfileService.cs
@@ -238,9 +238,8 @@ public sealed class ProfileService : IProfileService
             cloud = CloudEnvironment.Public;
         }
 
-        // Check for environment variable bypass
-        var envSpnSecret = System.Environment.GetEnvironmentVariable(CredentialProviderFactory.SpnSecretEnvVar);
-        var bypassCredentialStore = !string.IsNullOrWhiteSpace(envSpnSecret);
+        // Check for environment variable bypass (PPDS_SPN_SECRET or PPDS_TEST_CLIENT_SECRET)
+        var bypassCredentialStore = CredentialProviderFactory.ShouldBypassCredentialStore();
 
         NativeCredentialStore? credentialStore = null;
         string? storedCredentialKey = null;


### PR DESCRIPTION
## Summary

- Fix integration test failures caused by credential store bypass not triggering in CI
- The `auth create` command only checked `PPDS_SPN_SECRET` for bypassing, but CI sets `PPDS_TEST_CLIENT_SECRET`
- When bypass didn't trigger, `NativeCredentialStore` tried to use Windows Credential Manager which isn't available on CI runners
- Added centralized helper methods in `CredentialProviderFactory` to simplify the bypass logic

## Changes

- Add `GetSpnSecretFromEnvironment()` - checks both `PPDS_SPN_SECRET` and `PPDS_TEST_CLIENT_SECRET`
- Add `ShouldBypassCredentialStore()` - single line check for call sites
- Update 4 locations to use the centralized helpers

## Test plan

- [x] Build passes with `--warnaserror`
- [x] Unit tests pass (1464+ tests)
- [ ] Integration tests pass on CI (this was the failing scenario)

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)