### PR TITLE
feat: add devcontainer for Linux-based development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,47 @@
+# PPDS Development Container
+# Base: .NET 10.0 devcontainer image (Ubuntu 24.04 Noble)
+# Includes: .NET 8/9/10 SDKs, Node.js 22, PowerShell 7, GitHub CLI, Claude Code
+FROM mcr.microsoft.com/devcontainers/dotnet:10.0
+
+# Install additional .NET SDKs for multi-target testing (net8.0, net9.0)
+COPY --from=mcr.microsoft.com/dotnet/sdk:8.0 /usr/share/dotnet/sdk /usr/share/dotnet/sdk
+COPY --from=mcr.microsoft.com/dotnet/sdk:8.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+COPY --from=mcr.microsoft.com/dotnet/sdk:9.0 /usr/share/dotnet/sdk /usr/share/dotnet/sdk
+COPY --from=mcr.microsoft.com/dotnet/sdk:9.0 /usr/share/dotnet/shared /usr/share/dotnet/shared
+
+# Install Node.js 22
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g npm@latest
+
+# Install PowerShell 7 (requires Microsoft package repo for Ubuntu)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget apt-transport-https \
+    && wget -q "https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb" \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends powershell
+
+# Install GitHub CLI
+RUN (type -p wget >/dev/null || apt-get install -y --no-install-recommends wget) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] \
+       https://cli.github.com/packages stable main" \
+       | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh
+
+# Clean up apt cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code as the vscode user (native installer)
+USER vscode
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/vscode/.local/bin:${PATH}"
+USER root
+
+# Set terminal for TUI support (Terminal.Gui)
+ENV TERM=xterm-256color

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,10 @@
   },
   "mounts": [
     "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
-    "source=${localEnv:USERPROFILE}/.claude.json,target=/home/vscode/.claude.json,type=bind"
+    "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
+    "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly"
   ],
