### PR TITLE
feat: devcontainer git state sync (sync command + push conflict handling)

### DIFF
--- a/docs/plans/2026-02-11-devcontainer-sync-design.md
+++ b/docs/plans/2026-02-11-devcontainer-sync-design.md
@@ -1,0 +1,130 @@
+# Devcontainer Git State Sync
+
+**Date:** 2026-02-11
+**Branch:** fix/push-divergence-handling
+**File:** scripts/devcontainer.ps1
+
+## Problem
+
+After initial clone, the container has no mechanism to sync git state from origin. This causes:
+- Stale tracking refs (container never learns about origin changes)
+- Main falls behind (only set at clone time)
+- Stale/deleted branches accumulate (no pruning)
+- Worktree history divergence after host-side rebases
+- Push failures when origin was force-pushed
+
+## Design Decisions
+
+1. **Sync only updates `refs/remotes/origin/*`** — never touches local branches or worktree working trees
+2. **Main checkout fast-forwarded** — only if clean, on main, and fast-forwardable
+3. **No auto-rebase of worktrees** — push already handles rebase-on-divergence
+4. **Full fetch scope** — all origin branches bundled, enables pruning
+5. **Sync on every `up`** — except fresh clones (already current)
+6. **Conflict → Claude session** — push launches Claude Code in mid-rebase state instead of aborting
+
+## New: `sync` Command
+
+Updates the container's knowledge of origin. Equivalent to a credentialless `git fetch --prune`.
+
+### Mechanism
+
+```
+Host                              Container
+-----                             ---------
+git fetch origin --prune
+bundle create (all origin refs)
+        ---- docker cp ---->
+                                  delete all refs/remotes/origin/*
+                                  git fetch from bundle
+                                  (recreates only current origin refs)
+
+                                  if main checkout is clean + FF-able:
+                                    git merge --ff-only origin/main
+
+                                  report worktree status
+```
+
+### Output
+
+```
+  Fetching origin state...
+  Bundling 12 refs from origin...
+  Updated remote tracking refs (12 refs, pruned 2 stale).
+  Fast-forwarded main (abc1234 -> def5678).
+
+  Worktree status:
+    query-engine-v3   fix/query-perf     2 ahead, 0 behind
+    auth-refactor     auth-refactor      0 ahead, 5 behind
+    old-feature       old-feature        ! branch deleted on origin
+```
+
+## Changed: `up` Command
+
+Calls sync after container start, before worktree operations.
+
+```
+up flow (existing volume):
+  1. Ensure volumes exist
+  2. Start container
+  3. NEW: Sync-ContainerFromOrigin (skip if fresh clone)
+  4. Repair host worktree .git files
+  5. Repair container worktree .git files
+  6. Create missing worktrees (now using fresh refs)
+```
+
+## Changed: `push` Command — Conflict Handling
+
+Current: rebase fails -> abort -> print error -> exit.
+New: rebase fails -> leave mid-rebase -> launch Claude Code -> exit.
+
+### Plan mode toggle
+
+```powershell
+param(
+    ...
+    [switch]$NoPlanMode
+)
+```
+
+Default (plan mode on): Claude analyzes conflicts and presents a plan before resolving.
+With -NoPlanMode: Claude resolves conflicts directly.
+
+### Flow
+
+```
+push (divergence detected):
+  1. Bundle origin state, send to container     (existing)
+  2. Container rebases onto origin              (existing)
+  3. If rebase conflicts:
+     a. DON'T abort the rebase
+     b. Print what happened
+     c. Launch Claude Code with conflict prompt
+     d. After Claude exits, exit push
+     e. User re-runs push when ready
+```
+
+## New Helper: `Sync-ContainerFromOrigin`
+
+Extracted as a function because both `sync` and `up` call it.
+
+```
+function Sync-ContainerFromOrigin {
+    1. Host: git fetch origin --prune
+    2. Host: collect refs/remotes/origin/* list
+    3. Host: git bundle create <all origin refs>
+    4. docker cp bundle into container
+    5. Container: delete all refs/remotes/origin/*
+    6. Container: git fetch from bundle
+    7. Container: ff main if clean
+    8. Container: report worktree status
+    9. Clean up bundles
+}
+```
+
+## Scope
+
+- ~80-100 new lines
+- ~5 lines modified in existing push block
+- One new function, one new switch case
+- Minor edits to up and push
+- No changes to: shell, claude, ppds, down, status, send, reset

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -162,8 +162,8 @@ function Sync-ContainerFromOrigin {
         return
     }
 
