### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/.github/workflows/tui-e2e.yml
+++ b/.github/workflows/tui-e2e.yml
@@ -58,7 +58,7 @@ jobs:
       run: npm test
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: tui-e2e-results
@@ -68,7 +68,7 @@ jobs:
         retention-days: 7
 
     - name: Upload snapshots on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: failure()
       with:
         name: tui-e2e-snapshot-diff

--- a/src/PPDS.Auth/PPDS.Auth.csproj
+++ b/src/PPDS.Auth/PPDS.Auth.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <!-- Azure Identity for OIDC and DefaultAzureCredential -->
-    <PackageReference Include="Azure.Identity" Version="1.13.*" />
+    <PackageReference Include="Azure.Identity" Version="1.17.*" />
 
     <!-- MSAL for device code and token caching -->
     <PackageReference Include="Microsoft.Identity.Client" Version="4.81.0" />
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.*" />
 
     <!-- Logging -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
 
     <!-- JSON serialization -->
     <PackageReference Include="System.Text.Json" Version="9.0.*" />

--- a/src/PPDS.Auth/PPDS.Auth.csproj
+++ b/src/PPDS.Auth/PPDS.Auth.csproj
@@ -40,23 +40,23 @@
 
   <ItemGroup>
     <!-- Azure Identity for OIDC and DefaultAzureCredential -->
-    <PackageReference Include="Azure.Identity" Version="1.17.*" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
 
     <!-- MSAL for device code and token caching -->
     <PackageReference Include="Microsoft.Identity.Client" Version="4.81.0" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
 
     <!-- Dataverse ServiceClient -->
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.*" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
 
     <!-- Logging -->
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
 
     <!-- JSON serialization -->
-    <PackageReference Include="System.Text.Json" Version="9.0.*" />
+    <PackageReference Include="System.Text.Json" Version="9.0.12" />
 
     <!-- JWT token parsing for extracting claims -->
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.*" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
 
     <!-- Native OS credential storage (Windows Credential Manager, macOS Keychain, Linux libsecret) -->
     <PackageReference Include="Devlooped.CredentialManager" Version="2.6.1.1" />

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -64,8 +64,8 @@
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="Spectre.Console" Version="0.54.*" />
     <PackageReference Include="Terminal.Gui" Version="1.19.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
     <PackageReference Include="System.CommandLine" Version="2.0.1" />

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -62,8 +62,8 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
     <PackageReference Include="CsvHelper" Version="33.1.0" />
-    <PackageReference Include="Spectre.Console" Version="0.54.*" />
-    <PackageReference Include="Terminal.Gui" Version="1.19.*" />
+    <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="Terminal.Gui" Version="1.19.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -43,17 +43,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <!-- Override vulnerable transitive dependency from Dataverse.Client (GHSA-555c-2p6r-68mm) -->
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.*" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />

--- a/src/PPDS.Mcp/PPDS.Mcp.csproj
+++ b/src/PPDS.Mcp/PPDS.Mcp.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
     <ProjectReference Include="..\PPDS.Auth\PPDS.Auth.csproj" />
     <ProjectReference Include="..\PPDS.Dataverse\PPDS.Dataverse.csproj" />

--- a/src/PPDS.Migration/PPDS.Migration.csproj
+++ b/src/PPDS.Migration/PPDS.Migration.csproj
@@ -49,10 +49,10 @@ dependency-aware tiered import, and CMT format compatibility for automated pipel
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
   <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />

--- a/tests/PPDS.Auth.Tests/PPDS.Auth.Tests.csproj
+++ b/tests/PPDS.Auth.Tests/PPDS.Auth.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.*" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
   </ItemGroup>
 

--- a/tests/PPDS.Cli.DaemonTests/PPDS.Cli.DaemonTests.csproj
+++ b/tests/PPDS.Cli.DaemonTests/PPDS.Cli.DaemonTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Nerdbank.Streams" Version="2.13.16" />
-    <PackageReference Include="StreamJsonRpc" Version="2.22.*" />
+    <PackageReference Include="StreamJsonRpc" Version="2.22.23" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
+++ b/tests/PPDS.Cli.Tests/PPDS.Cli.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Moq" Version="4.20.*" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PPDS.Dataverse.IntegrationTests/PPDS.Dataverse.IntegrationTests.csproj
+++ b/tests/PPDS.Dataverse.IntegrationTests/PPDS.Dataverse.IntegrationTests.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <!-- FakeXrmEasy for mocked Dataverse tests -->
     <PackageReference Include="FakeXrmEasy.v9" Version="3.8.0" />
   </ItemGroup>

--- a/tests/PPDS.Dataverse.Tests/PPDS.Dataverse.Tests.csproj
+++ b/tests/PPDS.Dataverse.Tests/PPDS.Dataverse.Tests.csproj
@@ -22,10 +22,10 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.*" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PPDS.Dataverse.Tests/PPDS.Dataverse.Tests.csproj
+++ b/tests/PPDS.Dataverse.Tests/PPDS.Dataverse.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.*" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />

--- a/tests/PPDS.LiveTests/PPDS.LiveTests.csproj
+++ b/tests/PPDS.LiveTests/PPDS.LiveTests.csproj
@@ -21,8 +21,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PPDS.Mcp.Tests/PPDS.Mcp.Tests.csproj
+++ b/tests/PPDS.Mcp.Tests/PPDS.Mcp.Tests.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.*" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PPDS.Mcp.Tests/PPDS.Mcp.Tests.csproj
+++ b/tests/PPDS.Mcp.Tests/PPDS.Mcp.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.*" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
   </ItemGroup>

--- a/tests/PPDS.Migration.Tests/PPDS.Migration.Tests.csproj
+++ b/tests/PPDS.Migration.Tests/PPDS.Migration.Tests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.*" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Azure.Identity 1.13.* → 1.17.*
- Microsoft.Extensions.DependencyInjection 10.0.1 → 10.0.2
- Microsoft.Extensions.DependencyInjection.Abstractions 10.0.1 → 10.0.2
- Microsoft.Extensions.Configuration 10.0.1 → 10.0.2
- Microsoft.Extensions.Configuration.Binder 10.0.1 → 10.0.2
- Microsoft.Extensions.Configuration.Json 10.0.1 → 10.0.2
- actions/setup-node v4 → v6
- actions/upload-artifact v4 → v6

Consolidates dependabot PRs #494, #495, #496, #498, #499, #505, #506.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)