### PR TITLE
fix: repair container worktree .git files with Windows paths

### DIFF
--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -197,6 +197,20 @@ switch ($Command) {
                 }
             }
 
+            # Repair container worktrees — fix .git files that have Windows host paths
+            $containerWorktrees = devcontainer exec --workspace-folder $WorkspaceFolder sh -c 'ls -d .worktrees/*/ 2>/dev/null' 2>$null
+            if ($containerWorktrees) {
+                $containerWorktrees -split "`n" | ForEach-Object { ($_.Trim() -replace '/$','') } | Where-Object { $_ } | ForEach-Object {
+                    $wtPath = $_
+                    $wtName = $wtPath -replace '^\.worktrees/',''
+                    $gitdir = devcontainer exec --workspace-folder $WorkspaceFolder sh -c "cat $wtPath/.git 2>/dev/null" 2>$null
+                    if ($gitdir -and $gitdir -match '[A-Z]:[\\/]') {
+                        Write-Step "Repairing container worktree '$wtName' .git file (was Windows host path)..."
+                        devcontainer exec --workspace-folder $WorkspaceFolder sh -c "echo 'gitdir: /workspaces/ppds/.git/worktrees/$wtName' > $wtPath/.git"
+                    }
+                }
+            }
+
             Write-Ok 'Container is running.'
             Write-Host ''
             Write-Host '  Next steps:' -ForegroundColor Yellow

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -198,6 +198,7 @@ switch ($Command) {
             }
 
             # Repair container worktrees — fix .git files that have Windows host paths
+            $containerWsFolder = (devcontainer exec --workspace-folder $WorkspaceFolder sh -c 'pwd' 2>$null).Trim()
             $containerWorktrees = devcontainer exec --workspace-folder $WorkspaceFolder sh -c 'ls -d .worktrees/*/ 2>/dev/null' 2>$null
             if ($containerWorktrees) {
                 $containerWorktrees -split "`n" | ForEach-Object { ($_.Trim() -replace '/$','') } | Where-Object { $_ } | ForEach-Object {
@@ -206,7 +207,7 @@ switch ($Command) {
                     $gitdir = devcontainer exec --workspace-folder $WorkspaceFolder sh -c "cat $wtPath/.git 2>/dev/null" 2>$null
                     if ($gitdir -and $gitdir -match '[A-Z]:[\\/]') {
                         Write-Step "Repairing container worktree '$wtName' .git file (was Windows host path)..."
-                        devcontainer exec --workspace-folder $WorkspaceFolder sh -c "echo 'gitdir: /workspaces/ppds/.git/worktrees/$wtName' > $wtPath/.git"
+                        devcontainer exec --workspace-folder $WorkspaceFolder sh -c "echo 'gitdir: $containerWsFolder/.git/worktrees/$wtName' > $wtPath/.git"
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add container-side worktree repair to `dev up` that detects `.git` files with Windows host paths (e.g., `C:/VS/ppdsw/ppds/.git/...`) and rewrites them to Linux container paths (`/workspaces/ppds/.git/...`)
- Mirrors the existing host-side repair that fixes the reverse (container Linux paths on Windows)
- Root cause: the old destructive `sync` command (now replaced by `send`) copied host `.git` files into the container volume without exclusions

## Test plan

- [ ] `dev up` with a corrupted container worktree `.git` file — should auto-repair
- [ ] `dev push` / `dev shell` on worktrees — should work without path errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)