### PR TITLE
feat(cli): update check, notification, and self-update system

### DIFF
--- a/docs/plans/2026-03-15-cli-update-check.md
+++ b/docs/plans/2026-03-15-cli-update-check.md
@@ -1,0 +1,1496 @@
+# CLI Update Version Check Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-blocking update check to the CLI that notifies users when a newer version of PPDS is available on NuGet, with an explicit `ppds version --check` command for on-demand comparison.
+
+**Architecture:** An `UpdateCheckService` Application Service queries the NuGet flat container API for available versions, caches results to `~/.ppds/update-check.json` for 24 hours, and compares against the current assembly version. At CLI startup, a non-blocking read of cached results displays a one-liner notification to stderr. The `ppds version --check` command forces a fresh fetch.
+
+**Tech Stack:** .NET 8+, System.CommandLine, System.Text.Json, HttpClient, xUnit + FluentAssertions + Moq
+
+**Issue:** [#564](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/564)
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test |
+|----|-----------|------|
+| AC-01 | `ppds version` displays current CLI version, SDK version, .NET version, and platform | `VersionCommandTests.Create_ReturnsCommandWithCorrectName` |
+| AC-02 | `ppds version --check` fetches latest versions from NuGet and displays current vs latest (stable and pre-release) | `UpdateCheckServiceTests.CheckAsync_ReturnsLatestStableAndPreRelease` |
+| AC-03 | When current version is older than latest stable, suggests `dotnet tool update PPDS.Cli -g` | `UpdateCheckServiceTests.CheckAsync_StableAvailable_SuggestsPlainUpdate` |
+| AC-04 | When user is on pre-release and newer pre-release exists (no newer stable), suggests command with `--prerelease` | `UpdateCheckServiceTests.CheckAsync_PreReleaseUser_NewerPreRelease_SuggestsPreReleaseFlag` |
+| AC-05 | Check result is cached to `~/.ppds/update-check.json` for 24 hours | `UpdateCheckServiceTests.CheckAsync_CachesResult` |
+| AC-06 | CLI startup reads cached result and shows one-liner notification to stderr if update available | `StartupUpdateNotifierTests.GetNotificationMessage_UpdateAvailable_ReturnsMessage` |
+| AC-07 | Startup notification never blocks or slows CLI execution | `StartupUpdateNotifierTests.GetNotificationMessage_NeverThrows` |
+| AC-08 | Network failures during check are handled gracefully (no crash, no output to stdout) | `UpdateCheckServiceTests.CheckAsync_NetworkError_ReturnsNull` |
+| AC-09 | Startup notification suppressed when `--quiet` or `-q` is passed | `StartupUpdateNotifierTests.ShouldShow_QuietFlag_ReturnsFalse` |
+| AC-10 | Version parsing handles SemVer with pre-release suffixes correctly | `NuGetVersionTests.Parse_ValidVersion_ExtractsComponents` |
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs` | SemVer value type — parse, compare, detect pre-release |
+| `src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs` | Service interface for version checking |
+| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs` | Implementation — NuGet API, caching, comparison logic |
+| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs` | Result records returned by service |
+| `src/PPDS.Cli/Commands/VersionCommand.cs` | `ppds version [--check]` command |
+| `tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs` | Version parsing/comparison tests |
+| `tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs` | Service logic tests |
+| `tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs` | Command structure tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs` | Add `UpdateCheck` error category |
+| `src/PPDS.Cli/Services/ServiceRegistration.cs` | Register `IUpdateCheckService` |
+| `src/PPDS.Cli/Program.cs` | Add `VersionCommand`, add startup notification call |
+
+---
+
+## Chunk 1: Version Parsing Foundation
+
+### Task 1: NuGetVersion — SemVer Value Type
+
+**Files:**
+- Create: `src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs`
+- Test: `tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs`
+
+- [ ] **Step 1: Write failing tests for NuGetVersion parsing**
+
+```csharp
+// tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
+using FluentAssertions;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.UpdateCheck;
+
+public class NuGetVersionTests
+{
+    [Theory]
+    [InlineData("1.0.0", 1, 0, 0, "")]
+    [InlineData("0.5.3-beta.1", 0, 5, 3, "beta.1")]
+    [InlineData("2.10.0-alpha.0", 2, 10, 0, "alpha.0")]
+    [InlineData("1.0.0-rc.1", 1, 0, 0, "rc.1")]
+    public void Parse_ValidVersion_ExtractsComponents(
+        string input, int major, int minor, int patch, string preRelease)
+    {
+        var version = NuGetVersion.Parse(input);
+
+        version.Major.Should().Be(major);
+        version.Minor.Should().Be(minor);
+        version.Patch.Should().Be(patch);
+        version.PreReleaseLabel.Should().Be(preRelease);
+    }
+
+    [Theory]
+    [InlineData("0.5.3-beta.1")]
+    [InlineData("1.0.0-alpha.0")]
+    [InlineData("0.3.0-rc.1")]
+    public void IsPreRelease_WithPreReleaseLabel_ReturnsTrue(string input)
+    {
+        NuGetVersion.Parse(input).IsPreRelease.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("0.6.0")]
+    [InlineData("2.0.0")]
+    public void IsPreRelease_StableVersion_ReturnsFalse(string input)
+    {
+        NuGetVersion.Parse(input).IsPreRelease.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("0.5.0")]
+    [InlineData("0.3.0")]
+    [InlineData("1.1.0")]
+    public void IsOddMinor_OddMinorVersion_ReturnsTrue(string input)
+    {
+        NuGetVersion.Parse(input).IsOddMinor.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("0.6.0")]
+    [InlineData("1.0.0")]
+    [InlineData("2.2.0")]
+    public void IsOddMinor_EvenMinorVersion_ReturnsFalse(string input)
+    {
+        NuGetVersion.Parse(input).IsOddMinor.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CompareTo_HigherMajor_IsGreater()
+    {
+        var v1 = NuGetVersion.Parse("2.0.0");
+        var v2 = NuGetVersion.Parse("1.0.0");
+
+        v1.CompareTo(v2).Should().BePositive();
+    }
+
+    [Fact]
+    public void CompareTo_StableBeatsPreRelease_SameBase()
+    {
+        var stable = NuGetVersion.Parse("1.0.0");
+        var preRelease = NuGetVersion.Parse("1.0.0-beta.1");
+
+        stable.CompareTo(preRelease).Should().BePositive();
+    }
+
+    [Fact]
+    public void CompareTo_HigherPreRelease_IsGreater()
+    {
+        var v1 = NuGetVersion.Parse("1.0.0-beta.2");
+        var v2 = NuGetVersion.Parse("1.0.0-beta.1");
+
+        v1.CompareTo(v2).Should().BePositive();
+    }
+
+    [Fact]
+    public void CompareTo_CrossMinorPreRelease_StableWins()
+    {
+        // 0.6.0 stable > 0.5.3-beta.1 pre-release
+        var stable = NuGetVersion.Parse("0.6.0");
+        var preRelease = NuGetVersion.Parse("0.5.3-beta.1");
+
+        stable.CompareTo(preRelease).Should().BePositive();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-version")]
+    [InlineData("1.0")]
+    public void TryParse_InvalidInput_ReturnsFalse(string input)
+    {
+        NuGetVersion.TryParse(input, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_ValidInput_ReturnsTrueAndVersion()
+    {
+        NuGetVersion.TryParse("1.2.3", out var version).Should().BeTrue();
+        version!.Major.Should().Be(1);
+    }
+
+    [Fact]
+    public void ToString_RoundTrips()
+    {
+        var version = NuGetVersion.Parse("1.2.3-beta.1");
+        version.ToString().Should().Be("1.2.3-beta.1");
+    }
+
+    [Fact]
+    public void Parse_VersionWithBuildMetadata_IgnoresBuildMetadata()
+    {
+        // InformationalVersion includes "+commitHash" — must be stripped
+        var version = NuGetVersion.Parse("1.2.3-beta.1+abc1234");
+
+        version.Major.Should().Be(1);
+        version.Minor.Should().Be(2);
+        version.Patch.Should().Be(3);
+        version.PreReleaseLabel.Should().Be("beta.1");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~NuGetVersionTests" --no-restore -v q`
+Expected: Build error — `NuGetVersion` type does not exist
+
+- [ ] **Step 3: Implement NuGetVersion**
+
+```csharp
+// src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Lightweight SemVer version type for NuGet version comparison.
+/// Handles major.minor.patch[-prerelease][+build] format.
+/// </summary>
+public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVersion>
+{
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    /// <summary>
+    /// Pre-release label (e.g., "beta.1", "alpha.0"). Empty string for stable versions.
+    /// </summary>
+    public string PreReleaseLabel { get; }
+
+    /// <summary>
+    /// True if this version has a pre-release label.
+    /// </summary>
+    public bool IsPreRelease => !string.IsNullOrEmpty(PreReleaseLabel);
+
+    /// <summary>
+    /// True if this version has an odd minor number (PPDS convention: odd = pre-release line).
+    /// </summary>
+    public bool IsOddMinor => Minor % 2 != 0;
+
+    private NuGetVersion(int major, int minor, int patch, string preReleaseLabel)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreReleaseLabel = preReleaseLabel;
+    }
+
+    /// <summary>
+    /// Parses a SemVer version string. Strips build metadata (+hash) if present.
+    /// </summary>
+    /// <exception cref="FormatException">Thrown when the version string is invalid.</exception>
+    public static NuGetVersion Parse(string version)
+    {
+        if (!TryParse(version, out var result))
+            throw new FormatException($"Invalid version format: '{version}'");
+        return result!;
+    }
+
+    /// <summary>
+    /// Attempts to parse a SemVer version string.
+    /// </summary>
+    public static bool TryParse(string? version, out NuGetVersion? result)
+    {
+        result = null;
+
+        if (string.IsNullOrWhiteSpace(version))
+            return false;
+
+        // Strip build metadata (+commitHash)
+        var buildIndex = version.IndexOf('+');
+        if (buildIndex >= 0)
+            version = version[..buildIndex];
+
+        // Split pre-release label
+        var preRelease = string.Empty;
+        var dashIndex = version.IndexOf('-');
+        if (dashIndex >= 0)
+        {
+            preRelease = version[(dashIndex + 1)..];
+            version = version[..dashIndex];
+        }
+
+        // Parse major.minor.patch
+        var parts = version.Split('.');
+        if (parts.Length != 3)
+            return false;
+
+        if (!int.TryParse(parts[0], out var major) ||
+            !int.TryParse(parts[1], out var minor) ||
+            !int.TryParse(parts[2], out var patch))
+            return false;
+
+        result = new NuGetVersion(major, minor, patch, preRelease);
+        return true;
+    }
+
+    public int CompareTo(NuGetVersion? other)
+    {
+        if (other is null) return 1;
+
+        var cmp = Major.CompareTo(other.Major);
+        if (cmp != 0) return cmp;
+
+        cmp = Minor.CompareTo(other.Minor);
+        if (cmp != 0) return cmp;
+
+        cmp = Patch.CompareTo(other.Patch);
+        if (cmp != 0) return cmp;
+
+        // Stable (no pre-release) > pre-release for same base version
+        if (!IsPreRelease && other.IsPreRelease) return 1;
+        if (IsPreRelease && !other.IsPreRelease) return -1;
+
+        // Compare pre-release labels lexicographically
+        return string.Compare(PreReleaseLabel, other.PreReleaseLabel, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool Equals(NuGetVersion? other) =>
+        other is not null && CompareTo(other) == 0;
+
+    public override bool Equals(object? obj) =>
+        obj is NuGetVersion other && Equals(other);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Major, Minor, Patch, PreReleaseLabel.ToLowerInvariant());
+
+    public override string ToString() =>
+        IsPreRelease ? $"{Major}.{Minor}.{Patch}-{PreReleaseLabel}" : $"{Major}.{Minor}.{Patch}";
+
+    public static bool operator >(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) > 0;
+    public static bool operator <(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) < 0;
+    public static bool operator >=(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) >= 0;
+    public static bool operator <=(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) <= 0;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~NuGetVersionTests" --no-restore -v q`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
+git commit -m "feat(cli): add NuGetVersion SemVer value type for update check (#564)"
+```
+
+---
+
+### Task 2: Result Records and Service Interface
+
+**Files:**
+- Create: `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs`
+- Create: `src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs`
+
+- [ ] **Step 1: Create result records**
+
+```csharp
+// src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Result of a version update check against NuGet.
+/// </summary>
+public sealed record UpdateCheckResult
+{
+    /// <summary>Current installed version.</summary>
+    public required string CurrentVersion { get; init; }
+
+    /// <summary>Latest stable version on NuGet (null if none found).</summary>
+    public string? LatestStableVersion { get; init; }
+
+    /// <summary>Latest pre-release version on NuGet (null if none found).</summary>
+    public string? LatestPreReleaseVersion { get; init; }
+
+    /// <summary>Whether a newer stable version is available.</summary>
+    public bool StableUpdateAvailable { get; init; }
+
+    /// <summary>Whether a newer pre-release version is available.</summary>
+    public bool PreReleaseUpdateAvailable { get; init; }
+
+    /// <summary>Suggested dotnet tool update command, or null if up-to-date.</summary>
+    public string? UpdateCommand { get; init; }
+
+    /// <summary>When this result was fetched from NuGet.</summary>
+    public DateTimeOffset CheckedAt { get; init; }
+
+    /// <summary>True if any update (stable or pre-release) is available.</summary>
+    [JsonIgnore]
+    public bool UpdateAvailable => StableUpdateAvailable || PreReleaseUpdateAvailable;
+}
+```
+
+- [ ] **Step 2: Create service interface**
+
+```csharp
+// src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Checks for available updates by querying the NuGet package registry.
+/// </summary>
+/// <remarks>
+/// Constitution A1/A2: Single code path for CLI, TUI, and RPC version checks.
+/// </remarks>
+public interface IUpdateCheckService
+{
+    /// <summary>
+    /// Performs a fresh update check against the NuGet API.
+    /// Caches the result for subsequent calls.
+    /// </summary>
+    /// <param name="currentVersion">The currently installed version string (from assembly).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Update check result, or null if the check failed.</returns>
+    Task<UpdateCheckResult?> CheckAsync(string currentVersion, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the cached update check result without making a network request.
+    /// Returns null if no cached result exists or the cache is expired.
+    /// </summary>
+    Task<UpdateCheckResult?> GetCachedResultAsync(CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
+git commit -m "feat(cli): add UpdateCheckResult records and IUpdateCheckService interface (#564)"
+```
+
+---
+
+## Chunk 2: Service Implementation
+
+### Task 3: UpdateCheckService Implementation
+
+**Files:**
+- Create: `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs`
+- Test: `tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs`
+- Modify: `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs`
+
+- [ ] **Step 1: Add UpdateCheck error codes**
+
+Add to `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs`, after the `Plugin` class:
+
+```csharp
+    /// <summary>
+    /// Update check errors.
+    /// </summary>
+    public static class UpdateCheck
+    {
+        /// <summary>Failed to reach NuGet API.</summary>
+        public const string NetworkError = "UpdateCheck.NetworkError";
+
+        /// <summary>NuGet API returned unexpected data.</summary>
+        public const string ParseError = "UpdateCheck.ParseError";
+
+        /// <summary>Cache file is corrupt or unreadable.</summary>
+        public const string CacheError = "UpdateCheck.CacheError";
+    }
+```
+
+- [ ] **Step 2: Write failing tests for UpdateCheckService**
+
+```csharp
+// tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.UpdateCheck;
+
+public class UpdateCheckServiceTests : IDisposable
+{
+    private readonly string _tempCachePath;
+    private readonly Mock<ILogger<UpdateCheckService>> _mockLogger;
+
+    public UpdateCheckServiceTests()
+    {
+        var testId = Guid.NewGuid().ToString("N")[..8];
+        _tempCachePath = Path.Combine(Path.GetTempPath(), $"ppds-test-{testId}", "update-check.json");
+        _mockLogger = new Mock<ILogger<UpdateCheckService>>();
+    }
+
+    public void Dispose()
+    {
+        var dir = Path.GetDirectoryName(_tempCachePath)!;
+        if (Directory.Exists(dir))
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { /* ignore */ }
+        }
+    }
+
+    private static HttpClient CreateMockHttpClient(string responseJson, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseJson)
+            });
+        return new HttpClient(handler.Object);
+    }
+
+    private UpdateCheckService CreateService(HttpClient? httpClient = null)
+    {
+        return new UpdateCheckService(
+            httpClient ?? CreateMockHttpClient("""{"versions":["0.5.0","0.5.1-beta.1","0.6.0"]}"""),
+            _mockLogger.Object,
+            _tempCachePath);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ReturnsLatestStableAndPreRelease()
+    {
+        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.5.1-beta.2","0.6.0","0.7.0-alpha.0"]}""";
+        var service = CreateService(CreateMockHttpClient(json));
+
+        var result = await service.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.LatestStableVersion.Should().Be("0.6.0");
+        result.LatestPreReleaseVersion.Should().Be("0.7.0-alpha.0");
+    }
+
+    [Fact]
+    public async Task CheckAsync_CurrentIsLatest_NoUpdateAvailable()
+    {
+        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.6.0"]}""";
+        var service = CreateService(CreateMockHttpClient(json));
+
+        var result = await service.CheckAsync("0.6.0");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeFalse();
+        result.UpdateCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_StableAvailable_SuggestsPlainUpdate()
+    {
+        var json = """{"versions":["0.4.0","0.6.0"]}""";
+        var service = CreateService(CreateMockHttpClient(json));
+
+        var result = await service.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeTrue();
+        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
+    }
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_NewerPreRelease_SuggestsPreReleaseFlag()
+    {
+        // No stable version higher than current — only pre-release updates available
+        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.5.0-beta.2"]}""";
+        var service = CreateService(CreateMockHttpClient(json));
+
+        // User is on pre-release, newer pre-release exists, no newer stable
+        var result = await service.CheckAsync("0.5.0-beta.1");
+
+        result.Should().NotBeNull();
+        result!.PreReleaseUpdateAvailable.Should().BeTrue();
+        result.StableUpdateAvailable.Should().BeFalse();
+        // Should suggest --prerelease since user is on pre-release line and no stable upgrade path
+        result.UpdateCommand.Should().Contain("--prerelease");
+    }
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_StableAvailable_SuggestsStableUpdate()
+    {
+        // User on 0.5.x-beta, stable 0.6.0 available — suggest plain update
+        var json = """{"versions":["0.5.0-beta.1","0.6.0"]}""";
+        var service = CreateService(CreateMockHttpClient(json));
+
+        var result = await service.CheckAsync("0.5.0-beta.1");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeTrue();
+        // Stable update takes priority — no --prerelease needed
+        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
+    }
+
+    [Fact]
+    public async Task CheckAsync_CachesResult()
+    {
+        var service = CreateService();
+
+        await service.CheckAsync("0.4.0");
+
+        File.Exists(_tempCachePath).Should().BeTrue();
+        var cached = await service.GetCachedResultAsync();
+        cached.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetCachedResultAsync_NoCacheFile_ReturnsNull()
+    {
+        var service = CreateService();
+
+        var result = await service.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCachedResultAsync_ExpiredCache_ReturnsNull()
+    {
+        var service = CreateService();
+        // Write a cache file with old timestamp
+        Directory.CreateDirectory(Path.GetDirectoryName(_tempCachePath)!);
+        var oldResult = new UpdateCheckResult
+        {
+            CurrentVersion = "0.4.0",
+            LatestStableVersion = "0.6.0",
+            StableUpdateAvailable = true,
+            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25) // Expired
+        };
+        await File.WriteAllTextAsync(_tempCachePath, JsonSerializer.Serialize(oldResult));
+
+        var result = await service.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_NetworkError_ReturnsNull()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Network error"));
+
+        var service = CreateService(new HttpClient(handler.Object));
+
+        var result = await service.CheckAsync("0.4.0");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_NonSuccessStatusCode_ReturnsNull()
+    {
+        var service = CreateService(CreateMockHttpClient("{}", HttpStatusCode.NotFound));
+
+        var result = await service.CheckAsync("0.4.0");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCachedResultAsync_CorruptCacheFile_ReturnsNull()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_tempCachePath)!);
+        await File.WriteAllTextAsync(_tempCachePath, "not valid json{{{");
+
+        var service = CreateService();
+        var result = await service.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheckServiceTests" --no-restore -v q`
+Expected: Build error — `UpdateCheckService` class does not exist
+
+- [ ] **Step 4: Implement UpdateCheckService**
+
+```csharp
+// src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Checks for available PPDS CLI updates via the NuGet flat container API.
+/// Caches results to avoid repeated network calls.
+/// </summary>
+/// <remarks>
+/// When created via <see cref="Create"/>, this instance owns the HttpClient
+/// and must be disposed. When created via constructor with an injected HttpClient,
+/// the caller owns the HttpClient lifetime.
+/// </remarks>
+public sealed class UpdateCheckService : IUpdateCheckService, IDisposable
+{
+    /// <summary>NuGet flat container API URL for the PPDS.Cli package.</summary>
+    internal const string NuGetIndexUrl = "https://api.nuget.org/v3-flatcontainer/ppds.cli/index.json";
+
+    /// <summary>NuGet package ID used in update commands.</summary>
+    internal const string PackageId = "PPDS.Cli";
+
+    /// <summary>Cache duration before a fresh check is needed. Shared with StartupUpdateNotifier.</summary>
+    internal static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private readonly ILogger<UpdateCheckService>? _logger;
+    private readonly string _cachePath;
+
+    /// <summary>
+    /// Creates a new UpdateCheckService with an externally-managed HttpClient.
+    /// The caller owns the HttpClient lifetime.
+    /// </summary>
+    /// <param name="httpClient">HTTP client for NuGet API requests.</param>
+    /// <param name="logger">Optional logger.</param>
+    /// <param name="cachePath">
+    /// Path to the cache file. Defaults to ~/.ppds/update-check.json.
+    /// </param>
+    public UpdateCheckService(
+        HttpClient httpClient,
+        ILogger<UpdateCheckService>? logger = null,
+        string? cachePath = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _ownsHttpClient = false;
+        _logger = logger;
+        _cachePath = cachePath ?? DefaultCachePath;
+    }
+
+    private UpdateCheckService(
+        HttpClient httpClient,
+        bool ownsHttpClient,
+        ILogger<UpdateCheckService>? logger)
+    {
+        _httpClient = httpClient;
+        _ownsHttpClient = ownsHttpClient;
+        _logger = logger;
+        _cachePath = DefaultCachePath;
+    }
+
+    /// <summary>
+    /// Default cache file path: ~/.ppds/update-check.json
+    /// </summary>
+    internal static string DefaultCachePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".ppds",
+        "update-check.json");
+
+    /// <summary>
+    /// Factory method for creating a service with default HttpClient configuration.
+    /// The returned instance owns the HttpClient and must be disposed (Constitution R1).
+    /// Used by VersionCommand and StartupUpdateNotifier where full DI is not available.
+    /// </summary>
+    public static UpdateCheckService Create(ILogger<UpdateCheckService>? logger = null)
+    {
+        var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        return new UpdateCheckService(httpClient, ownsHttpClient: true, logger);
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
+    }
+
+    public async Task<UpdateCheckResult?> CheckAsync(
+        string currentVersion,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var versions = await FetchVersionsAsync(cancellationToken);
+            if (versions == null || versions.Count == 0)
+                return null;
+
+            var result = BuildResult(currentVersion, versions);
+            await WriteCacheAsync(result, cancellationToken);
+            return result;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger?.LogDebug(ex, "Update check network error");
+            return null;
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger?.LogDebug(ex, "Update check cancelled or timed out");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Update check failed");
+            return null;
+        }
+    }
+
+    public async Task<UpdateCheckResult?> GetCachedResultAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!File.Exists(_cachePath))
+                return null;
+
+            var json = await File.ReadAllTextAsync(_cachePath, cancellationToken);
+            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
+
+            if (result == null)
+                return null;
+
+            // Check if cache has expired
+            if (DateTimeOffset.UtcNow - result.CheckedAt > CacheDuration)
+                return null;
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to read update check cache");
+            return null;
+        }
+    }
+
+    private async Task<List<NuGetVersion>?> FetchVersionsAsync(CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync(NuGetIndexUrl, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger?.LogDebug("NuGet API returned {StatusCode}", response.StatusCode);
+            return null;
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var index = JsonSerializer.Deserialize<NuGetVersionIndex>(json, JsonOptions);
+
+        if (index?.Versions == null)
+            return null;
+
+        var parsed = new List<NuGetVersion>();
+        foreach (var v in index.Versions)
+        {
+            if (NuGetVersion.TryParse(v, out var version))
+                parsed.Add(version!);
+        }
+
+        return parsed;
+    }
+
+    internal static UpdateCheckResult BuildResult(string currentVersionString, List<NuGetVersion> allVersions)
+    {
+        NuGetVersion.TryParse(currentVersionString, out var currentVersion);
+
+        // Find latest stable (no pre-release label)
+        var latestStable = allVersions
+            .Where(v => !v.IsPreRelease)
+            .OrderDescending()
+            .FirstOrDefault();
+
+        // Find latest pre-release
+        var latestPreRelease = allVersions
+            .Where(v => v.IsPreRelease)
+            .OrderDescending()
+            .FirstOrDefault();
+
+        var stableAvailable = currentVersion != null && latestStable != null && latestStable > currentVersion;
+        var preReleaseAvailable = currentVersion != null && latestPreRelease != null && latestPreRelease > currentVersion;
+
+        // Build update command
+        string? updateCommand = null;
+        if (stableAvailable)
+        {
+            // Stable update available — plain command (works for both stable and pre-release users)
+            updateCommand = $"dotnet tool update {PackageId} -g";
+        }
+        else if (preReleaseAvailable && currentVersion?.IsPreRelease == true)
+        {
+            // User is on pre-release, newer pre-release available, no newer stable
+            updateCommand = $"dotnet tool update {PackageId} -g --prerelease";
+        }
+
+        return new UpdateCheckResult
+        {
+            CurrentVersion = currentVersionString,
+            LatestStableVersion = latestStable?.ToString(),
+            LatestPreReleaseVersion = latestPreRelease?.ToString(),
+            StableUpdateAvailable = stableAvailable,
+            PreReleaseUpdateAvailable = preReleaseAvailable,
+            UpdateCommand = updateCommand,
+            CheckedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    private async Task WriteCacheAsync(UpdateCheckResult result, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_cachePath)!;
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(result, JsonOptions);
+            await File.WriteAllTextAsync(_cachePath, json, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Failed to write update check cache");
+        }
+    }
+
+    /// <summary>
+    /// Internal record for deserializing the NuGet flat container API response.
+    /// </summary>
+    private sealed record NuGetVersionIndex
+    {
+        public List<string>? Versions { get; init; }
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheckServiceTests" --no-restore -v q`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+git commit -m "feat(cli): implement UpdateCheckService with NuGet API and caching (#564)"
+```
+
+---
+
+## Chunk 3: CLI Command and Startup Integration
+
+### Task 4: Version Command
+
+**Files:**
+- Create: `src/PPDS.Cli/Commands/VersionCommand.cs`
+- Test: `tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs`
+- Modify: `src/PPDS.Cli/Program.cs`
+
+- [ ] **Step 1: Write failing tests for VersionCommand structure**
+
+```csharp
+// tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
+using System.CommandLine;
+using FluentAssertions;
+using PPDS.Cli.Commands;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+public class VersionCommandTests
+{
+    private readonly Command _command;
+
+    public VersionCommandTests()
+    {
+        _command = VersionCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        _command.Name.Should().Be("version");
+    }
+
+    [Fact]
+    public void Create_HasCheckOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--check");
+        option.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Create_CheckOptionIsOptional()
+    {
+        var option = _command.Options.First(o => o.Name == "--check");
+        option.Required.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~VersionCommandTests" --no-restore -v q`
+Expected: Build error — `VersionCommand` does not exist
+
+- [ ] **Step 3: Implement VersionCommand**
+
+The command creates an `UpdateCheckService` via a factory method that encapsulates the HttpClient setup.
+This keeps the command as a thin wrapper (Constitution A1) while avoiding full DI since the version
+command doesn't need a Dataverse connection or profile resolution. The `UpdateCheckService` contains
+all the business logic (A2).
+
+```csharp
+// src/PPDS.Cli/Commands/VersionCommand.cs
+using System.CommandLine;
+using System.Runtime.InteropServices;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.UpdateCheck;
+
+namespace PPDS.Cli.Commands;
+
+/// <summary>
+/// The 'ppds version' command — shows version info and optionally checks for updates.
+/// </summary>
+public static class VersionCommand
+{
+    /// <summary>
+    /// Creates the 'version' command with optional --check flag.
+    /// </summary>
+    public static Command Create()
+    {
+        var checkOption = new Option<bool>("--check", "Check NuGet for available updates");
+
+        var command = new Command("version", "Show version information and check for updates")
+        {
+            checkOption
+        };
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var check = parseResult.GetValue(checkOption);
+            return await ExecuteAsync(check, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(bool check, CancellationToken cancellationToken)
+    {
+        // Always show version info (thin UI wrapper — no business logic here)
+        var cliVersion = ErrorOutput.Version;
+        var sdkVersion = ErrorOutput.SdkVersion;
+        var runtimeVersion = Environment.Version.ToString();
+        var platform = RuntimeInformation.OSDescription;
+
+        Console.Error.WriteLine($"PPDS CLI v{cliVersion}");
+        Console.Error.WriteLine($"SDK:      v{sdkVersion}");
+        Console.Error.WriteLine($".NET:     {runtimeVersion}");
+        Console.Error.WriteLine($"Platform: {platform}");
+
+        if (!check)
+            return ExitCodes.Success;
+
+        // Delegate to Application Service for update check logic (Constitution A1/A2)
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Checking for updates...");
+
+        using var service = UpdateCheckService.Create();
+        var result = await service.CheckAsync(cliVersion, cancellationToken);
+
+        if (result == null)
+        {
+            Console.Error.WriteLine("Could not check for updates. Try again later.");
+            return ExitCodes.Success; // Non-fatal
+        }
+
+        Console.Error.WriteLine();
+
+        if (result.LatestStableVersion != null)
+            Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion}");
+
+        if (result.LatestPreReleaseVersion != null)
+            Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion}");
+
+        Console.Error.WriteLine();
+
+        if (result.UpdateAvailable)
+        {
+            Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
+        }
+        else
+        {
+            Console.Error.WriteLine("You are up to date.");
+        }
+
+        return ExitCodes.Success;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~VersionCommandTests" --no-restore -v q`
+Expected: All tests PASS
+
+- [ ] **Step 5: Add VersionCommand to Program.cs**
+
+In `src/PPDS.Cli/Program.cs`, add after `rootCommand.Subcommands.Add(InteractiveCommand.Create());`:
+
+```csharp
+        rootCommand.Subcommands.Add(VersionCommand.Create());
+```
+
+Also add the using statement at the top if not already present (it should be — `DocsCommand` is in the same namespace).
+
+And add `"version"` to `SkipVersionHeaderArgs`:
+
+```csharp
+    private static readonly HashSet<string> SkipVersionHeaderArgs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--help", "-h", "-?", "--version", "version"
+    };
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PPDS.Cli/Commands/VersionCommand.cs tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs src/PPDS.Cli/Program.cs
+git commit -m "feat(cli): add 'ppds version [--check]' command (#564)"
+```
+
+---
+
+### Task 5: Startup Update Notification
+
+**Files:**
+- Create: `src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs`
+- Test: `tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs`
+- Modify: `src/PPDS.Cli/Program.cs`
+
+- [ ] **Step 1: Write failing tests for StartupUpdateNotifier**
+
+```csharp
+// tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
+using System.Text.Json;
+using FluentAssertions;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Infrastructure;
+
+public class StartupUpdateNotifierTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _cachePath;
+
+    public StartupUpdateNotifierTests()
+    {
+        var testId = Guid.NewGuid().ToString("N")[..8];
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ppds-test-{testId}");
+        _cachePath = Path.Combine(_tempDir, "update-check.json");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, recursive: true); }
+            catch { /* ignore */ }
+        }
+    }
+
+    [Fact]
+    public void GetNotificationMessage_UpdateAvailable_ReturnsMessage()
+    {
+        WriteCacheFile(new UpdateCheckResult
+        {
+            CurrentVersion = "0.4.0",
+            LatestStableVersion = "0.6.0",
+            StableUpdateAvailable = true,
+            UpdateCommand = "dotnet tool update PPDS.Cli -g",
+            CheckedAt = DateTimeOffset.UtcNow
+        });
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
+
+        message.Should().NotBeNull();
+        message.Should().Contain("0.6.0");
+        message.Should().Contain("dotnet tool update");
+    }
+
+    [Fact]
+    public void GetNotificationMessage_NoUpdate_ReturnsNull()
+    {
+        WriteCacheFile(new UpdateCheckResult
+        {
+            CurrentVersion = "0.6.0",
+            LatestStableVersion = "0.6.0",
+            StableUpdateAvailable = false,
+            CheckedAt = DateTimeOffset.UtcNow
+        });
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_NoCacheFile_ReturnsNull()
+    {
+        var message = StartupUpdateNotifier.GetNotificationMessage(
+            Path.Combine(_tempDir, "nonexistent.json"));
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_ExpiredCache_ReturnsNull()
+    {
+        WriteCacheFile(new UpdateCheckResult
+        {
+            CurrentVersion = "0.4.0",
+            LatestStableVersion = "0.6.0",
+            StableUpdateAvailable = true,
+            UpdateCommand = "dotnet tool update PPDS.Cli -g",
+            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25) // Expired
+        });
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_CorruptFile_ReturnsNull()
+    {
+        File.WriteAllText(_cachePath, "corrupt{{{json");
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_NeverThrows()
+    {
+        // Even with totally broken path, should return null, not throw
+        var act = () => StartupUpdateNotifier.GetNotificationMessage(
+            "/nonexistent/path/that/cant/exist/file.json");
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("--quiet")]
+    [InlineData("-q")]
+    public void ShouldShow_QuietFlag_ReturnsFalse(string flag)
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "data", "export", flag }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_NoQuietFlag_ReturnsTrue()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "data", "export" }).Should().BeTrue();
+    }
+
+    private void WriteCacheFile(UpdateCheckResult result)
+    {
+        var json = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(_cachePath, json);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~StartupUpdateNotifierTests" --no-restore -v q`
+Expected: Build error — `StartupUpdateNotifier` does not exist
+
+- [ ] **Step 3: Implement StartupUpdateNotifier**
+
+```csharp
+// src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
+using System.Text.Json;
+using PPDS.Cli.Services.UpdateCheck;
+
+namespace PPDS.Cli.Infrastructure;
+
+/// <summary>
+/// Reads cached update check results at startup and returns a notification message
+/// if an update is available. Designed to never throw or block.
+/// </summary>
+public static class StartupUpdateNotifier
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Determines whether the startup update notification should be shown,
+    /// based on CLI arguments. Suppressed when --quiet or -q is present.
+    /// </summary>
+    public static bool ShouldShow(string[] args)
+    {
+        return !args.Any(a => a is "--quiet" or "-q");
+    }
+
+    /// <summary>
+    /// Reads the cached update check result and returns a notification message
+    /// if an update is available. Returns null if no update, cache expired, or any error.
+    /// This method is synchronous and designed to never throw.
+    /// </summary>
+    public static string? GetNotificationMessage(string? cachePath = null)
+    {
+        try
+        {
+            cachePath ??= UpdateCheckService.DefaultCachePath;
+
+            if (!File.Exists(cachePath))
+                return null;
+
+            var json = File.ReadAllText(cachePath);
+            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
+
+            if (result == null || !result.UpdateAvailable)
+                return null;
+
+            // Check if cache has expired (uses same duration as UpdateCheckService)
+            if (DateTimeOffset.UtcNow - result.CheckedAt > UpdateCheckService.CacheDuration)
+                return null;
+
+            var version = result.StableUpdateAvailable
+                ? result.LatestStableVersion
+                : result.LatestPreReleaseVersion;
+
+            return $"Update available: {version} (run: {result.UpdateCommand})";
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fires a background update check that writes to the cache file for next startup.
+    /// Best-effort: does not block, does not throw. The background task is untracked
+    /// because the CLI process may exit before it completes — that's acceptable since
+    /// the cache will be refreshed on the next run.
+    /// </summary>
+    public static void RefreshCacheInBackground(string currentVersion)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                using var service = UpdateCheckService.Create();
+                await service.CheckAsync(currentVersion);
+            }
+            catch
+            {
+                // Swallow all errors — this is best-effort background work
+            }
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~StartupUpdateNotifierTests" --no-restore -v q`
+Expected: All tests PASS
+
+- [ ] **Step 5: Integrate startup notification into Program.cs**
+
+In `src/PPDS.Cli/Program.cs`, add after the `ErrorOutput.WriteVersionHeader()` call (inside the `if` block at ~line 50):
+
+```csharp
+        // Show cached update notification (non-blocking, reads local file only)
+        // Suppressed when --quiet or -q is passed
+        if (StartupUpdateNotifier.ShouldShow(args))
+        {
+            var updateMessage = StartupUpdateNotifier.GetNotificationMessage();
+            if (updateMessage != null)
+            {
+                Console.Error.WriteLine(updateMessage);
+            }
+        }
+
+        // Fire-and-forget background cache refresh for next startup
+        StartupUpdateNotifier.RefreshCacheInBackground(ErrorOutput.Version);
+```
+
+Add the `using PPDS.Cli.Infrastructure;` statement if not already present.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs src/PPDS.Cli/Program.cs
+git commit -m "feat(cli): add non-blocking startup update notification (#564)"
+```
+
+---
+
+### Task 6: DI Registration and Final Wiring
+
+**Files:**
+- Modify: `src/PPDS.Cli/Services/ServiceRegistration.cs`
+
+- [ ] **Step 1: Register UpdateCheckService in DI**
+
+In `src/PPDS.Cli/Services/ServiceRegistration.cs`, add at the end of `AddCliApplicationServices` (before `return services;`):
+
+```csharp
+        // Update check service — singleton since it manages its own cache file.
+        // Uses Create() factory which owns the HttpClient (R1 compliance).
+        services.AddSingleton<IUpdateCheckService>(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<UpdateCheckService>>();
+            return UpdateCheckService.Create(logger);
+        });
+```
+
+Add the using statement:
+```csharp
+using PPDS.Cli.Services.UpdateCheck;
+```
+
+- [ ] **Step 2: Build the solution to verify compilation**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj --no-restore -v q`
+Expected: Build succeeded
+
+- [ ] **Step 3: Run all update check tests**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheck|FullyQualifiedName~VersionCommand|FullyQualifiedName~StartupUpdateNotifier" -v q`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/PPDS.Cli/Services/ServiceRegistration.cs
+git commit -m "feat(cli): register UpdateCheckService in DI container (#564)"
+```
+
+---
+
+### Task 7: Verify Full Build and Existing Tests
+
+- [ ] **Step 1: Build entire solution**
+
+Run: `dotnet build PPDS.sln --no-restore -v q`
+Expected: Build succeeded with no errors
+
+- [ ] **Step 2: Run all CLI unit tests**
+
+Run: `dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration" -v q`
+Expected: All tests PASS (both new and existing)
+
+- [ ] **Step 3: Manual smoke test**
+
+Run: `ppds version` — should show version info
+Run: `ppds version --check` — should check NuGet and display update status
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git commit -m "chore: verify full build and tests pass for update check feature (#564)"
+```
+
+---
+
+## Design Decisions
+
+### Why NuGet flat container API?
+The flat container API (`/v3-flatcontainer/{id}/index.json`) returns a simple JSON array of version strings. It requires no authentication, no API key, and no complex query parameters. It's the lightest-weight NuGet endpoint available and perfect for a version-check use case.
+
+### Why file-based caching instead of in-memory?
+The CLI is a short-lived process — in-memory caching wouldn't persist across invocations. File-based caching in `~/.ppds/` follows the existing pattern used by `QueryHistoryService` and ensures the 24-hour TTL works across process lifetimes.
+
+### Why synchronous cache read at startup?
+The startup notification reads a single small JSON file from local disk. Making this async would add complexity (async Main, await before parse) with no measurable benefit. The file read is sub-millisecond. The network refresh is fire-and-forget in the background.
+
+### Why no IHttpClientFactory?
+The existing codebase uses direct `HttpClient` instantiation (see `ConnectionService`). Adding `IHttpClientFactory` would be an unrelated infrastructure change. The update check creates one `HttpClient` per check (infrequent — at most once per 24h), so socket exhaustion is not a concern.
+
+### Why lexicographic pre-release comparison?
+SemVer spec says numeric pre-release identifiers should be compared as integers (so `beta.10 > beta.2`). Our implementation uses lexicographic comparison, which would order `beta.10 < beta.2`. This is acceptable because PPDS pre-release labels use single-digit numeric segments (e.g., `alpha.0`, `beta.1`). If multi-digit segments are ever needed, upgrade to proper SemVer numeric comparison.
+
+### Why stable update command takes priority?
+When a user is on pre-release `0.5.x-beta` and stable `0.6.0` is available, we suggest the plain `dotnet tool update` command (without `--prerelease`). This aligns with the PPDS odd/even versioning convention: odd-minor is the pre-release line leading to the next even-minor stable release. The user's intent is almost always to reach stable.

--- a/docs/plans/2026-03-15-cli-update-check.md
+++ b/docs/plans/2026-03-15-cli-update-check.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a non-blocking update check to the CLI that notifies users when a newer version of PPDS is available on NuGet, with an explicit `ppds version --check` command for on-demand comparison.
 
-**Architecture:** An `UpdateCheckService` Application Service queries the NuGet flat container API for available versions, caches results to `~/.ppds/update-check.json` for 24 hours, and compares against the current assembly version. At CLI startup, a non-blocking read of cached results displays a one-liner notification to stderr. The `ppds version --check` command forces a fresh fetch.
+**Architecture:** An `UpdateCheckService` queries the NuGet flat container API for available versions, caches results to `~/.ppds/update-check.json` for 24 hours, and compares against the current assembly version. At CLI startup, a non-blocking read of cached results displays a one-liner to stderr. The `ppds version --check` command forces a fresh fetch.
 
 **Tech Stack:** .NET 8+, System.CommandLine, System.Text.Json, HttpClient, xUnit + FluentAssertions + Moq
 
@@ -19,13 +19,13 @@
 | AC-01 | `ppds version` displays current CLI version, SDK version, .NET version, and platform | `VersionCommandTests.Create_ReturnsCommandWithCorrectName` |
 | AC-02 | `ppds version --check` fetches latest versions from NuGet and displays current vs latest (stable and pre-release) | `UpdateCheckServiceTests.CheckAsync_ReturnsLatestStableAndPreRelease` |
 | AC-03 | When current version is older than latest stable, suggests `dotnet tool update PPDS.Cli -g` | `UpdateCheckServiceTests.CheckAsync_StableAvailable_SuggestsPlainUpdate` |
-| AC-04 | When user is on pre-release and newer pre-release exists (no newer stable), suggests command with `--prerelease` | `UpdateCheckServiceTests.CheckAsync_PreReleaseUser_NewerPreRelease_SuggestsPreReleaseFlag` |
+| AC-04 | When user is on pre-release and newer pre-release exists (no newer stable), suggests command with `--prerelease` | `UpdateCheckServiceTests.CheckAsync_PreReleaseUser_SuggestsPreReleaseFlag` |
 | AC-05 | Check result is cached to `~/.ppds/update-check.json` for 24 hours | `UpdateCheckServiceTests.CheckAsync_CachesResult` |
 | AC-06 | CLI startup reads cached result and shows one-liner notification to stderr if update available | `StartupUpdateNotifierTests.GetNotificationMessage_UpdateAvailable_ReturnsMessage` |
 | AC-07 | Startup notification never blocks or slows CLI execution | `StartupUpdateNotifierTests.GetNotificationMessage_NeverThrows` |
 | AC-08 | Network failures during check are handled gracefully (no crash, no output to stdout) | `UpdateCheckServiceTests.CheckAsync_NetworkError_ReturnsNull` |
 | AC-09 | Startup notification suppressed when `--quiet` or `-q` is passed | `StartupUpdateNotifierTests.ShouldShow_QuietFlag_ReturnsFalse` |
-| AC-10 | Version parsing handles SemVer with pre-release suffixes correctly | `NuGetVersionTests.Parse_ValidVersion_ExtractsComponents` |
+| AC-10 | SemVer pre-release comparison handles multi-digit numeric segments correctly (`beta.10 > beta.2`) | `NuGetVersionTests.CompareTo_MultiDigitPreRelease` |
 
 ---
 
@@ -36,1461 +36,241 @@
 | File | Responsibility |
 |------|----------------|
 | `src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs` | SemVer value type — parse, compare, detect pre-release |
-| `src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs` | Service interface for version checking |
-| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs` | Implementation — NuGet API, caching, comparison logic |
-| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs` | Result records returned by service |
+| `src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs` | Service interface |
+| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs` | NuGet API fetch, caching, comparison logic |
+| `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs` | Result record |
+| `src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs` | Startup cache reader + quiet flag check |
 | `src/PPDS.Cli/Commands/VersionCommand.cs` | `ppds version [--check]` command |
 | `tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs` | Version parsing/comparison tests |
 | `tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs` | Service logic tests |
+| `tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs` | Startup notifier tests |
 | `tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs` | Command structure tests |
 
 ### Modified Files
 
 | File | Change |
 |------|--------|
-| `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs` | Add `UpdateCheck` error category |
-| `src/PPDS.Cli/Services/ServiceRegistration.cs` | Register `IUpdateCheckService` |
-| `src/PPDS.Cli/Program.cs` | Add `VersionCommand`, add startup notification call |
+| `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs` | Add `UpdateCheck` error category (before final closing brace) |
+| `src/PPDS.Cli/Program.cs` | Add `VersionCommand` to subcommands, add startup notification, add `"version"` to `SkipVersionHeaderArgs` (because `version` command displays its own version info, making the startup header redundant) |
 
 ---
 
-## Chunk 1: Version Parsing Foundation
+## Key Type Signatures
 
-### Task 1: NuGetVersion — SemVer Value Type
+### NuGetVersion
 
-**Files:**
-- Create: `src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs`
-- Test: `tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs`
-
-- [ ] **Step 1: Write failing tests for NuGetVersion parsing**
+Immutable SemVer value type. Implements `IComparable<NuGetVersion>`, `IEquatable<NuGetVersion>`.
 
 ```csharp
-// tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
-using FluentAssertions;
-using PPDS.Cli.Services.UpdateCheck;
-using Xunit;
-
-namespace PPDS.Cli.Tests.Services.UpdateCheck;
-
-public class NuGetVersionTests
-{
-    [Theory]
-    [InlineData("1.0.0", 1, 0, 0, "")]
-    [InlineData("0.5.3-beta.1", 0, 5, 3, "beta.1")]
-    [InlineData("2.10.0-alpha.0", 2, 10, 0, "alpha.0")]
-    [InlineData("1.0.0-rc.1", 1, 0, 0, "rc.1")]
-    public void Parse_ValidVersion_ExtractsComponents(
-        string input, int major, int minor, int patch, string preRelease)
-    {
-        var version = NuGetVersion.Parse(input);
-
-        version.Major.Should().Be(major);
-        version.Minor.Should().Be(minor);
-        version.Patch.Should().Be(patch);
-        version.PreReleaseLabel.Should().Be(preRelease);
-    }
-
-    [Theory]
-    [InlineData("0.5.3-beta.1")]
-    [InlineData("1.0.0-alpha.0")]
-    [InlineData("0.3.0-rc.1")]
-    public void IsPreRelease_WithPreReleaseLabel_ReturnsTrue(string input)
-    {
-        NuGetVersion.Parse(input).IsPreRelease.Should().BeTrue();
-    }
-
-    [Theory]
-    [InlineData("1.0.0")]
-    [InlineData("0.6.0")]
-    [InlineData("2.0.0")]
-    public void IsPreRelease_StableVersion_ReturnsFalse(string input)
-    {
-        NuGetVersion.Parse(input).IsPreRelease.Should().BeFalse();
-    }
-
-    [Theory]
-    [InlineData("0.5.0")]
-    [InlineData("0.3.0")]
-    [InlineData("1.1.0")]
-    public void IsOddMinor_OddMinorVersion_ReturnsTrue(string input)
-    {
-        NuGetVersion.Parse(input).IsOddMinor.Should().BeTrue();
-    }
-
-    [Theory]
-    [InlineData("0.6.0")]
-    [InlineData("1.0.0")]
-    [InlineData("2.2.0")]
-    public void IsOddMinor_EvenMinorVersion_ReturnsFalse(string input)
-    {
-        NuGetVersion.Parse(input).IsOddMinor.Should().BeFalse();
-    }
-
-    [Fact]
-    public void CompareTo_HigherMajor_IsGreater()
-    {
-        var v1 = NuGetVersion.Parse("2.0.0");
-        var v2 = NuGetVersion.Parse("1.0.0");
-
-        v1.CompareTo(v2).Should().BePositive();
-    }
-
-    [Fact]
-    public void CompareTo_StableBeatsPreRelease_SameBase()
-    {
-        var stable = NuGetVersion.Parse("1.0.0");
-        var preRelease = NuGetVersion.Parse("1.0.0-beta.1");
-
-        stable.CompareTo(preRelease).Should().BePositive();
-    }
-
-    [Fact]
-    public void CompareTo_HigherPreRelease_IsGreater()
-    {
-        var v1 = NuGetVersion.Parse("1.0.0-beta.2");
-        var v2 = NuGetVersion.Parse("1.0.0-beta.1");
-
-        v1.CompareTo(v2).Should().BePositive();
-    }
-
-    [Fact]
-    public void CompareTo_CrossMinorPreRelease_StableWins()
-    {
-        // 0.6.0 stable > 0.5.3-beta.1 pre-release
-        var stable = NuGetVersion.Parse("0.6.0");
-        var preRelease = NuGetVersion.Parse("0.5.3-beta.1");
-
-        stable.CompareTo(preRelease).Should().BePositive();
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("not-a-version")]
-    [InlineData("1.0")]
-    public void TryParse_InvalidInput_ReturnsFalse(string input)
-    {
-        NuGetVersion.TryParse(input, out _).Should().BeFalse();
-    }
-
-    [Fact]
-    public void TryParse_ValidInput_ReturnsTrueAndVersion()
-    {
-        NuGetVersion.TryParse("1.2.3", out var version).Should().BeTrue();
-        version!.Major.Should().Be(1);
-    }
-
-    [Fact]
-    public void ToString_RoundTrips()
-    {
-        var version = NuGetVersion.Parse("1.2.3-beta.1");
-        version.ToString().Should().Be("1.2.3-beta.1");
-    }
-
-    [Fact]
-    public void Parse_VersionWithBuildMetadata_IgnoresBuildMetadata()
-    {
-        // InformationalVersion includes "+commitHash" — must be stripped
-        var version = NuGetVersion.Parse("1.2.3-beta.1+abc1234");
-
-        version.Major.Should().Be(1);
-        version.Minor.Should().Be(2);
-        version.Patch.Should().Be(3);
-        version.PreReleaseLabel.Should().Be("beta.1");
-    }
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~NuGetVersionTests" --no-restore -v q`
-Expected: Build error — `NuGetVersion` type does not exist
-
-- [ ] **Step 3: Implement NuGetVersion**
-
-```csharp
-// src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
-namespace PPDS.Cli.Services.UpdateCheck;
-
-/// <summary>
-/// Lightweight SemVer version type for NuGet version comparison.
-/// Handles major.minor.patch[-prerelease][+build] format.
-/// </summary>
 public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVersion>
 {
     public int Major { get; }
     public int Minor { get; }
     public int Patch { get; }
+    public string PreReleaseLabel { get; }  // Empty string for stable
+    public bool IsPreRelease { get; }
+    public bool IsOddMinor { get; }         // PPDS convention: odd minor = pre-release line
 
-    /// <summary>
-    /// Pre-release label (e.g., "beta.1", "alpha.0"). Empty string for stable versions.
-    /// </summary>
-    public string PreReleaseLabel { get; }
-
-    /// <summary>
-    /// True if this version has a pre-release label.
-    /// </summary>
-    public bool IsPreRelease => !string.IsNullOrEmpty(PreReleaseLabel);
-
-    /// <summary>
-    /// True if this version has an odd minor number (PPDS convention: odd = pre-release line).
-    /// </summary>
-    public bool IsOddMinor => Minor % 2 != 0;
-
-    private NuGetVersion(int major, int minor, int patch, string preReleaseLabel)
-    {
-        Major = major;
-        Minor = minor;
-        Patch = patch;
-        PreReleaseLabel = preReleaseLabel;
-    }
-
-    /// <summary>
-    /// Parses a SemVer version string. Strips build metadata (+hash) if present.
-    /// </summary>
-    /// <exception cref="FormatException">Thrown when the version string is invalid.</exception>
-    public static NuGetVersion Parse(string version)
-    {
-        if (!TryParse(version, out var result))
-            throw new FormatException($"Invalid version format: '{version}'");
-        return result!;
-    }
-
-    /// <summary>
-    /// Attempts to parse a SemVer version string.
-    /// </summary>
-    public static bool TryParse(string? version, out NuGetVersion? result)
-    {
-        result = null;
-
-        if (string.IsNullOrWhiteSpace(version))
-            return false;
-
-        // Strip build metadata (+commitHash)
-        var buildIndex = version.IndexOf('+');
-        if (buildIndex >= 0)
-            version = version[..buildIndex];
-
-        // Split pre-release label
-        var preRelease = string.Empty;
-        var dashIndex = version.IndexOf('-');
-        if (dashIndex >= 0)
-        {
-            preRelease = version[(dashIndex + 1)..];
-            version = version[..dashIndex];
-        }
-
-        // Parse major.minor.patch
-        var parts = version.Split('.');
-        if (parts.Length != 3)
-            return false;
-
-        if (!int.TryParse(parts[0], out var major) ||
-            !int.TryParse(parts[1], out var minor) ||
-            !int.TryParse(parts[2], out var patch))
-            return false;
-
-        result = new NuGetVersion(major, minor, patch, preRelease);
-        return true;
-    }
-
-    public int CompareTo(NuGetVersion? other)
-    {
-        if (other is null) return 1;
-
-        var cmp = Major.CompareTo(other.Major);
-        if (cmp != 0) return cmp;
-
-        cmp = Minor.CompareTo(other.Minor);
-        if (cmp != 0) return cmp;
-
-        cmp = Patch.CompareTo(other.Patch);
-        if (cmp != 0) return cmp;
-
-        // Stable (no pre-release) > pre-release for same base version
-        if (!IsPreRelease && other.IsPreRelease) return 1;
-        if (IsPreRelease && !other.IsPreRelease) return -1;
-
-        // Compare pre-release labels lexicographically
-        return string.Compare(PreReleaseLabel, other.PreReleaseLabel, StringComparison.OrdinalIgnoreCase);
-    }
-
-    public bool Equals(NuGetVersion? other) =>
-        other is not null && CompareTo(other) == 0;
-
-    public override bool Equals(object? obj) =>
-        obj is NuGetVersion other && Equals(other);
-
-    public override int GetHashCode() =>
-        HashCode.Combine(Major, Minor, Patch, PreReleaseLabel.ToLowerInvariant());
-
-    public override string ToString() =>
-        IsPreRelease ? $"{Major}.{Minor}.{Patch}-{PreReleaseLabel}" : $"{Major}.{Minor}.{Patch}";
-
-    public static bool operator >(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) > 0;
-    public static bool operator <(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) < 0;
-    public static bool operator >=(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) >= 0;
-    public static bool operator <=(NuGetVersion left, NuGetVersion right) => left.CompareTo(right) <= 0;
+    public static NuGetVersion Parse(string version);
+    public static bool TryParse(string? version, out NuGetVersion? result);
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+**Parsing:** Strip build metadata (`+commitHash`) first, then split pre-release label on `-`, parse `major.minor.patch`. Must handle `InformationalVersion` format from assemblies (e.g., `1.2.3-beta.1+abc1234`).
 
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~NuGetVersionTests" --no-restore -v q`
-Expected: All tests PASS
+**Comparison:** Major → Minor → Patch → stable beats pre-release for same base → pre-release labels compared segment-by-segment. **Numeric segments must be compared as integers** (so `beta.10 > beta.2`). Split label on `.`, try `int.TryParse` on each segment; numeric segments sort before string segments per SemVer spec.
 
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
-git commit -m "feat(cli): add NuGetVersion SemVer value type for update check (#564)"
-```
-
----
-
-### Task 2: Result Records and Service Interface
-
-**Files:**
-- Create: `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs`
-- Create: `src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs`
-
-- [ ] **Step 1: Create result records**
+### UpdateCheckResult
 
 ```csharp
-// src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
-using System.Text.Json.Serialization;
-
-namespace PPDS.Cli.Services.UpdateCheck;
-
-/// <summary>
-/// Result of a version update check against NuGet.
-/// </summary>
 public sealed record UpdateCheckResult
 {
-    /// <summary>Current installed version.</summary>
     public required string CurrentVersion { get; init; }
-
-    /// <summary>Latest stable version on NuGet (null if none found).</summary>
     public string? LatestStableVersion { get; init; }
-
-    /// <summary>Latest pre-release version on NuGet (null if none found).</summary>
     public string? LatestPreReleaseVersion { get; init; }
-
-    /// <summary>Whether a newer stable version is available.</summary>
     public bool StableUpdateAvailable { get; init; }
-
-    /// <summary>Whether a newer pre-release version is available.</summary>
     public bool PreReleaseUpdateAvailable { get; init; }
-
-    /// <summary>Suggested dotnet tool update command, or null if up-to-date.</summary>
-    public string? UpdateCommand { get; init; }
-
-    /// <summary>When this result was fetched from NuGet.</summary>
+    public string? UpdateCommand { get; init; }    // null if up-to-date
     public DateTimeOffset CheckedAt { get; init; }
-
-    /// <summary>True if any update (stable or pre-release) is available.</summary>
-    [JsonIgnore]
     public bool UpdateAvailable => StableUpdateAvailable || PreReleaseUpdateAvailable;
 }
 ```
 
-- [ ] **Step 2: Create service interface**
+### IUpdateCheckService
 
 ```csharp
-// src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
-namespace PPDS.Cli.Services.UpdateCheck;
-
-/// <summary>
-/// Checks for available updates by querying the NuGet package registry.
-/// </summary>
-/// <remarks>
-/// Constitution A1/A2: Single code path for CLI, TUI, and RPC version checks.
-/// </remarks>
 public interface IUpdateCheckService
 {
-    /// <summary>
-    /// Performs a fresh update check against the NuGet API.
-    /// Caches the result for subsequent calls.
-    /// </summary>
-    /// <param name="currentVersion">The currently installed version string (from assembly).</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Update check result, or null if the check failed.</returns>
     Task<UpdateCheckResult?> CheckAsync(string currentVersion, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the cached update check result without making a network request.
-    /// Returns null if no cached result exists or the cache is expired.
-    /// </summary>
     Task<UpdateCheckResult?> GetCachedResultAsync(CancellationToken cancellationToken = default);
 }
 ```
 
-- [ ] **Step 3: Commit**
+---
 
-```bash
-git add src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
-git commit -m "feat(cli): add UpdateCheckResult records and IUpdateCheckService interface (#564)"
+## Design Constraints
+
+### HttpClient Pattern
+
+The existing codebase creates `HttpClient` internally (see `ConnectionService`). Extend this pattern by accepting an optional `HttpMessageHandler?` parameter for test injection. Constructor also accepts optional `string? cachePath` (defaults to `~/.ppds/update-check.json`) for test isolation.
+
+Do NOT hold `HttpClient` as a field. Create it within `CheckAsync` scope using `using var client = new HttpClient(handler, disposeHandler: false)` so the client is disposed after each call. This satisfies Constitution R1 without requiring `IDisposable` on the service.
+
+```csharp
+// Production
+var service = new UpdateCheckService();
+
+// Tests — handler for mocking HTTP, cachePath for temp directory isolation
+var service = new UpdateCheckService(handler: mockHandler, cachePath: tempPath);
 ```
+
+### Caching
+
+- **Location:** `~/.ppds/update-check.json` (follows `QueryHistoryService` pattern at `~/.ppds/history/`)
+- **TTL:** 24 hours from `CheckedAt` timestamp
+- **Atomic writes:** Write to temp file, then `File.Move(temp, target, overwrite: true)`. Prevents corruption if process exits mid-write.
+- **Read tolerance:** Catch all exceptions on read, return null. Corrupt/missing cache is not an error.
+
+### Startup Notification
+
+`StartupUpdateNotifier.ShouldShow(string[] args)` accepts the raw `args` array and checks for `"--quiet"` or `"-q"` via simple string matching. This runs before System.CommandLine parsing, matching the existing `SkipVersionHeaderArgs` pattern in `Program.cs`.
+
+`StartupUpdateNotifier.GetNotificationMessage` calls `GetCachedResultAsync` for the notification message (returns null if missing/expired/corrupt). For background refresh, it separately reads the cache file's `CheckedAt` timestamp to determine staleness — this avoids re-parsing the full result.
+
+### Background Refresh
+
+`StartupUpdateNotifier.RefreshCacheInBackground` must:
+1. **Check cache age first** — if cache file exists and `CheckedAt` is < 24h old, skip the HTTP call entirely
+2. Fire-and-forget `Task.Run` only when cache is stale or missing
+3. Since `HttpClient` is scoped within `CheckAsync` (not held as a field), no disposal concern with fire-and-forget
+4. Swallow all exceptions — best-effort, never crash the CLI
+
+### Update Command Logic
+
+| Current Version | Latest Stable | Latest Pre-release | Suggested Command |
+|----------------|---------------|-------------------|-------------------|
+| `0.4.0` | `0.6.0` | `0.7.0-alpha.0` | `dotnet tool update PPDS.Cli -g` |
+| `0.5.0-beta.1` | `0.6.0` | `0.5.0-beta.2` | `dotnet tool update PPDS.Cli -g` (stable takes priority) |
+| `0.5.0-beta.1` | `0.4.0` | `0.5.0-beta.2` | `dotnet tool update PPDS.Cli -g --prerelease` |
+| `0.6.0` | `0.6.0` | `0.5.0-beta.2` | null (up-to-date) |
+
+Stable update always takes priority over pre-release — aligns with PPDS odd/even versioning convention where odd-minor leads to next even-minor stable.
+
+### NuGet API
+
+- **Endpoint:** `https://api.nuget.org/v3-flatcontainer/ppds.cli/index.json`
+- **Response:** `{"versions":["0.1.0","0.2.0-beta.1",...]}`
+- **No auth required.** Simple GET, returns JSON array of version strings.
+- **Timeout:** 10 seconds. Failure returns null, never throws.
+
+### ErrorCodes
+
+Add `UpdateCheck` category to `ErrorCodes.cs`:
+- `UpdateCheck.NetworkError` — failed to reach NuGet API
+- `UpdateCheck.ParseError` — NuGet API returned unexpected data
+- `UpdateCheck.CacheError` — cache file unreadable
 
 ---
 
-## Chunk 2: Service Implementation
+## Task Breakdown
 
-### Task 3: UpdateCheckService Implementation
+### Task 1: NuGetVersion Value Type
 
-**Files:**
-- Create: `src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs`
-- Test: `tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs`
-- Modify: `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs`
+**Files:** `NuGetVersion.cs`, `NuGetVersionTests.cs`
 
-- [ ] **Step 1: Add UpdateCheck error codes**
+- [ ] Write tests: parsing valid versions, pre-release detection, `IsOddMinor`, `TryParse` with invalid input, build metadata stripping, `ToString` round-trip
+- [ ] Write tests: comparison — higher major/minor/patch wins, stable beats pre-release at same base, **multi-digit numeric pre-release segments** (`beta.10 > beta.2`), cross-minor comparison
+- [ ] Implement `NuGetVersion` satisfying all tests
+- [ ] Commit
 
-Add to `src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs`, after the `Plugin` class:
+### Task 2: Result Record and Service Interface
 
-```csharp
-    /// <summary>
-    /// Update check errors.
-    /// </summary>
-    public static class UpdateCheck
-    {
-        /// <summary>Failed to reach NuGet API.</summary>
-        public const string NetworkError = "UpdateCheck.NetworkError";
+**Files:** `UpdateCheckResult.cs`, `IUpdateCheckService.cs`
 
-        /// <summary>NuGet API returned unexpected data.</summary>
-        public const string ParseError = "UpdateCheck.ParseError";
+- [ ] Create `UpdateCheckResult` record and `IUpdateCheckService` interface per signatures above
+- [ ] Commit
 
-        /// <summary>Cache file is corrupt or unreadable.</summary>
-        public const string CacheError = "UpdateCheck.CacheError";
-    }
-```
+### Task 3: UpdateCheckService
 
-- [ ] **Step 2: Write failing tests for UpdateCheckService**
+**Files:** `UpdateCheckService.cs`, `UpdateCheckServiceTests.cs`, `ErrorCodes.cs`
 
-```csharp
-// tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
-using System.Net;
-using System.Text.Json;
-using FluentAssertions;
-using Microsoft.Extensions.Logging;
-using Moq;
-using Moq.Protected;
-using PPDS.Cli.Services.UpdateCheck;
-using Xunit;
+- [ ] Add `UpdateCheck` error codes to `ErrorCodes.cs`
+- [ ] Write tests: `CheckAsync` returns latest stable and pre-release from mocked API response
+- [ ] Write tests: current is latest → no update available, no command suggested
+- [ ] Write tests: stable available → suggests plain update command
+- [ ] Write tests: pre-release user, no newer stable, newer pre-release → suggests `--prerelease` command
+- [ ] Write tests: pre-release user, newer stable available → suggests plain command (stable priority)
+- [ ] Write tests: `CheckAsync` caches result, `GetCachedResultAsync` returns it
+- [ ] Write tests: expired cache returns null from `GetCachedResultAsync`
+- [ ] Write tests: network error returns null (no throw), non-success status returns null
+- [ ] Write tests: corrupt cache file returns null (no throw)
+- [ ] Implement `UpdateCheckService` with `HttpMessageHandler` injection, atomic cache writes, proper SemVer comparison
+- [ ] Commit
 
-namespace PPDS.Cli.Tests.Services.UpdateCheck;
+### Task 4: VersionCommand
 
-public class UpdateCheckServiceTests : IDisposable
-{
-    private readonly string _tempCachePath;
-    private readonly Mock<ILogger<UpdateCheckService>> _mockLogger;
+**Files:** `VersionCommand.cs`, `VersionCommandTests.cs`, `Program.cs`
 
-    public UpdateCheckServiceTests()
-    {
-        var testId = Guid.NewGuid().ToString("N")[..8];
-        _tempCachePath = Path.Combine(Path.GetTempPath(), $"ppds-test-{testId}", "update-check.json");
-        _mockLogger = new Mock<ILogger<UpdateCheckService>>();
-    }
+- [ ] Write tests: command name is `"version"`, has optional `--check` flag
+- [ ] Implement `VersionCommand` — thin wrapper that shows version info and delegates to `UpdateCheckService` for `--check`
+- [ ] Wire into `Program.cs`: add to subcommands, add `"version"` to `SkipVersionHeaderArgs`
+- [ ] Commit
 
-    public void Dispose()
-    {
-        var dir = Path.GetDirectoryName(_tempCachePath)!;
-        if (Directory.Exists(dir))
-        {
-            try { Directory.Delete(dir, recursive: true); }
-            catch { /* ignore */ }
-        }
-    }
+### Task 5: Startup Notification
 
-    private static HttpClient CreateMockHttpClient(string responseJson, HttpStatusCode statusCode = HttpStatusCode.OK)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseJson)
-            });
-        return new HttpClient(handler.Object);
-    }
+**Files:** `StartupUpdateNotifier.cs`, `StartupUpdateNotifierTests.cs`, `Program.cs`
 
-    private UpdateCheckService CreateService(HttpClient? httpClient = null)
-    {
-        return new UpdateCheckService(
-            httpClient ?? CreateMockHttpClient("""{"versions":["0.5.0","0.5.1-beta.1","0.6.0"]}"""),
-            _mockLogger.Object,
-            _tempCachePath);
-    }
+- [ ] Write tests: `GetNotificationMessage` — returns message when cache has update, returns null when no update/no file/expired/corrupt
+- [ ] Write tests: `GetNotificationMessage` never throws (even with broken paths)
+- [ ] Write tests: `ShouldShow` returns false for `--quiet` and `-q`, true otherwise
+- [ ] Implement `StartupUpdateNotifier` — synchronous cache read, quiet flag check, background refresh with cache-age guard
+- [ ] Wire into `Program.cs`: show notification after version header (guarded by `ShouldShow`), fire background refresh
+- [ ] Commit
 
-    [Fact]
-    public async Task CheckAsync_ReturnsLatestStableAndPreRelease()
-    {
-        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.5.1-beta.2","0.6.0","0.7.0-alpha.0"]}""";
-        var service = CreateService(CreateMockHttpClient(json));
+### Task 6: Full Build and Verification
 
-        var result = await service.CheckAsync("0.4.0");
-
-        result.Should().NotBeNull();
-        result!.LatestStableVersion.Should().Be("0.6.0");
-        result.LatestPreReleaseVersion.Should().Be("0.7.0-alpha.0");
-    }
-
-    [Fact]
-    public async Task CheckAsync_CurrentIsLatest_NoUpdateAvailable()
-    {
-        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.6.0"]}""";
-        var service = CreateService(CreateMockHttpClient(json));
-
-        var result = await service.CheckAsync("0.6.0");
-
-        result.Should().NotBeNull();
-        result!.StableUpdateAvailable.Should().BeFalse();
-        result.UpdateCommand.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task CheckAsync_StableAvailable_SuggestsPlainUpdate()
-    {
-        var json = """{"versions":["0.4.0","0.6.0"]}""";
-        var service = CreateService(CreateMockHttpClient(json));
-
-        var result = await service.CheckAsync("0.4.0");
-
-        result.Should().NotBeNull();
-        result!.StableUpdateAvailable.Should().BeTrue();
-        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
-    }
-
-    [Fact]
-    public async Task CheckAsync_PreReleaseUser_NewerPreRelease_SuggestsPreReleaseFlag()
-    {
-        // No stable version higher than current — only pre-release updates available
-        var json = """{"versions":["0.4.0","0.5.0-beta.1","0.5.0-beta.2"]}""";
-        var service = CreateService(CreateMockHttpClient(json));
-
-        // User is on pre-release, newer pre-release exists, no newer stable
-        var result = await service.CheckAsync("0.5.0-beta.1");
-
-        result.Should().NotBeNull();
-        result!.PreReleaseUpdateAvailable.Should().BeTrue();
-        result.StableUpdateAvailable.Should().BeFalse();
-        // Should suggest --prerelease since user is on pre-release line and no stable upgrade path
-        result.UpdateCommand.Should().Contain("--prerelease");
-    }
-
-    [Fact]
-    public async Task CheckAsync_PreReleaseUser_StableAvailable_SuggestsStableUpdate()
-    {
-        // User on 0.5.x-beta, stable 0.6.0 available — suggest plain update
-        var json = """{"versions":["0.5.0-beta.1","0.6.0"]}""";
-        var service = CreateService(CreateMockHttpClient(json));
-
-        var result = await service.CheckAsync("0.5.0-beta.1");
-
-        result.Should().NotBeNull();
-        result!.StableUpdateAvailable.Should().BeTrue();
-        // Stable update takes priority — no --prerelease needed
-        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
-    }
-
-    [Fact]
-    public async Task CheckAsync_CachesResult()
-    {
-        var service = CreateService();
-
-        await service.CheckAsync("0.4.0");
-
-        File.Exists(_tempCachePath).Should().BeTrue();
-        var cached = await service.GetCachedResultAsync();
-        cached.Should().NotBeNull();
-    }
-
-    [Fact]
-    public async Task GetCachedResultAsync_NoCacheFile_ReturnsNull()
-    {
-        var service = CreateService();
-
-        var result = await service.GetCachedResultAsync();
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task GetCachedResultAsync_ExpiredCache_ReturnsNull()
-    {
-        var service = CreateService();
-        // Write a cache file with old timestamp
-        Directory.CreateDirectory(Path.GetDirectoryName(_tempCachePath)!);
-        var oldResult = new UpdateCheckResult
-        {
-            CurrentVersion = "0.4.0",
-            LatestStableVersion = "0.6.0",
-            StableUpdateAvailable = true,
-            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25) // Expired
-        };
-        await File.WriteAllTextAsync(_tempCachePath, JsonSerializer.Serialize(oldResult));
-
-        var result = await service.GetCachedResultAsync();
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task CheckAsync_NetworkError_ReturnsNull()
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ThrowsAsync(new HttpRequestException("Network error"));
-
-        var service = CreateService(new HttpClient(handler.Object));
-
-        var result = await service.CheckAsync("0.4.0");
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task CheckAsync_NonSuccessStatusCode_ReturnsNull()
-    {
-        var service = CreateService(CreateMockHttpClient("{}", HttpStatusCode.NotFound));
-
-        var result = await service.CheckAsync("0.4.0");
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task GetCachedResultAsync_CorruptCacheFile_ReturnsNull()
-    {
-        Directory.CreateDirectory(Path.GetDirectoryName(_tempCachePath)!);
-        await File.WriteAllTextAsync(_tempCachePath, "not valid json{{{");
-
-        var service = CreateService();
-        var result = await service.GetCachedResultAsync();
-
-        result.Should().BeNull();
-    }
-}
-```
-
-- [ ] **Step 3: Run tests to verify they fail**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheckServiceTests" --no-restore -v q`
-Expected: Build error — `UpdateCheckService` class does not exist
-
-- [ ] **Step 4: Implement UpdateCheckService**
-
-```csharp
-// src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
-
-namespace PPDS.Cli.Services.UpdateCheck;
-
-/// <summary>
-/// Checks for available PPDS CLI updates via the NuGet flat container API.
-/// Caches results to avoid repeated network calls.
-/// </summary>
-/// <remarks>
-/// When created via <see cref="Create"/>, this instance owns the HttpClient
-/// and must be disposed. When created via constructor with an injected HttpClient,
-/// the caller owns the HttpClient lifetime.
-/// </remarks>
-public sealed class UpdateCheckService : IUpdateCheckService, IDisposable
-{
-    /// <summary>NuGet flat container API URL for the PPDS.Cli package.</summary>
-    internal const string NuGetIndexUrl = "https://api.nuget.org/v3-flatcontainer/ppds.cli/index.json";
-
-    /// <summary>NuGet package ID used in update commands.</summary>
-    internal const string PackageId = "PPDS.Cli";
-
-    /// <summary>Cache duration before a fresh check is needed. Shared with StartupUpdateNotifier.</summary>
-    internal static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        WriteIndented = true
-    };
-
-    private readonly HttpClient _httpClient;
-    private readonly bool _ownsHttpClient;
-    private readonly ILogger<UpdateCheckService>? _logger;
-    private readonly string _cachePath;
-
-    /// <summary>
-    /// Creates a new UpdateCheckService with an externally-managed HttpClient.
-    /// The caller owns the HttpClient lifetime.
-    /// </summary>
-    /// <param name="httpClient">HTTP client for NuGet API requests.</param>
-    /// <param name="logger">Optional logger.</param>
-    /// <param name="cachePath">
-    /// Path to the cache file. Defaults to ~/.ppds/update-check.json.
-    /// </param>
-    public UpdateCheckService(
-        HttpClient httpClient,
-        ILogger<UpdateCheckService>? logger = null,
-        string? cachePath = null)
-    {
-        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        _ownsHttpClient = false;
-        _logger = logger;
-        _cachePath = cachePath ?? DefaultCachePath;
-    }
-
-    private UpdateCheckService(
-        HttpClient httpClient,
-        bool ownsHttpClient,
-        ILogger<UpdateCheckService>? logger)
-    {
-        _httpClient = httpClient;
-        _ownsHttpClient = ownsHttpClient;
-        _logger = logger;
-        _cachePath = DefaultCachePath;
-    }
-
-    /// <summary>
-    /// Default cache file path: ~/.ppds/update-check.json
-    /// </summary>
-    internal static string DefaultCachePath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".ppds",
-        "update-check.json");
-
-    /// <summary>
-    /// Factory method for creating a service with default HttpClient configuration.
-    /// The returned instance owns the HttpClient and must be disposed (Constitution R1).
-    /// Used by VersionCommand and StartupUpdateNotifier where full DI is not available.
-    /// </summary>
-    public static UpdateCheckService Create(ILogger<UpdateCheckService>? logger = null)
-    {
-        var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-        return new UpdateCheckService(httpClient, ownsHttpClient: true, logger);
-    }
-
-    public void Dispose()
-    {
-        if (_ownsHttpClient)
-            _httpClient.Dispose();
-    }
-
-    public async Task<UpdateCheckResult?> CheckAsync(
-        string currentVersion,
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            var versions = await FetchVersionsAsync(cancellationToken);
-            if (versions == null || versions.Count == 0)
-                return null;
-
-            var result = BuildResult(currentVersion, versions);
-            await WriteCacheAsync(result, cancellationToken);
-            return result;
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger?.LogDebug(ex, "Update check network error");
-            return null;
-        }
-        catch (TaskCanceledException ex)
-        {
-            _logger?.LogDebug(ex, "Update check cancelled or timed out");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Update check failed");
-            return null;
-        }
-    }
-
-    public async Task<UpdateCheckResult?> GetCachedResultAsync(
-        CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (!File.Exists(_cachePath))
-                return null;
-
-            var json = await File.ReadAllTextAsync(_cachePath, cancellationToken);
-            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
-
-            if (result == null)
-                return null;
-
-            // Check if cache has expired
-            if (DateTimeOffset.UtcNow - result.CheckedAt > CacheDuration)
-                return null;
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to read update check cache");
-            return null;
-        }
-    }
-
-    private async Task<List<NuGetVersion>?> FetchVersionsAsync(CancellationToken cancellationToken)
-    {
-        using var response = await _httpClient.GetAsync(NuGetIndexUrl, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger?.LogDebug("NuGet API returned {StatusCode}", response.StatusCode);
-            return null;
-        }
-
-        var json = await response.Content.ReadAsStringAsync(cancellationToken);
-        var index = JsonSerializer.Deserialize<NuGetVersionIndex>(json, JsonOptions);
-
-        if (index?.Versions == null)
-            return null;
-
-        var parsed = new List<NuGetVersion>();
-        foreach (var v in index.Versions)
-        {
-            if (NuGetVersion.TryParse(v, out var version))
-                parsed.Add(version!);
-        }
-
-        return parsed;
-    }
-
-    internal static UpdateCheckResult BuildResult(string currentVersionString, List<NuGetVersion> allVersions)
-    {
-        NuGetVersion.TryParse(currentVersionString, out var currentVersion);
-
-        // Find latest stable (no pre-release label)
-        var latestStable = allVersions
-            .Where(v => !v.IsPreRelease)
-            .OrderDescending()
-            .FirstOrDefault();
-
-        // Find latest pre-release
-        var latestPreRelease = allVersions
-            .Where(v => v.IsPreRelease)
-            .OrderDescending()
-            .FirstOrDefault();
-
-        var stableAvailable = currentVersion != null && latestStable != null && latestStable > currentVersion;
-        var preReleaseAvailable = currentVersion != null && latestPreRelease != null && latestPreRelease > currentVersion;
-
-        // Build update command
-        string? updateCommand = null;
-        if (stableAvailable)
-        {
-            // Stable update available — plain command (works for both stable and pre-release users)
-            updateCommand = $"dotnet tool update {PackageId} -g";
-        }
-        else if (preReleaseAvailable && currentVersion?.IsPreRelease == true)
-        {
-            // User is on pre-release, newer pre-release available, no newer stable
-            updateCommand = $"dotnet tool update {PackageId} -g --prerelease";
-        }
-
-        return new UpdateCheckResult
-        {
-            CurrentVersion = currentVersionString,
-            LatestStableVersion = latestStable?.ToString(),
-            LatestPreReleaseVersion = latestPreRelease?.ToString(),
-            StableUpdateAvailable = stableAvailable,
-            PreReleaseUpdateAvailable = preReleaseAvailable,
-            UpdateCommand = updateCommand,
-            CheckedAt = DateTimeOffset.UtcNow
-        };
-    }
-
-    private async Task WriteCacheAsync(UpdateCheckResult result, CancellationToken cancellationToken)
-    {
-        try
-        {
-            var dir = Path.GetDirectoryName(_cachePath)!;
-            if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
-            var json = JsonSerializer.Serialize(result, JsonOptions);
-            await File.WriteAllTextAsync(_cachePath, json, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogDebug(ex, "Failed to write update check cache");
-        }
-    }
-
-    /// <summary>
-    /// Internal record for deserializing the NuGet flat container API response.
-    /// </summary>
-    private sealed record NuGetVersionIndex
-    {
-        public List<string>? Versions { get; init; }
-    }
-}
-```
-
-- [ ] **Step 5: Run tests to verify they pass**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheckServiceTests" --no-restore -v q`
-Expected: All tests PASS
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
-git commit -m "feat(cli): implement UpdateCheckService with NuGet API and caching (#564)"
-```
+- [ ] `dotnet build PPDS.sln` — must succeed with no errors
+- [ ] `dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration"` — all tests pass
+- [ ] Manual smoke test (see verification checklist below)
 
 ---
 
-## Chunk 3: CLI Command and Startup Integration
-
-### Task 4: Version Command
-
-**Files:**
-- Create: `src/PPDS.Cli/Commands/VersionCommand.cs`
-- Test: `tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs`
-- Modify: `src/PPDS.Cli/Program.cs`
-
-- [ ] **Step 1: Write failing tests for VersionCommand structure**
-
-```csharp
-// tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
-using System.CommandLine;
-using FluentAssertions;
-using PPDS.Cli.Commands;
-using Xunit;
-
-namespace PPDS.Cli.Tests.Commands;
-
-public class VersionCommandTests
-{
-    private readonly Command _command;
-
-    public VersionCommandTests()
-    {
-        _command = VersionCommand.Create();
-    }
-
-    [Fact]
-    public void Create_ReturnsCommandWithCorrectName()
-    {
-        _command.Name.Should().Be("version");
-    }
-
-    [Fact]
-    public void Create_HasCheckOption()
-    {
-        var option = _command.Options.FirstOrDefault(o => o.Name == "--check");
-        option.Should().NotBeNull();
-    }
-
-    [Fact]
-    public void Create_CheckOptionIsOptional()
-    {
-        var option = _command.Options.First(o => o.Name == "--check");
-        option.Required.Should().BeFalse();
-    }
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~VersionCommandTests" --no-restore -v q`
-Expected: Build error — `VersionCommand` does not exist
-
-- [ ] **Step 3: Implement VersionCommand**
-
-The command creates an `UpdateCheckService` via a factory method that encapsulates the HttpClient setup.
-This keeps the command as a thin wrapper (Constitution A1) while avoiding full DI since the version
-command doesn't need a Dataverse connection or profile resolution. The `UpdateCheckService` contains
-all the business logic (A2).
-
-```csharp
-// src/PPDS.Cli/Commands/VersionCommand.cs
-using System.CommandLine;
-using System.Runtime.InteropServices;
-using PPDS.Cli.Infrastructure.Errors;
-using PPDS.Cli.Services.UpdateCheck;
-
-namespace PPDS.Cli.Commands;
-
-/// <summary>
-/// The 'ppds version' command — shows version info and optionally checks for updates.
-/// </summary>
-public static class VersionCommand
-{
-    /// <summary>
-    /// Creates the 'version' command with optional --check flag.
-    /// </summary>
-    public static Command Create()
-    {
-        var checkOption = new Option<bool>("--check", "Check NuGet for available updates");
-
-        var command = new Command("version", "Show version information and check for updates")
-        {
-            checkOption
-        };
-
-        command.SetAction(async (parseResult, cancellationToken) =>
-        {
-            var check = parseResult.GetValue(checkOption);
-            return await ExecuteAsync(check, cancellationToken);
-        });
-
-        return command;
-    }
-
-    private static async Task<int> ExecuteAsync(bool check, CancellationToken cancellationToken)
-    {
-        // Always show version info (thin UI wrapper — no business logic here)
-        var cliVersion = ErrorOutput.Version;
-        var sdkVersion = ErrorOutput.SdkVersion;
-        var runtimeVersion = Environment.Version.ToString();
-        var platform = RuntimeInformation.OSDescription;
-
-        Console.Error.WriteLine($"PPDS CLI v{cliVersion}");
-        Console.Error.WriteLine($"SDK:      v{sdkVersion}");
-        Console.Error.WriteLine($".NET:     {runtimeVersion}");
-        Console.Error.WriteLine($"Platform: {platform}");
-
-        if (!check)
-            return ExitCodes.Success;
-
-        // Delegate to Application Service for update check logic (Constitution A1/A2)
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("Checking for updates...");
-
-        using var service = UpdateCheckService.Create();
-        var result = await service.CheckAsync(cliVersion, cancellationToken);
-
-        if (result == null)
-        {
-            Console.Error.WriteLine("Could not check for updates. Try again later.");
-            return ExitCodes.Success; // Non-fatal
-        }
-
-        Console.Error.WriteLine();
-
-        if (result.LatestStableVersion != null)
-            Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion}");
-
-        if (result.LatestPreReleaseVersion != null)
-            Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion}");
-
-        Console.Error.WriteLine();
-
-        if (result.UpdateAvailable)
-        {
-            Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
-        }
-        else
-        {
-            Console.Error.WriteLine("You are up to date.");
-        }
-
-        return ExitCodes.Success;
-    }
-}
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~VersionCommandTests" --no-restore -v q`
-Expected: All tests PASS
-
-- [ ] **Step 5: Add VersionCommand to Program.cs**
-
-In `src/PPDS.Cli/Program.cs`, add after `rootCommand.Subcommands.Add(InteractiveCommand.Create());`:
-
-```csharp
-        rootCommand.Subcommands.Add(VersionCommand.Create());
-```
-
-Also add the using statement at the top if not already present (it should be — `DocsCommand` is in the same namespace).
-
-And add `"version"` to `SkipVersionHeaderArgs`:
-
-```csharp
-    private static readonly HashSet<string> SkipVersionHeaderArgs = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "--help", "-h", "-?", "--version", "version"
-    };
-```
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/PPDS.Cli/Commands/VersionCommand.cs tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs src/PPDS.Cli/Program.cs
-git commit -m "feat(cli): add 'ppds version [--check]' command (#564)"
-```
-
----
-
-### Task 5: Startup Update Notification
-
-**Files:**
-- Create: `src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs`
-- Test: `tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs`
-- Modify: `src/PPDS.Cli/Program.cs`
-
-- [ ] **Step 1: Write failing tests for StartupUpdateNotifier**
-
-```csharp
-// tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
-using System.Text.Json;
-using FluentAssertions;
-using PPDS.Cli.Infrastructure;
-using PPDS.Cli.Services.UpdateCheck;
-using Xunit;
-
-namespace PPDS.Cli.Tests.Infrastructure;
-
-public class StartupUpdateNotifierTests : IDisposable
-{
-    private readonly string _tempDir;
-    private readonly string _cachePath;
-
-    public StartupUpdateNotifierTests()
-    {
-        var testId = Guid.NewGuid().ToString("N")[..8];
-        _tempDir = Path.Combine(Path.GetTempPath(), $"ppds-test-{testId}");
-        _cachePath = Path.Combine(_tempDir, "update-check.json");
-        Directory.CreateDirectory(_tempDir);
-    }
-
-    public void Dispose()
-    {
-        if (Directory.Exists(_tempDir))
-        {
-            try { Directory.Delete(_tempDir, recursive: true); }
-            catch { /* ignore */ }
-        }
-    }
-
-    [Fact]
-    public void GetNotificationMessage_UpdateAvailable_ReturnsMessage()
-    {
-        WriteCacheFile(new UpdateCheckResult
-        {
-            CurrentVersion = "0.4.0",
-            LatestStableVersion = "0.6.0",
-            StableUpdateAvailable = true,
-            UpdateCommand = "dotnet tool update PPDS.Cli -g",
-            CheckedAt = DateTimeOffset.UtcNow
-        });
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
-
-        message.Should().NotBeNull();
-        message.Should().Contain("0.6.0");
-        message.Should().Contain("dotnet tool update");
-    }
-
-    [Fact]
-    public void GetNotificationMessage_NoUpdate_ReturnsNull()
-    {
-        WriteCacheFile(new UpdateCheckResult
-        {
-            CurrentVersion = "0.6.0",
-            LatestStableVersion = "0.6.0",
-            StableUpdateAvailable = false,
-            CheckedAt = DateTimeOffset.UtcNow
-        });
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_NoCacheFile_ReturnsNull()
-    {
-        var message = StartupUpdateNotifier.GetNotificationMessage(
-            Path.Combine(_tempDir, "nonexistent.json"));
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_ExpiredCache_ReturnsNull()
-    {
-        WriteCacheFile(new UpdateCheckResult
-        {
-            CurrentVersion = "0.4.0",
-            LatestStableVersion = "0.6.0",
-            StableUpdateAvailable = true,
-            UpdateCommand = "dotnet tool update PPDS.Cli -g",
-            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25) // Expired
-        });
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_CorruptFile_ReturnsNull()
-    {
-        File.WriteAllText(_cachePath, "corrupt{{{json");
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(_cachePath);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_NeverThrows()
-    {
-        // Even with totally broken path, should return null, not throw
-        var act = () => StartupUpdateNotifier.GetNotificationMessage(
-            "/nonexistent/path/that/cant/exist/file.json");
-
-        act.Should().NotThrow();
-    }
-
-    [Theory]
-    [InlineData("--quiet")]
-    [InlineData("-q")]
-    public void ShouldShow_QuietFlag_ReturnsFalse(string flag)
-    {
-        StartupUpdateNotifier.ShouldShow(new[] { "data", "export", flag }).Should().BeFalse();
-    }
-
-    [Fact]
-    public void ShouldShow_NoQuietFlag_ReturnsTrue()
-    {
-        StartupUpdateNotifier.ShouldShow(new[] { "data", "export" }).Should().BeTrue();
-    }
-
-    private void WriteCacheFile(UpdateCheckResult result)
-    {
-        var json = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(_cachePath, json);
-    }
-}
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~StartupUpdateNotifierTests" --no-restore -v q`
-Expected: Build error — `StartupUpdateNotifier` does not exist
-
-- [ ] **Step 3: Implement StartupUpdateNotifier**
-
-```csharp
-// src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
-using System.Text.Json;
-using PPDS.Cli.Services.UpdateCheck;
-
-namespace PPDS.Cli.Infrastructure;
-
-/// <summary>
-/// Reads cached update check results at startup and returns a notification message
-/// if an update is available. Designed to never throw or block.
-/// </summary>
-public static class StartupUpdateNotifier
-{
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
-    /// <summary>
-    /// Determines whether the startup update notification should be shown,
-    /// based on CLI arguments. Suppressed when --quiet or -q is present.
-    /// </summary>
-    public static bool ShouldShow(string[] args)
-    {
-        return !args.Any(a => a is "--quiet" or "-q");
-    }
-
-    /// <summary>
-    /// Reads the cached update check result and returns a notification message
-    /// if an update is available. Returns null if no update, cache expired, or any error.
-    /// This method is synchronous and designed to never throw.
-    /// </summary>
-    public static string? GetNotificationMessage(string? cachePath = null)
-    {
-        try
-        {
-            cachePath ??= UpdateCheckService.DefaultCachePath;
-
-            if (!File.Exists(cachePath))
-                return null;
-
-            var json = File.ReadAllText(cachePath);
-            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
-
-            if (result == null || !result.UpdateAvailable)
-                return null;
-
-            // Check if cache has expired (uses same duration as UpdateCheckService)
-            if (DateTimeOffset.UtcNow - result.CheckedAt > UpdateCheckService.CacheDuration)
-                return null;
-
-            var version = result.StableUpdateAvailable
-                ? result.LatestStableVersion
-                : result.LatestPreReleaseVersion;
-
-            return $"Update available: {version} (run: {result.UpdateCommand})";
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Fires a background update check that writes to the cache file for next startup.
-    /// Best-effort: does not block, does not throw. The background task is untracked
-    /// because the CLI process may exit before it completes — that's acceptable since
-    /// the cache will be refreshed on the next run.
-    /// </summary>
-    public static void RefreshCacheInBackground(string currentVersion)
-    {
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                using var service = UpdateCheckService.Create();
-                await service.CheckAsync(currentVersion);
-            }
-            catch
-            {
-                // Swallow all errors — this is best-effort background work
-            }
-        });
-    }
-}
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~StartupUpdateNotifierTests" --no-restore -v q`
-Expected: All tests PASS
-
-- [ ] **Step 5: Integrate startup notification into Program.cs**
-
-In `src/PPDS.Cli/Program.cs`, add after the `ErrorOutput.WriteVersionHeader()` call (inside the `if` block at ~line 50):
-
-```csharp
-        // Show cached update notification (non-blocking, reads local file only)
-        // Suppressed when --quiet or -q is passed
-        if (StartupUpdateNotifier.ShouldShow(args))
-        {
-            var updateMessage = StartupUpdateNotifier.GetNotificationMessage();
-            if (updateMessage != null)
-            {
-                Console.Error.WriteLine(updateMessage);
-            }
-        }
-
-        // Fire-and-forget background cache refresh for next startup
-        StartupUpdateNotifier.RefreshCacheInBackground(ErrorOutput.Version);
-```
-
-Add the `using PPDS.Cli.Infrastructure;` statement if not already present.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs src/PPDS.Cli/Program.cs
-git commit -m "feat(cli): add non-blocking startup update notification (#564)"
-```
-
----
-
-### Task 6: DI Registration and Final Wiring
-
-**Files:**
-- Modify: `src/PPDS.Cli/Services/ServiceRegistration.cs`
-
-- [ ] **Step 1: Register UpdateCheckService in DI**
-
-In `src/PPDS.Cli/Services/ServiceRegistration.cs`, add at the end of `AddCliApplicationServices` (before `return services;`):
-
-```csharp
-        // Update check service — singleton since it manages its own cache file.
-        // Uses Create() factory which owns the HttpClient (R1 compliance).
-        services.AddSingleton<IUpdateCheckService>(sp =>
-        {
-            var logger = sp.GetRequiredService<ILogger<UpdateCheckService>>();
-            return UpdateCheckService.Create(logger);
-        });
-```
-
-Add the using statement:
-```csharp
-using PPDS.Cli.Services.UpdateCheck;
-```
-
-- [ ] **Step 2: Build the solution to verify compilation**
-
-Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj --no-restore -v q`
-Expected: Build succeeded
-
-- [ ] **Step 3: Run all update check tests**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "FullyQualifiedName~UpdateCheck|FullyQualifiedName~VersionCommand|FullyQualifiedName~StartupUpdateNotifier" -v q`
-Expected: All tests PASS
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add src/PPDS.Cli/Services/ServiceRegistration.cs
-git commit -m "feat(cli): register UpdateCheckService in DI container (#564)"
-```
-
----
-
-### Task 7: Verify Full Build and Existing Tests
-
-- [ ] **Step 1: Build entire solution**
-
-Run: `dotnet build PPDS.sln --no-restore -v q`
-Expected: Build succeeded with no errors
-
-- [ ] **Step 2: Run all CLI unit tests**
-
-Run: `dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration" -v q`
-Expected: All tests PASS (both new and existing)
-
-- [ ] **Step 3: Manual smoke test**
-
-Run: `ppds version` — should show version info
-Run: `ppds version --check` — should check NuGet and display update status
-
-- [ ] **Step 4: Final commit if any cleanup needed**
-
-```bash
-git commit -m "chore: verify full build and tests pass for update check feature (#564)"
-```
+## Manual Verification Checklist
+
+Run after implementation, before PR:
+
+1. `ppds version` — shows CLI version, SDK version, .NET, platform to stderr
+2. `ppds version --check` — hits NuGet, shows latest stable/pre-release, no crash
+3. Verify `~/.ppds/update-check.json` exists with valid JSON after step 2
+4. Run `ppds auth list` (or any normal command) — startup notification appears if update available, goes to stderr
+5. Run `ppds auth list --quiet` — update notification suppressed
+6. Delete `~/.ppds/update-check.json`, run `ppds auth list` — no notification (cache gone), cache file reappears after ~5s (background refresh)
+7. Corrupt the cache (`echo "broken" > ~/.ppds/update-check.json`), run `ppds version --check` — no crash, fetches fresh, overwrites corrupt file
 
 ---
 
 ## Design Decisions
 
 ### Why NuGet flat container API?
-The flat container API (`/v3-flatcontainer/{id}/index.json`) returns a simple JSON array of version strings. It requires no authentication, no API key, and no complex query parameters. It's the lightest-weight NuGet endpoint available and perfect for a version-check use case.
+The flat container API (`/v3-flatcontainer/{id}/index.json`) returns a simple JSON array of version strings. No auth, no API key, no complex queries. Lightest-weight NuGet endpoint available.
 
-### Why file-based caching instead of in-memory?
-The CLI is a short-lived process — in-memory caching wouldn't persist across invocations. File-based caching in `~/.ppds/` follows the existing pattern used by `QueryHistoryService` and ensures the 24-hour TTL works across process lifetimes.
+### Why file-based caching?
+The CLI is a short-lived process — in-memory caching doesn't persist. File-based caching in `~/.ppds/` follows the existing `QueryHistoryService` pattern and ensures the 24h TTL works across process lifetimes.
 
 ### Why synchronous cache read at startup?
-The startup notification reads a single small JSON file from local disk. Making this async would add complexity (async Main, await before parse) with no measurable benefit. The file read is sub-millisecond. The network refresh is fire-and-forget in the background.
+Reading a single small JSON file from local disk. Sub-millisecond. Async would add complexity with no measurable benefit. Network refresh is background fire-and-forget.
 
-### Why no IHttpClientFactory?
-The existing codebase uses direct `HttpClient` instantiation (see `ConnectionService`). Adding `IHttpClientFactory` would be an unrelated infrastructure change. The update check creates one `HttpClient` per check (infrequent — at most once per 24h), so socket exhaustion is not a concern.
+### Why HttpMessageHandler injection instead of IHttpClientFactory?
+The existing codebase creates `HttpClient` internally (see `ConnectionService`). We extend this pattern with optional `HttpMessageHandler?` injection for testability — the standard .NET pattern. `HttpClient` is scoped within `CheckAsync` (not held as a field), so no `IDisposable` needed on the service and no R1 concern with fire-and-forget background calls.
 
-### Why lexicographic pre-release comparison?
-SemVer spec says numeric pre-release identifiers should be compared as integers (so `beta.10 > beta.2`). Our implementation uses lexicographic comparison, which would order `beta.10 < beta.2`. This is acceptable because PPDS pre-release labels use single-digit numeric segments (e.g., `alpha.0`, `beta.1`). If multi-digit segments are ever needed, upgrade to proper SemVer numeric comparison.
+### Why no IProgressReporter?
+Constitution A3 requires `IProgressReporter` for operations >1 second. `ppds version --check` makes a single HTTP GET with a 10-second timeout, but completes sub-second under normal network conditions. Progress reporting for a single HTTP request adds no user value — the "Checking for updates..." message provides sufficient feedback.
 
-### Why stable update command takes priority?
-When a user is on pre-release `0.5.x-beta` and stable `0.6.0` is available, we suggest the plain `dotnet tool update` command (without `--prerelease`). This aligns with the PPDS odd/even versioning convention: odd-minor is the pre-release line leading to the next even-minor stable release. The user's intent is almost always to reach stable.
+### Why no DI registration?
+Nothing consumes `IUpdateCheckService` through DI. `VersionCommand` and `StartupUpdateNotifier` both construct the service directly. Adding a DI registration for a hypothetical future consumer is dead code. Add it when something needs it.
+
+### Why stable update takes priority?
+When a user is on pre-release `0.5.x-beta` and stable `0.6.0` is available, we suggest the plain `dotnet tool update` command. This aligns with PPDS odd/even versioning: odd-minor is the pre-release line leading to the next even-minor stable release.
+
+### Why atomic cache writes?
+`RefreshCacheInBackground` fires a `Task.Run` that writes the cache. If the CLI exits mid-write, the file is corrupted. Write to temp file + `File.Move` with overwrite prevents partial writes. The read path handles corruption gracefully regardless, but no reason to create it.

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -119,7 +119,7 @@ public static class VersionCommand
         {
             Console.Error.WriteLine();
             Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
-            if (result.PreReleaseUpdateCommand is not null)
+            if (result.PreReleaseUpdateCommand is not null && result.PreReleaseUpdateCommand != result.UpdateCommand)
                 Console.Error.WriteLine($"Pre-release available! Run: {result.PreReleaseUpdateCommand}");
         }
         else

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -50,8 +50,11 @@ public static class VersionCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion ?? "unknown"}");
-                    Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion ?? "unknown"}");
+                    if (result.LatestStableVersion is not null)
+                        Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion}");
+
+                    if (result.LatestPreReleaseVersion is not null)
+                        Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion}");
 
                     if (result.UpdateAvailable && result.UpdateCommand is not null)
                     {

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -8,13 +8,10 @@ using PPDS.Cli.Services.UpdateCheck;
 namespace PPDS.Cli.Commands;
 
 /// <summary>
-/// Displays version information for the PPDS CLI and optionally checks for updates.
+/// Displays version information for the PPDS CLI and optionally checks for updates or self-updates.
 /// </summary>
 public static class VersionCommand
 {
-    /// <summary>
-    /// Creates the 'version' command.
-    /// </summary>
     public static Command Create()
     {
         var command = new Command("version", "Show version information for the PPDS CLI");
@@ -24,11 +21,35 @@ public static class VersionCommand
             Description = "Check NuGet for the latest available version"
         };
 
+        var updateOption = new Option<bool>("--update")
+        {
+            Description = "Update PPDS CLI to the latest version"
+        };
+
+        var stableOption = new Option<bool>("--stable")
+        {
+            Description = "Force update to latest stable version"
+        };
+
+        var preReleaseOption = new Option<bool>("--prerelease")
+        {
+            Description = "Force update to latest pre-release version"
+        };
+
+        var yesOption = new Option<bool>("--yes", new[] { "-y" })
+        {
+            Description = "Skip confirmation prompt"
+        };
+
         command.Options.Add(checkOption);
+        command.Options.Add(updateOption);
+        command.Options.Add(stableOption);
+        command.Options.Add(preReleaseOption);
+        command.Options.Add(yesOption);
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
-            var runtimeVersion = Environment.Version.ToString();
+            var runtimeVersion = System.Environment.Version.ToString();
             var platform = RuntimeInformation.OSDescription;
 
             Console.Error.WriteLine($"PPDS CLI v{ErrorOutput.Version}");
@@ -36,45 +57,130 @@ public static class VersionCommand
             Console.Error.WriteLine($".NET {runtimeVersion}");
             Console.Error.WriteLine($"Platform: {platform}");
 
+            var update = parseResult.GetValue(updateOption);
+            var stable = parseResult.GetValue(stableOption);
+            var preRelease = parseResult.GetValue(preReleaseOption);
+            var yes = parseResult.GetValue(yesOption);
             var check = parseResult.GetValue(checkOption);
+
+            // Validate mutual exclusivity (AC-49)
+            if (stable && preRelease)
+            {
+                Console.Error.WriteLine("Error: --stable and --prerelease are mutually exclusive.");
+                return ExitCodes.InvalidArguments;
+            }
+
+            if (update || stable || preRelease)
+            {
+                return await HandleUpdateAsync(stable, preRelease, yes, cancellationToken);
+            }
+
             if (check)
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine("Checking for updates...");
-
-                await using var localProvider = ProfileServiceFactory.CreateLocalProvider();
-                var service = localProvider.GetRequiredService<IUpdateCheckService>();
-                var result = await service.CheckAsync(ErrorOutput.Version, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (result is null)
-                {
-                    Console.Error.WriteLine("Unable to check for updates (network unavailable or check failed).");
-                }
-                else
-                {
-                    if (result.LatestStableVersion is not null)
-                        Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion}");
-
-                    if (result.LatestPreReleaseVersion is not null)
-                        Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion}");
-
-                    if (result.UpdateAvailable && result.UpdateCommand is not null)
-                    {
-                        Console.Error.WriteLine();
-                        Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine();
-                        Console.Error.WriteLine("You are up to date.");
-                    }
-                }
+                return await HandleCheckAsync(cancellationToken);
             }
 
             return ExitCodes.Success;
         });
 
         return command;
+    }
+
+    private static async Task<int> HandleCheckAsync(CancellationToken cancellationToken)
+    {
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Checking for updates...");
+
+        await using var localProvider = ProfileServiceFactory.CreateLocalProvider();
+        var service = localProvider.GetRequiredService<IUpdateCheckService>();
+        var result = await service.CheckAsync(ErrorOutput.Version, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result is null)
+        {
+            Console.Error.WriteLine("Unable to check for updates (network unavailable or check failed).");
+            return ExitCodes.Success;
+        }
+
+        if (result.LatestStableVersion is not null)
+            Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion}");
+
+        if (result.LatestPreReleaseVersion is not null)
+            Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion}");
+
+        if (result.UpdateAvailable && result.UpdateCommand is not null)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
+            if (result.PreReleaseUpdateCommand is not null)
+                Console.Error.WriteLine($"Pre-release available! Run: {result.PreReleaseUpdateCommand}");
+        }
+        else
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("You are up to date.");
+        }
+
+        return ExitCodes.Success;
+    }
+
+    private static async Task<int> HandleUpdateAsync(
+        bool forceStable,
+        bool forcePreRelease,
+        bool skipConfirmation,
+        CancellationToken cancellationToken)
+    {
+        var channel = forceStable ? UpdateChannel.Stable
+            : forcePreRelease ? UpdateChannel.PreRelease
+            : UpdateChannel.Current;
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("Checking for updates...");
+
+        try
+        {
+            await using var localProvider = ProfileServiceFactory.CreateLocalProvider();
+            var service = localProvider.GetRequiredService<IUpdateCheckService>();
+            var result = await service.UpdateAsync(channel, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (result.IsNonGlobalInstall)
+            {
+                Console.Error.WriteLine(result.ErrorMessage);
+                if (result.ManualCommand is not null)
+                    Console.Error.WriteLine($"  Run: {result.ManualCommand}");
+                return ExitCodes.Success;
+            }
+
+            if (result.Success && result.ErrorMessage?.Contains("up to date",
+                StringComparison.OrdinalIgnoreCase) == true)
+            {
+                Console.Error.WriteLine("You are already up to date.");
+                return ExitCodes.Success;
+            }
+
+            if (!skipConfirmation && result.InstalledVersion is not null)
+            {
+                Console.Error.Write($"Update to {result.InstalledVersion}? [Y/n] ");
+                var response = Console.ReadLine();
+                if (!string.IsNullOrEmpty(response) &&
+                    !response.StartsWith("y", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.Error.WriteLine("Update cancelled.");
+                    return ExitCodes.Success;
+                }
+            }
+
+            Console.Error.WriteLine($"Updating to {result.InstalledVersion}...");
+            Console.Error.WriteLine("The update will complete in the background.");
+            return ExitCodes.Success;
+        }
+        catch (PpdsException ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.UserMessage}");
+            if (ex.Context?.TryGetValue("manualCommand", out var cmd) == true)
+                Console.Error.WriteLine($"  Run manually: {cmd}");
+            return ExitCodes.Failure;
+        }
     }
 }

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -1,0 +1,74 @@
+using System.CommandLine;
+using System.Runtime.InteropServices;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.UpdateCheck;
+
+namespace PPDS.Cli.Commands;
+
+/// <summary>
+/// Displays version information for the PPDS CLI and optionally checks for updates.
+/// </summary>
+public static class VersionCommand
+{
+    /// <summary>
+    /// Creates the 'version' command.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("version", "Show version information for the PPDS CLI");
+
+        var checkOption = new Option<bool>("--check")
+        {
+            Description = "Check NuGet for the latest available version"
+        };
+
+        command.Options.Add(checkOption);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var runtimeVersion = Environment.Version.ToString();
+            var platform = RuntimeInformation.OSDescription;
+
+            Console.Error.WriteLine($"PPDS CLI v{ErrorOutput.Version}");
+            Console.Error.WriteLine($"SDK v{ErrorOutput.SdkVersion}");
+            Console.Error.WriteLine($".NET {runtimeVersion}");
+            Console.Error.WriteLine($"Platform: {platform}");
+
+            var check = parseResult.GetValue(checkOption);
+            if (check)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Checking for updates...");
+
+                var service = new UpdateCheckService();
+                var result = await service.CheckAsync(ErrorOutput.Version, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (result is null)
+                {
+                    Console.Error.WriteLine("Unable to check for updates (network unavailable or check failed).");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"Latest stable:      {result.LatestStableVersion ?? "unknown"}");
+                    Console.Error.WriteLine($"Latest pre-release: {result.LatestPreReleaseVersion ?? "unknown"}");
+
+                    if (result.UpdateAvailable && result.UpdateCommand is not null)
+                    {
+                        Console.Error.WriteLine();
+                        Console.Error.WriteLine($"Update available! Run: {result.UpdateCommand}");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine();
+                        Console.Error.WriteLine("You are up to date.");
+                    }
+                }
+            }
+
+            return ExitCodes.Success;
+        });
+
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -1,5 +1,7 @@
 using System.CommandLine;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Services.UpdateCheck;
 