-    # Collect all origin refs
-    $originRefs = @(git -C $WorkspaceFolder for-each-ref --format='%(refname)' refs/remotes/origin/)
+    # Collect all origin refs (exclude HEAD symref — causes duplicate update errors)
+    $originRefs = @(git -C $WorkspaceFolder for-each-ref --format='%(refname)' refs/remotes/origin/) | Where-Object { $_ -ne 'refs/remotes/origin/HEAD' }
     if ($originRefs.Count -eq 0) {
         Write-Err 'No remote refs found.'
         return
@@ -247,8 +247,8 @@ function Sync-ContainerFromOrigin {
         Write-Host ''
     }
 
-    # Clean up
-    devcontainer exec --workspace-folder $WorkspaceFolder rm -f /tmp/sync.bundle
+    # Clean up (bundle was docker cp'd as root, so remove as root)
+    docker exec $containerId rm -f /tmp/sync.bundle
 }
 
 switch ($Command) {

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -18,16 +18,19 @@
     .\scripts\devcontainer.ps1 push query-engine-v3      # push worktree branch via host
     .\scripts\devcontainer.ps1 send                      # send host files to container (prompts for worktree)
     .\scripts\devcontainer.ps1 send query-engine-v3      # send host worktree to container worktree
+    .\scripts\devcontainer.ps1 sync                      # sync origin git state into container
     .\scripts\devcontainer.ps1 reset                    # nuke everything, full clean rebuild
 #>
 
 param(
     [Parameter(Position = 0)]
-    [ValidateSet('up', 'shell', 'claude', 'ppds', 'down', 'status', 'send', 'push', 'reset', 'help')]
+    [ValidateSet('up', 'shell', 'claude', 'ppds', 'down', 'status', 'send', 'push', 'sync', 'reset', 'help')]
     [string]$Command = 'help',
 
     [Parameter(Position = 1)]
-    [string]$Target
+    [string]$Target,
+
+    [switch]$NoPlanMode
 )
 
 $ErrorActionPreference = 'Stop'
@@ -143,8 +146,114 @@ function Select-WorkingDirectory {
     exit 1
 }
 
+function Sync-ContainerFromOrigin {
+    # Sync origin's git state into the container via bundle (container has no credentials)
+    $containerId = (docker ps -q --filter "label=devcontainer.local_folder=$WorkspaceFolder").Trim()
+    if (-not $containerId) {
+        Write-Err 'Container is not running.'
+        return
+    }
+
+    # Host fetches latest from origin
+    Write-Step 'Fetching from origin...'
+    git -C $WorkspaceFolder fetch origin --prune
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err 'Failed to fetch from origin.'
+        return
+    }
+
+    # Collect all origin refs
+    $originRefs = @(git -C $WorkspaceFolder for-each-ref --format='%(refname)' refs/remotes/origin/)
+    if ($originRefs.Count -eq 0) {
+        Write-Err 'No remote refs found.'
+        return
+    }
+
+    # Bundle all origin refs
+    Write-Step "Bundling $($originRefs.Count) refs from origin..."
+    $bundlePath = Join-Path $env:TEMP 'ppds-sync.bundle'
+    git -C $WorkspaceFolder bundle create $bundlePath @originRefs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err 'Failed to create bundle.'
+        Remove-Item $bundlePath -ErrorAction SilentlyContinue
+        return
+    }
+
+    # Send bundle to container
+    docker cp $bundlePath "${containerId}:/tmp/sync.bundle" | Out-Null
+    Remove-Item $bundlePath -ErrorAction SilentlyContinue
+
+    # Container: clear stale origin refs and fetch fresh ones from bundle
+    # Clearing first ensures pruning — refs deleted on origin get removed
+    devcontainer exec --workspace-folder $WorkspaceFolder bash -c "git for-each-ref --format='delete %(refname)' refs/remotes/origin/ | git update-ref --stdin" 2>$null
+    devcontainer exec --workspace-folder $WorkspaceFolder bash -c "git fetch /tmp/sync.bundle 'refs/remotes/origin/*:refs/remotes/origin/*'" 2>$null
+    $refCount = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c "git for-each-ref --format='%(refname)' refs/remotes/origin/ | wc -l" 2>$null).Trim()
+    Write-Ok "Updated remote tracking refs ($refCount refs synced)."
+
+    # Fast-forward main if the main checkout is clean and on main
+    $currentBranch = (devcontainer exec --workspace-folder $WorkspaceFolder git branch --show-current 2>$null).Trim()
+    if ($currentBranch -ne 'main') {
+        Write-Step 'Main checkout is not on main — skipping fast-forward.'
+    }
+    else {
+        devcontainer exec --workspace-folder $WorkspaceFolder bash -c "git diff --quiet && git diff --cached --quiet" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Step 'Main checkout has uncommitted changes — skipping fast-forward.'
+        }
+        else {
+            $oldSha = (devcontainer exec --workspace-folder $WorkspaceFolder git rev-parse --short HEAD 2>$null).Trim()
+            devcontainer exec --workspace-folder $WorkspaceFolder git merge --ff-only origin/main 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Err 'main has diverged from origin (local commits?) — resolve manually.'
+            }
+            else {
+                $newSha = (devcontainer exec --workspace-folder $WorkspaceFolder git rev-parse --short HEAD 2>$null).Trim()
+                if ($oldSha -eq $newSha) {
+                    Write-Ok 'main is up-to-date.'
+                }
+                else {
+                    Write-Ok "Fast-forwarded main ($oldSha -> $newSha)."
+                }
+            }
+        }
+    }
+
+    # Report worktree status
+    $worktrees = @(Get-Worktrees)
+    if ($worktrees.Count -gt 0) {
+        Write-Host ''
+        Write-Host '  Worktree status:' -ForegroundColor Yellow
+        foreach ($wt in $worktrees) {
+            $branch = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd .worktrees/$wt && git branch --show-current" 2>$null).Trim()
+            if (-not $branch) {
+                $padWt = $wt.PadRight(20)
+                Write-Host "    $padWt (detached HEAD)" -ForegroundColor DarkYellow
+                continue
+            }
+            devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd .worktrees/$wt && git rev-parse origin/$branch" 2>$null | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                $padWt = $wt.PadRight(20)
+                $padBranch = $branch.PadRight(25)
+                Write-Host "    $padWt $padBranch " -ForegroundColor White -NoNewline
+                Write-Host "branch deleted on origin" -ForegroundColor Red
+                continue
+            }
+            $ahead = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd .worktrees/$wt && git rev-list --count origin/${branch}..HEAD" 2>$null).Trim()
+            $behind = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd .worktrees/$wt && git rev-list --count HEAD..origin/${branch}" 2>$null).Trim()
+            $padWt = $wt.PadRight(20)
+            $padBranch = $branch.PadRight(25)
+            Write-Host "    $padWt $padBranch ${ahead} ahead, ${behind} behind" -ForegroundColor White
+        }
+        Write-Host ''
+    }
+
+    # Clean up
+    devcontainer exec --workspace-folder $WorkspaceFolder rm -f /tmp/sync.bundle
+}
+
 switch ($Command) {
     'up' {
+        $freshClone = -not (docker volume ls -q --filter "name=^${WorkspaceVolume}$")
         Ensure-WorkspaceVolume
 
         # Ensure cache volumes exist with correct ownership (Docker creates as root)
@@ -159,6 +268,11 @@ switch ($Command) {
         Write-Step 'Building and starting devcontainer...'
         devcontainer up --workspace-folder $WorkspaceFolder
         if ($LASTEXITCODE -eq 0) {
+            # Sync origin state into container (skip on fresh clone — already current)
+            if (-not $freshClone) {
+                Sync-ContainerFromOrigin
+            }
+
             # Repair host worktrees — fix .git files that have container Linux paths
             $hostWtDir = Join-Path $WorkspaceFolder '.worktrees'
             if (Test-Path $hostWtDir) {
@@ -341,9 +455,17 @@ switch ($Command) {
                 Write-Step "Rebasing new commits onto updated origin/$branch..."
                 devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd $workdir && git rebase origin/$branch"
                 if ($LASTEXITCODE -ne 0) {
-                    Write-Err "Rebase failed (conflicts). Resolve in container shell, then push again."
-                    devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd $workdir && git rebase --abort"
                     devcontainer exec --workspace-folder $WorkspaceFolder rm -f /tmp/origin.bundle
+                    Write-Err "Rebase has conflicts in '$workdir'."
+                    Write-Step 'Launching Claude Code to help resolve conflicts...'
+                    $planInstruction = if ($NoPlanMode) {
+                        'Resolve all conflicts directly.'
+                    } else {
+                        'Start by using plan mode to analyze the conflicts and present a resolution strategy before making changes.'
+                    }
+                    $conflictPrompt = "A git rebase of branch '${branch}' onto origin/${branch} has resulted in merge conflicts. Run git status to see conflicted files. Analyze each conflict, resolve them, git add the resolved files, and run git rebase --continue. If there are multiple conflicting commits, continue resolving until the rebase is complete. ${planInstruction}"
+                    devcontainer exec --workspace-folder $WorkspaceFolder bash -c "cd $workdir && claude --dangerously-skip-permissions -p '${conflictPrompt}'"
+                    Write-Step "Claude session ended. Re-run 'push' when conflicts are resolved."
                     exit 1
                 }
                 devcontainer exec --workspace-folder $WorkspaceFolder rm -f /tmp/origin.bundle
@@ -438,6 +560,11 @@ switch ($Command) {
         else { Write-Err 'Sync failed.'; exit 1 }
     }
 
+    'sync' {
+        Ensure-ContainerRunning
+        Sync-ContainerFromOrigin
+    }
+
     'reset' {
         Write-Step 'Nuking everything for a clean rebuild...'
 
@@ -482,7 +609,11 @@ switch ($Command) {
         Write-Host '    status                Check if container is running'
         Write-Host '    push [worktree]       Push container commits to origin via host credentials'
         Write-Host '    send [worktree]       Send host files to container (preserves .git state)'
+        Write-Host '    sync                  Sync origin git state into container (auto-runs on up)'
         Write-Host '    reset                 Nuke container + all volumes + rebuild from scratch'
+        Write-Host ''
+        Write-Host '  Options:' -ForegroundColor White
+        Write-Host '    -NoPlanMode           Skip plan mode when Claude resolves rebase conflicts'
         Write-Host ''
         Write-Host '  Examples:' -ForegroundColor White
         Write-Host '    .\scripts\devcontainer.ps1 claude                   # prompts for location'
@@ -492,6 +623,7 @@ switch ($Command) {
         Write-Host '    .\scripts\devcontainer.ps1 shell main               # shell at repo root'
         Write-Host '    .\scripts\devcontainer.ps1 push query-engine-v3      # push worktree branch via host'
         Write-Host '    .\scripts\devcontainer.ps1 send query-engine-v3      # send host worktree to container'
+        Write-Host '    .\scripts\devcontainer.ps1 sync                      # sync origin refs into container'
         Write-Host ''
     }
 }


### PR DESCRIPTION
## Summary

- **`sync` command**: Pulls all origin git state into the container via bundle transfer (host fetches, bundles `refs/remotes/origin/*`, docker cp into container). Updates tracking refs, fast-forwards main if clean, prunes deleted branches, reports worktree status.
- **Auto-sync on `up`**: Existing volumes get synced on every boot so the container starts with fresh origin state. Skipped on fresh clones.
- **Push conflict resolution**: When `push` detects divergence and rebase has conflicts, launches a Claude Code session in the container to help resolve (plan mode by default, `-NoPlanMode` to skip). No longer aborts the rebase — leaves mid-rebase state intact for resolution.

## Context

The container has no git credentials — it cannot `git fetch` from origin directly. After initial clone, there was no mechanism to update origin state, causing stale tracking refs, main falling behind, push failures after host-side rebases, and stranded commits requiring manual rescue.

## Test plan

- [ ] Run `.\scripts\devcontainer.ps1 sync` with container running — verify refs update, main fast-forwards, worktree status prints
- [ ] Run `.\scripts\devcontainer.ps1 up` on existing volume — verify sync runs automatically before worktree operations
- [ ] Run `.\scripts\devcontainer.ps1 up` on fresh clone — verify sync is skipped
- [ ] Force-push a branch on origin, then run `push` from container — verify rebase conflict launches Claude session instead of aborting
- [ ] Verify `-NoPlanMode` flag changes Claude prompt behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)