### PR TITLE
fix: devcontainer obj/ files owned by root break incremental builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
     "source=ppds-auth-cache,target=/home/vscode/.ppds,type=volume",
     "source=ppds-claude-sessions,target=/home/vscode/.claude/projects,type=volume"
   ],
+  "remoteUser": "vscode",
   "postCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {
     "vscode": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -100,4 +100,13 @@ node -e "
 echo "=== Restoring .NET packages ==="
 dotnet restore PPDS.sln
 
+# --- Step 5: Fix workspace ownership ---
+# postCreateCommand may run as root depending on devcontainer CLI version.
+# dotnet restore creates obj/ dirs — if root-owned, MSBuild can't set timestamps
+# (utimensat requires file ownership, not just write permission).
+if [ "$(id -u)" = "0" ]; then
+    echo "=== Fixing workspace ownership (running as root) ==="
+    chown -R 1000:1000 "$(pwd)"
+fi
+
 echo "=== Setup complete ==="

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -106,7 +106,7 @@ dotnet restore PPDS.sln
 # (utimensat requires file ownership, not just write permission).
 if [ "$(id -u)" = "0" ]; then
     echo "=== Fixing workspace ownership (running as root) ==="
-    chown -R vscode:vscode "$(pwd)"
+    chown -hR --from=root vscode:vscode ./
 fi
 
 echo "=== Setup complete ==="

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -106,7 +106,7 @@ dotnet restore PPDS.sln
 # (utimensat requires file ownership, not just write permission).
 if [ "$(id -u)" = "0" ]; then
     echo "=== Fixing workspace ownership (running as root) ==="
-    chown -R 1000:1000 "$(pwd)"
+    chown -R vscode:vscode "$(pwd)"
 fi
 
 echo "=== Setup complete ==="

--- a/scripts/devcontainer.ps1
+++ b/scripts/devcontainer.ps1
@@ -542,7 +542,7 @@ switch ($Command) {
             exit 1
         }
 
-        $newBase = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c "git log --oneline -1 origin/main").Trim()
+        $newBase = (devcontainer exec --workspace-folder $WorkspaceFolder bash -c 'cd "$1" && git log --oneline -1 origin/main' -- $workdir).Trim()
         Write-Ok "Rebased '$branch' onto origin/main ($newBase)."
     }
 


### PR DESCRIPTION
## Summary

- `postCreateCommand` runs `dotnet restore` as root in some devcontainer CLI versions, creating `obj/` directories owned by `root:root`
- MSBuild's incremental build fails with `MSB3374` because `utimensat()` requires file **ownership** to set timestamps — `777` permissions aren't sufficient
- Adds explicit `remoteUser: vscode` to `devcontainer.json` and a `chown` safety net in `setup.sh` after `dotnet restore`

## Test plan

- [ ] Run `dev reset` to rebuild the container from scratch
- [ ] Run `dev ppds` on main repo — verify build succeeds
- [ ] Run `dev ppds` on a worktree — verify build succeeds
- [ ] Verify `ls -la src/PPDS.Cli/obj/Debug/net10.0/` shows `vscode:vscode` ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)