### PR TITLE
docs: March 2026 release preparation

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -8,6 +8,8 @@ on:
       - 'Migration-v*'
       - 'Auth-v*'
       - 'Cli-v*'
+      - 'Query-v*'
+      - 'Mcp-v*'
 
 jobs:
   publish:
@@ -48,6 +50,12 @@ jobs:
         elif [[ $TAG == Cli-v* ]]; then
           echo "package=PPDS.Cli" >> $GITHUB_OUTPUT
           echo "projects=src/PPDS.Cli/PPDS.Cli.csproj" >> $GITHUB_OUTPUT
+        elif [[ $TAG == Query-v* ]]; then
+          echo "package=PPDS.Query" >> $GITHUB_OUTPUT
+          echo "projects=src/PPDS.Query/PPDS.Query.csproj" >> $GITHUB_OUTPUT
+        elif [[ $TAG == Mcp-v* ]]; then
+          echo "package=PPDS.Mcp" >> $GITHUB_OUTPUT
+          echo "projects=src/PPDS.Mcp/PPDS.Mcp.csproj" >> $GITHUB_OUTPUT
         else
           echo "Unknown tag format: $TAG"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This repository contains multiple packages with independent release cycles.
 - [PPDS.Migration](src/PPDS.Migration/CHANGELOG.md) - Data migration library
 - [PPDS.Auth](src/PPDS.Auth/CHANGELOG.md) - Authentication profiles and credentials
 - [PPDS.Cli](src/PPDS.Cli/CHANGELOG.md) - Unified CLI tool (`ppds` command)
+- [PPDS.Query](src/PPDS.Query/CHANGELOG.md) - SQL query engine for Dataverse
+- [PPDS.Mcp](src/PPDS.Mcp/CHANGELOG.md) - MCP server for AI assistant integration
 
 ## GitHub Releases
 
@@ -27,6 +29,8 @@ Each package has its own tag prefix:
 | PPDS.Migration | `Migration-v{version}` | `Migration-v1.0.0` |
 | PPDS.Auth | `Auth-v{version}` | `Auth-v1.0.0` |
 | PPDS.Cli | `Cli-v{version}` | `Cli-v1.0.0` |
