### PR TITLE
fix: devcontainer CRLF line endings, image naming, and review cleanup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/home/vscode/.local/bin:${PATH}"
-USER root
 
 # Set terminal for TUI support (Terminal.Gui)
 ENV TERM=xterm-256color

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly"
   ],
-  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
   "name": "PPDS",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "initializeCommand": "docker build -t ppds-devcontainer .devcontainer/",
+  "image": "ppds-devcontainer",
   "mounts": [
     "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
     "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
-    "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly"
+    "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly",
+    "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly"
   ],
   "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh",
   "customizations": {
@@ -24,8 +24,5 @@
         "terminal.integrated.defaultProfile.linux": "bash"
       }
     }
-  },
-  "remoteEnv": {
-    "TERM": "xterm-256color"
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -88,3 +88,13 @@ csharp_style_namespace_declarations = block_scoped:none
 
 # Don't warn about partial class declarations
 dotnet_diagnostic.CA1052.severity = none
+
+# Linux-targeted files - must use LF line endings
+[*.sh]
+end_of_line = lf
+
+[Dockerfile*]
+end_of_line = lf
+
+[devcontainer.json]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Auto-detect text files and normalize to LF in the repository
+* text=auto
+
+# Linux-targeted files - MUST be LF (executed in containers)
+*.sh text eol=lf
+Dockerfile* text eol=lf
+.dockerignore text eol=lf
+devcontainer.json text eol=lf
+
+# Binary files - do not modify
+*.snk binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.dll binary
+*.exe binary
+*.nupkg binary
+*.snupkg binary

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -107,7 +107,11 @@ switch ($Command) {
         $img = docker images -q $ImageName 2>$null
         if ($img) {
             Write-Step "Removing image $ImageName..."
-            docker rmi $ImageName | Out-Null
+            docker rmi $ImageName
+            if ($LASTEXITCODE -ne 0) {
+                Write-Err "Failed to remove image '$ImageName'. It may be in use. Aborting reset."
+                exit 1
+            }
         }
 
         # Full rebuild no cache

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -17,6 +17,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $WorkspaceFolder = Split-Path -Parent $PSScriptRoot
+$ImageName = 'ppds-devcontainer'
 $VolumeName = 'ppds-claude-plugins'
 
 function Write-Step($msg) { Write-Host "  $msg" -ForegroundColor Cyan }
@@ -32,6 +33,18 @@ function Stop-Container {
     if ($ids) {
         Write-Step 'Stopping container...'
         $ids | ForEach-Object { docker rm -f $_ } | Out-Null
+    }
+}
+
+function Ensure-ContainerRunning {
+    $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
+    if (-not $id) {
+        Write-Step 'Container not running, starting it...'
+        devcontainer up --workspace-folder $WorkspaceFolder | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err 'Failed to start container.'
+            exit 1
+        }
     }
 }
 
@@ -52,20 +65,12 @@ switch ($Command) {
     }
 
     'shell' {
-        $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
-        if (-not $id) {
-            Write-Step 'Container not running, starting it...'
-            devcontainer up --workspace-folder $WorkspaceFolder | Out-Null
-        }
+        Ensure-ContainerRunning
         devcontainer exec --workspace-folder $WorkspaceFolder bash
     }
 
     'claude' {
-        $id = docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder"
-        if (-not $id) {
-            Write-Step 'Container not running, starting it...'
-            devcontainer up --workspace-folder $WorkspaceFolder | Out-Null
-        }
+        Ensure-ContainerRunning
         devcontainer exec --workspace-folder $WorkspaceFolder claude --dangerously-skip-permissions
     }
 
@@ -98,9 +103,16 @@ switch ($Command) {
             docker volume rm $VolumeName | Out-Null
         }
 
+        # Remove the named image so it rebuilds from scratch
+        $img = docker images -q $ImageName 2>$null
+        if ($img) {
+            Write-Step "Removing image $ImageName..."
+            docker rmi $ImageName | Out-Null
+        }
+
         # Full rebuild no cache
         Write-Step 'Rebuilding image (no cache)...'
-        devcontainer build --workspace-folder $WorkspaceFolder --no-cache
+        docker build --no-cache -t $ImageName "$WorkspaceFolder/.devcontainer/"
         if ($LASTEXITCODE -ne 0) { Write-Err 'Build failed.'; exit 1 }
 
         # Start fresh


### PR DESCRIPTION
## Summary
- **Fix CRLF line endings** breaking `setup.sh` in the Linux container — add `.gitattributes` to enforce LF for shell scripts/Dockerfiles, add `.editorconfig` overrides, and a `sed` safeguard in `postCreateCommand`
- **Fix image naming** — switch from VS Code's auto-generated hash-based names (`vsc-ppds-10d4023f...`) to a fixed `ppds-devcontainer` image via `initializeCommand` + `image`, shared across all worktrees
- **Address PR #526 review feedback**: remove unnecessary `USER root` from Dockerfile, remove duplicate `TERM` env var, extract `Ensure-ContainerRunning` helper with error handling in `devcontainer.ps1`
- **Mount user-level skills** (`~/.claude/skills/`) read-only into the container

## Test plan
- [ ] Run `.\scripts\devcontainer.ps1 reset` — image builds as `ppds-devcontainer`, container starts, `setup.sh` completes without `\r` errors
- [ ] Run `docker images` — verify image is named `ppds-devcontainer`, no `vsc-ppds-*` hash names
- [ ] Verify Claude Code works inside the container with skills available

🤖 Generated with [Claude Code](https://claude.com/claude-code)