### PR TITLE
perf: volume-based devcontainer with push/send workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,11 @@ RUN (type -p wget >/dev/null || apt-get install -y --no-install-recommends wget)
     && apt-get update \
     && apt-get install -y --no-install-recommends gh
 
+# Configure UTF-8 locale (required for Terminal.Gui box-drawing characters)
+RUN apt-get update && apt-get install -y --no-install-recommends locales \
+    && sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen
+
 # Clean up apt cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -42,5 +47,7 @@ USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/home/vscode/.local/bin:${PATH}"
 
-# Set terminal for TUI support (Terminal.Gui)
+# Set terminal and locale for TUI support (Terminal.Gui)
 ENV TERM=xterm-256color
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
     "source=${localEnv:USERPROFILE}/.claude/settings.json,target=/tmp/host-claude-settings.json,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly",
-    "source=ppds-nuget-cache,target=/home/vscode/.nuget,type=volume"
+    "source=ppds-nuget-cache,target=/home/vscode/.nuget,type=volume",
+    "source=ppds-auth-cache,target=/home/vscode/.ppds,type=volume"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
     "source=${localEnv:USERPROFILE}/.claude/skills,target=/home/vscode/.claude/skills,type=bind,readonly",
     "source=${localEnv:USERPROFILE}/.gitconfig,target=/tmp/host-gitconfig,type=bind,readonly",
     "source=ppds-nuget-cache,target=/home/vscode/.nuget,type=volume",
-    "source=ppds-auth-cache,target=/home/vscode/.ppds,type=volume"
+    "source=ppds-auth-cache,target=/home/vscode/.ppds,type=volume",
+    "source=ppds-claude-sessions,target=/home/vscode/.claude/projects,type=volume"
   ],
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -98,8 +98,6 @@ node -e "
 
 # --- Step 4: Restore .NET packages ---
 echo "=== Restoring .NET packages ==="
-# Fix ownership on NuGet volume (Docker creates volume mount points as root)
-sudo chown -R vscode:vscode "$HOME/.nuget"
 dotnet restore PPDS.sln
 
 echo "=== Setup complete ==="

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -73,7 +73,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     {
         new MenuBarItem("_Query", new MenuItem[]
         {
-            new("Execute", "Ctrl+Enter", () => _ = ExecuteQueryAsync()),
+            new("Execute", "F5", () => _ = ExecuteQueryAsync()),
             new("Show FetchXML", "Ctrl+Shift+F", ShowFetchXmlDialog),
             new("History", "Ctrl+Shift+H", ShowHistoryDialog),
             new("", "", () => {}, null, null, Key.Null), // Separator
@@ -92,7 +92,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         _deviceCodeCallback = deviceCodeCallback;
 
         // Query input area
-        _queryFrame = new FrameView("Query (Ctrl+Enter to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)")
+        _queryFrame = new FrameView("Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)")
         {
             X = 0,
             Y = 0,
@@ -266,11 +266,11 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         // The table's built-in selection highlighting is sufficient
         _queryFrame.Enter += (_) =>
         {
-            _queryFrame.Title = "\u25b6 Query (Ctrl+Enter to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
+            _queryFrame.Title = "\u25b6 Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
         };
         _queryFrame.Leave += (_) =>
         {
-            _queryFrame.Title = "Query (Ctrl+Enter to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
+            _queryFrame.Title = "Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
         };
         _resultsTable.Enter += (_) =>
         {
@@ -322,7 +322,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
             else
                 _queryInput.SetFocus();
         });
-        RegisterHotkey(registry, Key.CtrlMask | Key.Enter, "Execute query", () => _ = ExecuteQueryAsync());
+        RegisterHotkey(registry, Key.F5, "Execute query", () => _ = ExecuteQueryAsync());
         RegisterHotkey(registry, Key.CtrlMask | Key.ShiftMask | Key.F, "Show FetchXML", ShowFetchXmlDialog);
     }
 


### PR DESCRIPTION
## Summary

- **Volume-based workspace** — Docker volume (`ppds-workspace`) replaces bind mounts for native Linux I/O. Host repo is only used for devcontainer config.
- **`dev push`** — Push container commits to origin via host credentials using git bundles. Container stays credential-free. Uses `git ls-remote` for accurate remote comparison.
- **`dev send`** — Rsync host file changes into the container (replaces destructive `sync`). Preserves `.git` and `.worktrees` state, supports worktree targeting.
- **Persistent volumes** — NuGet cache, PPDS auth (`~/.ppds`), and Claude Code sessions (`~/.claude/projects`) survive container rebuilds. Only `dev reset` wipes them.
- **Host worktree repair** — `dev up` auto-fixes `.git` files with stale container Linux paths (`/workspaces/...` → Windows paths) so MinVer works on host.
- **F5 for query execution** — Replaces Ctrl+Enter which is indistinguishable from Enter on Unix terminals.
- **UTF-8 locale** in Dockerfile for Terminal.Gui box-drawing characters.
- **Worktree sync on `up`** — Detects host worktrees and recreates matching branches in the container volume.

## Test plan

- [ ] `dev reset` — full clean rebuild, verify volume creation and clone
- [ ] `dev up` / `dev down` — verify auth and session volumes persist across restart
- [ ] `dev push <worktree>` — verify commits reach origin, correct count shown
- [ ] `dev send <worktree>` — verify host file edits appear in container, `.git` intact
- [ ] `dev shell` / `dev claude` / `dev ppds` — worktree selection works
- [ ] F5 executes query in TUI on both Windows and Linux
- [ ] Device code login persists after `dev down` + `dev up`
- [ ] `/resume` works after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)