### PR TITLE
deps: bump NuGet package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="RadLine" Version="0.9.0" />
     <PackageVersion Include="Terminal.Gui" Version="1.19.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.1" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.81.0" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
   </ItemGroup>
 
   <ItemGroup Label="Microsoft.Extensions">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
   <ItemGroup Label="RPC and MCP">
     <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.3" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.22.23" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers and Build">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Devlooped.CredentialManager" Version="2.6.1.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.81.0" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.81.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.82.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.82.1" />
     <PackageVersion Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
   </ItemGroup>

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-  <PackageReference Include="Microsoft.Identity.Client" />
+    <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="MinVer" PrivateAssets="all" />
     <!-- Override vulnerable transitive dependency from Dataverse.Client (GHSA-555c-2p6r-68mm) -->
-  <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 

--- a/src/PPDS.Dataverse/PPDS.Dataverse.csproj
+++ b/src/PPDS.Dataverse/PPDS.Dataverse.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="MinVer" PrivateAssets="all" />
     <!-- Override vulnerable transitive dependency from Dataverse.Client (GHSA-555c-2p6r-68mm) -->
+  <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bump `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` from 4.81.0 to 4.82.1
- Bump `System.IdentityModel.Tokens.Jwt` from 8.3.1 to 8.15.0
- Bump `System.CommandLine` from 2.0.1 to 2.0.2
- Bump `StreamJsonRpc` from 2.22.23 to 2.24.84
- Bump `Microsoft.SourceLink.GitHub` from 8.0.0 to 10.0.102
- Add explicit `Microsoft.Identity.Client` and `System.IdentityModel.Tokens.Jwt` references to PPDS.Dataverse to pin transitive dependency versions

## Test plan
- [x] Solution builds with 0 errors across net8.0/net9.0/net10.0
- [x] All unit tests pass (0 failures across all test projects and TFMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)