@@ -40,7 +42,8 @@ public static class VersionCommand
                 Console.Error.WriteLine();
                 Console.Error.WriteLine("Checking for updates...");
 
-                var service = new UpdateCheckService();
+                await using var localProvider = ProfileServiceFactory.CreateLocalProvider();
+                var service = localProvider.GetRequiredService<IUpdateCheckService>();
                 var result = await service.CheckAsync(ErrorOutput.Version, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/PPDS.Cli/Commands/VersionCommand.cs
+++ b/src/PPDS.Cli/Commands/VersionCommand.cs
@@ -63,6 +63,13 @@ public static class VersionCommand
             var yes = parseResult.GetValue(yesOption);
             var check = parseResult.GetValue(checkOption);
 
+            // Validate: --stable and --prerelease require --update
+            if ((stable || preRelease) && !update)
+            {
+                Console.Error.WriteLine("Error: --stable and --prerelease require --update.");
+                return ExitCodes.InvalidArguments;
+            }
+
             // Validate mutual exclusivity (AC-49)
             if (stable && preRelease)
             {
@@ -70,7 +77,7 @@ public static class VersionCommand
                 return ExitCodes.InvalidArguments;
             }
 
-            if (update || stable || preRelease)
+            if (update)
             {
                 return await HandleUpdateAsync(stable, preRelease, yes, cancellationToken);
             }
@@ -141,6 +148,51 @@ public static class VersionCommand
         {
             await using var localProvider = ProfileServiceFactory.CreateLocalProvider();
             var service = localProvider.GetRequiredService<IUpdateCheckService>();
+
+            // First check what's available (no side effects)
+            var checkResult = await service.CheckAsync(ErrorOutput.Version, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (checkResult is null)
+            {
+                Console.Error.WriteLine("Unable to check for updates (network unavailable or check failed).");
+                return ExitCodes.Failure;
+            }
+
+            if (!checkResult.StableUpdateAvailable && !checkResult.PreReleaseUpdateAvailable)
+            {
+                Console.Error.WriteLine("You are already up to date.");
+                return ExitCodes.Success;
+            }
+
+            // Determine target version based on channel
+            var usePreRelease = channel switch
+            {
+                UpdateChannel.Stable => false,
+                UpdateChannel.PreRelease => true,
+                UpdateChannel.Current => NuGetVersion.TryParse(
+                    checkResult.CurrentVersion, out var cv) && cv!.IsOddMinor,
+                _ => false
+            };
+
+            var targetVersion = usePreRelease
+                ? checkResult.LatestPreReleaseVersion
+                : checkResult.LatestStableVersion;
+
+            // Confirm BEFORE spawning (the fix)
+            if (!skipConfirmation && targetVersion is not null)
+            {
+                Console.Error.Write($"Update to {targetVersion}? [Y/n] ");
+                var response = Console.ReadLine();
+                if (!string.IsNullOrEmpty(response) &&
+                    !response.StartsWith("y", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.Error.WriteLine("Update cancelled.");
+                    return ExitCodes.Success;
+                }
+            }
+
+            // NOW spawn the update (after confirmation)
             var result = await service.UpdateAsync(channel, cancellationToken)
                 .ConfigureAwait(false);
 
@@ -150,25 +202,6 @@ public static class VersionCommand
                 if (result.ManualCommand is not null)
                     Console.Error.WriteLine($"  Run: {result.ManualCommand}");
                 return ExitCodes.Success;
-            }
-
-            if (result.Success && result.ErrorMessage?.Contains("up to date",
-                StringComparison.OrdinalIgnoreCase) == true)
-            {
-                Console.Error.WriteLine("You are already up to date.");
-                return ExitCodes.Success;
-            }
-
-            if (!skipConfirmation && result.InstalledVersion is not null)
-            {
-                Console.Error.Write($"Update to {result.InstalledVersion}? [Y/n] ");
-                var response = Console.ReadLine();
-                if (!string.IsNullOrEmpty(response) &&
-                    !response.StartsWith("y", StringComparison.OrdinalIgnoreCase))
-                {
-                    Console.Error.WriteLine("Update cancelled.");
-                    return ExitCodes.Success;
-                }
             }
 
             Console.Error.WriteLine($"Updating to {result.InstalledVersion}...");

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -223,4 +223,19 @@ public static class ErrorCodes
         /// <summary>Specified user for impersonation was not found.</summary>
         public const string UserNotFound = "Plugin.UserNotFound";
     }
+
+    /// <summary>
+    /// Update check errors.
+    /// </summary>
+    public static class UpdateCheck
+    {
+        /// <summary>Failed to reach the NuGet API.</summary>
+        public const string NetworkError = "UpdateCheck.NetworkError";
+
+        /// <summary>NuGet API returned unexpected or unparseable data.</summary>
+        public const string ParseError = "UpdateCheck.ParseError";
+
+        /// <summary>Cache file is unreadable or corrupt.</summary>
+        public const string CacheError = "UpdateCheck.CacheError";
+    }
 }

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -223,19 +223,4 @@ public static class ErrorCodes
         /// <summary>Specified user for impersonation was not found.</summary>
         public const string UserNotFound = "Plugin.UserNotFound";
     }
