### PR TITLE
perf: optimize devcontainer for clone-in-volume workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,16 @@
 {
   "name": "PPDS",
-  "initializeCommand": "docker build -t ppds-devcontainer .devcontainer/",
-  "image": "ppds-devcontainer",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
   "mounts": [
     "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
     "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly",
-    "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly"
+    "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly",
+    "source=ppds-nuget-cache,target=/home/vscode/.nuget/packages,type=volume"
   ],
   "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,7 +8,7 @@ PLUGINS_DIR="$CLAUDE_DIR/plugins"
 STAGED_CONFIG="/tmp/host-claude-config.json"
 STAGED_SETTINGS="/tmp/host-claude-settings.json"
 
-# --- Step 0: Mark bind-mounted workspace as safe for git ---
+# --- Step 0: Mark workspace as safe for git ---
 echo "=== Configuring git safe directories ==="
 WORKSPACE_ROOT="$(pwd)"
 git config --global --add safe.directory "$WORKSPACE_ROOT"
@@ -36,35 +36,6 @@ if [ -f "$HOST_GITCONFIG" ]; then
     fi
 else
     echo "WARNING: Host .gitconfig not found. Git commits will require manual config."
-fi
-
-# --- Step 0b: Fix worktree .git paths (Windows -> Linux) ---
-echo "=== Fixing worktree paths ==="
-WORKSPACE_ROOT="$(pwd)"
-if [ -d ".worktrees" ]; then
-    for wt_dir in .worktrees/*/; do
-        gitfile="$wt_dir.git"
-        if [ -f "$gitfile" ]; then
-            gitdir=$(sed 's/^gitdir: //' "$gitfile")
-            if echo "$gitdir" | grep -qE '^[A-Za-z]:'; then
-                wt_name=$(basename "$wt_dir")
-                new_gitdir="$WORKSPACE_ROOT/.git/worktrees/$wt_name"
-                if [ -d "$new_gitdir" ]; then
-                    echo "gitdir: $new_gitdir" > "$gitfile"
-                    # Fix the reverse pointer so git knows where the worktree is
-                    reverse_file="$new_gitdir/gitdir"
-                    if [ -f "$reverse_file" ]; then
-                        echo "$WORKSPACE_ROOT/.worktrees/$wt_name/.git" > "$reverse_file"
-                    fi
-                    echo "Fixed worktree: $wt_name"
-                else
-                    echo "WARNING: Worktree metadata not found for $wt_name at $new_gitdir"
-                fi
-            fi
-        fi
-    done
-else
-    echo "No worktrees found."
 fi
 
 # --- Step 1: Extract oauthAccount from staged host config ---


### PR DESCRIPTION
## Summary
- Switch from `initializeCommand`/`image` to `build.dockerfile`/`context` for proper VS Code build lifecycle support with clone-in-volume
- Add named Docker volume (`ppds-nuget-cache`) for NuGet package cache to persist across container rebuilds
- Remove Windows-to-Linux worktree path fixup (Step 0b) — unnecessary with clone-in-volume since paths are natively Linux

## Test plan
- [ ] Use "Dev Containers: Clone Repository in Container Volume" from VS Code command palette
- [ ] Verify container builds successfully with `build.dockerfile` config
- [ ] Verify `dotnet restore` completes and NuGet cache volume persists on container rebuild
- [ ] Verify Claude Code auth, settings, and marketplace setup complete in `setup.sh`
- [ ] Confirm reduced CPU/memory usage vs bind-mount approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)