### PR TITLE
perf: volume-based devcontainer workspace for native I/O

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,15 +4,17 @@
     "dockerfile": "Dockerfile",
     "context": "."
   },
+  "workspaceMount": "source=ppds-workspace,target=/workspaces/ppds,type=volume",
+  "workspaceFolder": "/workspaces/ppds",
   "mounts": [
     "source=${localEnv:USERPROFILE}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind",
     "source=${localEnv:USERPROFILE}/.claude.json,target=/tmp/host-claude-config.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly",
-    "source=ppds-nuget-cache,target=/home/vscode/.nuget/packages,type=volume"
+    "source=ppds-nuget-cache,target=/home/vscode/.nuget,type=volume"
   ],
-  "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh",
+  "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -98,6 +98,8 @@ node -e "
 
 # --- Step 4: Restore .NET packages ---
 echo "=== Restoring .NET packages ==="
+# Fix ownership on NuGet volume (Docker creates volume mount points as root)
+sudo chown -R vscode:vscode "$HOME/.nuget"
 dotnet restore PPDS.sln
 
 echo "=== Setup complete ==="

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -232,7 +232,7 @@ switch ($Command) {
         docker run --rm `
             -v "${WorkspaceVolume}:/workspace" `
             -v "${WorkspaceFolder}:/source:ro" `
-            alpine sh -c "cd /workspace && rm -rf /workspace/* /workspace/.* 2>/dev/null; cp -a /source/. /workspace/"
+            alpine sh -c "cd /workspace && find . -mindepth 1 -delete; cp -a /source/. ."
         if ($LASTEXITCODE -eq 0) {
             Write-Ok "Volume synced to local state ($branch)."
         }


### PR DESCRIPTION
## Summary
- Switch workspace from bind-mount to Docker volume (`ppds-workspace`) via `workspaceMount`/`workspaceFolder` — eliminates 9P filesystem overhead for native Linux I/O performance
- Add NuGet cache volume (`ppds-nuget-cache`) with ownership fix so packages persist across container rebuilds
- Update `devcontainer.ps1` script to manage volume lifecycle: create, clone, sync, reset
- Auto-recreate host-side worktrees in the container volume during `up` (detects `.worktrees/` on Windows, runs `git worktree add` inside the container)
- Remove CRLF `sed` fix (unnecessary with volume clone) and Windows-to-Linux worktree path fixup (Step 0b)
- New `sync` command to push local repo state into the workspace volume

## Test plan
- [ ] Run `.\scripts\devcontainer.ps1 reset` — full clean rebuild with volume clone
- [ ] Run `.\scripts\devcontainer.ps1 up` — verify worktrees are recreated from host
- [ ] Run `.\scripts\devcontainer.ps1 claude` — verify worktree picker shows container worktrees
- [ ] Run `.\scripts\devcontainer.ps1 shell` — verify bash shell works in worktree
- [ ] Verify `dotnet restore` completes without NuGet permission errors
- [ ] Verify reduced CPU/memory usage vs bind-mount approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)