-
-    /// <summary>
-    /// Update check errors.
-    /// </summary>
-    public static class UpdateCheck
-    {
-        /// <summary>Failed to reach the NuGet API.</summary>
-        public const string NetworkError = "UpdateCheck.NetworkError";
-
-        /// <summary>NuGet API returned unexpected or unparseable data.</summary>
-        public const string ParseError = "UpdateCheck.ParseError";
-
-        /// <summary>Cache file is unreadable or corrupt.</summary>
-        public const string CacheError = "UpdateCheck.CacheError";
-    }
 }

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -223,4 +223,22 @@ public static class ErrorCodes
         /// <summary>Specified user for impersonation was not found.</summary>
         public const string UserNotFound = "Plugin.UserNotFound";
     }
+
+    /// <summary>
+    /// Update check and self-update errors.
+    /// </summary>
+    public static class UpdateCheck
+    {
+        /// <summary>NuGet API query failed (network, timeout, non-2xx).</summary>
+        public const string NetworkError = "UpdateCheck.NetworkError";
+
+        /// <summary>Cache file is corrupt or unreadable.</summary>
+        public const string CacheCorrupt = "UpdateCheck.CacheCorrupt";
+
+        /// <summary>Cannot locate the dotnet runtime executable.</summary>
+        public const string DotnetNotFound = "UpdateCheck.DotnetNotFound";
+
+        /// <summary>The dotnet tool update process exited with non-zero.</summary>
+        public const string UpdateFailed = "UpdateCheck.UpdateFailed";
+    }
 }

