### PR TITLE
fix(auth): query MSAL for token state instead of stale profile metadata

### DIFF
--- a/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/AzureDevOpsFederatedCredentialProvider.cs
@@ -151,6 +151,21 @@ public sealed class AzureDevOpsFederatedCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Return cached token info if we have one
+        if (_cachedToken.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_cachedToken.Value.ExpiresOn, _applicationId));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateFileCredentialProvider.cs
@@ -266,6 +266,22 @@ public sealed class CertificateFileCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Certificate auth uses connection string internally - we don't have access to MSAL cache.
+        // Return estimated expiry if we've authenticated, otherwise null.
+        if (_tokenExpiresAt.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_tokenExpiresAt.Value, _applicationId));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/CertificateStoreCredentialProvider.cs
@@ -239,6 +239,22 @@ public sealed class CertificateStoreCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Certificate store auth uses connection string internally - we don't have access to MSAL cache.
+        // Return estimated expiry if we've authenticated, otherwise null.
+        if (_tokenExpiresAt.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_tokenExpiresAt.Value, _applicationId));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/ClientSecretCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ClientSecretCredentialProvider.cs
@@ -208,6 +208,22 @@ public sealed class ClientSecretCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Service principal auth uses connection string internally - we don't have access to MSAL cache.
+        // Return estimated expiry if we've authenticated, otherwise null.
+        if (_tokenExpiresAt.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_tokenExpiresAt.Value, _applicationId));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/GitHubFederatedCredentialProvider.cs
@@ -162,6 +162,21 @@ public sealed class GitHubFederatedCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Return cached token info if we have one
+        if (_cachedToken.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_cachedToken.Value.ExpiresOn, _applicationId));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/ICredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ICredentialProvider.cs
@@ -71,6 +71,39 @@ public interface ICredentialProvider : IDisposable
     /// The ID token typically contains user claims like country that aren't in the access token.
     /// </summary>
     System.Security.Claims.ClaimsPrincipal? IdTokenClaims { get; }
+
+    /// <summary>
+    /// Gets cached token information without triggering interactive authentication.
+    /// Queries the MSAL token cache to determine current token state.
+    /// </summary>
+    /// <param name="environmentUrl">The Dataverse environment URL to check token for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Token information if a valid cached token exists, null if token is expired or not cached.</returns>
+    Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Information about a cached token, retrieved without triggering authentication.
+/// </summary>
+/// <param name="ExpiresOn">When the cached token expires.</param>
+/// <param name="Username">The username/identity associated with the token.</param>
+/// <param name="IsExpired">Whether the token is expired or will expire within 5 minutes.</param>
+public sealed record CachedTokenInfo(
+    DateTimeOffset ExpiresOn,
+    string? Username,
+    bool IsExpired
+)
+{
+    /// <summary>
+    /// Creates token info, automatically calculating IsExpired based on a 5-minute buffer.
+    /// </summary>
+    public static CachedTokenInfo Create(DateTimeOffset expiresOn, string? username)
+    {
+        var isExpired = expiresOn <= DateTimeOffset.UtcNow.AddMinutes(5);
+        return new CachedTokenInfo(expiresOn, username, isExpired);
+    }
 }
 
 /// <summary>

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -368,7 +368,7 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
         environmentUrl = environmentUrl.TrimEnd('/');
         var scopes = new[] { $"{environmentUrl}/.default" };
 
