### PR TITLE
fix: mount host .gitconfig and fix worktree paths in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
     "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
     "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly",
-    "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly"
+    "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly",
+    "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly"
   ],
   "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,7 +8,20 @@ PLUGINS_DIR="$CLAUDE_DIR/plugins"
 STAGED_CONFIG="/tmp/host-claude-config.json"
 STAGED_SETTINGS="/tmp/host-claude-settings.json"
 
-# --- Step 0: Configure git identity from host ---
+# --- Step 0: Mark bind-mounted workspace as safe for git ---
+echo "=== Configuring git safe directories ==="
+WORKSPACE_ROOT="$(pwd)"
+git config --global --add safe.directory "$WORKSPACE_ROOT"
+if [ -d ".worktrees" ]; then
+    for wt_dir in .worktrees/*/; do
+        wt_path="$WORKSPACE_ROOT/$(echo "$wt_dir" | sed 's:/$::')"
+        git config --global --add safe.directory "$wt_path"
+        echo "Safe directory: $wt_path"
+    done
+fi
+echo "Safe directory: $WORKSPACE_ROOT"
+
+# --- Step 0a: Configure git identity from host ---
 echo "=== Configuring git identity ==="
 HOST_GITCONFIG="/tmp/host-gitconfig"
 if [ -f "$HOST_GITCONFIG" ]; then

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,6 +8,52 @@ PLUGINS_DIR="$CLAUDE_DIR/plugins"
 STAGED_CONFIG="/tmp/host-claude-config.json"
 STAGED_SETTINGS="/tmp/host-claude-settings.json"
 
+# --- Step 0: Configure git identity from host ---
+echo "=== Configuring git identity ==="
+HOST_GITCONFIG="/tmp/host-gitconfig"
+if [ -f "$HOST_GITCONFIG" ]; then
+    GIT_NAME=$(git config -f "$HOST_GITCONFIG" user.name 2>/dev/null)
+    GIT_EMAIL=$(git config -f "$HOST_GITCONFIG" user.email 2>/dev/null)
+    if [ -n "$GIT_NAME" ] && [ -n "$GIT_EMAIL" ]; then
+        git config --global user.name "$GIT_NAME"
+        git config --global user.email "$GIT_EMAIL"
+        echo "Git identity: $GIT_NAME <$GIT_EMAIL>"
+    else
+        echo "WARNING: Host .gitconfig missing user.name or user.email."
+    fi
+else
+    echo "WARNING: Host .gitconfig not found. Git commits will require manual config."
+fi
+
+# --- Step 0b: Fix worktree .git paths (Windows -> Linux) ---
+echo "=== Fixing worktree paths ==="
+WORKSPACE_ROOT="$(pwd)"
+if [ -d ".worktrees" ]; then
+    for wt_dir in .worktrees/*/; do
+        gitfile="$wt_dir.git"
+        if [ -f "$gitfile" ]; then
+            gitdir=$(sed 's/^gitdir: //' "$gitfile")
+            if echo "$gitdir" | grep -qE '^[A-Za-z]:'; then
+                wt_name=$(basename "$wt_dir")
+                new_gitdir="$WORKSPACE_ROOT/.git/worktrees/$wt_name"
+                if [ -d "$new_gitdir" ]; then
+                    echo "gitdir: $new_gitdir" > "$gitfile"
+                    # Fix the reverse pointer so git knows where the worktree is
+                    reverse_file="$new_gitdir/gitdir"
+                    if [ -f "$reverse_file" ]; then
+                        echo "$WORKSPACE_ROOT/.worktrees/$wt_name/.git" > "$reverse_file"
+                    fi
+                    echo "Fixed worktree: $wt_name"
+                else
+                    echo "WARNING: Worktree metadata not found for $wt_name at $new_gitdir"
+                fi
+            fi
+        fi
+    done
+else
+    echo "No worktrees found."
+fi
+
 # --- Step 1: Extract oauthAccount from staged host config ---
 echo "=== Configuring Claude Code authentication ==="
 if [ -f "$STAGED_CONFIG" ]; then


### PR DESCRIPTION
## Summary
- Mount host `.gitconfig` read-only into the container so git identity is configured automatically — prevents Claude from setting itself as commit author
- Fix worktree `.git` file paths in `setup.sh`: detects Windows paths in `.worktrees/*/.git` and rewrites them to Linux container paths, including the reverse pointer in `.git/worktrees/*/gitdir` — prevents git from breaking and Claude from destructively reinitializing the repo

## Context
When opening the main repo's devcontainer, worktrees under `.worktrees/` have `.git` files pointing to Windows paths (e.g., `C:/VS/ppdsw/ppds/.git/worktrees/query-engine-v3`). These don't resolve inside the Linux container, causing `fatal: not a git repository` errors. Previously, Claude inside the container "fixed" this by running `rm .git && git init`, destroying all git history.

## Test plan
- [ ] `.\scripts\devcontainer.ps1 up` — container starts, setup.sh shows "Git identity: Josh Smith <...>"
- [ ] With a worktree present, setup.sh shows "Fixed worktree: <name>"
- [ ] Inside container, `cd .worktrees/<name> && git log --oneline -3` works with full history
- [ ] `git config user.name` inside container returns host user name

🤖 Generated with [Claude Code](https://claude.com/claude-code)