--- a/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
+++ b/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using PPDS.Cli.Services.UpdateCheck;
+
+namespace PPDS.Cli.Infrastructure;
+
+/// <summary>
+/// Reads the cached update-check result at startup and produces a one-liner notification message.
+/// Also fires a background cache refresh so the next startup has fresh data.
+/// </summary>
+/// <remarks>
+/// All methods are static and synchronous (except the fire-and-forget background refresh).
+/// The cache file is a small JSON document — reads are sub-millisecond and impose no
+/// perceptible startup latency.
+/// </remarks>
+public static class StartupUpdateNotifier
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Default path to the update-check cache file: <c>~/.ppds/update-check.json</c>.
+    /// </summary>
+    private static string DefaultCachePath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".ppds",
+        "update-check.json");
+
+    /// <summary>
+    /// Reads the cached update-check result and returns a formatted notification message,
+    /// or <see langword="null"/> if no update is available, the cache is missing, expired, or corrupt.
+    /// </summary>
+    /// <param name="cachePath">
+    /// Optional override for the cache file path. Pass <see langword="null"/> to use the default
+    /// <c>~/.ppds/update-check.json</c>.
+    /// </param>
+    /// <returns>
+    /// A message such as
+    /// <c>"Update available: 0.6.0 (run: dotnet tool update PPDS.Cli -g)"</c>,
+    /// or <see langword="null"/>.
+    /// </returns>
+    public static string? GetNotificationMessage(string? cachePath = null)
+    {
+        try
+        {
+            var path = cachePath ?? DefaultCachePath;
+
+            if (!File.Exists(path))
+                return null;
+
+            var json = File.ReadAllText(path);
+            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
+
+            if (result is null)
+                return null;
+
+            // Honour the same 24-hour TTL as UpdateCheckService
+            if (DateTimeOffset.UtcNow - result.CheckedAt > CacheTtl)
+                return null;
+
+            if (!result.UpdateAvailable)
+                return null;
+
+            // Prefer stable version in the message; fall back to pre-release
+            var latestVersion = result.StableUpdateAvailable
+                ? result.LatestStableVersion
+                : result.LatestPreReleaseVersion;
+
+            if (latestVersion is null || result.UpdateCommand is null)
+                return null;
+
+            return $"Update available: {latestVersion} (run: {result.UpdateCommand})";
+        }
+        catch
+        {
+            // Never propagate exceptions — broken paths, permissions, corrupt JSON, etc.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the update notification should be shown.
+    /// Returns <see langword="false"/> when <c>--quiet</c> or <c>-q</c> is present in <paramref name="args"/>.
+    /// </summary>
+    /// <param name="args">The raw command-line arguments (before System.CommandLine parsing).</param>
+    public static bool ShouldShow(string[] args)
+    {
+        foreach (var arg in args)
+        {
+            if (string.Equals(arg, "--quiet", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(arg, "-q", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Fires a best-effort background <see cref="Task"/> to refresh the update cache when
+    /// the existing cache is stale (older than 24 hours) or missing.
+    /// All exceptions are swallowed — this must never crash the CLI.
+    /// </summary>
+    /// <param name="currentVersion">The currently installed CLI version.</param>
+    /// <param name="cachePath">
+    /// Optional override for the cache file path (used in tests).
+    /// Pass <see langword="null"/> to use the default <c>~/.ppds/update-check.json</c>.
+    /// </param>
+    public static void RefreshCacheInBackground(string currentVersion, string? cachePath = null)
+    {
+        try
+        {
+            var path = cachePath ?? DefaultCachePath;
+
+            // Check cache age before firing the background task — skip if fresh
+            if (IsCacheFresh(path))
+                return;
+
+            // Fire-and-forget: no await, exceptions swallowed inside the task
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var svc = new UpdateCheckService(cachePath: path);
+                    await svc.CheckAsync(currentVersion).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort — never surface to the caller
+                }
+            });
+        }
+        catch
+        {
+            // Swallow filesystem errors in cache-age check
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the cache file exists and was written within the last 24 hours.
+    /// </summary>
+    private static bool IsCacheFresh(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return false;
+
+            var json = File.ReadAllText(path);
+            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
+
+            if (result is null)
+                return false;
+
+            return DateTimeOffset.UtcNow - result.CheckedAt <= CacheTtl;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
+++ b/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
@@ -1,89 +1,71 @@
-using System.Text.Json;
 using PPDS.Cli.Services.UpdateCheck;
 
 namespace PPDS.Cli.Infrastructure;
 
 /// <summary>
-/// Reads the cached update-check result at startup and produces a one-liner notification message.
-/// Also fires a background cache refresh so the next startup has fresh data.
+/// Pure presentation logic for startup update notifications.
+/// No file I/O, no cache knowledge — all data access is owned by <see cref="IUpdateCheckService"/>.
+/// Track-based filtering for startup notifications happens here.
 /// </summary>
-/// <remarks>
-/// All methods are static and synchronous (except the fire-and-forget background refresh).
-/// The cache file is a small JSON document — reads are sub-millisecond and impose no
-/// perceptible startup latency.
-/// </remarks>
 public static class StartupUpdateNotifier
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
     /// <summary>
-    /// Default path to the update-check cache file: <c>~/.ppds/update-check.json</c>.
+    /// Formats a human-readable update notification from a cached result.
+    /// Applies track-based filtering: stable users see only stable updates at startup;
+    /// pre-release users see both stable and pre-release.
+    /// Returns <see langword="null"/> if no update is available or the result is null.
     /// </summary>
-    private static string DefaultCachePath => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        ".ppds",
-        "update-check.json");
-
-    /// <summary>
-    /// Reads the cached update-check result and returns a formatted notification message,
-    /// or <see langword="null"/> if no update is available, the cache is missing, expired, or corrupt.
-    /// </summary>
-    /// <param name="cachePath">
-    /// Optional override for the cache file path. Pass <see langword="null"/> to use the default
-    /// <c>~/.ppds/update-check.json</c>.
-    /// </param>
-    /// <returns>
-    /// A message such as
-    /// <c>"Update available: 0.6.0 (run: dotnet tool update PPDS.Cli -g)"</c>,
-    /// or <see langword="null"/>.
-    /// </returns>
-    public static string? GetNotificationMessage(string? cachePath = null)
+    public static string? FormatNotification(UpdateCheckResult? result)
     {
-        try
-        {
-            var path = cachePath ?? DefaultCachePath;
-
-            if (!File.Exists(path))
-                return null;
-
-            var json = File.ReadAllText(path);
-            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
-
-            if (result is null)
-                return null;
-
-            // Honour the same 24-hour TTL as UpdateCheckService
-            if (DateTimeOffset.UtcNow - result.CheckedAt > UpdateCheckService.CacheTtl)
-                return null;
-
-            if (!result.UpdateAvailable)
-                return null;
-
-            // Prefer stable version in the message; fall back to pre-release
-            var latestVersion = result.StableUpdateAvailable
-                ? result.LatestStableVersion
-                : result.LatestPreReleaseVersion;
-
-            if (latestVersion is null || result.UpdateCommand is null)
-                return null;
-
-            return $"Update available: {latestVersion} (run: {result.UpdateCommand})";
-        }
-        catch
-        {
-            // Never propagate exceptions — broken paths, permissions, corrupt JSON, etc.
+        if (result is null || !result.UpdateAvailable)
             return null;
+
+        // Determine user's track from current version
+        var isPreReleaseTrack = NuGetVersion.TryParse(result.CurrentVersion, out var current)
+            && current!.IsOddMinor;
+
+        // Pre-release track user with both updates — two lines
+        if (isPreReleaseTrack
+            && result.StableUpdateAvailable && result.PreReleaseUpdateAvailable
+            && result.LatestStableVersion is not null
+            && result.LatestPreReleaseVersion is not null
+            && result.UpdateCommand is not null
+            && result.PreReleaseUpdateCommand is not null)
+        {
+            return $"Update available: {result.LatestStableVersion} (run: {result.UpdateCommand})\n"
+                 + $"Pre-release available: {result.LatestPreReleaseVersion} (run: {result.PreReleaseUpdateCommand})";
         }
+
+        // Stable track user: only show stable update (even if pre-release exists in data model)
+        if (!isPreReleaseTrack && result.StableUpdateAvailable
+            && result.LatestStableVersion is not null && result.UpdateCommand is not null)
+        {
+            return $"Update available: {result.LatestStableVersion} (run: {result.UpdateCommand})";
+        }
+
+        // Pre-release track, single update available
+        if (result.StableUpdateAvailable && result.LatestStableVersion is not null
+            && result.UpdateCommand is not null)
+        {
+            return $"Update available: {result.LatestStableVersion} (run: {result.UpdateCommand})";
+        }
+
+        if (result.PreReleaseUpdateAvailable && result.LatestPreReleaseVersion is not null)
+        {
+            var cmd = result.PreReleaseUpdateCommand ?? result.UpdateCommand;
+            if (cmd is not null)
+                return $"Update available: {result.LatestPreReleaseVersion} (run: {cmd})";
+        }
+
+        return null;
     }
 
     /// <summary>
     /// Returns <see langword="true"/> when the update notification should be shown.
-    /// Returns <see langword="false"/> when <c>--quiet</c> or <c>-q</c> is present in <paramref name="args"/>.
+    /// Returns <see langword="false"/> when <c>--quiet</c> or <c>-q</c> is present.
+    /// Other suppression (--help, --version, version subcommand) is handled by
+    /// Program.cs SkipVersionHeaderArgs — no duplication needed.
     /// </summary>
-    /// <param name="args">The raw command-line arguments (before System.CommandLine parsing).</param>
     public static bool ShouldShow(string[] args)
     {
         foreach (var arg in args)
@@ -96,69 +78,5 @@ public static class StartupUpdateNotifier
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Fires a best-effort background <see cref="Task"/> to refresh the update cache when
-    /// the existing cache is stale (older than 24 hours) or missing.
-    /// All exceptions are swallowed — this must never crash the CLI.
-    /// </summary>
-    /// <param name="currentVersion">The currently installed CLI version.</param>
-    /// <param name="cachePath">
-    /// Optional override for the cache file path (used in tests).
-    /// Pass <see langword="null"/> to use the default <c>~/.ppds/update-check.json</c>.
-    /// </param>
-    public static void RefreshCacheInBackground(string currentVersion, string? cachePath = null)
-    {
-        try
-        {
-            var path = cachePath ?? DefaultCachePath;
-
-            // Check cache age before firing the background task — skip if fresh
-            if (IsCacheFresh(path))
-                return;
-
-            // Fire-and-forget: no await, exceptions swallowed inside the task
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    var svc = new UpdateCheckService(cachePath: path);
-                    await svc.CheckAsync(currentVersion).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // Best-effort — never surface to the caller
-                }
-            });
-        }
-        catch
-        {
-            // Swallow filesystem errors in cache-age check
-        }
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> when the cache file exists and was written within the last 24 hours.
-    /// </summary>
-    private static bool IsCacheFresh(string path)
-    {
-        try
-        {
-            if (!File.Exists(path))
-                return false;
-
-            var json = File.ReadAllText(path);
-            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
-
-            if (result is null)
-                return false;
-
-            return DateTimeOffset.UtcNow - result.CheckedAt <= UpdateCheckService.CacheTtl;
-        }
-        catch
-        {
-            return false;
-        }
     }
 }

--- a/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
+++ b/src/PPDS.Cli/Infrastructure/StartupUpdateNotifier.cs
@@ -14,8 +14,6 @@ namespace PPDS.Cli.Infrastructure;
 /// </remarks>
 public static class StartupUpdateNotifier
 {
-    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
-
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
@@ -58,7 +56,7 @@ public static class StartupUpdateNotifier
                 return null;
 
             // Honour the same 24-hour TTL as UpdateCheckService
-            if (DateTimeOffset.UtcNow - result.CheckedAt > CacheTtl)
+            if (DateTimeOffset.UtcNow - result.CheckedAt > UpdateCheckService.CacheTtl)
                 return null;
 
             if (!result.UpdateAvailable)
@@ -156,7 +154,7 @@ public static class StartupUpdateNotifier
             if (result is null)
                 return false;
 
-            return DateTimeOffset.UtcNow - result.CheckedAt <= CacheTtl;
+            return DateTimeOffset.UtcNow - result.CheckedAt <= UpdateCheckService.CacheTtl;
         }
         catch
         {

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -20,6 +20,7 @@ using PPDS.Cli.Commands.Users;
 using PPDS.Cli.Commands;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.UpdateCheck;
 
 namespace PPDS.Cli;
 
@@ -52,15 +53,17 @@ public static class Program
             // Show cached update notification (guarded by --quiet)
             if (StartupUpdateNotifier.ShouldShow(args))
             {
-                var updateMessage = StartupUpdateNotifier.GetNotificationMessage();
+                var updateService = new UpdateCheckService();
+                var cached = updateService.GetCachedResult();
+                var updateMessage = StartupUpdateNotifier.FormatNotification(cached);
                 if (updateMessage != null)
                 {
                     Console.Error.WriteLine(updateMessage);
                 }
-            }
 
-            // Fire-and-forget background cache refresh for next startup
-            StartupUpdateNotifier.RefreshCacheInBackground(ErrorOutput.Version);
+                // Fire-and-forget background cache refresh for next startup
+                updateService.RefreshCacheInBackgroundIfStale(ErrorOutput.Version);
+            }
         }
 
         var rootCommand = new RootCommand(

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -33,7 +33,7 @@ public static class Program
     /// </summary>
     private static readonly HashSet<string> SkipVersionHeaderArgs = new(StringComparer.OrdinalIgnoreCase)
     {
-        "--help", "-h", "-?", "--version"
+        "--help", "-h", "-?", "--version", "version"
     };
 
     public static async Task<int> Main(string[] args)
@@ -88,6 +88,7 @@ public static class Program
         rootCommand.Subcommands.Add(RolesCommandGroup.Create());
         rootCommand.Subcommands.Add(ServeCommand.Create());
         rootCommand.Subcommands.Add(DocsCommand.Create());
+        rootCommand.Subcommands.Add(VersionCommand.Create());
         rootCommand.Subcommands.Add(InteractiveCommand.Create());
 
         // Internal/debug commands - only visible when PPDS_INTERNAL=1

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -48,6 +48,19 @@ public static class Program
         if (!args.Any(a => SkipVersionHeaderArgs.Contains(a)) && !IsInteractiveMode(args))
         {
             ErrorOutput.WriteVersionHeader();
+
+            // Show cached update notification (guarded by --quiet)
+            if (StartupUpdateNotifier.ShouldShow(args))
+            {
+                var updateMessage = StartupUpdateNotifier.GetNotificationMessage();
+                if (updateMessage != null)
+                {
+                    Console.Error.WriteLine(updateMessage);
+                }
+            }
+
+            // Fire-and-forget background cache refresh for next startup
+            StartupUpdateNotifier.RefreshCacheInBackground(ErrorOutput.Version);
         }
 
         var rootCommand = new RootCommand(

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -49,6 +49,7 @@ public static class Program
         if (!args.Any(a => SkipVersionHeaderArgs.Contains(a)) && !IsInteractiveMode(args))
         {
             ErrorOutput.WriteVersionHeader();
+            ReadAndDeleteUpdateStatus();
 
             // Show cached update notification (guarded by --quiet)
             if (StartupUpdateNotifier.ShouldShow(args))
@@ -109,6 +110,45 @@ public static class Program
 
         var parseResult = rootCommand.Parse(args);
         return await parseResult.InvokeAsync();
+    }
+
+    /// <summary>
+    /// Reads the post-update status file written by the detached wrapper script,
+    /// displays the result to the user, and deletes the file.
+    /// </summary>
+    private static void ReadAndDeleteUpdateStatus()
+    {
+        try
+        {
+            var statusPath = Path.Combine(
+                System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
+                ".ppds", "update-status.json");
+
+            if (!File.Exists(statusPath))
+                return;
+
+            var json = File.ReadAllText(statusPath);
+            File.Delete(statusPath);
+
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var success = root.TryGetProperty("success", out var s) && s.GetBoolean();
+            var version = root.TryGetProperty("targetVersion", out var v) ? v.GetString() : null;
+
+            if (success && version is not null)
+            {
+                Console.Error.WriteLine($"Successfully updated to {version}.");
+            }
+            else
+            {
+                Console.Error.WriteLine("Update failed. Run manually: dotnet tool update PPDS.Cli -g");
+            }
+        }
+        catch
+        {
+            // Status file read/delete failure is not fatal
+        }
     }
 
     /// <summary>

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -10,6 +10,7 @@ using PPDS.Cli.Services.Export;
 using PPDS.Cli.Services.History;
 using PPDS.Cli.Services.Profile;
 using PPDS.Cli.Services.Query;
+using PPDS.Cli.Services.UpdateCheck;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.BulkOperations;
 using PPDS.Dataverse.Metadata;
@@ -138,6 +139,9 @@ public static class ServiceRegistration
                 connectionInfo.EnvironmentId,
                 logger);
         });
+
+        // Update check service — singleton, manages its own cache file
+        services.AddSingleton<IUpdateCheckService, UpdateCheckService>();
 
         return services;
     }

--- a/src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
@@ -1,0 +1,22 @@
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Service for checking available updates to the PPDS CLI tool.
+/// </summary>
+public interface IUpdateCheckService
+{
+    /// <summary>
+    /// Asynchronously checks for available updates to the PPDS CLI.
+    /// </summary>
+    /// <param name="currentVersion">The currently installed version.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the update check result, or null if the check could not be completed.</returns>
+    Task<UpdateCheckResult?> CheckAsync(string currentVersion, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves a previously cached update check result.
+    /// </summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the cached result, or null if no cached result is available.</returns>
+    Task<UpdateCheckResult?> GetCachedResultAsync(CancellationToken cancellationToken = default);
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/IUpdateCheckService.cs
@@ -1,22 +1,34 @@
 namespace PPDS.Cli.Services.UpdateCheck;
 
 /// <summary>
-/// Service for checking available updates to the PPDS CLI tool.
+/// Service for checking available updates and performing self-update of the PPDS CLI tool.
+/// All cache format knowledge, TTL logic, and file I/O are owned by this service (A1).
 /// </summary>
 public interface IUpdateCheckService
 {
     /// <summary>
-    /// Asynchronously checks for available updates to the PPDS CLI.
+    /// Synchronously reads the cached update check result.
+    /// Returns <see langword="null"/> if the cache is missing, expired (&gt;24h), or corrupt.
+    /// Never throws.
     /// </summary>
-    /// <param name="currentVersion">The currently installed version.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains the update check result, or null if the check could not be completed.</returns>
+    UpdateCheckResult? GetCachedResult();
+
+    /// <summary>
+    /// Queries the NuGet flat-container API for available versions and returns the result.
+    /// Updates the cache on success. Returns <see langword="null"/> on network failure.
+    /// </summary>
     Task<UpdateCheckResult?> CheckAsync(string currentVersion, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Asynchronously retrieves a previously cached update check result.
+    /// Fires a best-effort background task to refresh the cache when it is stale.
+    /// Intentionally takes no <see cref="CancellationToken"/> — fire-and-forget by design (R2).
     /// </summary>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains the cached result, or null if no cached result is available.</returns>
-    Task<UpdateCheckResult?> GetCachedResultAsync(CancellationToken cancellationToken = default);
+    void RefreshCacheInBackgroundIfStale(string currentVersion);
+
+    /// <summary>
+    /// Performs a self-update of the PPDS CLI tool.
+    /// Returns <see cref="UpdateResult"/> for expected outcomes (non-global install, already current).
+    /// Throws <see cref="Infrastructure.Errors.PpdsException"/> for unexpected failures (dotnet not found).
+    /// </summary>
+    Task<UpdateResult> UpdateAsync(UpdateChannel channel, CancellationToken cancellationToken = default);
 }

--- a/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
@@ -1,0 +1,236 @@
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Immutable SemVer value type for parsing and comparing NuGet version strings.
+/// Handles the <c>major.minor.patch[-prerelease][+buildmetadata]</c> format,
+/// including the <c>InformationalVersion</c> format emitted by MinVer
+/// (e.g., <c>1.2.3-beta.1+abc1234</c>).
+/// </summary>
+public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVersion>
+{
+    /// <summary>Gets the major version component.</summary>
+    public int Major { get; }
+
+    /// <summary>Gets the minor version component.</summary>
+    public int Minor { get; }
+
+    /// <summary>Gets the patch version component.</summary>
+    public int Patch { get; }
+
+    /// <summary>
+    /// Gets the pre-release label (everything between <c>-</c> and <c>+</c>).
+    /// Returns <see cref="string.Empty"/> for stable releases.
+    /// </summary>
+    public string PreReleaseLabel { get; }
+
+    /// <summary>Gets a value indicating whether this version is a pre-release.</summary>
+    public bool IsPreRelease => PreReleaseLabel.Length > 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the minor version is odd.
+    /// PPDS convention: odd minor versions denote a pre-release/development line
+    /// (e.g., 1.1.x is the development line between stable 1.0.x and 1.2.x).
+    /// </summary>
+    public bool IsOddMinor => Minor % 2 != 0;
+
+    private NuGetVersion(int major, int minor, int patch, string preReleaseLabel)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreReleaseLabel = preReleaseLabel;
+    }
+
+    /// <summary>
+    /// Parses a NuGet version string. Build metadata (<c>+…</c>) is stripped before parsing.
+    /// </summary>
+    /// <param name="version">The version string to parse.</param>
+    /// <returns>The parsed <see cref="NuGetVersion"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="version"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException"><paramref name="version"/> is not a valid SemVer string.</exception>
+    public static NuGetVersion Parse(string version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        if (!TryParseCore(version, out var result))
+            throw new FormatException($"'{version}' is not a valid NuGet/SemVer version string.");
+
+        return result!;
+    }
+
+    /// <summary>
+    /// Attempts to parse a NuGet version string.
+    /// </summary>
+    /// <param name="version">The version string to parse, or <see langword="null"/>.</param>
+    /// <param name="result">
+    /// When this method returns <see langword="true"/>, contains the parsed <see cref="NuGetVersion"/>;
+    /// otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if parsing succeeded; otherwise <see langword="false"/>.</returns>
+    public static bool TryParse(string? version, out NuGetVersion? result)
+    {
+        if (version is null)
+        {
+            result = null;
+            return false;
+        }
+
+        return TryParseCore(version, out result);
+    }
+
+    private static bool TryParseCore(string version, out NuGetVersion? result)
+    {
+        result = null;
+
+        if (string.IsNullOrEmpty(version))
+            return false;
+
+        // Strip build metadata (everything from '+' onwards)
+        var plusIndex = version.IndexOf('+');
+        var withoutMeta = plusIndex >= 0 ? version[..plusIndex] : version;
+
+        // Split on the first '-' to separate core from pre-release label
+        var dashIndex = withoutMeta.IndexOf('-');
+        string core;
+        string preRelease;
+
+        if (dashIndex >= 0)
+        {
+            core = withoutMeta[..dashIndex];
+            preRelease = withoutMeta[(dashIndex + 1)..];
+        }
+        else
+        {
+            core = withoutMeta;
+            preRelease = string.Empty;
+        }
+
+        // Parse major.minor.patch
+        var parts = core.Split('.');
+        if (parts.Length != 3)
+            return false;
+
+        if (!int.TryParse(parts[0], out var major) ||
+            !int.TryParse(parts[1], out var minor) ||
+            !int.TryParse(parts[2], out var patch))
+            return false;
+
+        result = new NuGetVersion(major, minor, patch, preRelease);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public int CompareTo(NuGetVersion? other)
+    {
+        if (other is null) return 1;
+
+        var cmp = Major.CompareTo(other.Major);
+        if (cmp != 0) return cmp;
+
+        cmp = Minor.CompareTo(other.Minor);
+        if (cmp != 0) return cmp;
+
+        cmp = Patch.CompareTo(other.Patch);
+        if (cmp != 0) return cmp;
+
+        // Same major.minor.patch: stable beats pre-release
+        var thisIsPreRelease = IsPreRelease;
+        var otherIsPreRelease = other.IsPreRelease;
+
+        if (!thisIsPreRelease && !otherIsPreRelease) return 0;  // both stable
+        if (!thisIsPreRelease && otherIsPreRelease) return 1;   // stable > pre-release
+        if (thisIsPreRelease && !otherIsPreRelease) return -1;  // pre-release < stable
+
+        // Both are pre-release: compare labels segment by segment
+        return ComparePreReleaseLabels(PreReleaseLabel, other.PreReleaseLabel);
+    }
+
+    /// <summary>
+    /// Compares two pre-release labels segment by segment per SemVer 2.0.0 spec:
+    /// <list type="bullet">
+    ///   <item>Segments are split on <c>.</c></item>
+    ///   <item>Numeric segments are compared as integers.</item>
+    ///   <item>Alphanumeric segments are compared lexicographically (ordinal).</item>
+    ///   <item>Numeric segments always sort before alphanumeric segments.</item>
+    ///   <item>A longer label with a common prefix is greater than a shorter one.</item>
+    /// </list>
+    /// </summary>
+    private static int ComparePreReleaseLabels(string a, string b)
+    {
+        var aSegments = a.Split('.');
+        var bSegments = b.Split('.');
+
+        var length = Math.Min(aSegments.Length, bSegments.Length);
+
+        for (var i = 0; i < length; i++)
+        {
+            var aIsNum = int.TryParse(aSegments[i], out var aNum);
+            var bIsNum = int.TryParse(bSegments[i], out var bNum);
+
+            int cmp;
+            if (aIsNum && bIsNum)
+            {
+                // Both numeric: integer comparison
+                cmp = aNum.CompareTo(bNum);
+            }
+            else if (!aIsNum && !bIsNum)
+            {
+                // Both alphanumeric: lexicographic (ordinal)
+                cmp = string.Compare(aSegments[i], bSegments[i], StringComparison.Ordinal);
+            }
+            else
+            {
+                // Mixed: numeric < alphanumeric (per SemVer spec)
+                cmp = aIsNum ? -1 : 1;
+            }
+
+            if (cmp != 0) return cmp;
+        }
+
+        // Common prefix — more segments wins
+        return aSegments.Length.CompareTo(bSegments.Length);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(NuGetVersion? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return Major == other.Major
+            && Minor == other.Minor
+            && Patch == other.Patch
+            && string.Equals(PreReleaseLabel, other.PreReleaseLabel, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as NuGetVersion);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(Major, Minor, Patch, PreReleaseLabel);
+
+    /// <summary>
+    /// Returns the canonical string representation: <c>major.minor.patch</c> for stable versions,
+    /// or <c>major.minor.patch-prerelease</c> for pre-release versions.
+    /// Build metadata is never included.
+    /// </summary>
+    public override string ToString() =>
+        IsPreRelease ? $"{Major}.{Minor}.{Patch}-{PreReleaseLabel}" : $"{Major}.{Minor}.{Patch}";
+
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> is greater than <paramref name="right"/>.</summary>
+    public static bool operator >(NuGetVersion? left, NuGetVersion? right) =>
+        left is not null && left.CompareTo(right) > 0;
+
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> is less than <paramref name="right"/>.</summary>
+    public static bool operator <(NuGetVersion? left, NuGetVersion? right) =>
+        right is not null && right.CompareTo(left) > 0;
+
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> is greater than or equal to <paramref name="right"/>.</summary>
+    public static bool operator >=(NuGetVersion? left, NuGetVersion? right) =>
+        left is not null && left.CompareTo(right) >= 0;
+
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> is less than or equal to <paramref name="right"/>.</summary>
+    public static bool operator <=(NuGetVersion? left, NuGetVersion? right) =>
+        right is not null && right.CompareTo(left) >= 0;
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
@@ -115,6 +115,10 @@ public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVe
             !int.TryParse(parts[2], out var patch))
             return false;
 
+        // SemVer requires non-negative integers
+        if (major < 0 || minor < 0 || patch < 0)
+            return false;
+
         result = new NuGetVersion(major, minor, patch, preRelease);
         return true;
     }

--- a/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
@@ -138,12 +138,9 @@ public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVe
         if (cmp != 0) return cmp;
 
         // Same major.minor.patch: stable beats pre-release
-        var thisIsPreRelease = IsPreRelease;
-        var otherIsPreRelease = other.IsPreRelease;
-
-        if (!thisIsPreRelease && !otherIsPreRelease) return 0;  // both stable
-        if (!thisIsPreRelease && otherIsPreRelease) return 1;   // stable > pre-release
-        if (thisIsPreRelease && !otherIsPreRelease) return -1;  // pre-release < stable
+        if (!IsPreRelease && !other.IsPreRelease) return 0;   // both stable
+        if (!IsPreRelease) return 1;                           // this stable, other pre-release
+        if (!other.IsPreRelease) return -1;                    // this pre-release, other stable
 
         // Both are pre-release: compare labels segment by segment
         return ComparePreReleaseLabels(PreReleaseLabel, other.PreReleaseLabel);

--- a/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/NuGetVersion.cs
@@ -218,6 +218,14 @@ public sealed class NuGetVersion : IComparable<NuGetVersion>, IEquatable<NuGetVe
     public override string ToString() =>
         IsPreRelease ? $"{Major}.{Minor}.{Patch}-{PreReleaseLabel}" : $"{Major}.{Minor}.{Patch}";
 
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> equals <paramref name="right"/> by value.</summary>
+    public static bool operator ==(NuGetVersion? left, NuGetVersion? right) =>
+        left is null ? right is null : left.Equals(right);
+
+    /// <summary>Returns <see langword="true"/> if <paramref name="left"/> does not equal <paramref name="right"/> by value.</summary>
+    public static bool operator !=(NuGetVersion? left, NuGetVersion? right) =>
+        !(left == right);
+
     /// <summary>Returns <see langword="true"/> if <paramref name="left"/> is greater than <paramref name="right"/>.</summary>
     public static bool operator >(NuGetVersion? left, NuGetVersion? right) =>
         left is not null && left.CompareTo(right) > 0;

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateChannel.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateChannel.cs
@@ -1,0 +1,16 @@
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Specifies which release track to target for self-update.
+/// </summary>
+public enum UpdateChannel
+{
+    /// <summary>Stay on current track (stable→stable, pre-release→pre-release).</summary>
+    Current,
+
+    /// <summary>Force update to latest stable version.</summary>
+    Stable,
+
+    /// <summary>Force update to latest pre-release version.</summary>
+    PreRelease
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
@@ -33,9 +33,16 @@ public sealed record UpdateCheckResult
     public bool PreReleaseUpdateAvailable { get; init; }
 
     /// <summary>
-    /// Gets the command to run to update the PPDS CLI, or null if already up-to-date.
+    /// Gets the primary update command (stable preferred), or null if already up-to-date.
     /// </summary>
     public string? UpdateCommand { get; init; }
+
+    /// <summary>
+    /// Gets the pre-release update command when a newer pre-release is also available
+    /// alongside a stable update. Null when no pre-release update exists or when
+    /// only a pre-release update is available (in that case <see cref="UpdateCommand"/> holds it).
+    /// </summary>
+    public string? PreReleaseUpdateCommand { get; init; }
 
     /// <summary>
     /// Gets the timestamp when this check was performed.

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
@@ -38,9 +38,7 @@ public sealed record UpdateCheckResult
     public string? UpdateCommand { get; init; }
 
     /// <summary>
-    /// Gets the pre-release update command when a newer pre-release is also available
-    /// alongside a stable update. Null when no pre-release update exists or when
-    /// only a pre-release update is available (in that case <see cref="UpdateCommand"/> holds it).
+    /// Gets the pre-release update command when a pre-release update is available, or null when no pre-release update exists.
     /// </summary>
     public string? PreReleaseUpdateCommand { get; init; }
 

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckResult.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Represents the result of checking for available PPDS CLI updates.
+/// </summary>
+public sealed record UpdateCheckResult
+{
+    /// <summary>
+    /// Gets the currently installed version of the PPDS CLI.
+    /// </summary>
+    public required string CurrentVersion { get; init; }
+
+    /// <summary>
+    /// Gets the latest stable version available on NuGet, or null if unable to determine.
+    /// </summary>
+    public string? LatestStableVersion { get; init; }
+
+    /// <summary>
+    /// Gets the latest pre-release version available on NuGet, or null if unable to determine.
+    /// </summary>
+    public string? LatestPreReleaseVersion { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a stable update is available.
+    /// </summary>
+    public bool StableUpdateAvailable { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a pre-release update is available.
+    /// </summary>
+    public bool PreReleaseUpdateAvailable { get; init; }
+
+    /// <summary>
+    /// Gets the command to run to update the PPDS CLI, or null if already up-to-date.
+    /// </summary>
+    public string? UpdateCommand { get; init; }
+
+    /// <summary>
+    /// Gets the timestamp when this check was performed.
+    /// </summary>
+    public DateTimeOffset CheckedAt { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether any update (stable or pre-release) is available.
+    /// </summary>
+    [JsonIgnore]
+    public bool UpdateAvailable => StableUpdateAvailable || PreReleaseUpdateAvailable;
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -161,8 +161,31 @@ public sealed class UpdateCheckService : IUpdateCheckService
     /// <inheritdoc/>
     public void RefreshCacheInBackgroundIfStale(string currentVersion)
     {
-        // Implemented in Task 6
-        throw new NotImplementedException();
+        try
+        {
+            // Check cache freshness synchronously before spawning a task
+            var cached = GetCachedResult();
+            if (cached is not null)
+                return; // Cache is fresh — no refresh needed
+
+            // Fire-and-forget: no await, no CancellationToken (R2)
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await CheckAsync(currentVersion, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort — never surface to caller
+                }
+            });
+        }
+        catch
+        {
+            // Swallow errors in freshness check
+        }
     }
 
     /// <inheritdoc/>

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using PPDS.Cli.Commands;
+using PPDS.Cli.Infrastructure.Errors;
 
 namespace PPDS.Cli.Services.UpdateCheck;
 
@@ -33,12 +36,14 @@ public sealed class UpdateCheckService : IUpdateCheckService
 
     private readonly HttpMessageHandler? _handler;
     private readonly string _cachePath;
+    private readonly string _statusPath;
+    private readonly string _lockPath;
 
     /// <summary>
     /// Initializes the service for production use with default HTTP and cache path.
     /// </summary>
     public UpdateCheckService()
-        : this(handler: null, cachePath: null)
+        : this(handler: null, cachePath: null, statusPath: null)
     {
     }
 
@@ -53,13 +58,21 @@ public sealed class UpdateCheckService : IUpdateCheckService
     /// Optional full path to the cache JSON file.
     /// Pass <see langword="null"/> to use the default <c>~/.ppds/update-check.json</c>.
     /// </param>
-    public UpdateCheckService(HttpMessageHandler? handler = null, string? cachePath = null)
+    /// <param name="statusPath">
+    /// Optional full path to the update status JSON file.
+    /// Pass <see langword="null"/> to use the default <c>~/.ppds/update-status.json</c>.
+    /// </param>
+    public UpdateCheckService(
+        HttpMessageHandler? handler = null,
+        string? cachePath = null,
+        string? statusPath = null)
     {
         _handler = handler;
-        _cachePath = cachePath ?? Path.Combine(
-            System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
-            ".ppds",
-            "update-check.json");
+        var ppdsDir = Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".ppds");
+        _cachePath = cachePath ?? Path.Combine(ppdsDir, "update-check.json");
+        _statusPath = statusPath ?? Path.Combine(ppdsDir, "update-status.json");
+        _lockPath = Path.Combine(ppdsDir, "update.lock");
     }
 
     /// <inheritdoc/>
@@ -192,10 +205,116 @@ public sealed class UpdateCheckService : IUpdateCheckService
     }
 
     /// <inheritdoc/>
-    public Task<UpdateResult> UpdateAsync(UpdateChannel channel, CancellationToken cancellationToken = default)
+    public async Task<UpdateResult> UpdateAsync(
+        UpdateChannel channel,
+        CancellationToken cancellationToken = default)
     {
-        // Implemented in Task 10
-        throw new NotImplementedException();
+        // Guard: check for existing update-in-progress (AC-52)
+        if (File.Exists(_lockPath))
+        {
+            try
+            {
+                var pidStr = File.ReadAllText(_lockPath).Trim();
+                if (int.TryParse(pidStr, out var pid))
+                {
+                    try
+                    {
+                        using var proc = Process.GetProcessById(pid);
+                        // Process still running — update in progress
+                        return new UpdateResult
+                        {
+                            Success = false,
+                            ErrorMessage = "An update is already in progress. Try again later."
+                        };
+                    }
+                    catch (ArgumentException)
+                    {
+                        // PID doesn't exist — stale lock, clean up
+                        File.Delete(_lockPath);
+                    }
+                }
+                else
+                {
+                    File.Delete(_lockPath); // corrupt lock
+                }
+            }
+            catch
+            {
+                // Ignore lock file read errors
+            }
+        }
+
+        // Step 1: Determine target version
+        var cached = GetCachedResult();
+        if (cached is null)
+        {
+            cached = await CheckAsync(
+                ErrorOutput.Version, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (cached is null)
+        {
+            throw new PpdsException(
+                ErrorCodes.UpdateCheck.NetworkError,
+                "Cannot determine latest version. Check your network connection.");
+        }
+
+        if (!cached.StableUpdateAvailable && !cached.PreReleaseUpdateAvailable)
+        {
+            return new UpdateResult
+            {
+                Success = true,
+                ErrorMessage = "Already up to date.",
+                InstalledVersion = cached.CurrentVersion
+            };
+        }
+
+        // Step 2: Detect install type
+        if (!IsGlobalToolInstall())
+        {
+            return new UpdateResult
+            {
+                IsNonGlobalInstall = true,
+                ManualCommand = "dotnet tool update PPDS.Cli",
+                ErrorMessage = "PPDS is installed as a local tool. Update your tool manifest manually."
+            };
+        }
+
+        // Step 3: Determine command based on channel
+        var usePreRelease = channel switch
+        {
+            UpdateChannel.Stable => false,
+            UpdateChannel.PreRelease => true,
+            UpdateChannel.Current => NuGetVersion.TryParse(
+                cached.CurrentVersion, out var cv) && cv!.IsOddMinor,
+            _ => false
+        };
+
+        var targetVersion = usePreRelease
+            ? cached.LatestPreReleaseVersion
+            : cached.LatestStableVersion;
+
+        var updateArgs = usePreRelease
+            ? "tool update PPDS.Cli -g --prerelease"
+            : "tool update PPDS.Cli -g";
+
+        // Step 4: Resolve dotnet path (S2: no shell: true on user input)
+        var dotnetPath = ResolveDotnetPath();
+        if (dotnetPath is null)
+        {
+            throw new PpdsException(
+                ErrorCodes.UpdateCheck.DotnetNotFound,
+                "Cannot locate the dotnet runtime. Run manually: dotnet tool update PPDS.Cli -g");
+        }
+
+        // Step 5: Spawn detached update via wrapper script
+        SpawnDetachedUpdate(dotnetPath, updateArgs, targetVersion);
+
+        return new UpdateResult
+        {
+            Success = true,
+            InstalledVersion = targetVersion
+        };
     }
 
     #region Private Helpers
@@ -262,6 +381,115 @@ public sealed class UpdateCheckService : IUpdateCheckService
     {
         NuGetVersion.TryParse(v, out var parsed);
         return parsed;
+    }
+
+    /// <summary>
+    /// Determines whether the CLI is running as a global dotnet tool by checking
+    /// if <see cref="AppContext.BaseDirectory"/> resides under <c>~/.dotnet/tools</c>.
+    /// </summary>
+    internal static bool IsGlobalToolInstall()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var dotnetToolsDir = Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
+            ".dotnet", "tools");
+        return baseDir.StartsWith(dotnetToolsDir, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the full path to the <c>dotnet</c> executable.
+    /// Uses <see cref="System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory"/>
+    /// and navigates up 3 levels (avoiding <c>Process.MainModule</c> which returns the apphost shim).
+    /// Falls back to <c>DOTNET_ROOT</c> and platform defaults.
+    /// </summary>
+    internal static string? ResolveDotnetPath()
+    {
+        var dotnetExeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+
+        // Primary: navigate up from runtime directory
+        try
+        {
+#pragma warning disable SYSLIB0019 // RuntimeEnvironment is obsolete but reliable for this purpose
+            var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+#pragma warning restore SYSLIB0019
+            var dotnetFromRuntime = Path.GetFullPath(
+                Path.Combine(runtimeDir, "..", "..", "..", dotnetExeName));
+            if (File.Exists(dotnetFromRuntime))
+                return dotnetFromRuntime;
+        }
+        catch
+        {
+            // Fall through to alternatives
+        }
+
+        // Fallback: DOTNET_ROOT
+        var dotnetRoot = System.Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        if (!string.IsNullOrEmpty(dotnetRoot))
+        {
+            var dotnetExe = Path.Combine(dotnetRoot, dotnetExeName);
+            if (File.Exists(dotnetExe))
+                return dotnetExe;
+        }
+
+        // Platform defaults
+        if (OperatingSystem.IsWindows())
+        {
+            var pf = Path.Combine(
+                System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFiles),
+                "dotnet", "dotnet.exe");
+            if (File.Exists(pf)) return pf;
+        }
+        else
+        {
+            foreach (var p in new[] { "/usr/local/share/dotnet/dotnet", "/usr/share/dotnet/dotnet" })
+                if (File.Exists(p)) return p;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Writes a platform-specific wrapper script and spawns it as a detached process.
+    /// The script waits for the parent PID to exit, then runs dotnet tool update.
+    /// </summary>
+    /// <remarks>
+    /// S2 justification: We use <c>cmd.exe /c</c> (Windows) or <c>/bin/sh</c> (Unix) to execute
+    /// a script that we generate ourselves. The shell is not interpreting user input — the script
+    /// content is fully controlled by this code, and the dotnet invocation uses a fully qualified path.
+    /// </remarks>
+    private void SpawnDetachedUpdate(string dotnetPath, string updateArgs, string? targetVersion)
+    {
+        var parentPid = System.Environment.ProcessId;
+        var scriptPath = UpdateScriptWriter.WriteScript(
+            dotnetPath, updateArgs, targetVersion, parentPid, _statusPath, _lockPath);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            Arguments = OperatingSystem.IsWindows()
+                ? $"/c \"{scriptPath}\""
+                : scriptPath,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false
+        };
+
+        try
+        {
+            var process = Process.Start(psi);
+            if (process is not null)
+            {
+                File.WriteAllText(_lockPath, process.Id.ToString());
+                process.Dispose(); // R1: don't hold the process handle
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new PpdsException(
+                ErrorCodes.UpdateCheck.UpdateFailed,
+                $"Failed to start update process: {ex.Message}");
+        }
     }
 
     #endregion

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -132,17 +132,14 @@ public sealed class UpdateCheckService : IUpdateCheckService
     }
 
     /// <inheritdoc/>
-    public async Task<UpdateCheckResult?> GetCachedResultAsync(
-        CancellationToken cancellationToken = default)
+    public UpdateCheckResult? GetCachedResult()
     {
         try
         {
             if (!File.Exists(_cachePath))
                 return null;
 
-            var json = await File.ReadAllTextAsync(_cachePath, cancellationToken)
-                .ConfigureAwait(false);
-
+            var json = File.ReadAllText(_cachePath);
             var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
 
             if (result is null)
@@ -159,6 +156,20 @@ public sealed class UpdateCheckService : IUpdateCheckService
             // Corrupt, missing, or inaccessible cache is not an error condition
             return null;
         }
+    }
+
+    /// <inheritdoc/>
+    public void RefreshCacheInBackgroundIfStale(string currentVersion)
+    {
+        // Implemented in Task 6
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc/>
+    public Task<UpdateResult> UpdateAsync(UpdateChannel channel, CancellationToken cancellationToken = default)
+    {
+        // Implemented in Task 10
+        throw new NotImplementedException();
     }
 
     #region Private Helpers

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -21,7 +21,8 @@ public sealed class UpdateCheckService : IUpdateCheckService
     private const string UpdateCommand = "dotnet tool update PPDS.Cli -g";
     private const string UpdateCommandPreRelease = "dotnet tool update PPDS.Cli -g --prerelease";
 
-    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+    /// <summary>How long a cached result is considered fresh. Shared with <see cref="Infrastructure.StartupUpdateNotifier"/>.</summary>
+    internal static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
     private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(10);
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -84,6 +84,8 @@ public sealed class UpdateCheckService : IUpdateCheckService
 
         var current = TryParseVersion(currentVersion);
 
+        // Always populate both versions regardless of user's track (AC-19).
+        // Track-based filtering is a presentation concern (notifier/command).
         var latestStable = versions
             .Select(TryParseVersion)
             .Where(v => v is not null && !v.IsPreRelease)
@@ -96,24 +98,24 @@ public sealed class UpdateCheckService : IUpdateCheckService
             .OrderDescending()
             .FirstOrDefault();
 
+        // Honestly computed — no track filtering at the data model level
         var stableUpdateAvailable = latestStable is not null
             && (current is null || latestStable > current);
 
         var preReleaseUpdateAvailable = latestPreRelease is not null
-            && !stableUpdateAvailable
             && (current is null || latestPreRelease > current);
 
-        // Determine command: stable takes priority; fall back to pre-release only if
-        // no stable update is available and the user is already on a pre-release track.
+        // Primary command: stable if available, else pre-release
         string? command = null;
         if (stableUpdateAvailable)
-        {
             command = UpdateCommand;
-        }
         else if (preReleaseUpdateAvailable)
-        {
             command = UpdateCommandPreRelease;
-        }
+
+        // Pre-release command: populated when a pre-release update exists
+        string? preReleaseUpdateCommand = preReleaseUpdateAvailable
+            ? UpdateCommandPreRelease
+            : null;
 
         var result = new UpdateCheckResult
         {
@@ -123,6 +125,7 @@ public sealed class UpdateCheckService : IUpdateCheckService
             StableUpdateAvailable = stableUpdateAvailable,
             PreReleaseUpdateAvailable = preReleaseUpdateAvailable,
             UpdateCommand = command,
+            PreReleaseUpdateCommand = preReleaseUpdateCommand,
             CheckedAt = DateTimeOffset.UtcNow
         };
 

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateCheckService.cs
@@ -1,0 +1,241 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Application service for checking available updates to the PPDS CLI via the NuGet flat-container API.
+/// </summary>
+/// <remarks>
+/// <para>Results are cached for 24 hours at <c>~/.ppds/update-check.json</c>.</para>
+/// <para>
+/// The constructor accepts optional <paramref name="handler"/> and <paramref name="cachePath"/>
+/// parameters to facilitate testing without live network or filesystem side-effects.
+/// </para>
+/// </remarks>
+public sealed class UpdateCheckService : IUpdateCheckService
+{
+    private const string NuGetIndexUrl =
+        "https://api.nuget.org/v3-flatcontainer/ppds.cli/index.json";
+
+    private const string UpdateCommand = "dotnet tool update PPDS.Cli -g";
+    private const string UpdateCommandPreRelease = "dotnet tool update PPDS.Cli -g --prerelease";
+
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+    private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(10);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpMessageHandler? _handler;
+    private readonly string _cachePath;
+
+    /// <summary>
+    /// Initializes the service for production use with default HTTP and cache path.
+    /// </summary>
+    public UpdateCheckService()
+        : this(handler: null, cachePath: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes the service with optional overrides for testing.
+    /// </summary>
+    /// <param name="handler">
+    /// Optional <see cref="HttpMessageHandler"/> for mocking HTTP calls.
+    /// Pass <see langword="null"/> to use the default handler.
+    /// </param>
+    /// <param name="cachePath">
+    /// Optional full path to the cache JSON file.
+    /// Pass <see langword="null"/> to use the default <c>~/.ppds/update-check.json</c>.
+    /// </param>
+    public UpdateCheckService(HttpMessageHandler? handler = null, string? cachePath = null)
+    {
+        _handler = handler;
+        _cachePath = cachePath ?? Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile),
+            ".ppds",
+            "update-check.json");
+    }
+
+    /// <inheritdoc/>
+    public async Task<UpdateCheckResult?> CheckAsync(
+        string currentVersion,
+        CancellationToken cancellationToken = default)
+    {
+        List<string>? versions;
+
+        try
+        {
+            versions = await FetchVersionsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Network or parse failures must not propagate to callers
+            return null;
+        }
+
+        if (versions is null)
+            return null;
+
+        var current = TryParseVersion(currentVersion);
+
+        var latestStable = versions
+            .Select(TryParseVersion)
+            .Where(v => v is not null && !v.IsPreRelease)
+            .OrderDescending()
+            .FirstOrDefault();
+
+        var latestPreRelease = versions
+            .Select(TryParseVersion)
+            .Where(v => v is not null && v.IsPreRelease)
+            .OrderDescending()
+            .FirstOrDefault();
+
+        var stableUpdateAvailable = latestStable is not null
+            && (current is null || latestStable > current);
+
+        var preReleaseUpdateAvailable = latestPreRelease is not null
+            && !stableUpdateAvailable
+            && (current is null || latestPreRelease > current);
+
+        // Determine command: stable takes priority; fall back to pre-release only if
+        // no stable update is available and the user is already on a pre-release track.
+        string? command = null;
+        if (stableUpdateAvailable)
+        {
+            command = UpdateCommand;
+        }
+        else if (preReleaseUpdateAvailable)
+        {
+            command = UpdateCommandPreRelease;
+        }
+
+        var result = new UpdateCheckResult
+        {
+            CurrentVersion = currentVersion,
+            LatestStableVersion = latestStable?.ToString(),
+            LatestPreReleaseVersion = latestPreRelease?.ToString(),
+            StableUpdateAvailable = stableUpdateAvailable,
+            PreReleaseUpdateAvailable = preReleaseUpdateAvailable,
+            UpdateCommand = command,
+            CheckedAt = DateTimeOffset.UtcNow
+        };
+
+        await WriteCacheAsync(result, cancellationToken).ConfigureAwait(false);
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<UpdateCheckResult?> GetCachedResultAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (!File.Exists(_cachePath))
+                return null;
+
+            var json = await File.ReadAllTextAsync(_cachePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            var result = JsonSerializer.Deserialize<UpdateCheckResult>(json, JsonOptions);
+
+            if (result is null)
+                return null;
+
+            // Honour TTL
+            if (DateTimeOffset.UtcNow - result.CheckedAt > CacheTtl)
+                return null;
+
+            return result;
+        }
+        catch
+        {
+            // Corrupt, missing, or inaccessible cache is not an error condition
+            return null;
+        }
+    }
+
+    #region Private Helpers
+
+    /// <summary>
+    /// Fetches version strings from the NuGet flat-container index.
+    /// Returns <see langword="null"/> on non-success HTTP status.
+    /// Throws on network/parse errors (caller handles).
+    /// </summary>
+    private async Task<List<string>?> FetchVersionsAsync(CancellationToken cancellationToken)
+    {
+        // R1: dispose HttpClient after each call — do not hold as a field
+        using var client = _handler is not null
+            ? new HttpClient(_handler, disposeHandler: false)
+            : new HttpClient();
+
+        client.Timeout = HttpTimeout;
+
+        using var response = await client
+            .GetAsync(NuGetIndexUrl, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var json = await response.Content
+            .ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var envelope = JsonSerializer.Deserialize<NuGetVersionsEnvelope>(json, JsonOptions);
+        return envelope?.Versions;
+    }
+
+    /// <summary>
+    /// Persists <paramref name="result"/> to the cache file using an atomic write.
+    /// Failures are silently swallowed — cache write errors must not surface to callers.
+    /// </summary>
+    private async Task WriteCacheAsync(
+        UpdateCheckResult result,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_cachePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+
+            var json = JsonSerializer.Serialize(result, JsonOptions);
+            var tempPath = _cachePath + ".tmp";
+
+            await File.WriteAllTextAsync(tempPath, json, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Atomic replace (prevents corrupt reads if the process exits mid-write)
+            File.Move(tempPath, _cachePath, overwrite: true);
+        }
+        catch
+        {
+            // Cache write failure is not fatal
+        }
+    }
+
+    private static NuGetVersion? TryParseVersion(string? v)
+    {
+        NuGetVersion.TryParse(v, out var parsed);
+        return parsed;
+    }
+
+    #endregion
+
+    #region API Response Model
+
+    /// <summary>Response envelope from <c>https://api.nuget.org/v3-flatcontainer/{id}/index.json</c>.</summary>
+    private sealed class NuGetVersionsEnvelope
+    {
+        [JsonPropertyName("versions")]
+        public List<string>? Versions { get; init; }
+    }
+
+    #endregion
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateResult.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateResult.cs
@@ -1,0 +1,26 @@
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Represents the outcome of a self-update attempt.
+/// </summary>
+/// <remarks>
+/// Expected outcomes (non-global install, already current) are returned as results.
+/// Unexpected failures (dotnet not found, spawn failed) throw <see cref="Infrastructure.Errors.PpdsException"/>.
+/// </remarks>
+public sealed record UpdateResult
+{
+    /// <summary>Whether the update was successfully initiated.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>The version being installed, if known.</summary>
+    public string? InstalledVersion { get; init; }
+
+    /// <summary>Error message for non-fatal failures.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>True when PPDS is installed as a local tool (not global).</summary>
+    public bool IsNonGlobalInstall { get; init; }
+
+    /// <summary>Manual update command to show when automation isn't possible.</summary>
+    public string? ManualCommand { get; init; }
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateScriptWriter.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateScriptWriter.cs
@@ -1,0 +1,78 @@
+namespace PPDS.Cli.Services.UpdateCheck;
+
+/// <summary>
+/// Generates platform-specific wrapper scripts for detached self-update.
+/// The script waits for the parent ppds process to exit (unlocking .store DLLs),
+/// then runs dotnet tool update, captures the result, and writes a status file.
+/// </summary>
+internal static class UpdateScriptWriter
+{
+    public static string WriteScript(
+        string dotnetPath, string updateArgs, string? targetVersion,
+        int parentPid, string statusPath, string lockPath)
+    {
+        var scriptDir = Path.GetTempPath();
+        var scriptPath = OperatingSystem.IsWindows()
+            ? Path.Combine(scriptDir, $"ppds-update-{Guid.NewGuid():N}.cmd")
+            : Path.Combine(scriptDir, $"ppds-update-{Guid.NewGuid():N}.sh");
+
+        var content = OperatingSystem.IsWindows()
+            ? GenerateWindowsScript(dotnetPath, updateArgs, targetVersion, parentPid, statusPath, lockPath, scriptPath)
+            : GenerateUnixScript(dotnetPath, updateArgs, targetVersion, parentPid, statusPath, lockPath, scriptPath);
+
+        File.WriteAllText(scriptPath, content);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(scriptPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        return scriptPath;
+    }
+
+    private static string GenerateWindowsScript(
+        string dotnetPath, string updateArgs, string? targetVersion,
+        int parentPid, string statusPath, string lockPath, string scriptPath)
+    {
+        var safeTarget = targetVersion ?? "unknown";
+        // Use tasklist to poll for parent PID exit, then run update.
+        // $$""" means {{ }} is interpolation, single { } are literal.
+        return $$"""
+            @echo off
+            :wait
+            tasklist /FI "PID eq {{parentPid}}" 2>NUL | find /I "{{parentPid}}" >NUL
+            if not errorlevel 1 (
+                timeout /t 1 /nobreak >NUL
+                goto wait
+            )
+            "{{dotnetPath}}" {{updateArgs}}
+            set EXIT_CODE=%ERRORLEVEL%
+            if %EXIT_CODE% EQU 0 (
+                echo {"success":true,"exitCode":0,"targetVersion":"{{safeTarget}}","timestamp":"%DATE%T%TIME%"} > "{{statusPath}}"
+            ) else (
+                echo {"success":false,"exitCode":%EXIT_CODE%,"targetVersion":"{{safeTarget}}","timestamp":"%DATE%T%TIME%"} > "{{statusPath}}"
+            )
+            del "{{lockPath}}" 2>NUL
+            del "%~f0" 2>NUL
+            """;
+    }
+
+    private static string GenerateUnixScript(
+        string dotnetPath, string updateArgs, string? targetVersion,
+        int parentPid, string statusPath, string lockPath, string scriptPath)
+    {
+        var safeTarget = targetVersion ?? "unknown";
+        // $$""" means {{ }} is interpolation, single { } are literal.
+        return $$"""
+            #!/bin/sh
+            while kill -0 {{parentPid}} 2>/dev/null; do sleep 1; done
+            "{{dotnetPath}}" {{updateArgs}}
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+                printf '{"success":true,"exitCode":0,"targetVersion":"{{safeTarget}}","timestamp":"%s"}' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "{{statusPath}}"
+            else
+                printf '{"success":false,"exitCode":%d,"targetVersion":"{{safeTarget}}","timestamp":"%s"}' "$EXIT_CODE" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "{{statusPath}}"
+            fi
+            rm -f "{{lockPath}}" "{{scriptPath}}"
+            """;
+    }
+}

--- a/src/PPDS.Cli/Services/UpdateCheck/UpdateScriptWriter.cs
+++ b/src/PPDS.Cli/Services/UpdateCheck/UpdateScriptWriter.cs
@@ -47,9 +47,9 @@ internal static class UpdateScriptWriter
             "{{dotnetPath}}" {{updateArgs}}
             set EXIT_CODE=%ERRORLEVEL%
             if %EXIT_CODE% EQU 0 (
-                echo {"success":true,"exitCode":0,"targetVersion":"{{safeTarget}}","timestamp":"%DATE%T%TIME%"} > "{{statusPath}}"
+                echo {"success":true,"exitCode":0,"targetVersion":"{{safeTarget}}"} > "{{statusPath}}"
             ) else (
-                echo {"success":false,"exitCode":%EXIT_CODE%,"targetVersion":"{{safeTarget}}","timestamp":"%DATE%T%TIME%"} > "{{statusPath}}"
+                echo {"success":false,"exitCode":%EXIT_CODE%,"targetVersion":"{{safeTarget}}"} > "{{statusPath}}"
             )
             del "{{lockPath}}" 2>NUL
             del "%~f0" 2>NUL

--- a/tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
@@ -1,0 +1,60 @@
+using System.CommandLine;
+using PPDS.Cli.Commands;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands;
+
+/// <summary>
+/// Tests for the structure of the 'version' command.
+/// </summary>
+public class VersionCommandTests
+{
+    private readonly Command _command;
+
+    public VersionCommandTests()
+    {
+        _command = VersionCommand.Create();
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("version", _command.Name);
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithDescription()
+    {
+        Assert.NotNull(_command.Description);
+        Assert.NotEmpty(_command.Description);
+    }
+
+    [Fact]
+    public void Create_HasNoSubcommands()
+    {
+        // version is a standalone command, not a command group
+        Assert.Empty(_command.Subcommands);
+    }
+
+    [Fact]
+    public void Create_HasCheckOption()
+    {
+        var checkOption = _command.Options.FirstOrDefault(o => o.Name == "--check");
+        Assert.NotNull(checkOption);
+    }
+
+    [Fact]
+    public void Create_CheckOption_IsNotRequired()
+    {
+        var checkOption = _command.Options.FirstOrDefault(o => o.Name == "--check");
+        Assert.NotNull(checkOption);
+        Assert.False(checkOption!.Required);
+    }
+
+    [Fact]
+    public void Create_HasAction()
+    {
+        // The command should have a handler set
+        Assert.NotNull(_command.Action);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/VersionCommandTests.cs
@@ -57,4 +57,32 @@ public class VersionCommandTests
         // The command should have a handler set
         Assert.NotNull(_command.Action);
     }
+
+    [Fact]
+    public void VersionCommand_HasUpdateOption()
+    {
+        var command = VersionCommand.Create();
+        Assert.Contains(command.Options, o => o.Name == "--update");
+    }
+
+    [Fact]
+    public void VersionCommand_HasStableOption()
+    {
+        var command = VersionCommand.Create();
+        Assert.Contains(command.Options, o => o.Name == "--stable");
+    }
+
+    [Fact]
+    public void VersionCommand_HasPreReleaseOption()
+    {
+        var command = VersionCommand.Create();
+        Assert.Contains(command.Options, o => o.Name == "--prerelease");
+    }
+
+    [Fact]
+    public void VersionCommand_HasYesOption()
+    {
+        var command = VersionCommand.Create();
+        Assert.Contains(command.Options, o => o.Name == "--yes");
+    }
 }

--- a/tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
@@ -1,219 +1,171 @@
-using System.Text.Json;
-using FluentAssertions;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Services.UpdateCheck;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Infrastructure;
 
-/// <summary>
-/// Unit tests for <see cref="StartupUpdateNotifier"/>.
-/// </summary>
-public class StartupUpdateNotifierTests : IDisposable
+public sealed class StartupUpdateNotifierTests
 {
-    private readonly string _tempPath;
-    private readonly string _cacheFile;
+    #region FormatNotification
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    [Fact]
+    public void FormatNotification_NullResult_ReturnsNull()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
-    public StartupUpdateNotifierTests()
-    {
-        _tempPath = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempPath);
-        _cacheFile = Path.Combine(_tempPath, "update-check.json");
+        Assert.Null(StartupUpdateNotifier.FormatNotification(null));
     }
 
-    public void Dispose()
+    [Fact]
+    public void FormatNotification_NoUpdateAvailable_ReturnsNull()
     {
-        if (Directory.Exists(_tempPath))
-        {
-            try { Directory.Delete(_tempPath, recursive: true); }
-            catch { /* ignore cleanup errors */ }
-        }
+        var result = MakeResult(stableUpdate: false, preReleaseUpdate: false);
+        Assert.Null(StartupUpdateNotifier.FormatNotification(result));
     }
 
-    #region Helpers
-
-    private void WriteCacheFile(UpdateCheckResult result)
+    [Fact]
+    public void FormatNotification_StableOnlyUpdate_ReturnsSingleLine()
     {
-        var json = JsonSerializer.Serialize(result, JsonOptions);
-        File.WriteAllText(_cacheFile, json);
+        var result = MakeResult(
+            currentVersion: "0.4.0", // stable track
+            stableUpdate: true,
+            preReleaseUpdate: false,
+            latestStable: "0.6.0",
+            updateCommand: "dotnet tool update PPDS.Cli -g");
+
+        var message = StartupUpdateNotifier.FormatNotification(result);
+
+        Assert.NotNull(message);
+        Assert.Contains("0.6.0", message);
+        Assert.Contains("dotnet tool update PPDS.Cli -g", message);
+        Assert.DoesNotContain("\n", message!.Trim());
     }
 
-    private static UpdateCheckResult MakeResult(
-        bool stableUpdateAvailable = false,
-        bool preReleaseUpdateAvailable = false,
-        string? latestStableVersion = null,
-        string? latestPreReleaseVersion = null,
-        string? updateCommand = null,
-        DateTimeOffset? checkedAt = null)
+    [Fact]
+    public void FormatNotification_StableUser_HidesPreRelease()
     {
-        return new UpdateCheckResult
-        {
-            CurrentVersion = "0.5.0",
-            LatestStableVersion = latestStableVersion,
-            LatestPreReleaseVersion = latestPreReleaseVersion,
-            StableUpdateAvailable = stableUpdateAvailable,
-            PreReleaseUpdateAvailable = preReleaseUpdateAvailable,
-            UpdateCommand = updateCommand,
-            CheckedAt = checkedAt ?? DateTimeOffset.UtcNow
-        };
+        // Stable user (even minor) should only see stable in startup notification
+        var result = MakeResult(
+            currentVersion: "0.4.0", // even minor = stable track
+            stableUpdate: true,
+            preReleaseUpdate: true,
+            latestStable: "0.6.0",
+            latestPreRelease: "0.7.0-alpha.1",
+            updateCommand: "dotnet tool update PPDS.Cli -g",
+            preReleaseUpdateCommand: "dotnet tool update PPDS.Cli -g --prerelease");
+
+        var message = StartupUpdateNotifier.FormatNotification(result);
+
+        Assert.NotNull(message);
+        Assert.Contains("0.6.0", message);
+        // Stable user should NOT see pre-release in startup notification
+        Assert.DoesNotContain("0.7.0-alpha.1", message);
+        Assert.DoesNotContain("\n", message!.Trim());
+    }
+
+    [Fact]
+    public void FormatNotification_PreReleaseUser_BothUpdatesAvailable_ReturnsTwoLines()
+    {
+        // Pre-release user (odd minor) should see both
+        var result = MakeResult(
+            currentVersion: "0.5.0-beta.1", // odd minor = pre-release track
+            stableUpdate: true,
+            preReleaseUpdate: true,
+            latestStable: "0.6.0",
+            latestPreRelease: "0.7.0-alpha.1",
+            updateCommand: "dotnet tool update PPDS.Cli -g",
+            preReleaseUpdateCommand: "dotnet tool update PPDS.Cli -g --prerelease");
+
+        var message = StartupUpdateNotifier.FormatNotification(result);
+
+        Assert.NotNull(message);
+        var lines = message!.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("0.6.0", lines[0]);
+        Assert.Contains("0.7.0-alpha.1", lines[1]);
+    }
+
+    [Fact]
+    public void FormatNotification_PreReleaseOnlyUpdate_ReturnsSingleLine()
+    {
+        var result = MakeResult(
+            currentVersion: "0.5.0-beta.1",
+            stableUpdate: false,
+            preReleaseUpdate: true,
+            latestPreRelease: "0.7.0-alpha.1",
+            updateCommand: "dotnet tool update PPDS.Cli -g --prerelease");
+
+        var message = StartupUpdateNotifier.FormatNotification(result);
+
+        Assert.NotNull(message);
+        Assert.Contains("0.7.0-alpha.1", message);
+        Assert.DoesNotContain("\n", message!.Trim());
     }
 
     #endregion
 
-    // ─── GetNotificationMessage: update available ──────────────────────────────
+    #region ShouldShow
 
     [Fact]
-    public void GetNotificationMessage_StableUpdateAvailable_ReturnsMessage()
+    public void ShouldShow_EmptyArgs_ReturnsTrue()
     {
-        WriteCacheFile(MakeResult(
-            stableUpdateAvailable: true,
-            latestStableVersion: "0.6.0",
-            updateCommand: "dotnet tool update PPDS.Cli -g"));
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().NotBeNull();
-        message.Should().Contain("0.6.0");
-        message.Should().Contain("dotnet tool update PPDS.Cli -g");
-    }
-
-    [Fact]
-    public void GetNotificationMessage_PreReleaseUpdateAvailable_ReturnsMessage()
-    {
-        WriteCacheFile(MakeResult(
-            preReleaseUpdateAvailable: true,
-            latestPreReleaseVersion: "0.6.0-beta.1",
-            updateCommand: "dotnet tool update PPDS.Cli -g --prerelease"));
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().NotBeNull();
-        message.Should().Contain("0.6.0-beta.1");
-        message.Should().Contain("dotnet tool update PPDS.Cli -g --prerelease");
-    }
-
-    // ─── GetNotificationMessage: no update ────────────────────────────────────
-
-    [Fact]
-    public void GetNotificationMessage_NoUpdateAvailable_ReturnsNull()
-    {
-        WriteCacheFile(MakeResult(
-            stableUpdateAvailable: false,
-            preReleaseUpdateAvailable: false));
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_NoCacheFile_ReturnsNull()
-    {
-        // _cacheFile does not exist
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_ExpiredCache_ReturnsNull()
-    {
-        WriteCacheFile(MakeResult(
-            stableUpdateAvailable: true,
-            latestStableVersion: "0.6.0",
-            updateCommand: "dotnet tool update PPDS.Cli -g",
-            checkedAt: DateTimeOffset.UtcNow.AddHours(-25)));
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().BeNull();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_CorruptCacheFile_ReturnsNull()
-    {
-        File.WriteAllText(_cacheFile, "{ not valid json {{{{");
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().BeNull();
-    }
-
-    // ─── GetNotificationMessage: never throws ─────────────────────────────────
-
-    [Fact]
-    public void GetNotificationMessage_InvalidPath_NeverThrows()
-    {
-        var act = () => StartupUpdateNotifier.GetNotificationMessage(
-            cachePath: @"Z:\nonexistent\very\deep\path\update-check.json");
-
-        act.Should().NotThrow();
-    }
-
-    [Fact]
-    public void GetNotificationMessage_NullPath_NeverThrows()
-    {
-        // With a null cachePath it will fall back to the default path which may not exist — must not throw
-        var act = () => StartupUpdateNotifier.GetNotificationMessage(cachePath: null);
-
-        act.Should().NotThrow();
-    }
-
-    // ─── ShouldShow ───────────────────────────────────────────────────────────
-
-    [Fact]
-    public void ShouldShow_NoArgs_ReturnsTrue()
-    {
-        StartupUpdateNotifier.ShouldShow(Array.Empty<string>()).Should().BeTrue();
+        Assert.True(StartupUpdateNotifier.ShouldShow(Array.Empty<string>()));
     }
 
     [Fact]
     public void ShouldShow_NormalArgs_ReturnsTrue()
     {
-        StartupUpdateNotifier.ShouldShow(new[] { "env", "list" }).Should().BeTrue();
+        Assert.True(StartupUpdateNotifier.ShouldShow(new[] { "query", "sql" }));
     }
 
     [Fact]
-    public void ShouldShow_QuietLongFlag_ReturnsFalse()
+    public void ShouldShow_QuietLong_ReturnsFalse()
     {
-        StartupUpdateNotifier.ShouldShow(new[] { "--quiet" }).Should().BeFalse();
+        Assert.False(StartupUpdateNotifier.ShouldShow(new[] { "--quiet" }));
     }
 
     [Fact]
-    public void ShouldShow_QuietShortFlag_ReturnsFalse()
+    public void ShouldShow_QuietShort_ReturnsFalse()
     {
-        StartupUpdateNotifier.ShouldShow(new[] { "-q" }).Should().BeFalse();
+        Assert.False(StartupUpdateNotifier.ShouldShow(new[] { "-q" }));
     }
 
     [Fact]
-    public void ShouldShow_QuietFlagAmongOtherArgs_ReturnsFalse()
+    public void ShouldShow_HelpFlag_ReturnsTrue()
     {
-        StartupUpdateNotifier.ShouldShow(new[] { "env", "list", "--quiet" }).Should().BeFalse();
+        // --help suppression handled by Program.cs SkipVersionHeaderArgs, not ShouldShow
+        Assert.True(StartupUpdateNotifier.ShouldShow(new[] { "--help" }));
     }
 
     [Fact]
-    public void ShouldShow_QuietShortFlagAmongOtherArgs_ReturnsFalse()
+    public void ShouldShow_QuietAmongOtherArgs_ReturnsFalse()
     {
-        StartupUpdateNotifier.ShouldShow(new[] { "env", "list", "-q" }).Should().BeFalse();
+        Assert.False(StartupUpdateNotifier.ShouldShow(new[] { "query", "sql", "--quiet" }));
     }
 
-    // ─── Message format ───────────────────────────────────────────────────────
+    #endregion
 
-    [Fact]
-    public void GetNotificationMessage_Format_ContainsUpdateAvailablePrefix()
+    #region Helpers
+
+    private static UpdateCheckResult MakeResult(
+        string currentVersion = "0.5.0-beta.1",
+        bool stableUpdate = false,
+        bool preReleaseUpdate = false,
+        string? latestStable = null,
+        string? latestPreRelease = null,
+        string? updateCommand = null,
+        string? preReleaseUpdateCommand = null)
     {
-        WriteCacheFile(MakeResult(
-            stableUpdateAvailable: true,
-            latestStableVersion: "0.6.0",
-            updateCommand: "dotnet tool update PPDS.Cli -g"));
-
-        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
-
-        message.Should().StartWith("Update available:");
+        return new UpdateCheckResult
+        {
+            CurrentVersion = currentVersion,
+            LatestStableVersion = latestStable,
+            LatestPreReleaseVersion = latestPreRelease,
+            StableUpdateAvailable = stableUpdate,
+            PreReleaseUpdateAvailable = preReleaseUpdate,
+            UpdateCommand = updateCommand,
+            PreReleaseUpdateCommand = preReleaseUpdateCommand,
+            CheckedAt = DateTimeOffset.UtcNow
+        };
     }
+
+    #endregion
 }

--- a/tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/StartupUpdateNotifierTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using FluentAssertions;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="StartupUpdateNotifier"/>.
+/// </summary>
+public class StartupUpdateNotifierTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _cacheFile;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public StartupUpdateNotifierTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempPath);
+        _cacheFile = Path.Combine(_tempPath, "update-check.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+        {
+            try { Directory.Delete(_tempPath, recursive: true); }
+            catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    #region Helpers
+
+    private void WriteCacheFile(UpdateCheckResult result)
+    {
+        var json = JsonSerializer.Serialize(result, JsonOptions);
+        File.WriteAllText(_cacheFile, json);
+    }
+
+    private static UpdateCheckResult MakeResult(
+        bool stableUpdateAvailable = false,
+        bool preReleaseUpdateAvailable = false,
+        string? latestStableVersion = null,
+        string? latestPreReleaseVersion = null,
+        string? updateCommand = null,
+        DateTimeOffset? checkedAt = null)
+    {
+        return new UpdateCheckResult
+        {
+            CurrentVersion = "0.5.0",
+            LatestStableVersion = latestStableVersion,
+            LatestPreReleaseVersion = latestPreReleaseVersion,
+            StableUpdateAvailable = stableUpdateAvailable,
+            PreReleaseUpdateAvailable = preReleaseUpdateAvailable,
+            UpdateCommand = updateCommand,
+            CheckedAt = checkedAt ?? DateTimeOffset.UtcNow
+        };
+    }
+
+    #endregion
+
+    // ─── GetNotificationMessage: update available ──────────────────────────────
+
+    [Fact]
+    public void GetNotificationMessage_StableUpdateAvailable_ReturnsMessage()
+    {
+        WriteCacheFile(MakeResult(
+            stableUpdateAvailable: true,
+            latestStableVersion: "0.6.0",
+            updateCommand: "dotnet tool update PPDS.Cli -g"));
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().NotBeNull();
+        message.Should().Contain("0.6.0");
+        message.Should().Contain("dotnet tool update PPDS.Cli -g");
+    }
+
+    [Fact]
+    public void GetNotificationMessage_PreReleaseUpdateAvailable_ReturnsMessage()
+    {
+        WriteCacheFile(MakeResult(
+            preReleaseUpdateAvailable: true,
+            latestPreReleaseVersion: "0.6.0-beta.1",
+            updateCommand: "dotnet tool update PPDS.Cli -g --prerelease"));
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().NotBeNull();
+        message.Should().Contain("0.6.0-beta.1");
+        message.Should().Contain("dotnet tool update PPDS.Cli -g --prerelease");
+    }
+
+    // ─── GetNotificationMessage: no update ────────────────────────────────────
+
+    [Fact]
+    public void GetNotificationMessage_NoUpdateAvailable_ReturnsNull()
+    {
+        WriteCacheFile(MakeResult(
+            stableUpdateAvailable: false,
+            preReleaseUpdateAvailable: false));
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_NoCacheFile_ReturnsNull()
+    {
+        // _cacheFile does not exist
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_ExpiredCache_ReturnsNull()
+    {
+        WriteCacheFile(MakeResult(
+            stableUpdateAvailable: true,
+            latestStableVersion: "0.6.0",
+            updateCommand: "dotnet tool update PPDS.Cli -g",
+            checkedAt: DateTimeOffset.UtcNow.AddHours(-25)));
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_CorruptCacheFile_ReturnsNull()
+    {
+        File.WriteAllText(_cacheFile, "{ not valid json {{{{");
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().BeNull();
+    }
+
+    // ─── GetNotificationMessage: never throws ─────────────────────────────────
+
+    [Fact]
+    public void GetNotificationMessage_InvalidPath_NeverThrows()
+    {
+        var act = () => StartupUpdateNotifier.GetNotificationMessage(
+            cachePath: @"Z:\nonexistent\very\deep\path\update-check.json");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetNotificationMessage_NullPath_NeverThrows()
+    {
+        // With a null cachePath it will fall back to the default path which may not exist — must not throw
+        var act = () => StartupUpdateNotifier.GetNotificationMessage(cachePath: null);
+
+        act.Should().NotThrow();
+    }
+
+    // ─── ShouldShow ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShouldShow_NoArgs_ReturnsTrue()
+    {
+        StartupUpdateNotifier.ShouldShow(Array.Empty<string>()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldShow_NormalArgs_ReturnsTrue()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "env", "list" }).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldShow_QuietLongFlag_ReturnsFalse()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "--quiet" }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_QuietShortFlag_ReturnsFalse()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "-q" }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_QuietFlagAmongOtherArgs_ReturnsFalse()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "env", "list", "--quiet" }).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldShow_QuietShortFlagAmongOtherArgs_ReturnsFalse()
+    {
+        StartupUpdateNotifier.ShouldShow(new[] { "env", "list", "-q" }).Should().BeFalse();
+    }
+
+    // ─── Message format ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetNotificationMessage_Format_ContainsUpdateAvailablePrefix()
+    {
+        WriteCacheFile(MakeResult(
+            stableUpdateAvailable: true,
+            latestStableVersion: "0.6.0",
+            updateCommand: "dotnet tool update PPDS.Cli -g"));
+
+        var message = StartupUpdateNotifier.GetNotificationMessage(cachePath: _cacheFile);
+
+        message.Should().StartWith("Update available:");
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/NuGetVersionTests.cs
@@ -1,0 +1,441 @@
+using FluentAssertions;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.UpdateCheck;
+
+public class NuGetVersionTests
+{
+    #region Parsing - Valid Versions
+
+    [Fact]
+    public void Parse_StableVersion_ParsesCorrectly()
+    {
+        var v = NuGetVersion.Parse("1.2.3");
+
+        v.Major.Should().Be(1);
+        v.Minor.Should().Be(2);
+        v.Patch.Should().Be(3);
+        v.PreReleaseLabel.Should().Be(string.Empty);
+        v.IsPreRelease.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_PreReleaseVersion_ParsesCorrectly()
+    {
+        var v = NuGetVersion.Parse("1.2.3-beta.1");
+
+        v.Major.Should().Be(1);
+        v.Minor.Should().Be(2);
+        v.Patch.Should().Be(3);
+        v.PreReleaseLabel.Should().Be("beta.1");
+        v.IsPreRelease.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_VersionWithBuildMetadata_StripsMetadata()
+    {
+        var v = NuGetVersion.Parse("1.2.3+abc1234");
+
+        v.Major.Should().Be(1);
+        v.Minor.Should().Be(2);
+        v.Patch.Should().Be(3);
+        v.PreReleaseLabel.Should().Be(string.Empty);
+        v.IsPreRelease.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_InformationalVersionFormat_ParsesCorrectly()
+    {
+        // e.g., from AssemblyInformationalVersionAttribute: "1.2.3-beta.1+abc1234"
+        var v = NuGetVersion.Parse("1.2.3-beta.1+abc1234");
+
+        v.Major.Should().Be(1);
+        v.Minor.Should().Be(2);
+        v.Patch.Should().Be(3);
+        v.PreReleaseLabel.Should().Be("beta.1");
+        v.IsPreRelease.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_ZeroVersion_ParsesCorrectly()
+    {
+        var v = NuGetVersion.Parse("0.0.0");
+
+        v.Major.Should().Be(0);
+        v.Minor.Should().Be(0);
+        v.Patch.Should().Be(0);
+    }
+
+    [Fact]
+    public void Parse_LargeNumbers_ParsesCorrectly()
+    {
+        var v = NuGetVersion.Parse("100.200.300");
+
+        v.Major.Should().Be(100);
+        v.Minor.Should().Be(200);
+        v.Patch.Should().Be(300);
+    }
+
+    #endregion
+
+    #region Parsing - Pre-Release Detection
+
+    [Theory]
+    [InlineData("1.0.0-alpha", true)]
+    [InlineData("1.0.0-beta.1", true)]
+    [InlineData("1.0.0-rc.1", true)]
+    [InlineData("1.0.0-alpha.0", true)]
+    [InlineData("1.0.0", false)]
+    [InlineData("2.5.0", false)]
+    public void IsPreRelease_ReturnsCorrectValue(string version, bool expected)
+    {
+        var v = NuGetVersion.Parse(version);
+        v.IsPreRelease.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region IsOddMinor
+
+    [Theory]
+    [InlineData("1.0.0", false)]
+    [InlineData("1.1.0", true)]
+    [InlineData("1.2.0", false)]
+    [InlineData("1.3.0", true)]
+    [InlineData("2.0.0", false)]
+    [InlineData("2.1.0", true)]
+    [InlineData("0.1.0", true)]
+    [InlineData("0.0.0", false)]
+    public void IsOddMinor_ReturnsCorrectValue(string version, bool expected)
+    {
+        var v = NuGetVersion.Parse(version);
+        v.IsOddMinor.Should().Be(expected);
+    }
+
+    #endregion
+
+    #region TryParse
+
+    [Fact]
+    public void TryParse_ValidVersion_ReturnsTrueAndResult()
+    {
+        var success = NuGetVersion.TryParse("1.2.3", out var result);
+
+        success.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.Major.Should().Be(1);
+        result.Minor.Should().Be(2);
+        result.Patch.Should().Be(3);
+    }
+
+    [Fact]
+    public void TryParse_NullInput_ReturnsFalseAndNull()
+    {
+        var success = NuGetVersion.TryParse(null, out var result);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParse_EmptyString_ReturnsFalseAndNull()
+    {
+        var success = NuGetVersion.TryParse(string.Empty, out var result);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("not-a-version")]
+    [InlineData("1.2")]
+    [InlineData("1.2.x")]
+    [InlineData("abc")]
+    [InlineData("1.2.3.4")]
+    [InlineData(".1.2")]
+    public void TryParse_InvalidInput_ReturnsFalseAndNull(string input)
+    {
+        var success = NuGetVersion.TryParse(input, out var result);
+
+        success.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParse_ValidVersionWithPreRelease_ReturnsTrueAndResult()
+    {
+        var success = NuGetVersion.TryParse("2.0.0-alpha.1+build999", out var result);
+
+        success.Should().BeTrue();
+        result.Should().NotBeNull();
+        result!.PreReleaseLabel.Should().Be("alpha.1");
+    }
+
+    #endregion
+
+    #region ToString Round-Trip
+
+    [Theory]
+    [InlineData("1.2.3")]
+    [InlineData("0.0.0")]
+    [InlineData("1.0.0-beta.1")]
+    [InlineData("2.3.4-rc.2")]
+    public void ToString_StableAndPreRelease_RoundTrips(string version)
+    {
+        // Build metadata is stripped; stable and pre-release should round-trip
+        var v = NuGetVersion.Parse(version);
+        v.ToString().Should().Be(version);
+    }
+
+    [Fact]
+    public void ToString_WithBuildMetadata_StripsMetadata()
+    {
+        var v = NuGetVersion.Parse("1.2.3-beta.1+abc1234");
+        v.ToString().Should().Be("1.2.3-beta.1");
+    }
+
+    #endregion
+
+    #region Comparison - Basic Ordering
+
+    [Fact]
+    public void CompareTo_HigherMajor_Wins()
+    {
+        var v1 = NuGetVersion.Parse("2.0.0");
+        var v2 = NuGetVersion.Parse("1.0.0");
+
+        v1.CompareTo(v2).Should().BePositive();
+        v2.CompareTo(v1).Should().BeNegative();
+    }
+
+    [Fact]
+    public void CompareTo_HigherMinor_Wins()
+    {
+        var v1 = NuGetVersion.Parse("1.2.0");
+        var v2 = NuGetVersion.Parse("1.1.0");
+
+        v1.CompareTo(v2).Should().BePositive();
+        v2.CompareTo(v1).Should().BeNegative();
+    }
+
+    [Fact]
+    public void CompareTo_HigherPatch_Wins()
+    {
+        var v1 = NuGetVersion.Parse("1.0.1");
+        var v2 = NuGetVersion.Parse("1.0.0");
+
+        v1.CompareTo(v2).Should().BePositive();
+        v2.CompareTo(v1).Should().BeNegative();
+    }
+
+    [Fact]
+    public void CompareTo_EqualVersions_ReturnsZero()
+    {
+        var v1 = NuGetVersion.Parse("1.2.3");
+        var v2 = NuGetVersion.Parse("1.2.3");
+
+        v1.CompareTo(v2).Should().Be(0);
+    }
+
+    #endregion
+
+    #region Comparison - Stable Beats Pre-Release
+
+    [Fact]
+    public void CompareTo_StableBeatsPreReleaseAtSameBase()
+    {
+        var stable = NuGetVersion.Parse("1.0.0");
+        var preRelease = NuGetVersion.Parse("1.0.0-beta.1");
+
+        stable.CompareTo(preRelease).Should().BePositive();
+        preRelease.CompareTo(stable).Should().BeNegative();
+    }
+
+    [Fact]
+    public void CompareTo_TwoPreReleasesSameBase_LabelComparison()
+    {
+        var alpha = NuGetVersion.Parse("1.0.0-alpha.1");
+        var beta = NuGetVersion.Parse("1.0.0-beta.1");
+
+        // "beta" > "alpha" alphabetically
+        beta.CompareTo(alpha).Should().BePositive();
+        alpha.CompareTo(beta).Should().BeNegative();
+    }
+
+    #endregion
+
+    #region Comparison - Multi-Digit Numeric Pre-Release Segments
+
+    [Fact]
+    public void CompareTo_NumericPreReleaseSegments_ComparedAsIntegers()
+    {
+        var beta10 = NuGetVersion.Parse("1.0.0-beta.10");
+        var beta2 = NuGetVersion.Parse("1.0.0-beta.2");
+
+        // beta.10 > beta.2 when compared as integers (not strings where "10" < "2")
+        beta10.CompareTo(beta2).Should().BePositive();
+        beta2.CompareTo(beta10).Should().BeNegative();
+    }
+
+    [Fact]
+    public void CompareTo_NumericPreReleaseSegments_SingleDigitEqualMultiDigit()
+    {
+        var v10 = NuGetVersion.Parse("1.0.0-alpha.10");
+        var v10b = NuGetVersion.Parse("1.0.0-alpha.10");
+
+        v10.CompareTo(v10b).Should().Be(0);
+    }
+
+    [Fact]
+    public void CompareTo_NumericVsStringSegments_NumericSortsBefore()
+    {
+        // Per SemVer: numeric identifiers always have lower precedence than alphanumeric identifiers
+        var numeric = NuGetVersion.Parse("1.0.0-1");
+        var alphanumeric = NuGetVersion.Parse("1.0.0-alpha");
+
+        numeric.CompareTo(alphanumeric).Should().BeNegative();
+        alphanumeric.CompareTo(numeric).Should().BePositive();
+    }
+
+    [Fact]
+    public void CompareTo_AlphaZeroVsAlphaTen_AlphaTenWins()
+    {
+        var alpha0 = NuGetVersion.Parse("1.0.0-alpha.0");
+        var alpha10 = NuGetVersion.Parse("1.0.0-alpha.10");
+
+        alpha10.CompareTo(alpha0).Should().BePositive();
+    }
+
+    #endregion
+
+    #region Comparison - Cross-Minor
+
+    [Fact]
+    public void CompareTo_CrossMinor_HigherMinorWins()
+    {
+        var v120 = NuGetVersion.Parse("1.2.0");
+        var v110 = NuGetVersion.Parse("1.1.9");
+
+        v120.CompareTo(v110).Should().BePositive();
+    }
+
+    [Fact]
+    public void CompareTo_CrossMinorPreRelease_StableOlderMinorLosesToNewerMinorPreRelease()
+    {
+        // 1.2.0-beta.1 > 1.1.0 (major.minor.patch take precedence over pre-release)
+        var v120beta = NuGetVersion.Parse("1.2.0-beta.1");
+        var v110 = NuGetVersion.Parse("1.1.0");
+
+        v120beta.CompareTo(v110).Should().BePositive();
+    }
+
+    #endregion
+
+    #region Operators
+
+    [Fact]
+    public void GreaterThan_Operator_WorksCorrectly()
+    {
+        var v2 = NuGetVersion.Parse("2.0.0");
+        var v1 = NuGetVersion.Parse("1.0.0");
+
+        (v2 > v1).Should().BeTrue();
+        (v1 > v2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void LessThan_Operator_WorksCorrectly()
+    {
+        var v2 = NuGetVersion.Parse("2.0.0");
+        var v1 = NuGetVersion.Parse("1.0.0");
+
+        (v1 < v2).Should().BeTrue();
+        (v2 < v1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void GreaterThanOrEqual_Operator_WorksCorrectly()
+    {
+        var v1a = NuGetVersion.Parse("1.0.0");
+        var v1b = NuGetVersion.Parse("1.0.0");
+        var v2 = NuGetVersion.Parse("2.0.0");
+
+        (v2 >= v1a).Should().BeTrue();
+        (v1a >= v1b).Should().BeTrue();
+        (v1a >= v2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void LessThanOrEqual_Operator_WorksCorrectly()
+    {
+        var v1a = NuGetVersion.Parse("1.0.0");
+        var v1b = NuGetVersion.Parse("1.0.0");
+        var v2 = NuGetVersion.Parse("2.0.0");
+
+        (v1a <= v2).Should().BeTrue();
+        (v1a <= v1b).Should().BeTrue();
+        (v2 <= v1a).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Equality
+
+    [Fact]
+    public void Equals_SameVersion_ReturnsTrue()
+    {
+        var v1 = NuGetVersion.Parse("1.2.3-beta.1");
+        var v2 = NuGetVersion.Parse("1.2.3-beta.1");
+
+        v1.Equals(v2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentVersion_ReturnsFalse()
+    {
+        var v1 = NuGetVersion.Parse("1.2.3");
+        var v2 = NuGetVersion.Parse("1.2.4");
+
+        v1.Equals(v2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_BuildMetadataStripped_SameVersionConsideredEqual()
+    {
+        var v1 = NuGetVersion.Parse("1.2.3-beta.1+build123");
+        var v2 = NuGetVersion.Parse("1.2.3-beta.1+build456");
+
+        // Build metadata is stripped; should be equal
+        v1.Equals(v2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetHashCode_EqualVersions_SameHashCode()
+    {
+        var v1 = NuGetVersion.Parse("1.2.3");
+        var v2 = NuGetVersion.Parse("1.2.3");
+
+        v1.GetHashCode().Should().Be(v2.GetHashCode());
+    }
+
+    #endregion
+
+    #region Parse - Error Cases
+
+    [Fact]
+    public void Parse_InvalidVersion_ThrowsFormatException()
+    {
+        var act = () => NuGetVersion.Parse("not-valid");
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Parse_NullVersion_ThrowsArgumentNullException()
+    {
+        var act = () => NuGetVersion.Parse(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/SelfUpdateTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/SelfUpdateTests.cs
@@ -1,0 +1,92 @@
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.UpdateCheck;
+
+public sealed class SelfUpdateTests
+{
+    [Fact]
+    public void ResolveDotnetPath_FindsDotnet()
+    {
+        var path = UpdateCheckService.ResolveDotnetPath();
+        Assert.NotNull(path);
+        Assert.True(File.Exists(path), $"Dotnet not found at: {path}");
+        Assert.Contains("dotnet", Path.GetFileName(path), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResolveDotnetPath_DoesNotReturnAppHostShim()
+    {
+        var path = UpdateCheckService.ResolveDotnetPath();
+        Assert.NotNull(path);
+        // Must NOT return ppds.exe (the apphost shim)
+        Assert.DoesNotContain("ppds", Path.GetFileName(path!), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IsGlobalToolInstall_ReturnsBool()
+    {
+        // In test environment, not running as global tool
+        var result = UpdateCheckService.IsGlobalToolInstall();
+        Assert.IsType<bool>(result);
+    }
+
+    [Fact]
+    public void UpdateScriptWriter_GeneratesScript()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        var statusPath = Path.Combine(tempDir, "status.json");
+        var lockPath = Path.Combine(tempDir, "update.lock");
+
+        try
+        {
+            var scriptPath = UpdateScriptWriter.WriteScript(
+                "dotnet", "tool update PPDS.Cli -g", "1.0.0",
+                12345, statusPath, lockPath);
+
+            Assert.True(File.Exists(scriptPath));
+            var content = File.ReadAllText(scriptPath);
+            Assert.Contains("dotnet", content);
+            Assert.Contains("tool update PPDS.Cli -g", content);
+            Assert.Contains("12345", content); // parent PID
+            Assert.Contains(statusPath, content);
+
+            if (OperatingSystem.IsWindows())
+                Assert.EndsWith(".cmd", scriptPath);
+            else
+                Assert.EndsWith(".sh", scriptPath);
+
+            // Cleanup
+            File.Delete(scriptPath);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void UpdateScriptWriter_NullTargetVersion_UsesUnknown()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        var statusPath = Path.Combine(tempDir, "status.json");
+        var lockPath = Path.Combine(tempDir, "update.lock");
+
+        try
+        {
+            var scriptPath = UpdateScriptWriter.WriteScript(
+                "dotnet", "tool update PPDS.Cli -g", null,
+                12345, statusPath, lockPath);
+
+            var content = File.ReadAllText(scriptPath);
+            Assert.Contains("unknown", content);
+
+            // Cleanup
+            File.Delete(scriptPath);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -152,16 +152,16 @@ public class UpdateCheckServiceTests : IDisposable
         result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
     }
 
-    // ─── Scenario 6: CheckAsync caches result; GetCachedResultAsync returns it ─
+    // ─── Scenario 6: CheckAsync caches result; GetCachedResult returns it ──────
 
     [Fact]
-    public async Task CheckAsync_CachesResult_GetCachedResultAsyncReturnsIt()
+    public async Task CheckAsync_CachesResult_GetCachedResultReturnsIt()
     {
         var handler = BuildHandler(MakeVersionsJson("0.4.0", "0.5.0"));
         var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
 
         var checkResult = await svc.CheckAsync("0.4.0");
-        var cachedResult = await svc.GetCachedResultAsync();
+        var cachedResult = svc.GetCachedResult();
 
         cachedResult.Should().NotBeNull();
         cachedResult!.CurrentVersion.Should().Be(checkResult!.CurrentVersion);
@@ -172,7 +172,7 @@ public class UpdateCheckServiceTests : IDisposable
     // ─── Scenario 7: Expired cache returns null ────────────────────────────────
 
     [Fact]
-    public async Task GetCachedResultAsync_ExpiredCache_ReturnsNull()
+    public void GetCachedResult_ExpiredCache_ReturnsNull()
     {
         // Write a cache file with a timestamp > 24 hours ago
         var staleResult = new UpdateCheckResult
@@ -187,11 +187,11 @@ public class UpdateCheckServiceTests : IDisposable
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         });
-        await File.WriteAllTextAsync(_cacheFile, json);
+        File.WriteAllText(_cacheFile, json);
 
         var svc = new UpdateCheckService(cachePath: _cacheFile);
 
-        var result = await svc.GetCachedResultAsync();
+        var result = svc.GetCachedResult();
 
         result.Should().BeNull();
     }
@@ -225,13 +225,13 @@ public class UpdateCheckServiceTests : IDisposable
     // ─── Scenario 10: Corrupt cache file returns null (no throw) ──────────────
 
     [Fact]
-    public async Task GetCachedResultAsync_CorruptCache_ReturnsNull()
+    public void GetCachedResult_CorruptCache_ReturnsNull()
     {
-        await File.WriteAllTextAsync(_cacheFile, "this is not valid json {{{{");
+        File.WriteAllText(_cacheFile, "this is not valid json {{{{");
 
         var svc = new UpdateCheckService(cachePath: _cacheFile);
 
-        var result = await svc.GetCachedResultAsync();
+        var result = svc.GetCachedResult();
 
         result.Should().BeNull();
     }
@@ -239,13 +239,46 @@ public class UpdateCheckServiceTests : IDisposable
     // ─── Additional edge-case coverage ────────────────────────────────────────
 
     [Fact]
-    public async Task GetCachedResultAsync_NoCacheFile_ReturnsNull()
+    public void GetCachedResult_NoCacheFile_ReturnsNull()
     {
         var svc = new UpdateCheckService(cachePath: _cacheFile);
 
-        var result = await svc.GetCachedResultAsync();
+        var result = svc.GetCachedResult();
 
         result.Should().BeNull();
+    }
+
+    // ─── New GetCachedResult tests (Task 5) ───────────────────────────────────
+
+    [Fact]
+    public async Task GetCachedResult_ReturnsCachedResult_WhenCacheIsFresh()
+    {
+        var handler = BuildHandler(MakeVersionsJson("1.0.0", "2.0.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+        await svc.CheckAsync("1.0.0");
+
+        var cached = svc.GetCachedResult();
+
+        Assert.NotNull(cached);
+        Assert.Equal("1.0.0", cached.CurrentVersion);
+    }
+
+    [Fact]
+    public void GetCachedResult_ReturnsNull_WhenNoCacheFile()
+    {
+        var svc = new UpdateCheckService(cachePath: _cacheFile);
+        var cached = svc.GetCachedResult();
+        Assert.Null(cached);
+    }
+
+    [Fact]
+    public void GetCachedResult_ReturnsNull_WhenCacheCorrupt()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFile)!);
+        File.WriteAllText(_cacheFile, "not json");
+        var svc = new UpdateCheckService(cachePath: _cacheFile);
+        var cached = svc.GetCachedResult();
+        Assert.Null(cached);
     }
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -411,4 +411,70 @@ public class UpdateCheckServiceTests : IDisposable
         var cached = svc2.GetCachedResult();
         Assert.NotNull(cached);
     }
+
+    // ─── Pre-release track logic tests (Task 7) ───────────────────────────────
+
+    [Fact]
+    public async Task CheckAsync_AlwaysPopulatesBothVersions()
+    {
+        // AC-19: Service always populates both versions regardless of user track
+        var handler = BuildHandler(MakeVersionsJson("0.4.0", "0.6.0", "0.7.0-alpha.1"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0"); // stable user
+
+        Assert.NotNull(result);
+        Assert.Equal("0.6.0", result.LatestStableVersion);
+        Assert.Equal("0.7.0-alpha.1", result.LatestPreReleaseVersion);
+        Assert.True(result.StableUpdateAvailable);
+        Assert.True(result.PreReleaseUpdateAvailable); // honestly computed
+    }
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_BothUpdatesAvailable()
+    {
+        // AC-20
+        var handler = BuildHandler(MakeVersionsJson("0.5.0-beta.1", "0.6.0", "0.7.0-alpha.1"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        Assert.NotNull(result);
+        Assert.True(result.StableUpdateAvailable);
+        Assert.True(result.PreReleaseUpdateAvailable);
+        Assert.Equal("0.6.0", result.LatestStableVersion);
+        Assert.Equal("0.7.0-alpha.1", result.LatestPreReleaseVersion);
+        Assert.Equal("dotnet tool update PPDS.Cli -g", result.UpdateCommand);
+        Assert.Equal("dotnet tool update PPDS.Cli -g --prerelease", result.PreReleaseUpdateCommand);
+    }
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_OnlyPreReleaseAvailable()
+    {
+        // AC-22
+        var handler = BuildHandler(MakeVersionsJson("0.5.0-beta.1", "0.4.0", "0.7.0-alpha.1"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        Assert.NotNull(result);
+        Assert.False(result.StableUpdateAvailable);
+        Assert.True(result.PreReleaseUpdateAvailable);
+        Assert.Equal("0.7.0-alpha.1", result.LatestPreReleaseVersion);
+        Assert.Equal("dotnet tool update PPDS.Cli -g --prerelease", result.UpdateCommand);
+    }
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUpdateCommand_UsesPreReleaseFlag()
+    {
+        // AC-23
+        var handler = BuildHandler(MakeVersionsJson("0.5.0-beta.1", "0.6.0", "0.7.0-alpha.1"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        Assert.NotNull(result);
+        Assert.Contains("--prerelease", result!.PreReleaseUpdateCommand);
+        Assert.DoesNotContain("--prerelease", result.UpdateCommand!);
+    }
 }

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -449,6 +449,22 @@ public class UpdateCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CheckAsync_PreReleaseUser_OnlyStableAvailable()
+    {
+        // AC-21: Pre-release user, newer stable only, no newer pre-release
+        var handler = BuildHandler(MakeVersionsJson("0.6.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        Assert.NotNull(result);
+        Assert.True(result.StableUpdateAvailable);
+        Assert.False(result.PreReleaseUpdateAvailable);
+        Assert.Equal("0.6.0", result.LatestStableVersion);
+        Assert.Null(result.LatestPreReleaseVersion); // No pre-release versions exist on NuGet
+    }
+
+    [Fact]
     public async Task CheckAsync_PreReleaseUser_OnlyPreReleaseAvailable()
     {
         // AC-22

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -62,6 +62,20 @@ public class UpdateCheckServiceTests : IDisposable
         return mock.Object;
     }
 
+    private static HttpMessageHandler BuildThrowingHandler()
+    {
+        return new ThrowingHandler();
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Simulated network error");
+        }
+    }
+
     private static string MakeVersionsJson(params string[] versions)
     {
         return JsonSerializer.Serialize(new { versions });
@@ -353,5 +367,48 @@ public class UpdateCheckServiceTests : IDisposable
         // Should not throw — cancelled network call returns null
         var result = await svc.CheckAsync("0.4.0", cts.Token);
         result.Should().BeNull();
+    }
+
+    // ─── RefreshCacheInBackgroundIfStale tests (Task 6) ──────────────────────
+
+    [Fact]
+    public async Task RefreshCacheInBackgroundIfStale_RefreshesWhenCacheExpired()
+    {
+        var oldResult = new UpdateCheckResult
+        {
+            CurrentVersion = "1.0.0",
+            LatestStableVersion = "1.0.0",
+            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25)
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(_cacheFile)!);
+        var jsonOpts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        File.WriteAllText(_cacheFile, JsonSerializer.Serialize(oldResult, jsonOpts));
+
+        var handler = BuildHandler(MakeVersionsJson("1.0.0", "2.0.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        svc.RefreshCacheInBackgroundIfStale("1.0.0");
+        await Task.Delay(1000);
+
+        var cached = svc.GetCachedResult();
+        Assert.NotNull(cached);
+        Assert.True(cached.StableUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task RefreshCacheInBackgroundIfStale_SkipsWhenCacheFresh()
+    {
+        var handler = BuildHandler(MakeVersionsJson("1.0.0", "2.0.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+        await svc.CheckAsync("1.0.0");
+
+        var throwingHandler = BuildThrowingHandler();
+        var svc2 = new UpdateCheckService(handler: throwingHandler, cachePath: _cacheFile);
+
+        svc2.RefreshCacheInBackgroundIfStale("1.0.0");
+        await Task.Delay(500);
+
+        var cached = svc2.GetCachedResult();
+        Assert.NotNull(cached);
     }
 }

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -43,7 +43,7 @@ public class UpdateCheckServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            .ReturnsAsync(() => new HttpResponseMessage(statusCode)
             {
                 Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
             });

--- a/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/UpdateCheck/UpdateCheckServiceTests.cs
@@ -1,0 +1,324 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using PPDS.Cli.Services.UpdateCheck;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.UpdateCheck;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateCheckService"/>.
+/// </summary>
+public class UpdateCheckServiceTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly string _cacheFile;
+
+    public UpdateCheckServiceTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempPath);
+        _cacheFile = Path.Combine(_tempPath, "update-check.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+        {
+            try { Directory.Delete(_tempPath, recursive: true); }
+            catch { /* ignore cleanup errors */ }
+        }
+    }
+
+    #region Helpers
+
+    private static HttpMessageHandler BuildHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            });
+        return mock.Object;
+    }
+
+    private static HttpMessageHandler BuildThrowingHandler(Exception ex)
+    {
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(ex);
+        return mock.Object;
+    }
+
+    private static string MakeVersionsJson(params string[] versions)
+    {
+        return JsonSerializer.Serialize(new { versions });
+    }
+
+    #endregion
+
+    // ─── Scenario 1: CheckAsync returns latest stable and pre-release ──────────
+
+    [Fact]
+    public async Task CheckAsync_ReturnsLatestStableAndPreRelease()
+    {
+        var handler = BuildHandler(MakeVersionsJson(
+            "0.1.0", "0.2.0", "0.3.0-alpha.1", "0.4.0", "0.5.0-beta.2"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.1.0");
+
+        result.Should().NotBeNull();
+        result!.LatestStableVersion.Should().Be("0.4.0");
+        result.LatestPreReleaseVersion.Should().Be("0.5.0-beta.2");
+    }
+
+    // ─── Scenario 2: Current is latest → no update available ──────────────────
+
+    [Fact]
+    public async Task CheckAsync_CurrentIsLatest_NoUpdateAvailable()
+    {
+        var handler = BuildHandler(MakeVersionsJson("0.4.0", "0.3.0", "0.2.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeFalse();
+        result.PreReleaseUpdateAvailable.Should().BeFalse();
+        result.UpdateAvailable.Should().BeFalse();
+        result.UpdateCommand.Should().BeNull();
+    }
+
+    // ─── Scenario 3: Stable available → plain update command ──────────────────
+
+    [Fact]
+    public async Task CheckAsync_StableUpdateAvailable_SuggestsPlainCommand()
+    {
+        var handler = BuildHandler(MakeVersionsJson("0.4.0", "0.5.0", "0.6.0", "0.7.0-alpha.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeTrue();
+        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
+    }
+
+    // ─── Scenario 4: Pre-release user, no newer stable, newer pre-release → --prerelease ─
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_NoNewerStable_NewerPreRelease_SuggestsPrereleaseCommand()
+    {
+        // Current: 0.5.0-beta.1  Latest stable: 0.4.0  Latest pre-release: 0.5.0-beta.2
+        var handler = BuildHandler(MakeVersionsJson(
+            "0.4.0", "0.5.0-beta.1", "0.5.0-beta.2"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeFalse();
+        result.PreReleaseUpdateAvailable.Should().BeTrue();
+        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g --prerelease");
+    }
+
+    // ─── Scenario 5: Pre-release user, newer stable available → plain command (stable priority) ─
+
+    [Fact]
+    public async Task CheckAsync_PreReleaseUser_NewerStableAvailable_SuggestsPlainCommand()
+    {
+        // Current: 0.5.0-beta.1  Latest stable: 0.6.0  Latest pre-release: 0.5.0-beta.2
+        var handler = BuildHandler(MakeVersionsJson(
+            "0.4.0", "0.5.0-beta.1", "0.5.0-beta.2", "0.6.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.5.0-beta.1");
+
+        result.Should().NotBeNull();
+        result!.StableUpdateAvailable.Should().BeTrue();
+        result.UpdateCommand.Should().Be("dotnet tool update PPDS.Cli -g");
+    }
+
+    // ─── Scenario 6: CheckAsync caches result; GetCachedResultAsync returns it ─
+
+    [Fact]
+    public async Task CheckAsync_CachesResult_GetCachedResultAsyncReturnsIt()
+    {
+        var handler = BuildHandler(MakeVersionsJson("0.4.0", "0.5.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var checkResult = await svc.CheckAsync("0.4.0");
+        var cachedResult = await svc.GetCachedResultAsync();
+
+        cachedResult.Should().NotBeNull();
+        cachedResult!.CurrentVersion.Should().Be(checkResult!.CurrentVersion);
+        cachedResult.LatestStableVersion.Should().Be(checkResult.LatestStableVersion);
+        cachedResult.CheckedAt.Should().Be(checkResult.CheckedAt);
+    }
+
+    // ─── Scenario 7: Expired cache returns null ────────────────────────────────
+
+    [Fact]
+    public async Task GetCachedResultAsync_ExpiredCache_ReturnsNull()
+    {
+        // Write a cache file with a timestamp > 24 hours ago
+        var staleResult = new UpdateCheckResult
+        {
+            CurrentVersion = "0.4.0",
+            LatestStableVersion = "0.5.0",
+            StableUpdateAvailable = true,
+            UpdateCommand = "dotnet tool update PPDS.Cli -g",
+            CheckedAt = DateTimeOffset.UtcNow.AddHours(-25)
+        };
+        var json = JsonSerializer.Serialize(staleResult, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+        await File.WriteAllTextAsync(_cacheFile, json);
+
+        var svc = new UpdateCheckService(cachePath: _cacheFile);
+
+        var result = await svc.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+
+    // ─── Scenario 8: Network error returns null (no throw) ────────────────────
+
+    [Fact]
+    public async Task CheckAsync_NetworkError_ReturnsNull()
+    {
+        var handler = BuildThrowingHandler(new HttpRequestException("Network unavailable"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().BeNull();
+    }
+
+    // ─── Scenario 9: Non-success HTTP status returns null ─────────────────────
+
+    [Fact]
+    public async Task CheckAsync_NonSuccessHttpStatus_ReturnsNull()
+    {
+        var handler = BuildHandler("{\"error\":\"not found\"}", HttpStatusCode.NotFound);
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().BeNull();
+    }
+
+    // ─── Scenario 10: Corrupt cache file returns null (no throw) ──────────────
+
+    [Fact]
+    public async Task GetCachedResultAsync_CorruptCache_ReturnsNull()
+    {
+        await File.WriteAllTextAsync(_cacheFile, "this is not valid json {{{{");
+
+        var svc = new UpdateCheckService(cachePath: _cacheFile);
+
+        var result = await svc.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+
+    // ─── Additional edge-case coverage ────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCachedResultAsync_NoCacheFile_ReturnsNull()
+    {
+        var svc = new UpdateCheckService(cachePath: _cacheFile);
+
+        var result = await svc.GetCachedResultAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_PopulatesCurrentVersion()
+    {
+        var handler = BuildHandler(MakeVersionsJson("0.4.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.CurrentVersion.Should().Be("0.4.0");
+    }
+
+    [Fact]
+    public async Task CheckAsync_CheckedAt_IsRecentUtcTimestamp()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var handler = BuildHandler(MakeVersionsJson("0.4.0"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.CheckedAt.Should().BeOnOrAfter(before);
+        result.CheckedAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task CheckAsync_VersionListWithOnlyPreReleases_LatestStableIsNull()
+    {
+        var handler = BuildHandler(MakeVersionsJson("0.1.0-alpha", "0.2.0-beta.1"));
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.1.0-alpha");
+
+        result.Should().NotBeNull();
+        result!.LatestStableVersion.Should().BeNull();
+        result.LatestPreReleaseVersion.Should().Be("0.2.0-beta.1");
+    }
+
+    [Fact]
+    public async Task CheckAsync_EmptyVersionList_ReturnsResultWithNulls()
+    {
+        var handler = BuildHandler(MakeVersionsJson());
+        var svc = new UpdateCheckService(handler: handler, cachePath: _cacheFile);
+
+        var result = await svc.CheckAsync("0.4.0");
+
+        result.Should().NotBeNull();
+        result!.LatestStableVersion.Should().BeNull();
+        result.LatestPreReleaseVersion.Should().BeNull();
+        result.UpdateAvailable.Should().BeFalse();
+        result.UpdateCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckAsync_CancellationToken_PropagatedToHttp()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException());
+        var svc = new UpdateCheckService(handler: mock.Object, cachePath: _cacheFile);
+
+        // Should not throw — cancelled network call returns null
+        var result = await svc.CheckAsync("0.4.0", cts.Token);
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Closes #564

## Summary

Complete CLI update check and self-update system per `specs/update-check.md` (52 acceptance criteria).

- **NuGetVersion**: Immutable SemVer 2.0 value type with parsing, comparison, pre-release segment logic, odd-minor detection
- **UpdateCheckService**: NuGet flat-container API query, 24h cache with atomic writes, sync cache reads for startup, background refresh, self-update via detached wrapper script
- **StartupUpdateNotifier**: Pure presentation (no I/O) — `FormatNotification(result)` with track-based filtering, `ShouldShow(args)` for `--quiet` suppression
- **VersionCommand**: `ppds version [--check] [--update [--stable|--prerelease] [--yes]]`
- **Self-update**: Platform-specific wrapper scripts (.cmd/.sh) that wait for parent PID exit, run `dotnet tool update`, write status file. Dotnet path resolved via `RuntimeEnvironment.GetRuntimeDirectory()` (not `Process.MainModule` which returns the apphost shim). Lock file prevents concurrent updates.

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| Sync cache reads | Startup uses `File.ReadAllText` on <1KB file — sub-millisecond, no async overhead |
| Wrapper script for self-update | Windows locks `.store` DLLs while ppds runs — `dotnet tool update` fails unless ppds exits first (tested empirically) |
| `RuntimeEnvironment.GetRuntimeDirectory()` for dotnet path | `Process.MainModule.FileName` returns apphost shim (`ppds.exe`), not `dotnet.exe` (tested empirically) |
| Track-based self-update (VS Code model) | `--update` stays on current track; `--stable`/`--prerelease` to switch |
| Data model vs presentation split | Service always populates both versions honestly; track filtering in notifier/command |
| `ShouldShow` checks only `--quiet`/`-q` | Other suppression handled by `SkipVersionHeaderArgs` in Program.cs — no duplication |

### Verification

- 2130 tests passing (net8.0, net9.0, net10.0)
- Manual: `ppds version`, `ppds version --check` (live NuGet), `--update --yes`, validation errors, startup notification, status file lifecycle
- Simulated: Wrapper script full lifecycle (success + failure paths) on Windows

## Test plan

- [x] `ppds version` shows CLI/SDK/.NET/platform to stderr
- [x] `ppds version --check` queries live NuGet, shows available versions
- [x] `ppds version --update --yes` with no update available says "already up to date"
- [x] `ppds version --stable` without `--update` returns InvalidArguments
- [x] `ppds version --update --stable --prerelease` returns mutual exclusivity error
- [x] Startup notification with cached update displays correctly
- [x] `--quiet` suppresses notification
- [x] `--help` skips notification block entirely
- [x] Post-update status file read, displayed, and deleted on next run
- [x] Wrapper script: PID wait, command execution, status write, lock cleanup, self-delete (simulated)
- [x] 2130 unit tests across 3 TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)