-        AuthDebugLog.WriteLine($"GetCachedTokenInfoAsync: url={environmentUrl}");
+        AuthDebugLog.WriteLine($"[InteractiveBrowser] GetCachedTokenInfoAsync: url={environmentUrl}");
 
         // Initialize MSAL client to load persistent cache
         await EnsureMsalClientInitializedAsync().ConfigureAwait(false);

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -358,6 +358,69 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public async Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(environmentUrl))
+            return null;
+
+        environmentUrl = environmentUrl.TrimEnd('/');
+        var scopes = new[] { $"{environmentUrl}/.default" };
+
+        AuthDebugLog.WriteLine($"GetCachedTokenInfoAsync: url={environmentUrl}");
+
+        // Initialize MSAL client to load persistent cache
+        await EnsureMsalClientInitializedAsync().ConfigureAwait(false);
+
+        // Check in-memory cache first
+        if (_cachedResult != null)
+        {
+            AuthDebugLog.WriteLine($"  In-memory cache has token expiring at {_cachedResult.ExpiresOn:HH:mm:ss}");
+            return CachedTokenInfo.Create(_cachedResult.ExpiresOn, _cachedResult.Account?.Username);
+        }
+
+        // Try to find account in persistent cache
+        var account = await FindAccountAsync().ConfigureAwait(false);
+        if (account == null)
+        {
+            AuthDebugLog.WriteLine("  No cached account found");
+            return null;
+        }
+
+        AuthDebugLog.WriteLine($"  Found cached account: {account.Username}");
+
+        try
+        {
+            // Try silent acquisition - this will use cached tokens if available
+            // WithForceRefresh(false) ensures we only check cache, don't refresh
+            var result = await _msalClient!
+                .AcquireTokenSilent(scopes, account)
+                .WithForceRefresh(false)
+                .ExecuteAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // Update in-memory cache
+            _cachedResult = result;
+
+            AuthDebugLog.WriteLine($"  Silent acquisition returned token expiring at {result.ExpiresOn:HH:mm:ss}");
+            return CachedTokenInfo.Create(result.ExpiresOn, result.Account?.Username);
+        }
+        catch (MsalUiRequiredException ex)
+        {
+            // Token is expired or requires user interaction
+            AuthDebugLog.WriteLine($"  Token requires re-authentication: {ex.Message}");
+            return null;
+        }
+        catch (MsalServiceException ex)
+        {
+            // Service error (network, etc.) - can't determine token state
+            AuthDebugLog.WriteLine($"  Service error checking token: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/ManagedIdentityCredentialProvider.cs
@@ -161,6 +161,21 @@ public sealed class ManagedIdentityCredentialProvider : ICredentialProvider
     }
 
     /// <inheritdoc />
+    public Task<CachedTokenInfo?> GetCachedTokenInfoAsync(
+        string environmentUrl,
+        CancellationToken cancellationToken = default)
+    {
+        // Return cached token info if we have one
+        if (_cachedToken.HasValue)
+        {
+            return Task.FromResult<CachedTokenInfo?>(
+                CachedTokenInfo.Create(_cachedToken.Value.ExpiresOn, Identity));
+        }
+
+        return Task.FromResult<CachedTokenInfo?>(null);
+    }
+
+    /// <inheritdoc />
     public void Dispose()
     {
         if (_disposed)

--- a/src/PPDS.Auth/Profiles/AuthProfile.cs
+++ b/src/PPDS.Auth/Profiles/AuthProfile.cs
@@ -132,13 +132,6 @@ public sealed class AuthProfile
     #region Token Claims
 
     /// <summary>
-    /// Gets or sets when the access token expires.
-    /// Populated after successful authentication.
-    /// </summary>
-    [JsonPropertyName("tokenExpiresOn")]
-    public DateTimeOffset? TokenExpiresOn { get; set; }
-
-    /// <summary>
     /// Gets or sets the user's PUID from the JWT 'puid' claim.
     /// </summary>
     [JsonPropertyName("puid")]
@@ -284,7 +277,6 @@ public sealed class AuthProfile
             Environment = Environment?.Clone(),
             CreatedAt = CreatedAt,
             LastUsedAt = LastUsedAt,
-            TokenExpiresOn = TokenExpiresOn,
             Puid = Puid,
             HomeAccountId = HomeAccountId,
             Authority = Authority

--- a/src/PPDS.Cli/Services/Profile/ProfileService.cs
+++ b/src/PPDS.Cli/Services/Profile/ProfileService.cs
@@ -315,7 +315,6 @@ public sealed class ProfileService : IProfileService
                 // Populate profile from auth result
                 profile.Username = provider.Identity;
                 profile.ObjectId = provider.ObjectId;
-                profile.TokenExpiresOn = provider.TokenExpiresAt;
                 profile.HomeAccountId = provider.HomeAccountId;
 
                 if (string.IsNullOrEmpty(profile.TenantId) && !string.IsNullOrEmpty(provider.TenantId))

--- a/tests/PPDS.Auth.Tests/Profiles/AuthProfileTests.cs
+++ b/tests/PPDS.Auth.Tests/Profiles/AuthProfileTests.cs
@@ -375,7 +375,6 @@ public class AuthProfileTests
             Environment = EnvironmentInfo.Create("https://test.crm.dynamics.com", "Test"),
             CreatedAt = DateTimeOffset.Parse("2024-01-01T00:00:00Z"),
             LastUsedAt = DateTimeOffset.Parse("2024-01-02T00:00:00Z"),
-            TokenExpiresOn = DateTimeOffset.Parse("2024-01-03T00:00:00Z"),
             Puid = "puid",
             HomeAccountId = "home-id"
         };
@@ -396,7 +395,6 @@ public class AuthProfileTests
         clone.Environment!.Url.Should().Be("https://test.crm.dynamics.com");
         clone.CreatedAt.Should().Be(profile.CreatedAt);
         clone.LastUsedAt.Should().Be(profile.LastUsedAt);
-        clone.TokenExpiresOn.Should().Be(profile.TokenExpiresOn);
         clone.Puid.Should().Be("puid");
         clone.HomeAccountId.Should().Be("home-id");
     }


### PR DESCRIPTION
## Summary

- Remove `TokenExpiresOn` from `AuthProfile` - it was set once at profile creation and never updated when MSAL silently refreshed tokens
- Add `ICredentialProvider.GetCachedTokenInfoAsync()` to query MSAL cache directly for current token state
- Update all consumers (`ppds auth who`, MCP tool, RPC handler, TUI dialog) to query MSAL instead of reading stale profile metadata

This fixes the bug where `ppds auth who` showed "EXPIRED" immediately after login because the profile stored a stale token expiry snapshot while MSAL had silently refreshed to a valid token.

## Root Cause

The CLI had "split state" - MSAL maintained accurate token state in its persistent cache, but `profile.TokenExpiresOn` was a snapshot from initial login that became stale. Commands worked (they used MSAL's cache), but `ppds auth who` showed expired (it read the stale profile field).

## Changes

| File | Change |
|------|--------|
| `ICredentialProvider.cs` | Add `GetCachedTokenInfoAsync()`, `CachedTokenInfo` record |
| 10 credential providers | Implement `GetCachedTokenInfoAsync()` |
| `AuthProfile.cs` | Remove `TokenExpiresOn` property |
| `AuthCommandGroup.cs` | Query MSAL for token state in `who` command |
| `ProfileService.cs` | Remove `TokenExpiresOn` assignment |
| `AuthWhoTool.cs` | Query MSAL for token state |
| `RpcMethodHandler.cs` | Query MSAL for token state |
| `ProfileDetailsDialog.cs` | Query MSAL for token state |

## Test plan

- [x] Build succeeds with 0 errors, 0 warnings
- [x] All 6000+ unit tests pass
- [ ] Manual test: `ppds auth who` shows accurate token expiry after login
- [ ] Manual test: Token expiry updates after silent refresh

🤖 Generated with [Claude Code](https://claude.ai/code)