-  "postCreateCommand": "dotnet restore PPDS.sln",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "PPDS",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "mounts": [
+    "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
+    "source=${localEnv:USERPROFILE}/.claude.json,target=/home/vscode/.claude.json,type=bind"
+  ],
+  "postCreateCommand": "dotnet restore PPDS.sln",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-vscode.powershell",
+        "editorconfig.editorconfig"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "remoteEnv": {
+    "TERM": "xterm-256color"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,37 +1,73 @@
 #!/bin/bash
 # PPDS devcontainer post-create setup
+# Configures Claude Code auth + marketplace, restores .NET packages
 set -e
 
-PLUGINS_DIR="$HOME/.claude/plugins"
+CLAUDE_DIR="$HOME/.claude"
+PLUGINS_DIR="$CLAUDE_DIR/plugins"
+STAGED_CONFIG="/tmp/host-claude-config.json"
+STAGED_SETTINGS="/tmp/host-claude-settings.json"
 
-# Fix volume ownership (Docker creates named volumes as root)
-sudo chown -R vscode:vscode "$PLUGINS_DIR" 2>/dev/null || true
+# --- Step 1: Extract oauthAccount from staged host config ---
+echo "=== Configuring Claude Code authentication ==="
+if [ -f "$STAGED_CONFIG" ]; then
+    node -e "
+        const fs = require('fs');
+        const host = JSON.parse(fs.readFileSync('$STAGED_CONFIG', 'utf8'));
+        if (host.oauthAccount) {
+            const clean = {
+                oauthAccount: host.oauthAccount,
+                hasCompletedOnboarding: true
+            };
+            fs.writeFileSync('$HOME/.claude.json', JSON.stringify(clean, null, 2));
+            console.log('Auth config created for: ' + host.oauthAccount.emailAddress);
+        } else {
+            console.warn('WARNING: No oauthAccount in host config. Manual login required.');
+        }
+    "
+else
+    echo "WARNING: Host config not found at $STAGED_CONFIG. Manual login required."
+fi
 
-echo "=== Restoring .NET packages ==="
-dotnet restore PPDS.sln
+# --- Step 2: Copy settings.json if available ---
+echo "=== Configuring Claude Code settings ==="
+if [ -f "$STAGED_SETTINGS" ]; then
+    mkdir -p "$CLAUDE_DIR"
+    cp "$STAGED_SETTINGS" "$CLAUDE_DIR/settings.json"
+    echo "Settings copied from host."
+else
+    echo "No host settings found. Using defaults."
+fi
 
+# --- Step 3: Initialize marketplace with Linux paths ---
 echo "=== Setting up Claude Code marketplace ==="
+mkdir -p "$PLUGINS_DIR/marketplaces"
+
 if [ ! -d "$PLUGINS_DIR/marketplaces/claude-plugins-official" ]; then
     echo "Cloning Anthropic official marketplace..."
-    mkdir -p "$PLUGINS_DIR/marketplaces"
-    git clone https://github.com/anthropics/claude-plugins-official.git \
+    git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git \
         "$PLUGINS_DIR/marketplaces/claude-plugins-official"
-
-    # Write marketplace registry with Linux paths
-    cat > "$PLUGINS_DIR/known_marketplaces.json" << 'MKJSON'
-{
-  "claude-plugins-official": {
-    "source": {
-      "source": "github",
-      "repo": "anthropics/claude-plugins-official"
-    },
-    "installLocation": "/home/vscode/.claude/plugins/marketplaces/claude-plugins-official"
-  }
-}
-MKJSON
-    echo "Marketplace installed."
+    echo "Marketplace cloned."
 else
-    echo "Marketplace already present, skipping."
+    echo "Marketplace already present, skipping clone."
 fi
+
+node -e "
+    const fs = require('fs');
+    const marketplaces = {
+        'claude-plugins-official': {
+            source: { source: 'github', repo: 'anthropics/claude-plugins-official' },
+            installLocation: '$PLUGINS_DIR/marketplaces/claude-plugins-official',
+            lastUpdated: new Date().toISOString()
+        }
+    };
+    fs.mkdirSync('$PLUGINS_DIR', { recursive: true });
+    fs.writeFileSync('$PLUGINS_DIR/known_marketplaces.json', JSON.stringify(marketplaces, null, 2));
+    console.log('Marketplace registry written with Linux paths.');
+"
+
+# --- Step 4: Restore .NET packages ---
+echo "=== Restoring .NET packages ==="
+dotnet restore PPDS.sln
 
 echo "=== Setup complete ==="

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PPDS devcontainer post-create setup
+set -e
+
+PLUGINS_DIR="$HOME/.claude/plugins"
+
+# Fix volume ownership (Docker creates named volumes as root)
+sudo chown -R vscode:vscode "$PLUGINS_DIR" 2>/dev/null || true
+
+echo "=== Restoring .NET packages ==="
+dotnet restore PPDS.sln
+
+echo "=== Setting up Claude Code marketplace ==="
+if [ ! -d "$PLUGINS_DIR/marketplaces/claude-plugins-official" ]; then
+    echo "Cloning Anthropic official marketplace..."
+    mkdir -p "$PLUGINS_DIR/marketplaces"
+    git clone https://github.com/anthropics/claude-plugins-official.git \
+        "$PLUGINS_DIR/marketplaces/claude-plugins-official"
+
+    # Write marketplace registry with Linux paths
+    cat > "$PLUGINS_DIR/known_marketplaces.json" << 'MKJSON'
+{
+  "claude-plugins-official": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official"
+    },
+    "installLocation": "/home/vscode/.claude/plugins/marketplaces/claude-plugins-official"
+  }
+}
+MKJSON
+    echo "Marketplace installed."
+else
+    echo "Marketplace already present, skipping."
+fi
+
+echo "=== Setup complete ==="

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+    PPDS devcontainer management script.
+.EXAMPLE
+    .\scripts\devcontainer.ps1 up        # build + start + ready to go
+    .\scripts\devcontainer.ps1 shell     # bash shell in container
+    .\scripts\devcontainer.ps1 claude    # claude code in container
+    .\scripts\devcontainer.ps1 down      # stop container
+    .\scripts\devcontainer.ps1 reset     # nuke everything, full clean rebuild
+#>
+
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('up', 'shell', 'claude', 'down', 'status', 'reset', 'help')]
+    [string]$Command = 'help'
+)
+
+$ErrorActionPreference = 'Stop'
+$WorkspaceFolder = Split-Path -Parent $PSScriptRoot
+$VolumeName = 'ppds-claude-plugins'
+
+function Write-Step($msg) { Write-Host "  $msg" -ForegroundColor Cyan }
+function Write-Ok($msg)   { Write-Host "  $msg" -ForegroundColor Green }
+function Write-Err($msg)  { Write-Host "  $msg" -ForegroundColor Red }
+
+function Get-ContainerId {
+    docker ps -aq --filter "label=devcontainer.local_folder=$WorkspaceFolder" 2>$null
+}
+
+function Stop-Container {
+    $ids = Get-ContainerId
+    if ($ids) {
+        Write-Step 'Stopping container...'
+        $ids | ForEach-Object { docker rm -f $_ } | Out-Null
+    }
+}
+
+switch ($Command) {
+    'up' {
+        # Build + start in one command. devcontainer CLI handles caching.
+        Write-Step 'Building and starting devcontainer...'
+        devcontainer up --workspace-folder $WorkspaceFolder
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok 'Container is running.'
+            Write-Host ''
+            Write-Host '  Next steps:' -ForegroundColor Yellow
+            Write-Host '    .\scripts\devcontainer.ps1 shell     # bash shell'
+            Write-Host '    .\scripts\devcontainer.ps1 claude    # claude code'
+            Write-Host ''
+        }
+        else { Write-Err 'Failed to start container.'; exit 1 }
+    }
+
+    'shell' {
+        $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
+        if (-not $id) {
+            Write-Step 'Container not running, starting it...'
+            devcontainer up --workspace-folder $WorkspaceFolder | Out-Null
+        }
+        devcontainer exec --workspace-folder $WorkspaceFolder bash
+    }
+
+    'claude' {
+        $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
+        if (-not $id) {
+            Write-Step 'Container not running, starting it...'
+            devcontainer up --workspace-folder $WorkspaceFolder | Out-Null
+        }
+        devcontainer exec --workspace-folder $WorkspaceFolder claude --dangerously-skip-permissions
+    }
+
+    'down' {
+        Stop-Container
+        Write-Ok 'Container stopped.'
+    }
+
+    'status' {
+        $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
+        if ($id) {
+            Write-Ok 'Container is running.'
+            docker ps --filter "label=devcontainer.local_folder=$WorkspaceFolder" --format "table {{.ID}}\t{{.Status}}\t{{.Ports}}"
+        }
+        else {
+            Write-Err 'Container is not running.'
+        }
+    }
+
+    'reset' {
+        Write-Step 'Nuking everything for a clean rebuild...'
+
+        # Stop and remove container
+        Stop-Container
+
+        # Remove named volume (plugin cache)
+        $vol = docker volume ls -q --filter "name=$VolumeName" 2>$null
+        if ($vol) {
+            Write-Step "Removing volume $VolumeName..."
+            docker volume rm $VolumeName | Out-Null
+        }
+
+        # Full rebuild no cache
+        Write-Step 'Rebuilding image (no cache)...'
+        devcontainer build --workspace-folder $WorkspaceFolder --no-cache
+        if ($LASTEXITCODE -ne 0) { Write-Err 'Build failed.'; exit 1 }
+
+        # Start fresh
+        Write-Step 'Starting fresh container...'
+        devcontainer up --workspace-folder $WorkspaceFolder
+        if ($LASTEXITCODE -eq 0) {
+            Write-Ok 'Clean rebuild complete. Container is running.'
+            Write-Host ''
+            Write-Host '  Next steps:' -ForegroundColor Yellow
+            Write-Host '    .\scripts\devcontainer.ps1 shell     # bash shell'
+            Write-Host '    .\scripts\devcontainer.ps1 claude    # claude code'
+            Write-Host ''
+        }
+        else { Write-Err 'Failed to start container.'; exit 1 }
+    }
+
+    'help' {
+        Write-Host ''
+        Write-Host '  PPDS Devcontainer' -ForegroundColor Yellow
+        Write-Host ''
+        Write-Host '  Usage: .\scripts\devcontainer.ps1 <command>' -ForegroundColor White
+        Write-Host ''
+        Write-Host '  Commands:' -ForegroundColor White
+        Write-Host '    up        Build + start (one command, handles everything)'
+        Write-Host '    shell     Open bash shell (auto-starts if needed)'
+        Write-Host '    claude    Start Claude Code (auto-starts if needed)'
+        Write-Host '    down      Stop the container'
+        Write-Host '    status    Check if container is running'
+        Write-Host '    reset     Nuke container + volumes + rebuild from scratch'
+        Write-Host ''
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a complete devcontainer configuration for PPDS development on Linux (Ubuntu 24.04)
- **Dockerfile**: .NET 8/9/10 SDKs, Node.js 22, PowerShell 7, GitHub CLI, Claude Code
- **Auto-login**: Mounts host's `.claude.json` to a staging path (readonly), extracts only `oauthAccount` into a clean container config — no re-authentication on every container start
- **Marketplace**: Initializes the Claude Code plugin marketplace fresh with Linux-native paths, avoiding stale Windows paths/flags from the host config
- **Settings**: Copies host `settings.json` for plugin preferences and permission mode
- **Management script**: `scripts/devcontainer.ps1` with `up`, `shell`, `claude`, `down`, `status`, `reset` commands

## Test plan

- [ ] `.\scripts\devcontainer.ps1 reset` — full clean rebuild succeeds
- [ ] `.\scripts\devcontainer.ps1 claude` — Claude Code launches without login prompt
- [ ] Inside container: `/install <plugin>` works from marketplace
- [ ] `dotnet build PPDS.sln` succeeds with multi-target (net4.6.2, net8.0, net9.0, net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)