+| PPDS.Query | `Query-v{version}` | `Query-v1.0.0` |
+| PPDS.Mcp | `Mcp-v{version}` | `Mcp-v1.0.0` |
 
 Pre-release versions follow SemVer:
 - Alpha: `Dataverse-v1.0.0-alpha.1`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ ppds data export --schema schema.xml --output data.zip
 | **PPDS.Dataverse** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Dataverse.svg)](https://www.nuget.org/packages/PPDS.Dataverse/) | High-performance connection pooling and bulk operations |
 | **PPDS.Migration** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Migration.svg)](https://www.nuget.org/packages/PPDS.Migration/) | High-performance data migration engine |
 | **PPDS.Auth** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Auth.svg)](https://www.nuget.org/packages/PPDS.Auth/) | Authentication profiles and credential management |
+| **PPDS.Query** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Query.svg)](https://www.nuget.org/packages/PPDS.Query/) | SQL query engine with FetchXML transpilation and ADO.NET provider |
 | **PPDS.Cli** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Cli.svg)](https://www.nuget.org/packages/PPDS.Cli/) | CLI tool with TUI (.NET tool) |
 | **PPDS.Mcp** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Mcp.svg)](https://www.nuget.org/packages/PPDS.Mcp/) | MCP server for AI assistants (.NET tool) |
 
@@ -51,6 +52,7 @@ ppds data export --schema schema.xml --output data.zip
 | PPDS.Dataverse | net8.0, net9.0, net10.0 |
 | PPDS.Migration | net8.0, net9.0, net10.0 |
 | PPDS.Auth | net8.0, net9.0, net10.0 |
+| PPDS.Query | net8.0, net9.0, net10.0 |
 | PPDS.Cli | net8.0, net9.0, net10.0 |
 | PPDS.Mcp | net8.0, net9.0, net10.0 |
 
@@ -109,7 +111,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 | `ppds data` | Data operations (export, import, copy, schema, users, load, truncate) |
 | `ppds plugins` | Plugin registration (extract, deploy, diff, list, clean) |
 | `ppds metadata` | Entity browsing (entities, attributes, relationships, keys, optionsets) |
-| `ppds query` | Execute queries (fetch, sql) |
+| `ppds query` | Execute queries (fetch, sql, explain, history) |
 | `ppds serve` | Run RPC daemon for VS Code extension |
 
 ---
@@ -209,6 +211,41 @@ await importer.ImportAsync("data.zip");
 - Security-first: no PII in logs, connection string redaction
 
 See [PPDS.Migration documentation](src/PPDS.Migration/README.md) for details.
+
+---
+
+## PPDS.Query
+
+SQL query engine for Dataverse with FetchXML transpilation and an ADO.NET provider.
+
+```bash
+dotnet add package PPDS.Query
+```
+
+```csharp
+// ADO.NET provider — standard .NET data access for Dataverse
+using var connection = new PpdsDbConnection(pool);
+await connection.OpenAsync();
+
+using var command = connection.CreateCommand();
+command.CommandText = "SELECT name, revenue FROM account WHERE revenue > @threshold";
+command.Parameters.AddWithValue("@threshold", 1_000_000m);
+
+using var reader = await command.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    Console.WriteLine($"{reader["name"]}: {reader["revenue"]:C}");
+}
+```
+
+**Key Features:**
+- Full T-SQL support (SELECT, JOIN, WHERE, GROUP BY, subqueries, CTEs, window functions)
+- FetchXML transpilation with automatic pushdown optimization
+- DML support (INSERT, UPDATE, DELETE) with safety guards
+- Cross-environment queries with bracket syntax
+- Streaming Volcano-model execution engine
+
+See [PPDS.Query documentation](src/PPDS.Query/README.md) for details.
 
 ---
 

--- a/docs/plans/2026-03-02-release-preparation-design.md
+++ b/docs/plans/2026-03-02-release-preparation-design.md
@@ -1,0 +1,109 @@
+# Release Preparation Design - March 2026
+
+## Context
+
+531 commits since the last release (January 14, 2026). Two new packages (PPDS.Query, PPDS.Mcp) have never been published. Major features: Query Engine v3, TUI overhaul, SQL IntelliSense, cross-environment queries, DML support.
+
+## Packages to Release
+
+| Package | Current Version | New Version | Commits | Summary |
+|---------|----------------|-------------|---------|---------|
+| PPDS.Query | (new) | Query-v1.0.0-beta.1 | 109 | Full SQL query engine - first release |
+| PPDS.Cli | Cli-v1.0.0-beta.12 | Cli-v1.0.0-beta.13 | 137 | TUI overhaul, IntelliSense, DML, env config |
+| PPDS.Dataverse | Dataverse-v1.0.0-beta.5 | Dataverse-v1.0.0-beta.6 | 93 | Query engine nodes, metadata caching, adaptive threading |
+| PPDS.Auth | Auth-v1.0.0-beta.6 | Auth-v1.0.0-beta.7 | 22 | EnvironmentConfig, DI registration, safety settings |
+| PPDS.Mcp | (new) | Mcp-v1.0.0-beta.1 | 11 | MCP server - first release |
+| PPDS.Migration | Migration-v1.0.0-beta.6 | Migration-v1.0.0-beta.7 | 4 | Dependency updates only |
+| PPDS.Plugins | Plugins-v2.0.0 | Skip | 4 | No functional changes |
+| PPDS.Analyzers | v1.0.0 | Skip (internal) | - | Internal dev dependency |
+
+## Work Items
+
+### 1. Merge Dependabot PRs
+- PR #554: @types/node 25.3.2 → 25.3.3 (extension)
+- PR #555: minimatch 3.1.2 → 3.1.5 (extension, security)
+
+### 2. Infrastructure: Update publish-nuget.yml
+- Add `Query-v*` tag trigger and project mapping
+- Add `Mcp-v*` tag trigger and project mapping
+
+### 3. New Package: PPDS.Query
+- Create `src/PPDS.Query/CHANGELOG.md` with v1.0.0-beta.1 release notes
+- Create `src/PPDS.Query/README.md`
+
+### 4. New Package: PPDS.Mcp
+- Create `src/PPDS.Mcp/CHANGELOG.md` with v1.0.0-beta.1 release notes
+- Create `src/PPDS.Mcp/README.md`
+
+### 5. Changelog Updates: PPDS.Dataverse
+Populate [Unreleased] → v1.0.0-beta.6 with:
+- Query Engine v2 execution plan layer (Volcano iterator model)
+- SQL parser extensions (DML, UNION, subqueries, window functions, variables, IF/ELSE, CASE/WHEN)
+- Expression evaluator for client-side computation
+- Parallel partitioned aggregates (accurate COUNT(*) beyond 50K)
+- Adaptive aggregate retry with binary date-range splitting
+- TDS Endpoint routing
+- Prefetch scan node for page-ahead buffering
+- Metadata query system
+- Cached metadata provider (TTL-based for IntelliSense)
+- DML safety guard
+- Child record paging boundary detection for linked entities
+- Adaptive thread management for 429 backoff
+
+### 6. Changelog Updates: PPDS.Cli
+Finalize [Unreleased] → v1.0.0-beta.13 with additions:
+- Multi-tab architecture with query tabs
+- Environment config commands (`ppds env config`, `ppds env type`)
+- EnvironmentConfigDialog (label, type, color configuration)
+- Environment-colored tabs with user-configurable themes
+- DeviceCodeDialog with selectable code and auto-close
+- TDS Endpoint toggle (Ctrl+T)
+- F7/F8/F9 keybindings for Linux terminal compatibility
+- Escape key to cancel running queries
+- DML safety wiring with environment-specific settings
+- Cross-environment query support wired to CLI
+- Certificate Store and Username/Password auth in TUI
+- DI refactoring (AuthServices, EnvironmentConfigStore, ProfileStore injection)
+- Many TUI fixes (timer leaks, event leaks, splitter drag, cursor visibility, menu flicker)
+
+### 7. Changelog Updates: PPDS.Auth
+Populate [Unreleased] → v1.0.0-beta.7 with:
+- EnvironmentConfig models and EnvironmentConfigStore
+- AddAuthServices DI registration (ProfileStore, EnvironmentConfigStore, NativeCredentialStore)
+- EnvironmentType enum (moved from CLI to Auth)
+- QuerySafetySettings in EnvironmentConfig
+- ProtectionLevel for environment protection enforcement
+- Cross-environment DML policy enforcement
+- Token cache scope fix for browser auth profile creation
+- Disposal guards, typed catches, interface usage improvements
+
+### 8. Changelog Updates: PPDS.Migration
+Populate [Unreleased] → v1.0.0-beta.7 with:
+- Dependency update: Microsoft.Data.SqlClient 5.2.2 → 6.1.4
+
+### 9. Root CHANGELOG.md Index
+- Add PPDS.Query entry with link and description
+- Add PPDS.Mcp entry with link and description
+- Add Query-v and Mcp-v tag format rows to versioning table
+
+### 10. Root README.md
+- Add PPDS.Query and PPDS.Mcp to package listing
+
+## Dependency Order
+
+Packages must be released in dependency order:
+1. PPDS.Auth (no PPDS deps changing)
+2. PPDS.Dataverse (depends on Auth)
+3. PPDS.Query (depends on Dataverse)
+4. PPDS.Migration (depends on Dataverse)
+5. PPDS.Mcp (depends on Auth, Dataverse, Query, Migration)
+6. PPDS.Cli (depends on all above)
+
+Since these are NuGet packages with project references (not package references within the repo), the tags can be pushed in any order — MinVer determines version from tags, and the publish workflow builds the full solution.
+
+## Separate Repo: ppds-docs
+Major documentation gaps exist (separate work item for parallel session):
+- New pages: PPDS.Query SDK reference, PPDS.Mcp guide, SQL Query guide, TUI guide
+- Updates: CLI reference, SDK reference, Getting Started
+- Fill placeholders: Data Migration, Plugin Deployment, Architecture
+- Release blog post

--- a/docs/plans/2026-03-02-release-preparation-plan.md
+++ b/docs/plans/2026-03-02-release-preparation-plan.md
@@ -1,0 +1,454 @@
+# March 2026 Release Preparation - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prepare all PPDS packages for NuGet release — update changelogs, create new package docs, update CI workflows, and merge dependabot PRs.
+
+**Architecture:** Documentation and CI-only changes. No code changes. Each package has its own CHANGELOG.md following Keep a Changelog format. MinVer determines versions from git tags. publish-nuget.yml handles NuGet publishing on tag push.
+
+**Tech Stack:** Markdown (changelogs, READMEs), YAML (GitHub Actions), git (tags)
+
+---
+
+### Task 1: Merge Dependabot PRs
+
+**Step 1: Merge PR #555 (minimatch security fix)**
+
+Run: `cd /c/VS/ppdsw/ppds && gh pr merge 555 --merge`
+
+**Step 2: Merge PR #554 (@types/node patch)**
+
+Run: `cd /c/VS/ppdsw/ppds && gh pr merge 554 --merge`
+
+**Step 3: Pull merged changes**
+
+Run: `cd /c/VS/ppdsw/ppds && git pull`
+
+---
+
+### Task 2: Update publish-nuget.yml
+
+**Files:**
+- Modify: `.github/workflows/publish-nuget.yml`
+
+**Step 1: Add Query-v* and Mcp-v* tag triggers**
+
+In the `on.push.tags` section, add:
+```yaml
+      - 'Query-v*'
+      - 'Mcp-v*'
+```
+
+**Step 2: Add project mappings in the determine-package step**
+
+Add these elif blocks before the `else` block:
+```bash
+elif [[ $TAG == Query-v* ]]; then
+  echo "package=PPDS.Query" >> $GITHUB_OUTPUT
+  echo "projects=src/PPDS.Query/PPDS.Query.csproj" >> $GITHUB_OUTPUT
+elif [[ $TAG == Mcp-v* ]]; then
+  echo "package=PPDS.Mcp" >> $GITHUB_OUTPUT
+  echo "projects=src/PPDS.Mcp/PPDS.Mcp.csproj" >> $GITHUB_OUTPUT
+```
+
+**Step 3: Verify the file looks correct**
+
+Read the modified file and confirm the structure is correct.
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows/publish-nuget.yml
+git commit -m "ci: add PPDS.Query and PPDS.Mcp to NuGet publish workflow"
+```
+
+---
+
+### Task 3: Create PPDS.Query CHANGELOG.md
+
+**Files:**
+- Create: `src/PPDS.Query/CHANGELOG.md`
+
+**Step 1: Write the changelog**
+
+Content should follow Keep a Changelog format. Version: `1.0.0-beta.1`. Include all user-facing features from the 109 commits grouped by category:
+
+**Added section highlights:**
+- Full T-SQL parsing via Microsoft.SqlServer.TransactSql.ScriptDom
+- FetchXML transpilation from SQL AST
+- Execution plan engine with Volcano iterator model (streaming results)
+- ADO.NET provider (PpdsDbConnection, PpdsDbCommand, PpdsDbDataReader) for standard .NET data access
+- PpdsDbProviderFactory for ADO.NET provider discoverability
+- SELECT with columns, aliases, TOP, DISTINCT
+- WHERE with all comparison operators, LIKE, IN, BETWEEN, IS NULL, IS NOT DISTINCT FROM
+- JOIN support: INNER, LEFT, RIGHT, FULL OUTER, CROSS, OUTER APPLY — pushdown to FetchXML when possible, client-side hash/merge/nested-loop fallback
+- Multi-column key support in client-side JOIN ON conditions
+- GROUP BY with aggregates (COUNT, SUM, AVG, MIN, MAX, STDEV, STDEVP, VAR, VARP) including expression GROUP BY
+- HAVING clause with aggregate predicate support
+- ORDER BY with ASC/DESC
+- UNION and UNION ALL
+- Subqueries: IN (SELECT), NOT IN, EXISTS, NOT EXISTS, derived tables (FROM subquery), scalar subqueries
+- NOT IN subquery rewrite to LEFT OUTER JOIN for FetchXML pushdown
+- Window functions: ROW_NUMBER, RANK, DENSE_RANK, CUME_DIST, PERCENT_RANK with PARTITION BY and ORDER BY
+- Common Table Expressions (WITH ... AS) including recursive CTEs
+- CASE/WHEN/THEN/ELSE and IIF expressions
+- Computed column expressions in SELECT
+- Expression evaluation: ISNULL, COALESCE, NULLIF, CAST, string functions, date functions (DATEADD, DATEDIFF, DATEPART, YEAR, MONTH, DAY, GETDATE, GETUTCDATE, TIMEFROMPARTS)
+- DML: INSERT, UPDATE, DELETE with safety guards and row caps
+- INSERT ... SELECT with ordinal mapping
+- SELECT INTO #temp for script-scoped temporary tables
+- DECLARE/SET variable assignment (SELECT @var = expr)
+- IF/ELSE flow control for multi-statement scripts
+- WHILE loops with BREAK and CONTINUE
+- OPENJSON table-valued function
+- JSON_MODIFY with array path support
+- OPTION() query hints and comment-based hint parser
+- EXPLAIN command for query plan inspection with pool/parallelism metadata
+- TDS Endpoint routing for compatible queries
+- Parallel partitioned aggregates for accurate COUNT(*) beyond Dataverse 50K limit
+- Adaptive aggregate retry with binary date-range splitting when partitions exceed limits
+- Prefetch scan node for page-ahead buffering (improved streaming throughput)
+- Metadata query system (queryable entity/attribute schema via INFORMATION_SCHEMA-style access)
+- DML safety guard with configurable thresholds, environment protection levels, and cross-environment DML policy enforcement
+- Cross-environment query planning with bracket syntax ([environment].[entity])
+- Smart label detection for 2-part cross-environment references
+- RemoteScanNode for cross-environment FetchXML execution
+- IndexSpoolNode for correlated subquery caching
+- TableSpoolNode for in-memory result materialization
+- QueryExecutionException with structured error codes
+- @@ERROR and ERROR_MESSAGE() tracking in session context
+- Paging cap and materialization limit safety features
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Query/CHANGELOG.md
+git commit -m "docs: add PPDS.Query CHANGELOG with v1.0.0-beta.1 release notes"
+```
+
+---
+
+### Task 4: Create PPDS.Query README.md
+
+**Files:**
+- Create: `src/PPDS.Query/README.md`
+
+**Step 1: Write the README**
+
+Follow the pattern from `src/PPDS.Dataverse/README.md` — installation, quick start with code example, features list, target frameworks, license. Key sections:
+
+- Installation (`dotnet add package PPDS.Query`)
+- Quick Start: ADO.NET provider usage (PpdsDbConnection)
+- Quick Start: CLI usage (`ppds query sql "SELECT name FROM account WHERE revenue > 1000000"`)
+- Features: SQL support matrix, execution engine, safety features, cross-env queries
+- Target Frameworks: net8.0, net9.0, net10.0
+- License: MIT
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Query/README.md
+git commit -m "docs: add PPDS.Query README"
+```
+
+---
+
+### Task 5: Create PPDS.Mcp CHANGELOG.md
+
+**Files:**
+- Create: `src/PPDS.Mcp/CHANGELOG.md`
+
+**Step 1: Write the changelog**
+
+Version: `1.0.0-beta.1`. Features from 11 commits:
+
+**Added:**
+- MCP server exposing Power Platform capabilities for AI assistant integration
+- Distributed as .NET tool (`ppds-mcp-server`)
+- 12+ read-only Dataverse tools for Claude Code and other MCP clients
+- SQL and FetchXML query execution via MCP tools
+- Entity metadata exploration
+- Plugin registration and trace log analysis
+- DI-based architecture with injected ProfileStore and auth services
+- Integration with PPDS.Query engine (ScriptDom parser, FetchXML generator)
+- Supports all PPDS.Auth authentication methods
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Mcp/CHANGELOG.md
+git commit -m "docs: add PPDS.Mcp CHANGELOG with v1.0.0-beta.1 release notes"
+```
+
+---
+
+### Task 6: Create PPDS.Mcp README.md
+
+**Files:**
+- Create: `src/PPDS.Mcp/README.md`
+
+**Step 1: Write the README**
+
+Follow the pattern from other package READMEs. Key sections:
+
+- Installation (`dotnet tool install -g PPDS.Mcp`)
+- Quick Start: Claude Code configuration (settings.json snippet)
+- Available Tools: list of MCP tools with descriptions
+- Authentication: how to set up profiles
+- Target Frameworks: net8.0, net9.0, net10.0
+- License: MIT
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Mcp/README.md
+git commit -m "docs: add PPDS.Mcp README"
+```
+
+---
+
+### Task 7: Update PPDS.Auth CHANGELOG.md
+
+**Files:**
+- Modify: `src/PPDS.Auth/CHANGELOG.md`
+
+**Step 1: Populate the [Unreleased] section with v1.0.0-beta.7 release notes**
+
+Based on the 22 commits since Auth-v1.0.0-beta.6:
+
+**Added:**
+- `AddAuthServices()` DI registration extension for ProfileStore, EnvironmentConfigStore, and NativeCredentialStore
+- `EnvironmentConfig` models and `EnvironmentConfigStore` for per-environment configuration (label, type, color)
+- `EnvironmentType` enum (Development, Test, Production, Sandbox, Default)
+- `QuerySafetySettings` in `EnvironmentConfig` for per-environment DML safety thresholds
+- `ProtectionLevel` support for environment protection enforcement
+- Cross-environment DML policy enforcement
+
+**Changed:**
+- `EnvironmentConfig.Type` changed from `string` to `EnvironmentType` enum
+
+**Fixed:**
+- Token cache scope mismatch in browser auth profile creation
+- Disposal guards, empty-string-clears, and typed catches in credential providers
+
+Replace the empty `## [Unreleased]` section with versioned `## [1.0.0-beta.7]` and add new empty `## [Unreleased]` above it. Update comparison links at bottom.
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Auth/CHANGELOG.md
+git commit -m "docs: update PPDS.Auth CHANGELOG for v1.0.0-beta.7"
+```
+
+---
+
+### Task 8: Update PPDS.Dataverse CHANGELOG.md
+
+**Files:**
+- Modify: `src/PPDS.Dataverse/CHANGELOG.md`
+
+**Step 1: Finalize the [Unreleased] section as v1.0.0-beta.6 release notes**
+
+The existing Unreleased section already has good content. Enhance it with:
+
+**Added (additional items):**
+- Child record paging boundary detection for linked entities
+- Adaptive thread management for 429 backoff (reduces thread consumption during throttling)
+- Auto-paging for RemoteScanNode
+
+**Fixed:**
+- Floating-point equality comparisons for SQL semantics
+- Use TryGetValue instead of ContainsKey + indexer pattern
+
+Rename `## [Unreleased]` to `## [1.0.0-beta.6]` with date, add new empty `## [Unreleased]` above it. Update comparison links.
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Dataverse/CHANGELOG.md
+git commit -m "docs: update PPDS.Dataverse CHANGELOG for v1.0.0-beta.6"
+```
+
+---
+
+### Task 9: Update PPDS.Cli CHANGELOG.md
+
+**Files:**
+- Modify: `src/PPDS.Cli/CHANGELOG.md`
+
+**Step 1: Finalize the [Unreleased] section as v1.0.0-beta.13 release notes**
+
+The existing Unreleased section has some content but is missing major features. Add:
+
+**Added (additional items):**
+- Multi-tab architecture with per-environment query tabs
+- `ppds env config` command for setting environment label, type, and color
+- `ppds env type` command
+- EnvironmentConfigDialog for configuring environment label, type (dropdown), and color
+- DeviceCodeDialog with selectable code text and auto-close on auth completion
+- TDS Endpoint toggle with Ctrl+T shortcut
+- F7/F8/F9 keybindings for Linux terminal compatibility
+- Escape key to cancel running queries
+- Certificate Store and Username/Password auth methods in TUI
+- Environment selector with resolved labels, preview panel, and config access
+- DML safety wiring with environment-specific settings and protection levels
+- Cross-environment query support
+
+**Changed:**
+- Major DI refactoring: AuthServices, EnvironmentConfigStore, ProfileStore injection throughout CLI and TUI
+- Migrated from legacy SQL parser to PPDS.Query engine (ScriptDom-based)
+- Deleted legacy parser, AST, transpiler, and evaluator (-22K lines)
+
+**Fixed (additional items):**
+- Timer and event leaks in TUI
+- Splitter drag issues
+- Autocomplete interference during paste operations
+- Tab highlight color regression
+- Many CodeQL code scanning alerts resolved (70 findings)
+
+Rename `## [Unreleased]` to `## [1.0.0-beta.13]` with date, add new empty `## [Unreleased]` above it. Update comparison links.
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Cli/CHANGELOG.md
+git commit -m "docs: update PPDS.Cli CHANGELOG for v1.0.0-beta.13"
+```
+
+---
+
+### Task 10: Update PPDS.Migration CHANGELOG.md
+
+**Files:**
+- Modify: `src/PPDS.Migration/CHANGELOG.md`
+
+**Step 1: Add v1.0.0-beta.7 release notes**
+
+Based on 4 commits (dependency updates only):
+
+**Changed:**
+- Updated Microsoft.Data.SqlClient from 5.2.2 to 6.1.4
+
+Rename `## [Unreleased]` to `## [1.0.0-beta.7]` with date, add new empty `## [Unreleased]` above it. Update comparison links.
+
+**Step 2: Commit**
+
+```bash
+git add src/PPDS.Migration/CHANGELOG.md
+git commit -m "docs: update PPDS.Migration CHANGELOG for v1.0.0-beta.7"
+```
+
+---
+
+### Task 11: Update Root CHANGELOG.md Index
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Step 1: Add PPDS.Query and PPDS.Mcp to the per-package list**
+
+Add after the PPDS.Cli entry:
+```markdown
+- [PPDS.Query](src/PPDS.Query/CHANGELOG.md) - SQL query engine for Dataverse
+- [PPDS.Mcp](src/PPDS.Mcp/CHANGELOG.md) - MCP server for AI assistant integration
+```
+
+**Step 2: Add tag formats to versioning table**
+
+Add rows:
+```markdown
+| PPDS.Query | `Query-v{version}` | `Query-v1.0.0` |
+| PPDS.Mcp | `Mcp-v{version}` | `Mcp-v1.0.0` |
+```
+
+**Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add PPDS.Query and PPDS.Mcp to changelog index"
+```
+
+---
+
+### Task 12: Update Root README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add PPDS.Query to NuGet Libraries table**
+
+Add row after PPDS.Auth:
+```markdown
+| **PPDS.Query** | [![NuGet](https://img.shields.io/nuget/v/PPDS.Query.svg)](https://www.nuget.org/packages/PPDS.Query/) | SQL query engine with FetchXML transpilation and ADO.NET provider |
+```
+
+**Step 2: Add PPDS.Query to Compatibility table**
+
+Add row:
+```markdown
+| PPDS.Query | net8.0, net9.0, net10.0 |
+```
+
+**Step 3: Add `ppds query explain` to CLI Commands table**
+
+Update the query row to include explain and history:
+```markdown
+| `ppds query` | Execute queries (fetch, sql, explain, history) |
+```
+
+**Step 4: Add PPDS.Query section with code example**
+
+Add after the PPDS.Migration section, before Development:
+
+```markdown
+## PPDS.Query
+
+SQL query engine for Dataverse with FetchXML transpilation and an ADO.NET provider.
+
+\```bash
+dotnet add package PPDS.Query
+\```
+
+\```csharp
+// ADO.NET provider for standard .NET data access
+using var connection = new PpdsDbConnection(pool);
+await connection.OpenAsync();
+
+using var command = connection.CreateCommand();
+command.CommandText = "SELECT name, revenue FROM account WHERE revenue > @threshold";
+command.Parameters.AddWithValue("@threshold", 1_000_000m);
+
+using var reader = await command.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    Console.WriteLine($"{reader["name"]}: {reader["revenue"]:C}");
+}
+\```
+
+See [PPDS.Query documentation](src/PPDS.Query/README.md) for details.
+```
+
+**Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add PPDS.Query to root README"
+```
+
+---
+
+### Task 13: Final Review and Summary Commit
+
+**Step 1: Run `git log --oneline -15` to review all commits made**
+
+Verify each task produced a clean commit.
+
+**Step 2: Run `git diff --stat HEAD~12..HEAD` to see all changed files**
+
+Verify only documentation and CI files were changed.
+
+**Step 3: Verify build still passes**
+
+Run: `dotnet build PPDS.sln --configuration Release`
+
+This ensures no accidental code changes broke anything.

--- a/src/PPDS.Auth/CHANGELOG.md
+++ b/src/PPDS.Auth/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-03-02
+
+### Added
+
+- **`AddAuthServices()` DI registration** — Extension method for registering `ProfileStore`, `EnvironmentConfigStore`, and `NativeCredentialStore` into the DI container
+- **`EnvironmentConfig` models and `EnvironmentConfigStore`** — Per-environment configuration for label, type, and color settings
+- **`EnvironmentType` enum** — Typed environment classification (`Development`, `Test`, `Production`, `Sandbox`, `Default`), moved from CLI to Auth for shared use
+- **`QuerySafetySettings`** — Per-environment DML safety thresholds in `EnvironmentConfig`
+- **`ProtectionLevel`** — Environment protection level enforcement for production safety
+- **Cross-environment DML policy enforcement** — Safety policies for cross-environment data modification operations
+
+### Changed
+
+- **`EnvironmentConfig.Type` uses `EnvironmentType` enum** — Changed from `string` to typed enum for compile-time safety
+
+### Fixed
+
+- **Token cache scope mismatch in browser auth** — Fixed scope mismatch during interactive browser profile creation
+- **Disposal guards and typed catches** — Added disposal guards, empty-string-clears, and specific exception catches in credential providers
+
 ## [1.0.0-beta.6] - 2026-01-14
 
 ### Changed
@@ -117,7 +137,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JWT claims parsing for identity information
 - Targets: `net8.0`, `net9.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.6...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.7...HEAD
+[1.0.0-beta.7]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.6...Auth-v1.0.0-beta.7
 [1.0.0-beta.6]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.5...Auth-v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.4...Auth-v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Auth-v1.0.0-beta.3...Auth-v1.0.0-beta.4

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.13] - 2026-03-02
+
 ### Added
 
 - **SQL syntax highlighting** — Context-aware syntax coloring in the TUI query editor
@@ -19,12 +21,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Environment-colored tabs** — Tab bar reflects configured environment colors
 - **DML support** — INSERT, UPDATE, DELETE with safety guard and row caps
 - **Elapsed time spinner** — Query execution shows elapsed seconds in real-time
+- **Multi-tab query architecture** — Per-environment query tabs with independent editors and result views
+- **`ppds env config` command** — Configure environment label, type, and color
+- **EnvironmentConfigDialog** — TUI dialog for configuring environment label, type (dropdown), and color
+- **DeviceCodeDialog** — TUI dialog with selectable device code text and auto-close on auth completion
+- **TDS Endpoint toggle** — Toggle TDS Endpoint routing with Ctrl+T shortcut
+- **F7/F8/F9 keybindings** — Linux terminal compatibility keybindings
+- **Escape key cancels queries** — Press Escape to cancel a running query
+- **Certificate Store and Username/Password auth** — Additional authentication methods in TUI profile creation
+- **Environment selector improvements** — Resolved labels, preview panel, and config access
+- **DML safety with environment settings** — Environment-specific DML safety thresholds and protection levels
+- **Cross-environment query support** — Cross-environment queries wired to CLI and TUI
+
+### Changed
+
+- **Migrated to PPDS.Query engine** — Replaced legacy SQL parser with ScriptDom-based PPDS.Query engine
+- **Deleted legacy parser** — Removed legacy parser, AST, transpiler, and evaluator (-22K lines)
+- **Major DI refactoring** — AuthServices, EnvironmentConfigStore, ProfileStore injection throughout CLI and TUI
 
 ### Fixed
 
 - **Auth:** Profile creation flow, token scope mismatch, device code callbacks
 - **TUI:** Menu flicker, cursor visibility, first-frame colors, stale diagnostics clearing
 - **TUI:** High-contrast editor cursor with environment-colored tabs
+- **Timer and event leaks in TUI** — Fixed timer leak, event leak, and splitter drag issues
+- **Autocomplete interference during paste** — Prevented autocomplete popup from interfering with paste operations
+- **Tab highlight color regression** — Fixed tab color regression and config dialog defaults
+- **70 CodeQL code scanning alerts** — Resolved code quality findings across production code
 
 ## [1.0.0-beta.12] - 2026-01-14
 
@@ -350,7 +373,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packaged as .NET global tool (`ppds`)
 - Targets: `net8.0`, `net9.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.12...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.13...HEAD
+[1.0.0-beta.13]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.12...Cli-v1.0.0-beta.13
 [1.0.0-beta.12]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.11...Cli-v1.0.0-beta.12
 [1.0.0-beta.11]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.10...Cli-v1.0.0-beta.11
 [1.0.0-beta.10]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0-beta.9...Cli-v1.0.0-beta.10

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.6] - 2026-03-02
+
 ### Added
 
 - **Query Engine v2** — Execution plan layer with Volcano iterator model for streaming results
@@ -19,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Metadata query system** — Queryable entity/attribute schema access
 - **Cached metadata provider** — TTL-based caching layer for IntelliSense metadata
 - **DML safety guard** — Structured protections for data modification operations
+- **Child record paging boundary detection** — Detects when linked entity results cross page boundaries for correct pagination
+- **Adaptive thread management for 429 backoff** — Reduces thread consumption during throttling for better resource utilization
+- **Auto-paging for RemoteScanNode** — Automatic page-through for cross-environment query results
+
+### Fixed
+
+- **Floating-point equality comparisons** — Use proper SQL semantics for float comparisons
 
 ## [1.0.0-beta.5] - 2026-01-14
 
@@ -161,7 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed rate control presets (`Conservative`, `Balanced`, `Aggressive`) in favor of DOP-based parallelism
 - Removed adaptive rate control in favor of server-recommended limits
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.5...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.6...HEAD
+[1.0.0-beta.6]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.5...Dataverse-v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.4...Dataverse-v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.3...Dataverse-v1.0.0-beta.4
 [1.0.0-beta.3]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0-beta.2...Dataverse-v1.0.0-beta.3

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the PPDS.Mcp package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.1] - 2026-03-02
+
+### Added
+
+- **MCP server** for exposing Power Platform capabilities to AI assistants (Claude Code, etc.)
+- **Distributed as .NET tool** (`ppds-mcp-server`) installable via `dotnet tool install -g PPDS.Mcp`
+- **12+ read-only Dataverse tools** for querying, metadata exploration, and analysis
+- **SQL query execution** via MCP tools using PPDS.Query engine
+- **FetchXML query execution** via MCP tools
+- **Entity metadata exploration** for AI-driven schema understanding
+- **Plugin registration analysis** and trace log inspection
+- **DI-based architecture** with injected ProfileStore and auth services
+- **Integration with PPDS.Query engine** (ScriptDom parser, FetchXML generator)
+- **All PPDS.Auth authentication methods supported** (interactive browser, device code, service principal, etc.)
+
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0-beta.1...HEAD
+[1.0.0-beta.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Mcp-v1.0.0-beta.1

--- a/src/PPDS.Mcp/README.md
+++ b/src/PPDS.Mcp/README.md
@@ -1,0 +1,97 @@
+# PPDS.Mcp
+
+MCP server exposing Power Platform capabilities for AI assistant integration.
+
+## Installation
+
+```bash
+dotnet tool install -g PPDS.Mcp
+```
+
+## Quick Start - Claude Code
+
+Add the following to your Claude Code MCP settings (`.claude/settings.json` or global settings):
+
+```json
+{
+  "mcpServers": {
+    "ppds": {
+      "command": "ppds-mcp-server",
+      "args": []
+    }
+  }
+}
+```
+
+Once configured, Claude Code can query your Dataverse environment using natural language. The MCP server reads authentication from your PPDS profile (see [Authentication](#authentication) below).
+
+## Quick Start - Other MCP Clients
+
+PPDS.Mcp uses stdio transport. Launch the server and communicate over stdin/stdout:
+
+```bash
+ppds-mcp-server
+```
+
+Any MCP-compatible client can connect by spawning the process and exchanging JSON-RPC messages over stdio.
+
+## Available Tools
+
+### Authentication & Environment
+
+| Tool | Description |
+|------|-------------|
+| `ppds_auth_who` | Get the current authentication profile context including identity, connected environment, and token status. |
+| `ppds_env_list` | List available Dataverse environments accessible with the current profile. Supports filtering by name, URL, or ID. |
+| `ppds_env_select` | Select a Dataverse environment by URL, display name, or unique name. All subsequent tools use the selected environment. |
+
+### Querying
+
+| Tool | Description |
+|------|-------------|
+| `ppds_query_sql` | Execute a SQL SELECT query against Dataverse. Supports JOINs, WHERE, ORDER BY, TOP, and aggregate functions. SQL is transpiled to FetchXML via the PPDS.Query engine. |
+| `ppds_query_fetch` | Execute a raw FetchXML query against Dataverse. Use for advanced query features not available in SQL. |
+
+### Data & Schema Exploration
+
+| Tool | Description |
+|------|-------------|
+| `ppds_data_analyze` | Analyze entity data: record count, primary attributes, and sample records. |
+| `ppds_data_schema` | Get the schema (fields/attributes) for a Dataverse entity including types, constraints, and option set values. |
+| `ppds_metadata_entity` | Get detailed entity metadata including attributes, relationships, keys, and ownership type. |
+
+### Plugin Analysis
+
+| Tool | Description |
+|------|-------------|
+| `ppds_plugins_list` | List registered plugin assemblies with their types and step registrations. Supports filtering by assembly name. |
+| `ppds_plugin_traces_list` | List plugin trace logs with filtering by entity, message, type name, or errors only. |
+| `ppds_plugin_traces_get` | Get full details of a specific plugin trace including message block (trace output) and exception details. |
+| `ppds_plugin_traces_timeline` | Build a hierarchical execution timeline for a transaction using correlation ID. Shows how plugins chain together and identifies performance bottlenecks. |
+
+## Authentication
+
+PPDS.Mcp reads authentication from your PPDS profile store. Create a profile before using the MCP server:
+
+```bash
+# Interactive browser login (recommended for development)
+ppds auth create
+
+# Device code flow (for remote/headless scenarios)
+ppds auth create --method DeviceCode
+
+# Service principal (for CI/CD and automation)
+ppds auth create --method ClientSecret --client-id <id> --tenant-id <tid>
+```
+
+After creating a profile and selecting an environment, the MCP server automatically uses those credentials for all Dataverse operations.
+
+## Target Frameworks
+
+- `net8.0`
+- `net9.0`
+- `net10.0`
+
+## License
+
+MIT License

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta.7] - 2026-03-02
+
+### Changed
+
+- **Updated Microsoft.Data.SqlClient** — Bumped from 5.2.2 to 6.1.4
+
 ## [1.0.0-beta.6] - 2026-01-14
 
 ### Added
@@ -92,7 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DI integration via `AddDataverseMigration()` extension method
 - Targets: `net8.0`, `net9.0`, `net10.0`
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.6...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.7...HEAD
+[1.0.0-beta.7]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.6...Migration-v1.0.0-beta.7
 [1.0.0-beta.6]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.5...Migration-v1.0.0-beta.6
 [1.0.0-beta.5]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.4...Migration-v1.0.0-beta.5
 [1.0.0-beta.4]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0-beta.3...Migration-v1.0.0-beta.4

--- a/src/PPDS.Query/CHANGELOG.md
+++ b/src/PPDS.Query/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog - PPDS.Query
+
+All notable changes to PPDS.Query will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-beta.1] - 2026-03-02
+
+### Added
+
+#### SQL Language Support
+
+- **Full T-SQL parsing** via Microsoft.SqlServer.TransactSql.ScriptDom
+- **SELECT** with columns, aliases, TOP, DISTINCT
+- **WHERE** with all comparison operators, LIKE, IN, BETWEEN, IS NULL, IS NOT DISTINCT FROM
+- **JOIN support** — INNER, LEFT, RIGHT, FULL OUTER, CROSS, OUTER APPLY with FetchXML pushdown when possible, client-side hash/merge/nested-loop fallback
+- **Multi-column key support** in client-side JOIN ON conditions
+- **GROUP BY** with aggregates (COUNT, SUM, AVG, MIN, MAX, STDEV, STDEVP, VAR, VARP) including expression GROUP BY
+- **HAVING clause** with aggregate predicate support
+- **ORDER BY** with ASC/DESC
+- **UNION and UNION ALL**
+- **Subqueries** — IN (SELECT), NOT IN, EXISTS, NOT EXISTS, derived tables (FROM subquery), scalar subqueries
+- **NOT IN subquery rewrite** to LEFT OUTER JOIN for FetchXML pushdown
+- **Window functions** — ROW_NUMBER, RANK, DENSE_RANK, CUME_DIST, PERCENT_RANK with PARTITION BY and ORDER BY
+- **Common Table Expressions** (WITH ... AS) including recursive CTEs
+- **CASE/WHEN/THEN/ELSE and IIF** expressions
+- **Computed column expressions** in SELECT
+- **Expression evaluation** — ISNULL, COALESCE, NULLIF, CAST, string functions, date functions (DATEADD, DATEDIFF, DATEPART, YEAR, MONTH, DAY, GETDATE, GETUTCDATE, TIMEFROMPARTS)
+- **OPENJSON** table-valued function
+- **JSON_MODIFY** with array path support
+
+#### DML Support
+
+- **INSERT, UPDATE, DELETE** with safety guards and configurable row caps
+- **INSERT ... SELECT** with ordinal mapping
+- **SELECT INTO #temp** for script-scoped temporary tables
+
+#### Scripting & Flow Control
+
+- **DECLARE/SET** variable assignment (SELECT @var = expr)
+- **IF/ELSE** flow control for multi-statement scripts
+- **WHILE loops** with BREAK and CONTINUE
+- **@@ERROR and ERROR_MESSAGE()** tracking in session context
+
+#### Execution Engine
+
+- **FetchXML transpilation** from SQL AST
+- **Execution plan engine** with Volcano iterator model for streaming results
+- **Prefetch scan node** for page-ahead buffering
+- **TDS Endpoint routing** for compatible queries
+- **Parallel partitioned aggregates** for accurate COUNT(*) beyond Dataverse 50K limit
+- **Adaptive aggregate retry** with binary date-range splitting when partitions exceed limits
+- **IndexSpoolNode** for correlated subquery caching
+- **TableSpoolNode** for in-memory result materialization
+- **EXPLAIN command** for query plan inspection with pool/parallelism metadata
+- **OPTION() query hints** and comment-based hint parser
+
+#### ADO.NET Provider
+
+- **PpdsDbConnection** for standard .NET data access
+- **PpdsDbCommand** with parameterized query support
+- **PpdsDbDataReader** for streaming result consumption
+- **PpdsDbProviderFactory** for ADO.NET provider discoverability
+
+#### Cross-Environment Queries
+
+- **Cross-environment query planning** with bracket syntax (`[environment].[entity]`)
+- **Smart label detection** for 2-part cross-environment references
+- **RemoteScanNode** for cross-environment FetchXML execution
+
+#### Metadata
+
+- **Metadata query system** for querying entity/attribute schema
+
+#### Safety & Protection
+
+- **DML safety guard** with configurable thresholds and environment protection levels
+- **QueryExecutionException** with structured error codes
+
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Query-v1.0.0-beta.1...HEAD
+[1.0.0-beta.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Query-v1.0.0-beta.1

--- a/src/PPDS.Query/README.md
+++ b/src/PPDS.Query/README.md
@@ -1,0 +1,150 @@
+# PPDS.Query
+
+Production-grade SQL query engine for Dataverse with FetchXML transpilation and ADO.NET provider.
+
+## Installation
+
+```bash
+dotnet add package PPDS.Query
+```
+
+## Quick Start - ADO.NET Provider
+
+```csharp
+using PPDS.Query.Provider;
+
+await using var connection = new PpdsDbConnection(connectionPool);
+await connection.OpenAsync();
+
+await using var command = connection.CreateCommand();
+command.CommandText = @"
+    SELECT a.name, a.revenue, c.fullname
+    FROM account a
+    INNER JOIN contact c ON c.parentcustomerid = a.accountid
+    WHERE a.statecode = @statecode
+    ORDER BY a.revenue DESC";
+
+command.Parameters.AddWithValue("@statecode", 0);
+
+await using var reader = await command.ExecuteReaderAsync();
+while (await reader.ReadAsync())
+{
+    var name = reader.GetString(0);
+    var revenue = reader.IsDBNull(1) ? 0m : reader.GetDecimal(1);
+    var contact = reader.GetString(2);
+    Console.WriteLine($"{name} ({revenue:C}) - {contact}");
+}
+```
+
+## Quick Start - CLI
+
+```bash
+# Simple query
+ppds query sql "SELECT name, revenue FROM account WHERE statecode = 0 ORDER BY revenue DESC"
+
+# Join across entities
+ppds query sql "SELECT a.name, c.fullname FROM account a JOIN contact c ON c.parentcustomerid = a.accountid"
+
+# Aggregate query
+ppds query sql "SELECT ownerid, COUNT(*) as total FROM account GROUP BY ownerid HAVING COUNT(*) > 10"
+
+# Output as CSV
+ppds query sql "SELECT name, emailaddress1 FROM contact" -f csv
+
+# View the execution plan
+ppds query explain "SELECT name FROM account WHERE revenue > 1000000"
+```
+
+## Features
+
+### SQL Language Support
+
+Full T-SQL syntax parsed via Microsoft.SqlServer.TransactSql.ScriptDom:
+
+- **SELECT** with columns, aliases, TOP, DISTINCT, computed expressions
+- **WHERE** with all comparison operators, LIKE, IN, BETWEEN, IS NULL, IS NOT DISTINCT FROM
+- **JOIN** — INNER, LEFT, RIGHT, FULL OUTER, CROSS, OUTER APPLY
+- **GROUP BY** with aggregates: COUNT, SUM, AVG, MIN, MAX, STDEV, STDEVP, VAR, VARP
+- **HAVING** clause with aggregate predicates
+- **ORDER BY** with ASC/DESC
+- **UNION / UNION ALL**
+- **Subqueries** — IN, NOT IN, EXISTS, NOT EXISTS, derived tables, scalar subqueries
+- **Window functions** — ROW_NUMBER, RANK, DENSE_RANK, CUME_DIST, PERCENT_RANK
+- **CTEs** — Common Table Expressions including recursive CTEs
+- **CASE/WHEN/THEN/ELSE** and **IIF** expressions
+- **Built-in functions** — ISNULL, COALESCE, NULLIF, CAST, string functions, date functions (DATEADD, DATEDIFF, DATEPART, YEAR, MONTH, DAY, GETDATE, GETUTCDATE, TIMEFROMPARTS)
+- **JSON** — OPENJSON table-valued function, JSON_MODIFY with array paths
+- **Scripting** — DECLARE/SET variables, IF/ELSE, WHILE/BREAK/CONTINUE, SELECT INTO #temp
+
+### Execution Engine
+
+The query engine uses a Volcano iterator model for streaming results:
+
+```
+SQL Text
+  -> ScriptDom Parser -> SQL AST
+  -> Query Planner -> Execution Plan
+  -> FetchXML Transpiler -> FetchXML (pushed down to Dataverse)
+  -> Volcano Iterators -> Streaming rows
+```
+
+- **FetchXML pushdown** — Filters, joins, and aggregates are pushed to Dataverse when possible
+- **Client-side fallback** — Hash, merge, and nested-loop joins for queries that exceed FetchXML capabilities
+- **Prefetch buffering** — Page-ahead scan node for improved streaming throughput
+- **TDS Endpoint routing** — Automatically routes compatible queries to the SQL endpoint
+- **Parallel partitioned aggregates** — Accurate COUNT(*) beyond the Dataverse 50K limit via date-range partitioning
+- **Adaptive retry** — Binary date-range splitting when partitions exceed limits
+- **EXPLAIN** — Inspect query execution plans with pool and parallelism metadata
+
+### Cross-Environment Queries
+
+Query across Dataverse environments using bracket syntax:
+
+```sql
+-- Compare account counts across environments
+SELECT 'Dev' as env, COUNT(*) as total FROM [dev-org].[account]
+UNION ALL
+SELECT 'Prod' as env, COUNT(*) as total FROM [prod-org].[account]
+```
+
+- **Bracket syntax** — `[environment].[entity]` for cross-environment references
+- **Smart label detection** — Resolves 2-part names against configured environment labels
+- **Remote execution** — RemoteScanNode executes FetchXML on remote environments
+
+### DML Support
+
+Data modification with safety guards:
+
+```sql
+-- Insert with values
+INSERT INTO account (name, revenue) VALUES ('Contoso', 1000000)
+
+-- Insert from query
+INSERT INTO account (name, revenue)
+SELECT name, revenue FROM #staged_accounts
+
+-- Update with filter
+UPDATE contact SET jobtitle = 'Senior Developer' WHERE jobtitle = 'Developer'
+
+-- Delete with filter
+DELETE FROM account WHERE statecode = 1 AND modifiedon < '2024-01-01'
+```
+
+### Safety Features
+
+All DML operations are protected by configurable safety guards:
+
+- **Environment protection levels** — Prevent accidental writes to production environments
+- **Row caps** — Configurable maximum rows affected per DML statement
+- **Structured error codes** — QueryExecutionException with error codes for programmatic handling
+- **@@ERROR / ERROR_MESSAGE()** — Error state tracking within script sessions
+
+## Target Frameworks
+
+- `net8.0`
+- `net9.0`
+- `net10.0`
+
+## License
+
+MIT License


### PR DESCRIPTION
## Summary

Prepares all PPDS packages for the March 2026 NuGet release (531 commits since January 14).

- **CI:** Add PPDS.Query and PPDS.Mcp to `publish-nuget.yml` tag triggers
- **New package docs:** CHANGELOG and README for PPDS.Query (v1.0.0-beta.1) and PPDS.Mcp (v1.0.0-beta.1)
- **Changelog updates:** Auth (beta.7), Dataverse (beta.6), Cli (beta.13), Migration (beta.7)
- **Root docs:** Updated CHANGELOG index and README with PPDS.Query

### Packages in this release

| Package | Version | Highlights |
|---------|---------|-----------|
| PPDS.Query | 1.0.0-beta.1 (new) | Full SQL query engine — T-SQL parsing, FetchXML transpilation, ADO.NET provider |
| PPDS.Cli | 1.0.0-beta.13 | TUI overhaul, SQL IntelliSense, multi-tab, DML, cross-env queries |
| PPDS.Dataverse | 1.0.0-beta.6 | Query engine v2 nodes, metadata caching, adaptive threading |
| PPDS.Auth | 1.0.0-beta.7 | EnvironmentConfig, DI registration, safety settings |
| PPDS.Mcp | 1.0.0-beta.1 (new) | MCP server for AI assistants |
| PPDS.Migration | 1.0.0-beta.7 | Dependency updates |

### After merge

Create tags in dependency order to trigger NuGet publishing:
```
Auth-v1.0.0-beta.7
Dataverse-v1.0.0-beta.6
Query-v1.0.0-beta.1
Migration-v1.0.0-beta.7
Mcp-v1.0.0-beta.1
Cli-v1.0.0-beta.13
```

## Test plan

- [x] `dotnet build PPDS.sln --configuration Release` passes (0 errors)
- [ ] CI gate passes
- [ ] Verify publish-nuget.yml correctly maps Query-v* and Mcp-v* tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)