### PR TITLE
feat: tui-verify.mjs — interactive TUI verification tool

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -37,7 +37,7 @@ From $ARGUMENTS or changed files:
 - `src/PPDS.Extension/` → extension mode (CDP)
 - `src/PPDS.Cli/Commands/` (not Serve/) → CLI mode (run commands)
 - `src/PPDS.Mcp/` → MCP mode (Inspector)
-- `src/PPDS.Cli/Tui/` → TUI mode (snapshot tests — no blind verification yet)
+- `src/PPDS.Cli/Tui/` → TUI mode (tui-verify)
 - Mixed → run applicable modes sequentially
 
 ### Step 3: Dispatch Blind Verifier
@@ -128,6 +128,64 @@ Same structure but:
 - Tool access: Bash (only for `npx @modelcontextprotocol/inspector`)
 - Each check: call the MCP tool, capture response JSON, compare to expected
 - Evidence: response payloads
+
+#### TUI Mode — Verifier Prompt
+
+```
+You are a QA tester. You have NEVER seen the source code for this TUI
+application. You don't know how anything is implemented. You only know
+what the product SHOULD do.
+
+## Your Tools
+
+You may ONLY use these tools:
+- Bash: ONLY for running `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` commands
+- Read: ONLY for viewing screenshot JSON files (in $TEMP)
+
+You MUST NOT use Read/Grep/Glob on source code files. You cannot look
+at .cs, .ts, .json, or any file under src/. You are blind to the
+implementation.
+
+## Verification Protocol
+
+For EACH check below:
+1. Perform the action using tui-verify commands
+2. Read the relevant terminal row(s): `text <row>`
+3. Optionally dump full state: `screenshot $TEMP/qa-tui-{check-number}.json`
+4. Compare actual text to expected text
+5. Report PASS or FAIL with the actual text content as evidence
+
+If a check FAILS:
+- Show exactly what text you SAW vs what was EXPECTED
+- Include the row number and full row content
+- Do NOT speculate about why it failed
+
+## Setup
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up prior
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+```
+
+## Checks
+
+{paste generated checklist here}
+
+## Teardown
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+## Report Format
+
+| # | Check | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | description | PASS/FAIL | row N: "actual text content" |
+
+### Verdict: PASS (all green) / FAIL (N issues found)
+```
 
 ### Step 4: Evaluate Results
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -57,15 +57,45 @@ Verify:
 
 ### 4. TUI Mode
 
-TUI interactive verification via MCP is not yet available. Use snapshot tests:
+**Phase A: Build and Launch**
 
 ```bash
-npm run tui:test
+# Build and launch TUI in PTY
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# Wait for TUI to render
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# Read the title bar to confirm it loaded
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
 ```
 
-Verify:
-- All snapshot tests pass
-- No visual regressions in terminal output
+**Phase B: Interactive Verification (MANDATORY for TUI rendering/interaction changes)**
+
+If changed files touch `src/PPDS.Cli/Tui/`, Phase B is NOT optional.
+
+```bash
+# Navigate to the relevant screen
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+
+# Verify status bar content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29
+
+# Wait for expected screen title
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# Dump terminal state for debugging if needed
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify.json
+```
+
+**Phase C: Cleanup**
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+See @tui-verify skill for full command reference and Terminal.Gui keyboard patterns.
 
 ### 5. Extension Mode
 

--- a/.claude/skills/tui-verify/SKILL.md
+++ b/.claude/skills/tui-verify/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(node *tui-verify*), Bash(cd * && node *tui-verify*)
 
 # TUI Verify Tool
 
-Interact with the PPDS TUI running in a PTY. Read terminal text to verify what's rendered, send keystrokes to navigate, wait for specific content to appear. Text-based verification — the AI reads terminal rows directly instead of interpreting screenshots.
+Interact with the PPDS TUI (`ppds interactive`) running in a PTY. Read terminal text to verify what's rendered, send keystrokes to navigate, wait for specific content to appear. Text-based verification — the AI reads terminal rows directly instead of interpreting screenshots.
 
 ## When to Use
 
@@ -17,30 +17,40 @@ Interact with the PPDS TUI running in a PTY. Read terminal text to verify what's
 
 ## Setup
 
-The tool is at `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`. Uses `@microsoft/tui-test` (already a dev dependency). Requires the TUI to be built first.
+The tool is at `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`. Uses `@microsoft/tui-test` (already a dev dependency). Requires the TUI to be built first. The TUI subcommand is `ppds interactive` (the tool handles this internally).
 
-## Core Workflow
+## First Steps After Launch
+
+The TUI starts with no profile connected. You must select a profile and environment before most features work.
 
 ```bash
 # 1. Build and launch TUI in PTY (120x30 terminal)
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
 
-# 2. Wait for it to render
+# 2. Wait for splash screen to render
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
 
-# 3. Read specific rows to verify content
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0   # title bar
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # status bar
-
-# 4. Navigate with keystrokes
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+# 3. Select profile (Alt+P opens profile picker)
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+p"
+# Arrow to the desired profile, then Enter to select
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
 
-# 5. Verify expected content appeared
+# 4. Select environment (Alt+E opens environment picker)
+#    If environment auto-populated from profile, skip this step.
+#    Check row 28 to see current state:
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 28
+#    If it shows "Environment: None", open the picker:
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+e"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+
+# 5. Navigate to SQL Query screen
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+t"   # Tools menu
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"   # SQL Query (first item)
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
 
-# 6. When done
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+# 6. Verify connection — check the tab title includes environment name
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+# Expected: │[ 1: SQL Query - <env name> ] [+]
 ```
 
 ## Commands
@@ -50,7 +60,7 @@ node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
 | `launch [--build]` | `launch --build` | Start TUI in PTY. `--build` compiles first |
 | `close` | `close` | Kill PTY, clean up (idempotent) |
 | `text <row>` | `text 0` | Read terminal row content (0-based, 0-29) |
-| `key "<combo>"` | `key "ctrl+t"` | Send keystroke |
+| `key "<combo>"` | `key "alt+t"` | Send keystroke |
 | `type "<text>"` | `type "SELECT"` | Type text character by character |
 | `wait "<text>" [ms]` | `wait "PPDS" 5000` | Poll until text appears (default 10s) |
 | `screenshot <file>` | `screenshot $TEMP/debug.json` | Dump serialize() as JSON (text + colors) |
@@ -58,43 +68,82 @@ node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
 
 ## Key Combos
 
-| Combo | What it does in Terminal.Gui |
-|-------|------------------------------|
+| Combo | What it does in PPDS TUI |
+|-------|--------------------------|
 | `tab` | Cycle focus to next widget |
 | `shift+tab` | Cycle focus to previous widget |
 | `enter` | Activate focused button/menu item |
 | `escape` | Close dialog/cancel operation |
-| `alt+<letter>` | Menu bar shortcut (e.g., `alt+f` for File) |
-| `ctrl+q` | Quit (standard Terminal.Gui quit) |
+| `alt+f` | Open File menu |
+| `alt+q` | Open Query menu (on SQL Query screen) |
+| `alt+t` | Open Tools menu |
+| `alt+h` | Open Help menu |
+| `alt+p` | Open profile selector dialog |
+| `alt+e` | Open environment selector dialog |
+| `ctrl+q` | Quit TUI (exits immediately, no confirmation) |
 | `up`/`down` | Navigate lists, menus, tree views |
+| `F5` | Execute query (on SQL Query screen) |
 | `F1`-`F12` | Function key shortcuts |
-| `ctrl+t` | Common PPDS shortcut for TDS toggle |
+
+**Known issue:** `ctrl+shift+t` is bound to both "new query tab" and "TDS Read Replica toggle" — the new-tab binding wins. Use the Query menu instead: `alt+q` → navigate to "TDS Read Replica" → `enter`. See [#580](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/580).
+
+## Screen Layout (120x30 terminal)
+
+Understanding the row layout helps you read the right rows:
+
+| Rows | Content |
+|------|---------|
+| 0 | Title bar: "PPDS - Power Platform Developer Suite" |
+| 1 | Menu bar: File, Query/Tools, Help |
+| 2 | Tab bar (on SQL Query screen) |
+| 3 | Screen title (e.g., "SQL Query - Env Name") |
+| 4-9 | Query editor area |
+| 10 | Splitter |
+| 11-23 | Results table |
+| 24 | Inner status label (e.g., "Ready", "Mode: TDS Read Replica...") |
+| 25 | Inner frame border |
+| 26 | (empty) |
+| 27 | Error/notification bar |
+| 28 | Profile/Environment status: "Profile: ... Environment: ..." |
+| 29 | Bottom border |
+
+**Row 24** is the query status label. **Row 28** is the profile/environment bar. **Row 29** is just the border.
 
 ## Common Patterns
 
-### Verify a screen loaded
+### Open SQL Query screen
 ```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+t"   # Tools menu
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"   # SQL Query (first item)
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0  # check title
 ```
 
-### Navigate to a specific screen
+### Check query status label
 ```bash
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+s"  # Solutions menu
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "Solutions" 5000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 24  # inner status (Ready, Mode, error, etc.)
 ```
 
-### Check status bar after operation
+### Check profile and environment
 ```bash
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # bottom row
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 28  # Profile: ... Environment: ...
 ```
 
-### Type into a text field
+### Navigate Query menu items
 ```bash
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"  # focus the input
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT TOP 10 * FROM account"
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+q"   # open Query menu
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "down"    # navigate items
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"   # select
+```
+
+Query menu items (top to bottom): Execute, Show FetchXML, Show Execution Plan, History, (separator), Filter Results, (separator), TDS Read Replica.
+
+### Type and execute a query
+```bash
+# Focus is usually on the query editor after opening SQL Query
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT TOP 10 name FROM account"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "F5"     # execute
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "rows" 30000  # wait for results
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 24      # check status (e.g., "Returned 10 rows in 298ms via Dataverse")
 ```
 
 ### Debug rendering issues
@@ -103,10 +152,10 @@ node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-state.jso
 # Read the file to see full terminal state with colors
 ```
 
-### Read multiple rows
+### Read multiple rows to understand layout
 ```bash
-for i in 0 1 2 3 4 5; do
-  node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text $i
+for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29; do
+  echo "Row $i: $(node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text $i)"
 done
 ```
 
@@ -137,16 +186,26 @@ node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot debug.json
 
 ## Error Recovery
 
-### `launch` fails
+### `launch` fails or times out
 ```bash
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up stale session
+# Check the daemon log for diagnostics — this is the most important step
+cat tests/PPDS.Tui.E2eTests/tools/.tui-verify-daemon.log
+
+# Common causes:
+# - "Binary not found" → run with --build
+# - "PTY exited: code=1" → wrong subcommand or missing dependency
+# - No log file at all → node-pty compilation issue
+
+# Clean up and retry
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
 node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
 ```
 
 ### `wait` times out
 1. Check if TUI is alive: `text 0` — if error, TUI crashed. `close` then `launch --build`
 2. Check if you're on the right screen: read several rows with `text`
-3. Increase timeout: `wait "text" 30000`
+3. Check the daemon log: `cat tests/PPDS.Tui.E2eTests/tools/.tui-verify-daemon.log`
+4. Increase timeout: `wait "text" 30000`
 
 ### TUI crashes mid-session
 ```bash

--- a/.claude/skills/tui-verify/SKILL.md
+++ b/.claude/skills/tui-verify/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: tui-verify
+description: Interactive TUI verification via PTY — launch, navigate, read text, send keystrokes. Use after implementing or modifying any TUI-affecting change (screens, widgets, keyboard handlers, status bar). For non-visual changes (service logic, data access), compile + test is sufficient.
+allowed-tools: Bash(node *tui-verify*), Bash(cd * && node *tui-verify*)
+---
+
+# TUI Verify Tool
+
+Interact with the PPDS TUI running in a PTY. Read terminal text to verify what's rendered, send keystrokes to navigate, wait for specific content to appear. Text-based verification — the AI reads terminal rows directly instead of interpreting screenshots.
+
+## When to Use
+
+- After implementing or modifying any TUI screen, widget, or keyboard handler
+- When debugging TUI rendering — read specific rows to see what's there
+- When testing keyboard navigation — send keystrokes and verify focus moved
+- When verifying status bar content after an operation
+
+## Setup
+
+The tool is at `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`. Uses `@microsoft/tui-test` (already a dev dependency). Requires the TUI to be built first.
+
+## Core Workflow
+
+```bash
+# 1. Build and launch TUI in PTY (120x30 terminal)
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# 2. Wait for it to render
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# 3. Read specific rows to verify content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0   # title bar
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # status bar
+
+# 4. Navigate with keystrokes
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+
+# 5. Verify expected content appeared
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# 6. When done
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+## Commands
+
+| Command | Example | Purpose |
+|---------|---------|---------|
+| `launch [--build]` | `launch --build` | Start TUI in PTY. `--build` compiles first |
+| `close` | `close` | Kill PTY, clean up (idempotent) |
+| `text <row>` | `text 0` | Read terminal row content (0-based, 0-29) |
+| `key "<combo>"` | `key "ctrl+t"` | Send keystroke |
+| `type "<text>"` | `type "SELECT"` | Type text character by character |
+| `wait "<text>" [ms]` | `wait "PPDS" 5000` | Poll until text appears (default 10s) |
+| `screenshot <file>` | `screenshot $TEMP/debug.json` | Dump serialize() as JSON (text + colors) |
+| `rows` | `rows` | Show terminal dimensions (120x30) |
+
+## Key Combos
+
+| Combo | What it does in Terminal.Gui |
+|-------|------------------------------|
+| `tab` | Cycle focus to next widget |
+| `shift+tab` | Cycle focus to previous widget |
+| `enter` | Activate focused button/menu item |
+| `escape` | Close dialog/cancel operation |
+| `alt+<letter>` | Menu bar shortcut (e.g., `alt+f` for File) |
+| `ctrl+q` | Quit (standard Terminal.Gui quit) |
+| `up`/`down` | Navigate lists, menus, tree views |
+| `F1`-`F12` | Function key shortcuts |
+| `ctrl+t` | Common PPDS shortcut for TDS toggle |
+
+## Common Patterns
+
+### Verify a screen loaded
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0  # check title
+```
+
+### Navigate to a specific screen
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+s"  # Solutions menu
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "Solutions" 5000
+```
+
+### Check status bar after operation
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # bottom row
+```
+
+### Type into a text field
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"  # focus the input
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT TOP 10 * FROM account"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+```
+
+### Debug rendering issues
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-state.json
+# Read the file to see full terminal state with colors
+```
+
+### Read multiple rows
+```bash
+for i in 0 1 2 3 4 5; do
+  node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text $i
+done
+```
+
+## Screenshots
+
+The `screenshot` command dumps the terminal's `serialize()` output as JSON — text with color metadata. Not a PNG image. Use `$TEMP` for the output path:
+
+```bash
+# Good
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/debug.json
+
+# BAD — creates file in repo
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot debug.json
+```
+
+## Verification Before Completion
+
+**Interactive verification required** — any change affecting TUI rendering:
+- Screen layout, widget placement, borders
+- Keyboard handlers, focus order
+- Status bar content, menu items
+- Dialog boxes, error messages
+
+**Compile + test sufficient** — no visual impact:
+- Application Service logic (business rules)
+- Dataverse queries, data transformation
+- CLI command behavior (not TUI)
+
+## Error Recovery
+
+### `launch` fails
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up stale session
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+```
+
+### `wait` times out
+1. Check if TUI is alive: `text 0` — if error, TUI crashed. `close` then `launch --build`
+2. Check if you're on the right screen: read several rows with `text`
+3. Increase timeout: `wait "text" 30000`
+
+### TUI crashes mid-session
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close   # clean up
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+```
+
+## Gap Protocol
+
+If you encounter a TUI interaction that this tool cannot handle:
+
+1. **STOP** — do not work around it silently
+2. **Describe the gap** — what interaction you need
+3. **Propose an enhancement** — a new command or flag
+4. **Ask the user** — implement now or defer

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,10 @@ src/PPDS.Extension/test-results/
 src/PPDS.Extension/playwright-report/
 .vscode-test/
 
+# TUI verify tool session/log files
+.tui-verify-session.json
+.tui-verify-daemon.log
+
 # Git worktrees
 .worktrees/
 .muse/

--- a/docs/plans/2026-03-16-tui-verify-tool.md
+++ b/docs/plans/2026-03-16-tui-verify-tool.md
@@ -1,0 +1,1356 @@
+# TUI Verify Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a CLI tool (`tui-verify.mjs`) that lets AI agents launch, interact with, and inspect the PPDS TUI in a PTY — mirroring webview-cdp's daemon pattern with text-based verification.
+
+**Architecture:** Single-file Node.js tool with caller/daemon dual mode. Caller sends HTTP requests to a persistent daemon that holds a `@microsoft/tui-test` Terminal instance. Text-based primary workflow — `getBuffer()` for reading, `write()`/named methods for input, `serialize()` for debugging dumps.
+
+**Tech Stack:** Node.js, `@microsoft/tui-test@0.0.1-rc.5` (PTY via node-pty, terminal emulation via @xterm/headless)
+
+**Spec:** [`specs/tui-verify-tool.md`](../../specs/tui-verify-tool.md)
+
+**Reference Implementation:** [`src/PPDS.Extension/tools/webview-cdp.mjs`](../../src/PPDS.Extension/tools/webview-cdp.mjs)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` | Create | CLI tool — caller mode + daemon mode (single file) |
+| `tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs` | Create | Unit tests for pure functions (arg parsing, key mapping) |
+| `.claude/skills/tui-verify/SKILL.md` | Create | Skill file teaching agents how to use the tool |
+| `.claude/commands/verify.md` | Modify | Replace TUI Mode section with tui-verify steps |
+| `.claude/commands/qa.md` | Modify | Add TUI Mode blind verifier prompt |
+| `.gitignore` | Modify | Add `.tui-verify-session.json` pattern |
+
+---
+
+## Chunk 1: Core Tool — Pure Functions and Daemon Infrastructure
+
+### Prerequisites
+
+**Test runner:** Use Node.js built-in `node:test` and `node:assert` — zero additional dependencies. The `tests/PPDS.Tui.E2eTests/package.json` only has `@microsoft/tui-test` and `@playwright/test` as devDependencies; adding vitest is unnecessary for a handful of unit tests.
+
+**Windows path comparison:** The `main()` entry guard must use case-insensitive comparison: `resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()` since Windows paths may differ in casing.
+
+### Task 1: Scaffolding and Pure Functions
+
+**Files:**
+- Create: `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`
+- Create: `tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+
+**Context:** The tool has two categories of code: pure functions (argument parsing, key mapping) that can be unit tested, and side-effectful daemon/caller code that requires integration testing. Start with the pure functions.
+
+**Key reference:** `src/PPDS.Extension/tools/webview-cdp.mjs:21-109` — `parseKeyCombo()` and `parseArgs()` are the pure functions exported for testing. Mirror this pattern.
+
+- [ ] **Step 1: Write failing tests for `parseArgs()`**
+
+Create `tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`:
+
+```js
+import { describe, it } from 'node:test';
+import { deepStrictEqual, throws } from 'node:assert';
+import { parseArgs, parseKeyCombo } from './tui-verify.mjs';
+
+describe('parseArgs', () => {
+  it('parses launch with no flags', () => {
+    deepStrictEqual(parseArgs(['launch']), { command: 'launch', build: false });
+  });
+
+  it('parses launch --build', () => {
+    deepStrictEqual(parseArgs(['launch', '--build']), { command: 'launch', build: true });
+  });
+
+  it('parses close', () => {
+    deepStrictEqual(parseArgs(['close']), { command: 'close' });
+  });
+
+  it('parses text with row number', () => {
+    deepStrictEqual(parseArgs(['text', '5']), { command: 'text', row: 5 });
+  });
+
+  it('rejects text with out-of-range row', () => {
+    throws(() => parseArgs(['text', '50']), /Row must be 0-29/);
+  });
+
+  it('rejects text with negative row', () => {
+    throws(() => parseArgs(['text', '-1']), /Row must be 0-29/);
+  });
+
+  it('rejects text without row', () => {
+    throws(() => parseArgs(['text']), /Usage: text <row>/);
+  });
+
+  it('parses key with combo', () => {
+    deepStrictEqual(parseArgs(['key', 'ctrl+t']), { command: 'key', combo: 'ctrl+t' });
+  });
+
+  it('rejects key without combo', () => {
+    throws(() => parseArgs(['key']), /Usage: key <combo>/);
+  });
+
+  it('parses type with text', () => {
+    deepStrictEqual(parseArgs(['type', 'hello']), { command: 'type', text: 'hello' });
+  });
+
+  it('rejects type without text', () => {
+    throws(() => parseArgs(['type']), /Usage: type <text>/);
+  });
+
+  it('parses wait with text and default timeout', () => {
+    deepStrictEqual(parseArgs(['wait', 'PPDS']), { command: 'wait', text: 'PPDS', timeout: 10000 });
+  });
+
+  it('parses wait with text and custom timeout', () => {
+    deepStrictEqual(parseArgs(['wait', 'PPDS', '5000']), { command: 'wait', text: 'PPDS', timeout: 5000 });
+  });
+
+  it('rejects wait with zero timeout', () => {
+    throws(() => parseArgs(['wait', 'PPDS', '0']), /Invalid timeout/);
+  });
+
+  it('rejects wait without text', () => {
+    throws(() => parseArgs(['wait']), /Usage: wait/);
+  });
+
+  it('parses screenshot with file', () => {
+    deepStrictEqual(parseArgs(['screenshot', '/tmp/out.json']), { command: 'screenshot', file: '/tmp/out.json' });
+  });
+
+  it('rejects screenshot without file', () => {
+    throws(() => parseArgs(['screenshot']), /Usage: screenshot <file>/);
+  });
+
+  it('parses rows', () => {
+    deepStrictEqual(parseArgs(['rows']), { command: 'rows' });
+  });
+
+  it('rejects unknown command', () => {
+    throws(() => parseArgs(['bogus']), /Unknown command: bogus/);
+  });
+
+  it('rejects empty args', () => {
+    throws(() => parseArgs([]), /No command provided/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: FAIL — module not found or functions not exported
+
+- [ ] **Step 3: Implement `parseArgs()` in tui-verify.mjs**
+
+Create `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` with the pure functions:
+
+```js
+import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { spawn, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SESSION_FILE = resolve(__dirname, '.tui-verify-session.json');
+const LOG_FILE = resolve(__dirname, '.tui-verify-daemon.log');
+const VALID_COMMANDS = ['launch', 'close', 'screenshot', 'key', 'type', 'text', 'wait', 'rows'];
+const VALID_MODIFIERS = ['ctrl', 'alt', 'shift'];
+const ROWS = 30;
+const COLS = 120;
+
+// ── Pure functions (exported for testing) ──────────────────────────
+
+export function parseArgs(argv) {
+  if (!argv.length) throw new Error('No command provided');
+  const command = argv[0];
+  if (!VALID_COMMANDS.includes(command)) throw new Error(`Unknown command: ${command}`);
+
+  if (command === 'launch') {
+    return { command, build: argv.includes('--build') };
+  }
+  if (command === 'close' || command === 'rows') {
+    return { command };
+  }
+  if (command === 'text') {
+    if (!argv[1]) throw new Error('Usage: text <row>');
+    const row = parseInt(argv[1], 10);
+    if (isNaN(row) || row < 0 || row >= ROWS) throw new Error(`Row must be 0-${ROWS - 1} (terminal has ${ROWS} rows)`);
+    return { command, row };
+  }
+  if (command === 'key') {
+    if (!argv[1]) throw new Error('Usage: key <combo>');
+    return { command, combo: argv[1] };
+  }
+  if (command === 'type') {
+    if (!argv[1]) throw new Error('Usage: type <text>');
+    return { command, text: argv[1] };
+  }
+  if (command === 'wait') {
+    if (!argv[1]) throw new Error('Usage: wait <text> [timeout]');
+    const timeout = argv[2] ? parseInt(argv[2], 10) : 10000;
+    if (isNaN(timeout) || timeout <= 0) throw new Error('Invalid timeout');
+    return { command, text: argv[1], timeout };
+  }
+  if (command === 'screenshot') {
+    if (!argv[1]) throw new Error('Usage: screenshot <file>');
+    return { command, file: argv[1] };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: All parseArgs tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
+git commit -m "feat(tui-verify): add parseArgs with tests"
+```
+
+### Task 2: Key Combo Parsing
+
+**Files:**
+- Modify: `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`
+- Modify: `tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+
+**Context:** The key mapper translates human-readable combos like `"ctrl+t"`, `"tab"`, `"F1"` into objects the daemon can use to dispatch to the correct tui-test Terminal method. The daemon side (Task 4) will consume these parsed results.
+
+**Key reference:** `src/PPDS.Extension/tools/webview-cdp.mjs:21-40` — `parseKeyCombo()` in webview-cdp. Our version is different because we target terminal escape sequences instead of Playwright key names, but the parsing structure is similar.
+
+- [ ] **Step 1: Write failing tests for `parseKeyCombo()`**
+
+Add to `tui-verify.test.mjs`:
+
+```js
+describe('parseKeyCombo', () => {
+  it('parses single named key: enter', () => {
+    deepStrictEqual(parseKeyCombo('enter'), { key: 'enter', modifiers: {} });
+  });
+
+  it('parses single named key: tab', () => {
+    deepStrictEqual(parseKeyCombo('tab'), { key: 'tab', modifiers: {} });
+  });
+
+  it('parses single named key: escape', () => {
+    deepStrictEqual(parseKeyCombo('escape'), { key: 'escape', modifiers: {} });
+  });
+
+  it('parses arrow keys', () => {
+    deepStrictEqual(parseKeyCombo('up'), { key: 'up', modifiers: {} });
+    deepStrictEqual(parseKeyCombo('down'), { key: 'down', modifiers: {} });
+  });
+
+  it('parses function keys', () => {
+    deepStrictEqual(parseKeyCombo('F1'), { key: 'F1', modifiers: {} });
+    deepStrictEqual(parseKeyCombo('F12'), { key: 'F12', modifiers: {} });
+  });
+
+  it('parses ctrl+letter', () => {
+    deepStrictEqual(parseKeyCombo('ctrl+c'), { key: 'c', modifiers: { ctrl: true } });
+  });
+
+  it('parses alt+letter', () => {
+    deepStrictEqual(parseKeyCombo('alt+t'), { key: 't', modifiers: { alt: true } });
+  });
+
+  it('parses ctrl+shift+letter', () => {
+    deepStrictEqual(parseKeyCombo('ctrl+shift+t'), { key: 't', modifiers: { ctrl: true, shift: true } });
+  });
+
+  it('rejects empty combo', () => {
+    throws(() => parseKeyCombo(''), /Empty key combo/);
+  });
+
+  it('rejects unknown modifier', () => {
+    throws(() => parseKeyCombo('super+t'), /unknown modifier 'super'/);
+  });
+
+  it('handles single character key', () => {
+    deepStrictEqual(parseKeyCombo('a'), { key: 'a', modifiers: {} });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify parseKeyCombo tests fail**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: parseKeyCombo tests FAIL
+
+- [ ] **Step 3: Implement `parseKeyCombo()`**
+
+Add to `tui-verify.mjs` in the pure functions section:
+
+```js
+export function parseKeyCombo(combo) {
+  if (!combo) throw new Error('Empty key combo');
+  const parts = combo.split('+');
+  const key = parts.pop();
+  const modifiers = {};
+  for (const mod of parts) {
+    const m = mod.toLowerCase();
+    if (!VALID_MODIFIERS.includes(m)) {
+      throw new Error(`Invalid key combo: unknown modifier '${m}'`);
+    }
+    modifiers[m] = true;
+  }
+  return { key, modifiers };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
+git commit -m "feat(tui-verify): add parseKeyCombo with tests"
+```
+
+### Task 3: Session File I/O and HTTP Client
+
+**Files:**
+- Modify: `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`
+
+**Context:** These are the shared utilities used by both caller commands and the daemon. Session file read/write/delete, and the HTTP client that callers use to talk to the daemon.
+
+**Key reference:** `src/PPDS.Extension/tools/webview-cdp.mjs:112-139` — `readSession()`, `writeSession()`, `deleteSession()`, `sendToDaemon()`.
+
+- [ ] **Step 1: Add session I/O and HTTP client functions**
+
+Add to `tui-verify.mjs` after the pure functions:
+
+```js
+// ── Session file I/O ───────────────────────────────────────────────
+
+function readSession() {
+  if (!existsSync(SESSION_FILE))
+    throw new Error('No session found. Run `tui-verify launch` first.');
+  return JSON.parse(readFileSync(SESSION_FILE, 'utf-8'));
+}
+
+function writeSession(data) {
+  writeFileSync(SESSION_FILE, JSON.stringify(data, null, 2));
+}
+
+function deleteSession() {
+  if (existsSync(SESSION_FILE)) unlinkSync(SESSION_FILE);
+}
+
+// ── HTTP Client (caller mode) ──────────────────────────────────────
+
+async function sendToDaemon(session, action, params = {}) {
+  const body = JSON.stringify({ action, ...params });
+  const res = await fetch(`http://localhost:${session.daemonPort}/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  const result = await res.json();
+  if (!result.success) throw new Error(result.error);
+  return result;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+git commit -m "feat(tui-verify): add session I/O and HTTP client"
+```
+
+### Task 4: Daemon Mode — PTY Spawn, Action Handler, HTTP Server
+
+**Files:**
+- Modify: `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`
+
+**Context:** This is the core of the tool. The daemon spawns the TUI in a PTY via tui-test, exposes an HTTP server, and handles actions against the Terminal instance. The daemon runs as a detached child process forked by the `launch` command.
+
+**Key reference:** `src/PPDS.Extension/tools/webview-cdp.mjs:143-505` — `runDaemon()` is the daemon entry point. Study its structure: launch app → setup → HTTP server → action handler → cleanup.
+
+**Important tui-test API details (from `lib/terminal/term.d.ts`):**
+- `spawn(options, trace, traceEmitter)` — options: `{ program: { file, args }, rows, columns, shell }`
+- `terminal.getBuffer(): string[][]`
+- `terminal.getViewableBuffer(): string[][]`
+- `terminal.write(data: string): void`
+- `terminal.submit(data?: string): void`
+- `terminal.keyUp/Down/Left/Right/Escape/Delete/Backspace/CtrlC/CtrlD(count?): void`
+- `terminal.serialize(): { view: string, shifts: Map<string, CellShift> }`
+- `terminal.kill(): void`
+- `terminal.onExit: IEvent<{ exitCode, signal }>`
+- Shell enum: `{ Bash, Powershell, Cmd, ... }`
+
+- [ ] **Step 1: Add the `sendKey()` helper that maps parsed combos to terminal methods**
+
+This is the bridge between `parseKeyCombo()` output and the tui-test Terminal API.
+
+```js
+// ── Key dispatch ───────────────────────────────────────────────────
+
+// Function key escape sequences (VT220 standard)
+const FN_KEYS = {
+  F1: '\x1bOP', F2: '\x1bOQ', F3: '\x1bOR', F4: '\x1bOS',
+  F5: '\x1b[15~', F6: '\x1b[17~', F7: '\x1b[18~', F8: '\x1b[19~',
+  F9: '\x1b[20~', F10: '\x1b[21~', F11: '\x1b[23~', F12: '\x1b[24~',
+};
+
+function sendKey(terminal, parsed) {
+  const { key, modifiers } = parsed;
+  const hasCtrl = modifiers.ctrl;
+  const hasAlt = modifiers.alt;
+  const hasShift = modifiers.shift;
+  const lk = key.toLowerCase();
+
+  // No modifiers — use named methods or raw sequences
+  if (!hasCtrl && !hasAlt && !hasShift) {
+    if (lk === 'enter') { terminal.submit(); return; }
+    if (lk === 'tab') { terminal.write('\t'); return; }
+    if (lk === 'escape') { terminal.keyEscape(); return; }
+    if (lk === 'up') { terminal.keyUp(); return; }
+    if (lk === 'down') { terminal.keyDown(); return; }
+    if (lk === 'left') { terminal.keyLeft(); return; }
+    if (lk === 'right') { terminal.keyRight(); return; }
+    if (lk === 'backspace') { terminal.keyBackspace(); return; }
+    if (lk === 'delete') { terminal.keyDelete(); return; }
+    if (lk === 'space') { terminal.write(' '); return; }
+    if (FN_KEYS[key]) { terminal.write(FN_KEYS[key]); return; }
+    // Single character
+    terminal.write(key);
+    return;
+  }
+
+  // Ctrl+letter — send control character
+  if (hasCtrl && !hasAlt && key.length === 1) {
+    const code = key.toUpperCase().charCodeAt(0);
+    if (code >= 65 && code <= 90) {
+      // Ctrl+C and Ctrl+D have dedicated methods
+      if (lk === 'c') { terminal.keyCtrlC(); return; }
+      if (lk === 'd') { terminal.keyCtrlD(); return; }
+      terminal.write(String.fromCharCode(code - 64));
+      return;
+    }
+  }
+
+  // Alt+letter — send ESC + letter
+  if (hasAlt && !hasCtrl && key.length === 1) {
+    terminal.write('\x1b' + key);
+    return;
+  }
+
+  // Ctrl+Shift+letter — send ESC [ <code> ; 6 ~ (CSI modifier pattern)
+  // This is platform-dependent; best effort for Terminal.Gui
+  if (hasCtrl && hasShift && key.length === 1) {
+    const code = key.toUpperCase().charCodeAt(0);
+    terminal.write(String.fromCharCode(code - 64));
+    return;
+  }
+
+  // Fallback — try writing the key directly
+  terminal.write(key);
+}
+```
+
+- [ ] **Step 2: Add the daemon entry point**
+
+```js
+// ── Daemon Mode ────────────────────────────────────────────────────
+
+async function runDaemon() {
+  // Dynamic import — callers don't need tui-test
+  const tuiTest = await import('@microsoft/tui-test');
+  const { EventEmitter } = await import('node:events');
+
+  const repoRoot = resolve(__dirname, '..', '..', '..');
+  const exe = resolve(repoRoot, 'src/PPDS.Cli/bin/Debug/net10.0/ppds.exe');
+
+  if (!existsSync(exe)) {
+    console.error(`Binary not found: ${exe}`);
+    console.error('Run with --build or build manually first.');
+    process.exit(1);
+  }
+
+  const traceEmitter = new EventEmitter();
+  const terminal = await tuiTest.spawn(
+    { program: { file: exe, args: ['tui'] }, rows: ROWS, columns: COLS },
+    false,
+    traceEmitter,
+  );
+
+  let exited = false;
+  terminal.onExit(() => { exited = true; });
+
+  // Wait for Terminal.Gui to render (non-empty buffer)
+  const readyStart = Date.now();
+  while (Date.now() - readyStart < 30000) {
+    try {
+      const buf = terminal.getViewableBuffer();
+      const hasContent = buf.some(row => row.some(cell => cell.trim() !== ''));
+      if (hasContent) break;
+    } catch { /* buffer not ready yet */ }
+    await new Promise(r => setTimeout(r, 250));
+  }
+
+  // Action handler
+  async function handleAction(action, params) {
+    if (exited) throw new Error('TUI process exited. Run `launch` again.');
+
+    switch (action) {
+      case 'text': {
+        const { row } = params;
+        if (row < 0 || row >= ROWS) throw new Error(`Row must be 0-${ROWS - 1} (terminal has ${ROWS} rows)`);
+        const buffer = terminal.getViewableBuffer();
+        const text = buffer[row] ? buffer[row].join('').trimEnd() : '';
+        return { text };
+      }
+      case 'key': {
+        const parsed = parseKeyCombo(params.combo);
+        sendKey(terminal, parsed);
+        await new Promise(r => setTimeout(r, 100)); // settle time
+        return {};
+      }
+      case 'type': {
+        for (const ch of params.text) {
+          terminal.write(ch);
+          await new Promise(r => setTimeout(r, 30)); // per-character delay
+        }
+        return {};
+      }
+      case 'wait': {
+        const timeout = params.timeout || 10000;
+        const start = Date.now();
+        while (Date.now() - start < timeout) {
+          if (exited) throw new Error('TUI process exited. Run `launch` again.');
+          const buffer = terminal.getViewableBuffer();
+          for (const row of buffer) {
+            const line = row.join('');
+            if (line.includes(params.text)) return {};
+          }
+          await new Promise(r => setTimeout(r, 250));
+        }
+        throw new Error(`Timeout: '${params.text}' not found within ${timeout}ms`);
+      }
+      case 'screenshot': {
+        const { view, shifts } = terminal.serialize();
+        // Convert Map to plain object for JSON serialization
+        const shiftsObj = {};
+        if (shifts && typeof shifts.forEach === 'function') {
+          shifts.forEach((value, key) => { shiftsObj[key] = value; });
+        }
+        writeFileSync(resolve(params.file), JSON.stringify({ view, shifts: shiftsObj }, null, 2));
+        return { path: resolve(params.file) };
+      }
+      case 'rows': {
+        return { dimensions: `${COLS}x${ROWS}` };
+      }
+      default:
+        throw new Error(`Unknown action: ${action}`);
+    }
+  }
+
+  // HTTP server
+  function readBody(req) {
+    return new Promise((resolveBody) => {
+      let data = '';
+      req.on('data', chunk => { data += chunk; });
+      req.on('end', () => resolveBody(data));
+    });
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.url === '/health') {
+        res.writeHead(200); res.end('ok'); return;
+      }
+      if (req.url === '/shutdown') {
+        res.writeHead(200); res.end('ok');
+        await cleanup();
+        return;
+      }
+      if (req.url === '/execute' && req.method === 'POST') {
+        const body = await readBody(req);
+        const { action, ...params } = JSON.parse(body);
+        const result = await handleAction(action, params);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true, ...result }));
+        return;
+      }
+      res.writeHead(404); res.end('Not found');
+    } catch (err) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: false, error: err.message }));
+    }
+  });
+
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const daemonPort = server.address().port;
+
+  writeSession({ daemonPort, daemonPid: process.pid });
+  console.error(`Daemon ready on port ${daemonPort}`);
+
+  async function cleanup() {
+    try { terminal.kill(); } catch {}
+    deleteSession();
+    if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+    server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', cleanup);
+  process.on('SIGINT', cleanup);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+git commit -m "feat(tui-verify): add daemon mode — PTY spawn, action handler, HTTP server"
+```
+
+### Task 5: Caller Commands and Main Dispatch
+
+**Files:**
+- Modify: `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`
+
+**Context:** The caller-side functions that handle each CLI command. `launch` forks the daemon, `close` shuts it down, and everything else sends HTTP requests via `sendToDaemon()`.
+
+**Key reference:** `src/PPDS.Extension/tools/webview-cdp.mjs:509-725` — `cmdLaunch()`, `cmdClose()`, and the main dispatch switch.
+
+- [ ] **Step 1: Add caller command handlers**
+
+```js
+// ── Caller command handlers ────────────────────────────────────────
+
+async function cmdLaunch(parsed) {
+  if (parsed.build) {
+    const repoRoot = resolve(__dirname, '..', '..', '..');
+    console.error('Building PPDS CLI...');
+    try {
+      execFileSync('dotnet', ['build', resolve(repoRoot, 'src/PPDS.Cli/PPDS.Cli.csproj'), '-f', 'net10.0', '-v', 'q'], {
+        cwd: repoRoot,
+        stdio: 'inherit',
+      });
+    } catch {
+      throw new Error('Build failed — fix compilation errors above');
+    }
+    console.error('Build complete');
+  }
+
+  if (existsSync(SESSION_FILE)) {
+    const session = JSON.parse(readFileSync(SESSION_FILE, 'utf-8'));
+    try {
+      await fetch(`http://localhost:${session.daemonPort}/health`);
+      console.error('TUI already running. Run `close` first.');
+      return;
+    } catch {
+      // Stale session — clean up
+      try { process.kill(session.daemonPid); } catch {}
+      deleteSession();
+    }
+  }
+
+  // Redirect daemon stderr to a log file for diagnostics
+  const { openSync } = await import('node:fs');
+  const logFd = openSync(LOG_FILE, 'w');
+  const child = spawn(process.execPath, [__filename, '--daemon'], {
+    detached: true,
+    stdio: ['ignore', 'ignore', logFd],
+  });
+  child.unref();
+
+  const start = Date.now();
+  while (Date.now() - start < 30000) {
+    if (existsSync(SESSION_FILE)) {
+      const session = readSession();
+      console.error(`TUI launched (daemon PID ${session.daemonPid}, port ${session.daemonPort})`);
+      return;
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  // On timeout, show daemon log for diagnostics
+  if (existsSync(LOG_FILE)) {
+    const log = readFileSync(LOG_FILE, 'utf-8').split('\n').slice(-20).join('\n');
+    if (log.trim()) console.error('Daemon log:\n' + log);
+  }
+  throw new Error('Timeout: daemon did not start within 30 seconds');
+}
+
+async function cmdClose() {
+  if (!existsSync(SESSION_FILE)) {
+    console.error('No session found. Nothing to close.');
+    return;
+  }
+  const session = readSession();
+  try {
+    await fetch(`http://localhost:${session.daemonPort}/shutdown`);
+  } catch {
+    try { process.kill(session.daemonPid); } catch {}
+  }
+  const start = Date.now();
+  while (Date.now() - start < 10000) {
+    if (!existsSync(SESSION_FILE)) {
+      console.error('TUI closed');
+      return;
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+  // Force cleanup
+  try { process.kill(session.daemonPid); } catch {}
+  deleteSession();
+  if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+  console.error('TUI closed (forced)');
+}
+
+async function cmdText(parsed) {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'text', { row: parsed.row });
+  console.log(result.text);
+}
+
+async function cmdKey(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'key', { combo: parsed.combo });
+}
+
+async function cmdType(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'type', { text: parsed.text });
+}
+
+async function cmdWait(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'wait', { text: parsed.text, timeout: parsed.timeout });
+  console.log(`Found: ${parsed.text}`);
+}
+
+async function cmdScreenshot(parsed) {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'screenshot', { file: parsed.file });
+  console.log(result.path);
+}
+
+async function cmdRows() {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'rows', {});
+  console.log(result.dimensions);
+}
+```
+
+- [ ] **Step 2: Add main dispatch**
+
+```js
+// ── Main dispatch ──────────────────────────────────────────────────
+
+async function main() {
+  // Daemon mode
+  if (process.argv.includes('--daemon')) {
+    await runDaemon();
+    return;
+  }
+
+  // Caller mode
+  const parsed = parseArgs(process.argv.slice(2));
+  switch (parsed.command) {
+    case 'launch': await cmdLaunch(parsed); break;
+    case 'close': await cmdClose(); break;
+    case 'text': await cmdText(parsed); break;
+    case 'key': await cmdKey(parsed); break;
+    case 'type': await cmdType(parsed); break;
+    case 'wait': await cmdWait(parsed); break;
+    case 'screenshot': await cmdScreenshot(parsed); break;
+    case 'rows': await cmdRows(); break;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()) {
+  main().catch(err => {
+    process.stderr.write(err.message + '\n');
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 3: Run unit tests to confirm nothing broke**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+git commit -m "feat(tui-verify): add caller commands and main dispatch"
+```
+
+### Task 6: Gitignore
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add session and log files to .gitignore**
+
+Add `.tui-verify-session.json` and `.tui-verify-daemon.log` to the `.gitignore` file, near any existing webview-cdp session patterns.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore: add tui-verify session file to gitignore"
+```
+
+---
+
+## Chunk 2: Integration Testing (Eat Your Own Dog Food)
+
+### Task 7: Smoke Test — Launch, Read, Close
+
+**Files:** None (manual verification using the tool itself)
+
+**Context:** The tool is now code-complete. Before writing integration docs, verify it actually works by using it. This is the "eat your own dog food" step from the issue. Must work on Windows.
+
+- [ ] **Step 1: Build the TUI**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -f net10.0 -v q`
+Expected: Build succeeds
+
+- [ ] **Step 2: Launch with --build**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build`
+Expected: stderr shows "Build complete" then "TUI launched (daemon PID X, port Y)"
+
+- [ ] **Step 3: Verify session file was created**
+
+Check: `tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json` exists with `daemonPort` and `daemonPid`
+
+- [ ] **Step 4: Wait for TUI to render**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000`
+Expected: stdout shows "Found: PPDS"
+
+- [ ] **Step 5: Read the title bar**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0`
+Expected: stdout shows the top row of the TUI (should contain "PPDS" title text)
+
+- [ ] **Step 6: Read the status bar**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29`
+Expected: stdout shows the bottom row (status bar content)
+
+- [ ] **Step 7: Check dimensions**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs rows`
+Expected: stdout shows "120x30"
+
+- [ ] **Step 8: Send Tab keystroke**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"`
+Expected: No error. Then read a row to verify focus moved:
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2`
+
+- [ ] **Step 9: Dump terminal state**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-debug.json`
+Expected: File written, contains `view` and `shifts` keys. Read the file to inspect.
+
+- [ ] **Step 10: Test error handling**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 50`
+Expected: stderr "Row must be 0-29 (terminal has 30 rows)", exit 1
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "NONEXISTENT" 2000`
+Expected: stderr "Timeout: 'NONEXISTENT' not found within 2000ms", exit 1
+
+- [ ] **Step 11: Close**
+
+Run: `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close`
+Expected: stderr "TUI closed". Session file deleted. No orphaned processes.
+
+- [ ] **Step 12: Fix any issues found during smoke testing**
+
+If any command doesn't work as expected, fix the implementation. Common issues:
+- PTY binary path wrong → adjust path resolution in `runDaemon()`
+- Buffer not populated → increase ready-wait polling or check Terminal.Gui startup
+- Key combos not recognized by Terminal.Gui → adjust escape sequences in `sendKey()`
+- Windows-specific PTY behavior → check node-pty Windows handling
+
+- [ ] **Step 13: Commit any fixes**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+git commit -m "fix(tui-verify): fixes from smoke testing"
+```
+
+---
+
+## Chunk 3: Integration — Skill, Commands, Gitignore
+
+### Task 8: Create @tui-verify Skill
+
+**Files:**
+- Create: `.claude/skills/tui-verify/SKILL.md`
+
+**Context:** This skill teaches AI agents when and how to use tui-verify.mjs. It mirrors `.claude/skills/webview-cdp/SKILL.md` in structure. The spec's Integration section defines what must be included.
+
+**Key reference:** `.claude/skills/webview-cdp/SKILL.md` — the webview-cdp skill file. Mirror its structure: frontmatter, when to use, command table, common patterns, tips, gap protocol.
+
+- [ ] **Step 1: Create the skill file**
+
+Create `.claude/skills/tui-verify/SKILL.md` with:
+
+```markdown
+---
+name: tui-verify
+description: Interactive TUI verification via PTY — launch, navigate, read text, send keystrokes. Use after implementing or modifying any TUI-affecting change (screens, widgets, keyboard handlers, status bar). For non-visual changes (service logic, data access), compile + test is sufficient.
+allowed-tools: Bash(node *tui-verify*), Bash(cd * && node *tui-verify*)
+---
+
+# TUI Verify Tool
+
+Interact with the PPDS TUI running in a PTY. Read terminal text to verify what's rendered, send keystrokes to navigate, wait for specific content to appear. Text-based verification — the AI reads terminal rows directly instead of interpreting screenshots.
+
+## When to Use
+
+- After implementing or modifying any TUI screen, widget, or keyboard handler
+- When debugging TUI rendering — read specific rows to see what's there
+- When testing keyboard navigation — send keystrokes and verify focus moved
+- When verifying status bar content after an operation
+
+## Setup
+
+The tool is at `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`. Uses `@microsoft/tui-test` (already a dev dependency). Requires the TUI to be built first.
+
+## Core Workflow
+
+```bash
+# 1. Build and launch TUI in PTY (120x30 terminal)
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# 2. Wait for it to render
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# 3. Read specific rows to verify content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0   # title bar
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # status bar
+
+# 4. Navigate with keystrokes
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+
+# 5. Verify expected content appeared
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# 6. When done
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+## Commands
+
+| Command | Example | Purpose |
+|---------|---------|---------|
+| `launch [--build]` | `launch --build` | Start TUI in PTY. `--build` compiles first |
+| `close` | `close` | Kill PTY, clean up (idempotent) |
+| `text <row>` | `text 0` | Read terminal row content (0-based, 0-29) |
+| `key "<combo>"` | `key "ctrl+t"` | Send keystroke |
+| `type "<text>"` | `type "SELECT"` | Type text character by character |
+| `wait "<text>" [ms]` | `wait "PPDS" 5000` | Poll until text appears (default 10s) |
+| `screenshot <file>` | `screenshot $TEMP/debug.json` | Dump serialize() as JSON (text + colors) |
+| `rows` | `rows` | Show terminal dimensions (120x30) |
+
+## Key Combos
+
+| Combo | What it does in Terminal.Gui |
+|-------|------------------------------|
+| `tab` | Cycle focus to next widget |
+| `shift+tab` | Cycle focus to previous widget |
+| `enter` | Activate focused button/menu item |
+| `escape` | Close dialog/cancel operation |
+| `alt+<letter>` | Menu bar shortcut (e.g., `alt+f` for File) |
+| `ctrl+q` | Quit (standard Terminal.Gui quit) |
+| `up`/`down` | Navigate lists, menus, tree views |
+| `F1`-`F12` | Function key shortcuts |
+| `ctrl+t` | Common PPDS shortcut for TDS toggle |
+
+## Common Patterns
+
+### Verify a screen loaded
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0  # check title
+```
+
+### Navigate to a specific screen
+```bash
+# Use Alt+letter for menu shortcuts, then arrow keys and Enter
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "alt+s"  # Solutions menu
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "Solutions" 5000
+```
+
+### Check status bar after operation
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29  # bottom row
+```
+
+### Type into a text field
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"  # focus the input
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT TOP 10 * FROM account"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+```
+
+### Debug rendering issues
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-state.json
+# Read the file to see full terminal state with colors
+```
+
+### Read multiple rows
+```bash
+# Scan visible area for content
+for i in 0 1 2 3 4 5; do
+  node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text $i
+done
+```
+
+## Screenshots
+
+The `screenshot` command dumps the terminal's `serialize()` output as JSON — text with color metadata. Not a PNG image. Use `$TEMP` for the output path:
+
+```bash
+# Good
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/debug.json
+
+# BAD — creates file in repo
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot debug.json
+```
+
+## Verification Before Completion
+
+**Interactive verification required** — any change affecting TUI rendering:
+- Screen layout, widget placement, borders
+- Keyboard handlers, focus order
+- Status bar content, menu items
+- Dialog boxes, error messages
+
+**Compile + test sufficient** — no visual impact:
+- Application Service logic (business rules)
+- Dataverse queries, data transformation
+- CLI command behavior (not TUI)
+
+## Error Recovery
+
+### `launch` fails
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up stale session
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+```
+
+### `wait` times out
+1. Check if TUI is alive: `text 0` — if error, TUI crashed. `close` then `launch --build`
+2. Check if you're on the right screen: read several rows with `text`
+3. Increase timeout: `wait "text" 30000`
+
+### TUI crashes mid-session
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close   # clean up
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+```
+
+## Gap Protocol
+
+If you encounter a TUI interaction that this tool cannot handle:
+
+1. **STOP** — do not work around it silently
+2. **Describe the gap** — what interaction you need
+3. **Propose an enhancement** — a new command or flag
+4. **Ask the user** — implement now or defer
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/tui-verify/SKILL.md
+git commit -m "feat(tui-verify): add @tui-verify skill file"
+```
+
+### Task 9: Update /verify Command
+
+**Files:**
+- Modify: `.claude/commands/verify.md`
+
+**Context:** Replace Section 4 ("TUI Mode") which currently says "not yet available" with interactive tui-verify steps. The spec's Integration section provides the exact replacement content.
+
+**Key reference:** `.claude/commands/verify.md:56-68` — the current TUI Mode section to replace. Also look at Section 5 (Extension Mode) for the Phase A/B/C structure to mirror.
+
+- [ ] **Step 1: Read the current verify.md to find exact lines to replace**
+
+Read `.claude/commands/verify.md` and locate the TUI Mode section (around lines 56-68).
+
+- [ ] **Step 2: Replace the TUI Mode section**
+
+Replace the "TUI interactive verification via MCP is not yet available" block with:
+
+```markdown
+### 4. TUI Mode
+
+**Phase A: Build and Launch**
+
+```bash
+# Build and launch TUI in PTY
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# Wait for TUI to render
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# Read the title bar to confirm it loaded
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+```
+
+**Phase B: Interactive Verification (MANDATORY for TUI rendering/interaction changes)**
+
+If changed files touch `src/PPDS.Cli/Tui/`, Phase B is NOT optional.
+
+```bash
+# Navigate to the relevant screen
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+
+# Verify status bar content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29
+
+# Wait for expected screen title
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# Dump terminal state for debugging if needed
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify.json
+```
+
+**Phase C: Cleanup**
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+See @tui-verify skill for full command reference and Terminal.Gui keyboard patterns.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/commands/verify.md
+git commit -m "feat(tui-verify): update /verify tui with interactive verification"
+```
+
+### Task 10: Update /qa Command
+
+**Files:**
+- Modify: `.claude/commands/qa.md`
+
+**Context:** Add a "TUI Mode — Verifier Prompt" section to qa.md, and update the mode detection so `src/PPDS.Cli/Tui/` maps to "TUI mode (tui-verify)" instead of "snapshot tests — no blind verification yet". The spec provides the complete verifier prompt.
+
+**Key reference:** `.claude/commands/qa.md` — look at the "Extension Mode — Verifier Prompt" section for the pattern, and the "Step 2: Detect Mode" section for the mapping to update.
+
+- [ ] **Step 1: Read qa.md and find the mode detection and extension verifier sections**
+
+Read `.claude/commands/qa.md`, locate:
+- The Step 2 mode detection mapping (around line 40) where `src/PPDS.Cli/Tui/` is mapped
+- The Extension Mode verifier prompt section (to mirror its structure)
+
+- [ ] **Step 2: Update mode detection**
+
+Change `src/PPDS.Cli/Tui/` mapping from:
+```
+- `src/PPDS.Cli/Tui/` → TUI mode (snapshot tests — no blind verification yet)
+```
+to:
+```
+- `src/PPDS.Cli/Tui/` → TUI mode (tui-verify)
+```
+
+- [ ] **Step 3: Add TUI Mode blind verifier prompt**
+
+Add the following section after the Extension Mode verifier prompt:
+
+````markdown
+#### TUI Mode — Verifier Prompt
+
+```
+You are a QA tester. You have NEVER seen the source code for this TUI
+application. You don't know how anything is implemented. You only know
+what the product SHOULD do.
+
+## Your Tools
+
+You may ONLY use these tools:
+- Bash: ONLY for running `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` commands
+- Read: ONLY for viewing screenshot JSON files (in $TEMP)
+
+You MUST NOT use Read/Grep/Glob on source code files. You cannot look
+at .cs, .ts, .json, or any file under src/. You are blind to the
+implementation.
+
+## Verification Protocol
+
+For EACH check below:
+1. Perform the action using tui-verify commands
+2. Read the relevant terminal row(s): `text <row>`
+3. Optionally dump full state: `screenshot $TEMP/qa-tui-{check-number}.json`
+4. Compare actual text to expected text
+5. Report PASS or FAIL with the actual text content as evidence
+
+If a check FAILS:
+- Show exactly what text you SAW vs what was EXPECTED
+- Include the row number and full row content
+- Do NOT speculate about why it failed
+
+## Setup
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up prior
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+```
+
+## Checks
+
+{paste generated checklist here}
+
+## Teardown
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+## Report Format
+
+| # | Check | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | description | PASS/FAIL | row N: "actual text content" |
+
+### Verdict: PASS (all green) / FAIL (N issues found)
+```
+````
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/commands/qa.md
+git commit -m "feat(tui-verify): add TUI Mode blind verifier to /qa"
+```
+
+---
+
+## Chunk 4: Final Verification
+
+### Task 11: End-to-End Verification
+
+- [ ] **Step 1: Run the full verification sequence from the spec**
+
+Execute AC-01 through AC-17 from the spec's acceptance criteria:
+
+```bash
+# AC-01: launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# AC-10: wait finds existing text
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# AC-04: text reads row content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+
+# AC-14: rows returns dimensions
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs rows
+
+# AC-06: tab moves focus
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+
+# AC-07: enter activates
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+
+# AC-09: escape closes dialog
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "escape"
+
+# AC-08: ctrl+q sends Ctrl+Q
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "ctrl+q"
+# Then dismiss any quit dialog:
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "escape"
+
+# AC-12: type writes characters
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 5
+
+# AC-13: screenshot dumps serialize()
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify-final.json
+
+# AC-15: stale session detection
+# Read the session file to get daemon PID, then kill the daemon
+# without running `close` — this leaves a stale session file behind
+cat tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json
+# Note the daemonPid, then:
+# Windows: taskkill /F /PID <pid>   Linux: kill -9 <pid>
+# Verify session file still exists (stale), then launch should detect and clean up:
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+# Expected: launch detects stale session, cleans up, starts fresh
+
+# AC-02: launch without --build (uses existing binary)
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# AC-05: out-of-range row error
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 50
+
+# AC-11: wait timeout
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "NONEXISTENT" 2000
+
+# AC-03, AC-16: close cleans up
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+- [ ] **Step 2: Fix any remaining issues**
+
+If any acceptance criteria fail, fix and re-test.
+
+- [ ] **Step 3: Run unit tests one final time**
+
+Run: `node --test tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs`
+Expected: All PASS
+
+- [ ] **Step 4: Final commit if any fixes were needed**
+
+```bash
+git add tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+git commit -m "fix(tui-verify): final verification fixes"
+```
+
+### Task 12: Run Quality Gates
+
+- [ ] **Step 1: Run /gates**
+
+Invoke `/automated-quality-gates` to verify no build/lint/test regressions.
+
+- [ ] **Step 2: Fix any gate failures**
+
+If gates fail, fix and re-run.
+
+- [ ] **Step 3: Commit fixes**
+
+Stage only the files you changed, then commit:
+
+```bash
+git add <specific-files-that-were-fixed>
+git commit -m "fix: quality gate fixes"
+```

--- a/specs/tui-verify-tool.md
+++ b/specs/tui-verify-tool.md
@@ -1,0 +1,616 @@
+# TUI Verify Tool
+
+**Status:** Draft
+**Version:** 1.0
+**Last Updated:** 2026-03-16
+**Code:** [tests/PPDS.Tui.E2eTests/tools/](../tests/PPDS.Tui.E2eTests/tools/) | None
+
+---
+
+## Overview
+
+A CLI tool that lets AI agents launch the PPDS TUI in a PTY, send keystrokes, read terminal text, and wait for content — closing the feedback loop between TUI implementation and verification. Mirrors the `webview-cdp.mjs` pattern but targets Terminal.Gui applications instead of VS Code webviews.
+
+The primary verification workflow is text-based. The AI reads terminal rows directly and searches for expected strings. PNG rendering is deferred — terminal text is more useful than pixels for AI verification of a TUI.
+
+### Goals
+
+- **Interactive TUI verification**: AI agents can launch, navigate, and inspect the TUI without manual intervention
+- **Text-based feedback**: Read specific terminal rows, wait for text to appear, get terminal dimensions
+- **Keystroke injection**: Send individual keys, key combos (ctrl+shift+t), and typed text
+- **Same lifecycle model as webview-cdp**: Launch → interact → close, with a persistent daemon between commands
+
+### Non-Goals
+
+- PNG pixel rendering of terminal state (deferred — `serialize()` dump available for debugging)
+- Automated visual regression testing in CI (use `@microsoft/tui-test` snapshot tests directly)
+- Mouse interaction (Terminal.Gui keyboard-first; mouse support deferred)
+- Attaching to an already-running TUI process
+
+---
+
+## Architecture
+
+```
+Claude Code
+    |
+    |  Bash: node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs <command> [args]
+    v
++----------------------------+
+|   tui-verify CLI            |  Short-lived process per command
+|   (caller)                  |  Reads .tui-verify-session.json
++--------+-------------------+
+         |
+         +-- launch:  forks daemon -> daemon spawns PTY + HTTP server
+         |            daemon writes session file with port/pid
+         |
+         +-- other commands:  POST http://localhost:<port>/execute
+         |   daemon executes against Terminal instance
+         |   -> uses tui-test Terminal API (getBuffer, write, etc.)
+         |   -> returns result as JSON
+         |
+         +-- close:  POST /shutdown to daemon
+                     daemon kills PTY, cleans up, exits
+
++----------------------------+     +----------------------------+
+|  tui-verify daemon          |---->|  ppds tui (in PTY)          |
+|  (long-lived background)    |     |                             |
+|                             |     |  Terminal.Gui application    |
+|  HTTP server on random port |     |  120 cols x 30 rows         |
+|  Holds tui-test Terminal    |     |  Renders to virtual terminal |
+|  Executes commands via API  |     |                             |
++----------------------------+     +----------------------------+
+```
+
+### Why a daemon?
+
+Same reason as webview-cdp: the `@microsoft/tui-test` `Terminal` object owns the PTY process. When the Node.js process exits, the PTY is killed. A long-lived daemon keeps the PTY alive across multiple CLI invocations.
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `tui-verify.mjs` | CLI entry point (caller mode) + daemon mode (`--daemon` flag). Single file. |
+| Daemon process | Long-lived process holding the tui-test `Terminal` instance and HTTP server |
+| Session file | `.tui-verify-session.json` — persists `daemonPort`, `daemonPid` |
+| Key mapper | Translates human-readable key combos ("ctrl+shift+t") to terminal escape sequences |
+
+### Dependencies
+
+- **Runtime:** Node.js (already required by the extension build toolchain)
+- **npm:** `@microsoft/tui-test` (already a dev dependency in `tests/PPDS.Tui.E2eTests/`)
+- **Transitive:** `@homebridge/node-pty-prebuilt-multiarch` (PTY management, pulled in by tui-test), `@xterm/headless` (terminal emulation, pulled in by tui-test)
+- Depends on: [tui-foundation spec](./tui.md) (TUI architecture)
+- Mirrors: [webview-cdp spec](./vscode-webview-cdp-tool.md) (architecture pattern)
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. The tool MUST launch the PPDS TUI in a PTY via `@microsoft/tui-test`'s `spawn()` API
+2. The tool MUST persist the PTY across CLI invocations using a daemon process
+3. The tool MUST read terminal text content from specific rows via `getBuffer()`
+4. The tool MUST inject keystrokes via `write()` and named key methods
+5. The tool MUST poll terminal content for expected text with configurable timeout
+6. The tool MUST NOT use `shell: true` in any process spawn (CONSTITUTION S2)
+7. Terminal size MUST be 120 columns x 30 rows (matches existing tui-test config)
+8. All status messages MUST go to stderr; only command results go to stdout
+
+### Command Interface
+
+| Command | Signature | Purpose |
+|---------|-----------|---------|
+| `launch` | `launch [--build]` | Start ppds tui in a PTY. `--build` runs `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -f net10.0` first |
+| `close` | `close` | Kill PTY process, shut down daemon, clean up session file |
+| `screenshot` | `screenshot <file>` | Dump `terminal.serialize()` to file as JSON (text + color metadata for debugging) |
+| `key` | `key "<combo>"` | Send keystroke. Supports: named keys (enter, tab, escape, F1-F12), modifiers (ctrl+c, alt+t), raw characters |
+| `type` | `type "<text>"` | Write text string into focused input, character by character |
+| `text` | `text <row>` | Read and return text content at terminal row (0-based) |
+| `wait` | `wait "<text>" [timeout]` | Poll terminal content until text substring appears. Default timeout 10000ms |
+| `rows` | `rows` | Return terminal dimensions as `120x30` (cols x rows, standard WxH convention) |
+
+### Primary Flows
+
+**Launch flow (caller process):**
+
+1. **Check for stale session**: If session file exists, ping daemon HTTP server. If ping succeeds, warn "TUI already running" and exit. If fails, kill stale PID, delete session file.
+2. **Optional build**: If `--build` flag, run `execFileSync('dotnet', ['build', 'src/PPDS.Cli/PPDS.Cli.csproj', '-f', 'net10.0'])` — uses `execFileSync` (not `execSync`) to avoid shell invocation per CONSTITUTION S2.
+3. **Fork daemon**: Spawn `node tui-verify.mjs --daemon` as a detached background process. Redirect daemon stderr to `.tui-verify-daemon.log` via `openSync` file descriptor — provides diagnostics if the daemon fails to start.
+4. **Wait for session**: Poll for session file (daemon writes it when PTY is ready), up to 30 seconds. On timeout, read the last 20 lines of `.tui-verify-daemon.log` and include them in the error message.
+5. **Print confirmation**: Output "TUI launched (daemon PID X, port Y)" to stderr.
+
+**Launch flow (daemon process — `--daemon` flag):**
+
+1. **Resolve program path**: If `--build` was used, run the built binary directly (`src/PPDS.Cli/bin/Debug/net10.0/ppds.exe tui`). Otherwise, use the built binary path as well (caller is responsible for having built first). The daemon never invokes `dotnet run` — it always launches the compiled executable via tui-test's `spawn({ program: { file, args } })`.
+2. **Spawn PTY**: Call tui-test `spawn({ program: { file, args }, rows: 30, columns: 120 })`.
+3. **Wait for ready**: Poll `getBuffer()` until non-empty content appears (Terminal.Gui has rendered), up to 30 seconds.
+4. **Start HTTP server**: Listen on random available port. Expose `/execute`, `/shutdown`, `/health`.
+5. **Write session file**: `{ daemonPort, daemonPid: process.pid }`.
+6. **Wait for shutdown**: Listen for `/shutdown` request or `SIGTERM`/`SIGINT`. On any, call `terminal.kill()`, delete session file, exit.
+
+**Command execution flow (all commands except launch/close):**
+
+1. **Read session**: Load `daemonPort` from `.tui-verify-session.json`.
+2. **Send request**: POST to `http://localhost:<port>/execute` with action and params as JSON.
+3. **Daemon executes**: Runs the action against the Terminal instance.
+4. **Output result**: Print result to stdout.
+
+**Text read flow (`text <row>`):**
+
+1. **Get buffer**: `terminal.getBuffer()` returns `string[][]` (2D array of cells).
+2. **Extract row**: `buffer[row]` gives array of single-character strings.
+3. **Join and trim**: `buffer[row].join('').trimEnd()`.
+4. **Return**: Print row content to stdout.
+
+**Wait flow (`wait "<text>" [timeout]`):**
+
+1. **Start timer**: Record `Date.now()`.
+2. **Poll loop**: Every 250ms, scan all rows of `getBuffer()` for the search text as a substring.
+3. **Found**: Print "Found: <text>" to stdout, exit 0.
+4. **Timeout**: Print "Timeout: '<text>' not found within Xms" to stderr, exit 1.
+
+**Key flow (`key "<combo>"`):**
+
+1. **Parse combo**: Split on `+`, identify modifiers (ctrl, alt, shift) and the base key.
+2. **Map to terminal input**: Use tui-test's named methods where available (`keyUp`, `keyDown`, `keyEscape`, `keyCtrlC`, `keyCtrlD`). For other combos, map to raw ANSI escape sequences via `terminal.write()`. For `enter`, use `terminal.submit()`.
+3. **Execute**: Send the input to the PTY.
+4. **Brief settle**: Wait 100ms for Terminal.Gui to process the input.
+
+**Close flow:**
+
+1. **Read session**: Load `daemonPort` and `daemonPid`.
+2. **Request shutdown**: POST to `/shutdown`. Daemon calls `terminal.kill()`, deletes session file, exits.
+3. **Wait for cleanup**: Poll until session file disappears (up to 10 seconds).
+4. **Force kill if needed**: If session file persists, force-kill daemon PID, delete manually.
+5. **Print confirmation**: "TUI closed" to stderr.
+
+### Keystroke Mapping
+
+Terminal.Gui uses ANSI/VT escape sequences. The key mapper must handle:
+
+| Input | Method | Terminal Sequence |
+|-------|--------|-------------------|
+| `enter` | `terminal.submit()` | `\r` |
+| `tab` | `terminal.write('\t')` | `\t` |
+| `escape` | `terminal.keyEscape()` | `\x1b` |
+| `up` / `down` / `left` / `right` | `terminal.keyUp()` etc. | Arrow escape sequences |
+| `backspace` | `terminal.keyBackspace()` | `\x7f` |
+| `delete` | `terminal.keyDelete()` | `\x1b[3~` |
+| `ctrl+c` | `terminal.keyCtrlC()` | `\x03` |
+| `ctrl+d` | `terminal.keyCtrlD()` | `\x04` |
+| `ctrl+<letter>` | `terminal.write(String.fromCharCode(code - 64))` | Control character |
+| `alt+<letter>` | `terminal.write('\x1b' + letter)` | ESC + letter |
+| `F1`-`F12` | `terminal.write(fnSequence)` | Standard VT function key sequences |
+| `ctrl+shift+<letter>` | Compose modifier escape | Platform-dependent |
+
+### Constraints
+
+- Single file implementation (`tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`)
+- Uses `@microsoft/tui-test` (already a dev dependency in parent package.json)
+- Session file: `tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json` (gitignored)
+- Daemon log file: `tests/PPDS.Tui.E2eTests/tools/.tui-verify-daemon.log` (gitignored) — daemon stderr redirected here for diagnostics. On launch timeout, the caller prints the last 20 lines of this log before reporting failure. Deleted by `close`.
+- All errors to stderr, all results to stdout
+- Exit code 0 on success, 1 on error
+- Terminal dimensions: 120 columns x 30 rows (fixed, matching tui-test config)
+- Windows primary platform — PTY handling via `node-pty` (cross-platform, bundled with tui-test)
+- No `shell: true` anywhere (CONSTITUTION S2)
+- Daemon process runs detached — survives if calling terminal is closed
+
+### Security Considerations
+
+- **Local development only**: Spawns a local TUI process in a PTY.
+- **Process spawn (CONSTITUTION S2)**: `launch` forks a daemon via `child_process.spawn()` with `shell: false`. The daemon delegates to tui-test's `spawn()` which uses `node-pty` (no shell).
+- **No secrets in output (CONSTITUTION S3)**: Terminal buffer content may include connection strings if the TUI displays them. The tool passes through whatever the TUI renders — agents should avoid dumping full terminal state in logs.
+- **No innerHTML (CONSTITUTION S1)**: Not applicable — tool outputs plain text only.
+
+### Validation Rules
+
+| Input | Rule | Error |
+|-------|------|-------|
+| `screenshot <file>` | File path must be provided | "Usage: screenshot \<file\>" |
+| `text <row>` | Row must be integer 0-29 | "Row must be 0-29 (terminal has 30 rows)" |
+| `key "<combo>"` | Combo must be non-empty, modifiers must be ctrl/alt/shift | "Invalid key combo" |
+| `type "<text>"` | Text must be non-empty | "Usage: type \<text\>" |
+| `wait "<text>"` | Search text must be non-empty | "Usage: wait \<text\> [timeout]" |
+| `wait [timeout]` | Timeout must be positive integer, default 10000 | "Invalid timeout" |
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `launch --build` compiles `src/PPDS.Cli/PPDS.Cli.csproj -f net10.0` and starts the TUI in a PTY | Manual: run `launch --build`, verify TUI process starts and session file written | 🔲 |
+| AC-02 | `launch` without `--build` starts TUI using existing build | Manual: run `launch` after prior build, verify TUI starts | 🔲 |
+| AC-03 | `close` kills the PTY process and deletes the session file | Manual: run `close`, verify no orphaned processes and session file removed | 🔲 |
+| AC-04 | `text <row>` returns the text content of the specified terminal row | Manual: run `text 0`, verify output matches the TUI's top row (title bar) | 🔲 |
+| AC-05 | `text <row>` with out-of-range row returns an error | Manual: run `text 50`, verify error "Row must be 0-29" | 🔲 |
+| AC-06 | `key "tab"` sends a Tab keystroke to the TUI and moves focus | Manual: run `key "tab"`, then `text` on the focused row, verify focus moved | 🔲 |
+| AC-07 | `key "enter"` sends Enter to the TUI | Manual: navigate to a menu item, run `key "enter"`, verify action triggered | 🔲 |
+| AC-08 | `key "ctrl+q"` sends Ctrl+Q to the TUI | Manual: run `key "ctrl+q"`, verify TUI responds (quit dialog or exit) | 🔲 |
+| AC-09 | `key "escape"` sends Escape to the TUI | Manual: open a dialog, run `key "escape"`, verify dialog closed | 🔲 |
+| AC-10 | `wait "<text>"` finds text that is already on screen and returns immediately | Manual: run `wait "PPDS"` after launch, verify instant return | 🔲 |
+| AC-11 | `wait "<text>" [timeout]` times out when text never appears | Manual: run `wait "NONEXISTENT" 2000`, verify timeout error after ~2 seconds | 🔲 |
+| AC-12 | `type "<text>"` writes characters into the focused input field | Manual: focus a text field, run `type "SELECT"`, verify text appears | 🔲 |
+| AC-13 | `screenshot <file>` writes a JSON file containing `serialize()` output | Manual: run `screenshot $TEMP/debug.json`, verify file contains `view` and `shifts` keys | 🔲 |
+| AC-14 | `rows` returns `120x30` | Manual: run `rows`, verify output is `120x30` | 🔲 |
+| AC-15 | Stale session detection: `launch` when a prior daemon died cleans up and starts fresh | Manual: kill daemon PID manually, run `launch`, verify clean restart | 🔲 |
+| AC-16 | No orphaned processes after `close` | Manual: run `close`, check task manager for stale `dotnet` or `ppds` processes | 🔲 |
+| AC-17 | Tool works on Windows (primary dev platform) | Manual: all above criteria pass on Windows 11 | 🔲 |
+| AC-18 | `/verify tui` command updated to use tui-verify.mjs for interactive verification | Manual: run `/verify tui`, verify it uses tui-verify commands | 🔲 |
+| AC-19 | `@tui-verify` skill created with command reference and common patterns | Manual: invoke skill, verify content covers all commands and Terminal.Gui patterns | 🔲 |
+| AC-20 | `/qa` command updated with TUI Mode blind verifier section | Manual: run `/qa tui`, verify blind verifier dispatched with TUI-specific protocol | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| No session | Any command without prior `launch` | stderr: "No session found. Run `tui-verify launch` first.", exit 1 |
+| TUI crashed | Command after TUI process died | stderr: "TUI process exited. Run `launch` again.", exit 1 |
+| Row out of range | `text 35` | stderr: "Row must be 0-29 (terminal has 30 rows)", exit 1 |
+| Negative row | `text -1` | stderr: "Row must be 0-29 (terminal has 30 rows)", exit 1 |
+| Empty key combo | `key ""` | stderr: "Invalid key combo", exit 1 |
+| Unknown modifier | `key "super+t"` | stderr: "Invalid key combo: unknown modifier 'super'", exit 1 |
+| Wait with zero timeout | `wait "text" 0` | stderr: "Invalid timeout", exit 1 |
+| Double launch | `launch` when already running | stderr: "TUI already running. Run `close` first.", exit 0 |
+| Close without launch | `close` with no session | stderr: "No session found. Nothing to close.", exit 0 (idempotent) |
+| TUI slow to render | `launch` when Terminal.Gui takes >5s to draw | Daemon polls getBuffer() up to 30s before timing out |
+
+---
+
+## Core Types
+
+### Session File
+
+```json
+{
+  "daemonPort": 52345,
+  "daemonPid": 12345
+}
+```
+
+Written by daemon during launch, read by all commands, deleted during close.
+
+### Serialize Output (screenshot)
+
+The tui-test `terminal.serialize()` returns `{ view: string, shifts: Map<string, CellShift> }` where `CellShift` has properties: `bgColorMode`, `bgColor`, `fgColorMode`, `fgColor`, `blink`, `bold`, `dim`, `inverse`, `invisible`, `italic`, `overline`, `strike`, `underline`.
+
+Since `Map` doesn't JSON.stringify natively, the `screenshot` command converts `shifts` to a plain object before writing:
+
+```json
+{
+  "view": "┌─ PPDS ─────────────────────────────┐\n│ SQL Query    Solutions    Plugins   │\n...",
+  "shifts": {
+    "0,5": { "bold": 1, "fgColor": 4, "fgColorMode": 1 },
+    "1,2": { "fgColor": 12, "fgColorMode": 1 }
+  }
+}
+```
+
+The `view` field contains the rendered terminal text with line breaks. The `shifts` map keys are cell coordinates, values are the styling attributes for those cells. Useful for debugging rendering issues.
+
+> **Source:** Verified from `@microsoft/tui-test@0.0.1-rc.5` type definitions at `lib/terminal/term.d.ts:184-187`.
+
+### Usage Pattern
+
+```bash
+# Build and launch
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# Read the title bar
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+
+# Navigate with Tab, verify focus moved
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 1
+
+# Wait for a specific screen
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# Type into a focused input
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs type "SELECT TOP 10 * FROM account"
+
+# Execute with Enter
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "enter"
+
+# Dump terminal state for debugging
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-debug.json
+
+# Check dimensions
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs rows
+
+# Shut down
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+---
+
+## API/Contracts
+
+The daemon exposes three HTTP endpoints on `127.0.0.1:<randomPort>`.
+
+### `GET /health`
+
+Returns `200 OK` with body `ok` if the daemon and PTY are alive.
+
+### `POST /shutdown`
+
+Returns `200 OK` with body `ok`, then asynchronously kills the PTY, deletes the session file, and exits the daemon process.
+
+### `POST /execute`
+
+Executes an action against the terminal.
+
+**Request:**
+
+```json
+{
+  "action": "text",
+  "row": 0
+}
+```
+
+| Action | Params | Response |
+|--------|--------|----------|
+| `text` | `{ "row": number }` | `{ "success": true, "text": "row content" }` |
+| `key` | `{ "combo": "ctrl+t" }` | `{ "success": true }` |
+| `type` | `{ "text": "SELECT" }` | `{ "success": true }` |
+| `wait` | `{ "text": "SQL Query", "timeout": 10000 }` | `{ "success": true }` or `{ "success": false, "error": "Timeout..." }` |
+| `screenshot` | `{ "file": "/tmp/debug.json" }` | `{ "success": true, "path": "/tmp/debug.json" }` |
+| `rows` | `{}` | `{ "success": true, "dimensions": "120x30" }` |
+
+**Error response:**
+
+```json
+{
+  "success": false,
+  "error": "Row must be 0-29 (terminal has 30 rows)"
+}
+```
+
+HTTP status is always 200. Errors are reported via the `success` field (same pattern as webview-cdp).
+
+### Test Examples
+
+```bash
+# Verify launch and basic text read
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+# Expected: top row contains "PPDS" title text
+
+# Verify keyboard navigation
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+# Expected: focus indicator moved to next widget
+
+# Verify error handling
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 50
+# Expected: stderr "Row must be 0-29 (terminal has 30 rows)", exit 1
+
+# Verify dimensions
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs rows
+# Expected: "120x30"
+
+# Cleanup
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+---
+
+## Error Handling
+
+### Error Types
+
+| Error | Condition | Recovery |
+|-------|-----------|----------|
+| No session | Session file missing | "Run `tui-verify launch` first" |
+| TUI process exited | PTY process died | "Run `launch` again" |
+| Row out of range | Row index >= 30 or < 0 | Report valid range |
+| Invalid key combo | Unrecognized modifier or empty combo | Report valid modifiers |
+| Wait timeout | Text not found within timeout | Report what was searched and timeout used |
+| Build failed | `dotnet build` returned non-zero | Forward build error output |
+| Daemon timeout | PTY didn't produce content within 30s | "TUI failed to start" |
+
+### Recovery Strategies
+
+- **Connection errors**: Run `close` then `launch` again.
+- **Orphaned sessions**: `close` detects unreachable daemon, cleans up session file. Then `launch` fresh.
+- **TUI crash**: Daemon detects PTY exit via `terminal.onExit`. Next command gets "TUI process exited" error. Run `close` to clean up, then `launch`.
+
+---
+
+## Design Decisions
+
+### Why text-based verification instead of PNG screenshots?
+
+**Context:** The issue originally called for PNG screenshots mirroring webview-cdp's pixel captures.
+
+**Decision:** Use text-based verification as the primary workflow. The `screenshot` command dumps `serialize()` as JSON for debugging, not as a PNG image.
+
+**Rationale:**
+- AI agents read text better than they interpret terminal pixel renderings
+- `getBuffer()` gives exact cell content — no OCR errors, no font rendering differences
+- `wait "<text>"` is more reliable than pixel comparison for detecting TUI state
+- Terminal.Gui rendering is deterministic (same input = same text buffer) unlike browser rendering
+- PNG rendering would require an additional canvas library dependency for limited benefit
+
+**Alternatives considered:**
+- Full PNG rendering via `node-canvas`: Heavy dependency (~50MB), platform-specific native compilation, marginal benefit for AI verification
+- xterm.js addon rendering: Requires browser context, overkill for text verification
+
+**Consequences:**
+- Positive: Simpler tool, fewer dependencies, more reliable verification
+- Negative: Human reviewers can't "see" the TUI from the output. Mitigated by `serialize()` dump which preserves colors and structure.
+
+### Why put the tool in tests/PPDS.Tui.E2eTests/tools/?
+
+**Context:** Three possible locations: alongside webview-cdp in `src/PPDS.Extension/tools/`, at repo root `tools/`, or under the test project.
+
+**Decision:** `tests/PPDS.Tui.E2eTests/tools/` — colocated with the `@microsoft/tui-test` dependency.
+
+**Rationale:**
+- `@microsoft/tui-test` is already installed here — no duplicate dependency
+- The tool imports from tui-test directly — relative imports are clean
+- webview-cdp lives next to its dependency (`@playwright/test` in `src/PPDS.Extension/`) — same pattern
+
+**Alternatives considered:**
+- `src/PPDS.Extension/tools/`: Would need tui-test added as a dependency there — duplicates the install
+- `tools/` at repo root: Would need its own `package.json` or workspace config to resolve tui-test
+
+### Why the daemon pattern (same as webview-cdp)?
+
+**Context:** tui-test's `Terminal` object owns the PTY via `node-pty`. The PTY is killed when the owning process exits.
+
+**Decision:** Fork a daemon process that holds the Terminal alive. Same architecture as webview-cdp.
+
+**Alternatives considered:**
+- Serialize/deserialize PTY state between invocations: Not supported by node-pty
+- Single long-running command with stdin for commands: Breaks the "one command per CLI invocation" model that agents use
+
+---
+
+## Integration
+
+### Skill: `@tui-verify`
+
+Create `.claude/skills/tui-verify/SKILL.md` with:
+- **Frontmatter** must include `allowed-tools: Bash(node *tui-verify*), Bash(cd * && node *tui-verify*)` — sandboxes the skill to tui-verify commands only (mirrors webview-cdp's `Bash(node *webview-cdp*)` pattern)
+- When to use (after any TUI change that affects rendering or interaction)
+- Command reference table (all 8 commands with examples)
+- Common patterns (navigate screens, verify status bar, check menu items)
+- Terminal.Gui keyboard navigation specifics (Tab cycles focus, Enter activates, Escape closes dialogs, Alt+letter for menu shortcuts)
+- Debugging tips (use `screenshot` to dump serialize() output to `$TEMP`, read specific rows with `text`)
+- Gap protocol (same as webview-cdp — stop and report if interaction can't be accomplished)
+
+### Command: `/verify tui`
+
+Replace Section 4 ("TUI Mode") in `.claude/commands/verify.md`. The current content (lines 60-68) says "TUI interactive verification via MCP is not yet available. Use snapshot tests." Replace with:
+
+```markdown
+### 4. TUI Mode
+
+**Phase A: Build and Launch**
+
+```bash
+# Build and launch TUI in PTY
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+
+# Wait for TUI to render
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+
+# Read the title bar to confirm it loaded
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+```
+
+**Phase B: Interactive Verification (MANDATORY for TUI rendering/interaction changes)**
+
+If changed files touch `src/PPDS.Cli/Tui/`, Phase B is NOT optional.
+
+```bash
+# Navigate to the relevant screen
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+
+# Verify status bar content
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 29
+
+# Wait for expected screen title
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+
+# Dump terminal state for debugging if needed
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify.json
+```
+
+**Phase C: Cleanup**
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+See @tui-verify skill for full command reference and Terminal.Gui keyboard patterns.
+```
+
+### Command: `/qa tui`
+
+Add a "TUI Mode — Verifier Prompt" section to `.claude/commands/qa.md`, parallel to Extension Mode. The blind verifier prompt:
+
+```markdown
+#### TUI Mode — Verifier Prompt
+
+```
+You are a QA tester. You have NEVER seen the source code for this TUI
+application. You don't know how anything is implemented. You only know
+what the product SHOULD do.
+
+## Your Tools
+
+You may ONLY use these tools:
+- Bash: ONLY for running `node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` commands
+- Read: ONLY for viewing screenshot JSON files (in $TEMP)
+
+You MUST NOT use Read/Grep/Glob on source code files. You cannot look
+at .cs, .ts, .json, or any file under src/. You are blind to the
+implementation.
+
+## Verification Protocol
+
+For EACH check below:
+1. Perform the action using tui-verify commands
+2. Read the relevant terminal row(s): `text <row>`
+3. Optionally dump full state: `screenshot $TEMP/qa-tui-{check-number}.json`
+4. Compare actual text to expected text
+5. Report PASS or FAIL with the actual text content as evidence
+
+If a check FAILS:
+- Show exactly what text you SAW vs what was EXPECTED
+- Include the row number and full row content
+- Do NOT speculate about why it failed
+
+## Setup
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close  # clean up prior
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+```
+
+## Checks
+
+{paste generated checklist here}
+
+## Teardown
+
+```bash
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+## Report Format
+
+| # | Check | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | description | PASS/FAIL | row N: "actual text content" |
+
+### Verdict: PASS (all green) / FAIL (N issues found)
+```
+```
+
+Also update the mode detection in Step 2: change `src/PPDS.Cli/Tui/` from "TUI mode (snapshot tests — no blind verification yet)" to "TUI mode (tui-verify)".
+
+---
+
+## Related Specs
+
+- [tui.md](./tui.md) — TUI foundation architecture
+- [vscode-webview-cdp-tool.md](./vscode-webview-cdp-tool.md) — Reference implementation (same daemon pattern)
+
+---
+
+## Roadmap
+
+- **PNG rendering**: Add optional pixel rendering via canvas library for human-readable screenshots
+- **Mouse support**: Terminal.Gui supports mouse — add `click <row> <col>` command
+- **Record/replay**: Capture keystroke sequences for repeatable verification scripts
+- **CI integration**: Run TUI verification in CI with headless PTY

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -58,7 +58,8 @@ export function parseArgs(argv) {
   if (command === 'wait') {
     const text = argv[1];
     if (text === undefined) throw new Error('wait requires text');
-    const timeout = argv[2] !== undefined ? parseInt(argv[2], 10) : 30000;
+    const timeout = argv[2] !== undefined ? parseInt(argv[2], 10) : 10000;
+    if (timeout <= 0) throw new Error('Invalid timeout');
     return { command, text, timeout };
   }
 
@@ -222,8 +223,8 @@ async function runDaemon() {
         const row = params.row;
         const buf = terminal.getViewableBuffer();
         if (row < 0 || row >= buf.length) throw new Error(`Row ${row} out of range`);
-        const line = buf[row].join('').trimEnd();
-        return { line };
+        const text = buf[row].join('').trimEnd();
+        return { text };
       }
       case 'key': {
         const parsed = parseKeyCombo(params.combo);
@@ -240,7 +241,7 @@ async function runDaemon() {
         return {};
       }
       case 'wait': {
-        const timeout = params.timeout ?? 30000;
+        const timeout = params.timeout ?? 10000;
         const start = Date.now();
         while (Date.now() - start < timeout) {
           const buf = terminal.getViewableBuffer();
@@ -250,7 +251,7 @@ async function runDaemon() {
           }
           await new Promise(r => setTimeout(r, 250));
         }
-        throw new Error(`Timeout: '${params.text}' not found within ${(params.timeout ?? 30000) / 1000}s`);
+        throw new Error(`Timeout: '${params.text}' not found within ${(params.timeout ?? 10000) / 1000}s`);
       }
       case 'screenshot': {
         const snapshot = terminal.serialize();
@@ -268,7 +269,7 @@ async function runDaemon() {
         return { path: resolve(params.file) };
       }
       case 'rows': {
-        return { size: `${COLS}x${ROWS}` };
+        return { dimensions: `${COLS}x${ROWS}` };
       }
       default:
         throw new Error(`Unknown action: ${action}`);
@@ -333,16 +334,16 @@ async function runDaemon() {
 async function cmdLaunch(parsed) {
   if (parsed.build) {
     const repoRoot = resolve(__dirname, '..', '..', '..');
-    console.log('Building PPDS CLI...');
+    console.error('Building PPDS CLI...');
     try {
-      execFileSync('dotnet', ['build', 'src/PPDS.Cli/PPDS.Cli.csproj', '-c', 'Debug', '-v', 'q'], {
+      execFileSync('dotnet', ['build', 'src/PPDS.Cli/PPDS.Cli.csproj', '-f', 'net10.0', '-v', 'q'], {
         cwd: repoRoot,
         stdio: 'inherit',
       });
     } catch {
       throw new Error('Build failed — fix compilation errors above');
     }
-    console.log('Build complete');
+    console.error('Build complete');
   }
 
   // Check for stale session
@@ -350,7 +351,7 @@ async function cmdLaunch(parsed) {
     const session = JSON.parse(readFileSync(SESSION_FILE, 'utf-8'));
     try {
       await fetch(`http://localhost:${session.daemonPort}/health`);
-      console.log('TUI is already running. Run `close` first.');
+      console.error('TUI is already running. Run `close` first.');
       return;
     } catch {
       // Stale session — clean up
@@ -372,7 +373,7 @@ async function cmdLaunch(parsed) {
   while (Date.now() - start < 30000) {
     if (existsSync(SESSION_FILE)) {
       const session = readSession();
-      console.log(`TUI launched (daemon PID ${session.daemonPid}, port ${session.daemonPort})`);
+      console.error(`TUI launched (daemon PID ${session.daemonPid}, port ${session.daemonPort})`);
       return;
     }
     await new Promise(r => setTimeout(r, 500));
@@ -390,7 +391,7 @@ async function cmdLaunch(parsed) {
 
 async function cmdClose() {
   if (!existsSync(SESSION_FILE)) {
-    console.log('Nothing to close');
+    console.error('No session found. Nothing to close.');
     return;
   }
 
@@ -405,7 +406,7 @@ async function cmdClose() {
   const start = Date.now();
   while (Date.now() - start < 10000) {
     if (!existsSync(SESSION_FILE)) {
-      console.log('TUI closed');
+      console.error('TUI closed');
       return;
     }
     await new Promise(r => setTimeout(r, 200));
@@ -415,13 +416,13 @@ async function cmdClose() {
   try { process.kill(session.daemonPid); } catch {}
   deleteSession();
   if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
-  console.log('TUI closed (forced)');
+  console.error('TUI closed (forced)');
 }
 
 async function cmdText(parsed) {
   const session = readSession();
   const result = await sendToDaemon(session, 'text', { row: parsed.row });
-  console.log(result.line);
+  console.log(result.text);
 }
 
 async function cmdKey(parsed) {
@@ -449,7 +450,7 @@ async function cmdScreenshot(parsed) {
 async function cmdRows() {
   const session = readSession();
   const result = await sendToDaemon(session, 'rows', {});
-  console.log(result.size);
+  console.log(result.dimensions);
 }
 
 // ── Main dispatch ────────────────────────────────────────────────────

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -37,27 +37,27 @@ export function parseArgs(argv) {
 
   if (command === 'text') {
     const rowStr = argv[1];
-    if (rowStr === undefined) throw new Error('text requires a row number');
+    if (rowStr === undefined) throw new Error('Usage: text <row>');
     const row = parseInt(rowStr, 10);
-    if (isNaN(row) || row < 0 || row >= ROWS) throw new Error(`Row ${rowStr} out of range (0-${ROWS - 1})`);
+    if (isNaN(row) || row < 0 || row >= ROWS) throw new Error(`Row must be 0-${ROWS - 1} (terminal has ${ROWS} rows)`);
     return { command, row };
   }
 
   if (command === 'key') {
     const combo = argv[1];
-    if (!combo) throw new Error('key requires a key combo');
+    if (!combo) throw new Error('Usage: key <combo>');
     return { command, combo };
   }
 
   if (command === 'type') {
     const text = argv[1];
-    if (text === undefined) throw new Error('type requires text');
+    if (text === undefined) throw new Error('Usage: type <text>');
     return { command, text };
   }
 
   if (command === 'wait') {
     const text = argv[1];
-    if (text === undefined) throw new Error('wait requires text');
+    if (text === undefined) throw new Error('Usage: wait <text> [timeout]');
     const timeout = argv[2] !== undefined ? parseInt(argv[2], 10) : 10000;
     if (timeout <= 0) throw new Error('Invalid timeout');
     return { command, text, timeout };
@@ -65,7 +65,7 @@ export function parseArgs(argv) {
 
   if (command === 'screenshot') {
     const file = argv[1];
-    if (!file) throw new Error('screenshot requires a file path');
+    if (!file) throw new Error('Usage: screenshot <file>');
     return { command, file };
   }
 
@@ -129,6 +129,12 @@ async function runDaemon() {
   const repoRoot = resolve(__dirname, '..', '..', '..');
   const exe = resolve(repoRoot, 'src/PPDS.Cli/bin/Debug/net10.0/ppds.exe');
 
+  if (!existsSync(exe)) {
+    console.error(`Binary not found: ${exe}`);
+    console.error('Run with --build or build manually first.');
+    process.exit(1);
+  }
+
   const terminal = await tuiTest.spawn(
     { rows: ROWS, cols: COLS, program: { file: exe, args: ['tui'] } },
     false,
@@ -145,37 +151,30 @@ async function runDaemon() {
   // Wait for terminal to render (poll for non-empty content, 30s timeout)
   const renderStart = Date.now();
   while (Date.now() - renderStart < 30000) {
-    const buf = terminal.getViewableBuffer();
-    const hasContent = buf.some(row => row.some(cell => cell.trim() !== ''));
-    if (hasContent) break;
+    try {
+      const buf = terminal.getViewableBuffer();
+      const hasContent = buf.some(row => row.some(cell => cell.trim() !== ''));
+      if (hasContent) break;
+    } catch { /* buffer not ready */ }
     await new Promise(r => setTimeout(r, 250));
   }
 
   // ── sendKey helper ───────────────────────────────────────────────
 
+  const FN_KEYS = {
+    F1: '\x1bOP', F2: '\x1bOQ', F3: '\x1bOR', F4: '\x1bOS',
+    F5: '\x1b[15~', F6: '\x1b[17~', F7: '\x1b[18~', F8: '\x1b[19~',
+    F9: '\x1b[20~', F10: '\x1b[21~', F11: '\x1b[23~', F12: '\x1b[24~',
+  };
+
   function sendKey(term, parsed) {
     const { key, modifiers } = parsed;
     const lk = key.toLowerCase();
+    const hasCtrl = modifiers.ctrl;
+    const hasAlt = modifiers.alt;
 
-    // ctrl combos
-    if (modifiers.ctrl) {
-      if (lk === 'c') { term.keyCtrlC(); return; }
-      if (lk === 'd') { term.keyCtrlD(); return; }
-      // ctrl+letter → write control character
-      const code = lk.charCodeAt(0);
-      if (code >= 97 && code <= 122) {
-        term.write(String.fromCharCode(code - 96));
-        return;
-      }
-    }
-
-    // alt combos
-    if (modifiers.alt) {
-      term.write('\x1b' + key);
-      return;
-    }
-
-    // Named keys
+    // Named keys — handle first, regardless of modifiers
+    // (Terminal.Gui receives the modifier state separately for named keys)
     const namedKeys = {
       enter: () => term.submit(),
       tab: () => term.write('\t'),
@@ -195,21 +194,28 @@ async function runDaemon() {
     }
 
     // Function keys F1-F12 (VT220 escape sequences)
-    const fMatch = key.match(/^[Ff](\d+)$/);
-    if (fMatch) {
-      const fNum = parseInt(fMatch[1], 10);
-      const fSeqs = {
-        1: '\x1bOP', 2: '\x1bOQ', 3: '\x1bOR', 4: '\x1bOS',
-        5: '\x1b[15~', 6: '\x1b[17~', 7: '\x1b[18~', 8: '\x1b[19~',
-        9: '\x1b[20~', 10: '\x1b[21~', 11: '\x1b[23~', 12: '\x1b[24~',
-      };
-      if (fSeqs[fNum]) {
-        term.write(fSeqs[fNum]);
+    if (FN_KEYS[key] || FN_KEYS[key.toUpperCase()]) {
+      term.write(FN_KEYS[key] || FN_KEYS[key.toUpperCase()]);
+      return;
+    }
+
+    // Single character with modifiers
+    if (hasCtrl && key.length === 1) {
+      if (lk === 'c') { term.keyCtrlC(); return; }
+      if (lk === 'd') { term.keyCtrlD(); return; }
+      const code = key.toUpperCase().charCodeAt(0);
+      if (code >= 65 && code <= 90) {
+        term.write(String.fromCharCode(code - 64));
         return;
       }
     }
 
-    // Single character fallback
+    if (hasAlt && key.length === 1) {
+      term.write('\x1b' + key);
+      return;
+    }
+
+    // Single character, no modifiers
     term.write(key);
   }
 
@@ -251,7 +257,7 @@ async function runDaemon() {
           }
           await new Promise(r => setTimeout(r, 250));
         }
-        throw new Error(`Timeout: '${params.text}' not found within ${(params.timeout ?? 10000) / 1000}s`);
+        throw new Error(`Timeout: '${params.text}' not found within ${timeout}ms`);
       }
       case 'screenshot': {
         const snapshot = terminal.serialize();
@@ -438,7 +444,7 @@ async function cmdType(parsed) {
 async function cmdWait(parsed) {
   const session = readSession();
   await sendToDaemon(session, 'wait', { text: parsed.text, timeout: parsed.timeout });
-  console.log('Found');
+  console.log('Found: ' + parsed.text);
 }
 
 async function cmdScreenshot(parsed) {

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -136,7 +136,7 @@ async function runDaemon() {
   }
 
   const terminal = await tuiTest.spawn(
-    { rows: ROWS, cols: COLS, program: { file: exe, args: ['tui'] } },
+    { rows: ROWS, cols: COLS, program: { file: exe, args: ['interactive'] } },
     false,
     traceEmitter,
   );

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -1,0 +1,493 @@
+import { readFileSync, writeFileSync, unlinkSync, existsSync, openSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { spawn as spawnProcess, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SESSION_FILE = resolve(__dirname, '.tui-verify-session.json');
+const LOG_FILE = resolve(__dirname, '.tui-verify-daemon.log');
+
+export const ROWS = 30;
+export const COLS = 120;
+
+const VALID_COMMANDS = ['launch', 'close', 'screenshot', 'key', 'type', 'text', 'wait', 'rows'];
+const VALID_MODIFIERS = ['ctrl', 'alt', 'shift'];
+
+// ── Pure functions (exported for testing) ────────────────────────────
+
+export function parseArgs(argv) {
+  if (!argv.length) throw new Error('No command provided');
+  const command = argv[0];
+  if (!VALID_COMMANDS.includes(command)) throw new Error(`Unknown command: ${command}`);
+
+  if (command === 'launch') {
+    let build = false;
+    for (const arg of argv.slice(1)) {
+      if (arg === '--build') build = true;
+    }
+    return { command, build };
+  }
+
+  if (command === 'close' || command === 'rows') {
+    return { command };
+  }
+
+  if (command === 'text') {
+    const rowStr = argv[1];
+    if (rowStr === undefined) throw new Error('text requires a row number');
+    const row = parseInt(rowStr, 10);
+    if (isNaN(row) || row < 0 || row >= ROWS) throw new Error(`Row ${rowStr} out of range (0-${ROWS - 1})`);
+    return { command, row };
+  }
+
+  if (command === 'key') {
+    const combo = argv[1];
+    if (!combo) throw new Error('key requires a key combo');
+    return { command, combo };
+  }
+
+  if (command === 'type') {
+    const text = argv[1];
+    if (text === undefined) throw new Error('type requires text');
+    return { command, text };
+  }
+
+  if (command === 'wait') {
+    const text = argv[1];
+    if (text === undefined) throw new Error('wait requires text');
+    const timeout = argv[2] !== undefined ? parseInt(argv[2], 10) : 30000;
+    return { command, text, timeout };
+  }
+
+  if (command === 'screenshot') {
+    const file = argv[1];
+    if (!file) throw new Error('screenshot requires a file path');
+    return { command, file };
+  }
+
+  return { command };
+}
+
+export function parseKeyCombo(combo) {
+  if (!combo) throw new Error('Empty key combo');
+  const parts = combo.split('+');
+  const key = parts.pop();
+  const modifiers = {};
+  for (const mod of parts) {
+    const m = mod.toLowerCase();
+    if (!VALID_MODIFIERS.includes(m)) {
+      throw new Error(`Invalid key combo: unknown modifier '${mod}'`);
+    }
+    modifiers[m] = true;
+  }
+  return { key, modifiers };
+}
+
+// ── Session file I/O ─────────────────────────────────────────────────
+
+function readSession() {
+  if (!existsSync(SESSION_FILE))
+    throw new Error('No session found. Run `tui-verify launch` first.');
+  return JSON.parse(readFileSync(SESSION_FILE, 'utf-8'));
+}
+
+function writeSession(data) {
+  writeFileSync(SESSION_FILE, JSON.stringify(data, null, 2));
+}
+
+function deleteSession() {
+  if (existsSync(SESSION_FILE)) unlinkSync(SESSION_FILE);
+}
+
+// ── HTTP Client (caller mode) ────────────────────────────────────────
+
+async function sendToDaemon(session, action, params = {}) {
+  const body = JSON.stringify({ action, ...params });
+  const res = await fetch(`http://localhost:${session.daemonPort}/execute`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  const result = await res.json();
+  if (!result.success) throw new Error(result.error);
+  return result;
+}
+
+// ── Daemon Mode ──────────────────────────────────────────────────────
+
+async function runDaemon() {
+  const { EventEmitter } = await import('node:events');
+  const traceEmitter = new EventEmitter();
+
+  // Dynamic import — callers don't need tui-test
+  const tuiTest = await import('@microsoft/tui-test/lib/terminal/term.js');
+
+  const repoRoot = resolve(__dirname, '..', '..', '..');
+  const exe = resolve(repoRoot, 'src/PPDS.Cli/bin/Debug/net10.0/ppds.exe');
+
+  const terminal = await tuiTest.spawn(
+    { rows: ROWS, cols: COLS, program: { file: exe, args: ['tui'] } },
+    false,
+    traceEmitter,
+  );
+
+  // Track PTY exit
+  let exited = false;
+  terminal.onExit(({ exitCode, signal }) => {
+    exited = true;
+    console.error(`PTY exited: code=${exitCode} signal=${signal}`);
+  });
+
+  // Wait for terminal to render (poll for non-empty content, 30s timeout)
+  const renderStart = Date.now();
+  while (Date.now() - renderStart < 30000) {
+    const buf = terminal.getViewableBuffer();
+    const hasContent = buf.some(row => row.some(cell => cell.trim() !== ''));
+    if (hasContent) break;
+    await new Promise(r => setTimeout(r, 250));
+  }
+
+  // ── sendKey helper ───────────────────────────────────────────────
+
+  function sendKey(term, parsed) {
+    const { key, modifiers } = parsed;
+    const lk = key.toLowerCase();
+
+    // ctrl combos
+    if (modifiers.ctrl) {
+      if (lk === 'c') { term.keyCtrlC(); return; }
+      if (lk === 'd') { term.keyCtrlD(); return; }
+      // ctrl+letter → write control character
+      const code = lk.charCodeAt(0);
+      if (code >= 97 && code <= 122) {
+        term.write(String.fromCharCode(code - 96));
+        return;
+      }
+    }
+
+    // alt combos
+    if (modifiers.alt) {
+      term.write('\x1b' + key);
+      return;
+    }
+
+    // ctrl+shift+letter (best effort — same as ctrl+letter)
+    if (modifiers.shift && modifiers.ctrl) {
+      const code = lk.charCodeAt(0);
+      if (code >= 97 && code <= 122) {
+        term.write(String.fromCharCode(code - 96));
+        return;
+      }
+    }
+
+    // Named keys
+    const namedKeys = {
+      enter: () => term.submit(),
+      tab: () => term.write('\t'),
+      escape: () => term.keyEscape(),
+      up: () => term.keyUp(),
+      down: () => term.keyDown(),
+      left: () => term.keyLeft(),
+      right: () => term.keyRight(),
+      backspace: () => term.keyBackspace(),
+      delete: () => term.keyDelete(),
+      space: () => term.write(' '),
+    };
+
+    if (namedKeys[lk]) {
+      namedKeys[lk]();
+      return;
+    }
+
+    // Function keys F1-F12 (VT220 escape sequences)
+    const fMatch = key.match(/^[Ff](\d+)$/);
+    if (fMatch) {
+      const fNum = parseInt(fMatch[1], 10);
+      const fSeqs = {
+        1: '\x1bOP', 2: '\x1bOQ', 3: '\x1bOR', 4: '\x1bOS',
+        5: '\x1b[15~', 6: '\x1b[17~', 7: '\x1b[18~', 8: '\x1b[19~',
+        9: '\x1b[20~', 10: '\x1b[21~', 11: '\x1b[23~', 12: '\x1b[24~',
+      };
+      if (fSeqs[fNum]) {
+        term.write(fSeqs[fNum]);
+        return;
+      }
+    }
+
+    // Single character fallback
+    term.write(key);
+  }
+
+  // ── Action handler ───────────────────────────────────────────────
+
+  async function handleAction(action, params) {
+    if (exited) throw new Error('Terminal has exited');
+
+    switch (action) {
+      case 'text': {
+        const row = params.row;
+        const buf = terminal.getViewableBuffer();
+        if (row < 0 || row >= buf.length) throw new Error(`Row ${row} out of range`);
+        const line = buf[row].join('').trimEnd();
+        return { line };
+      }
+      case 'key': {
+        const parsed = parseKeyCombo(params.combo);
+        sendKey(terminal, parsed);
+        await new Promise(r => setTimeout(r, 100)); // 100ms settle
+        return {};
+      }
+      case 'type': {
+        const chars = params.text.split('');
+        for (const ch of chars) {
+          terminal.write(ch);
+          await new Promise(r => setTimeout(r, 30)); // 30ms per char
+        }
+        return {};
+      }
+      case 'wait': {
+        const timeout = params.timeout ?? 30000;
+        const start = Date.now();
+        while (Date.now() - start < timeout) {
+          const buf = terminal.getViewableBuffer();
+          for (const row of buf) {
+            const line = row.join('');
+            if (line.includes(params.text)) return {};
+          }
+          await new Promise(r => setTimeout(r, 250));
+        }
+        throw new Error(`Timeout: '${params.text}' not found within ${(params.timeout ?? 30000) / 1000}s`);
+      }
+      case 'screenshot': {
+        const snapshot = terminal.serialize();
+        // Convert Map to plain object for JSON serialization
+        const shifts = {};
+        if (snapshot.shifts instanceof Map) {
+          for (const [k, v] of snapshot.shifts) {
+            shifts[k] = v;
+          }
+        } else {
+          Object.assign(shifts, snapshot.shifts);
+        }
+        const data = { view: snapshot.view, shifts };
+        writeFileSync(resolve(params.file), JSON.stringify(data, null, 2));
+        return { path: resolve(params.file) };
+      }
+      case 'rows': {
+        return { size: `${COLS}x${ROWS}` };
+      }
+      default:
+        throw new Error(`Unknown action: ${action}`);
+    }
+  }
+
+  // ── HTTP server ──────────────────────────────────────────────────
+
+  function readBody(req) {
+    return new Promise((resolveBody) => {
+      let data = '';
+      req.on('data', chunk => { data += chunk; });
+      req.on('end', () => resolveBody(data));
+    });
+  }
+
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.url === '/health') {
+        res.writeHead(200); res.end('ok'); return;
+      }
+      if (req.url === '/shutdown') {
+        res.writeHead(200); res.end('ok');
+        await cleanup();
+        return;
+      }
+      if (req.url === '/execute' && req.method === 'POST') {
+        const body = await readBody(req);
+        const { action, ...params } = JSON.parse(body);
+        const result = await handleAction(action, params);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true, ...result }));
+        return;
+      }
+      res.writeHead(404); res.end('Not found');
+    } catch (err) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: false, error: err.message }));
+    }
+  });
+
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const daemonPort = server.address().port;
+
+  writeSession({ daemonPort, daemonPid: process.pid, logFile: LOG_FILE });
+  console.error(`Daemon ready on port ${daemonPort}`);
+
+  async function cleanup() {
+    try { terminal.kill(); } catch {}
+    deleteSession();
+    if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+    server.close();
+    process.exit(0);
+  }
+
+  process.on('SIGTERM', cleanup);
+  process.on('SIGINT', cleanup);
+}
+
+// ── Caller command handlers ──────────────────────────────────────────
+
+async function cmdLaunch(parsed) {
+  if (parsed.build) {
+    const repoRoot = resolve(__dirname, '..', '..', '..');
+    console.log('Building PPDS CLI...');
+    try {
+      execFileSync('dotnet', ['build', 'src/PPDS.Cli/PPDS.Cli.csproj', '-c', 'Debug', '-v', 'q'], {
+        cwd: repoRoot,
+        stdio: 'inherit',
+      });
+    } catch {
+      throw new Error('Build failed — fix compilation errors above');
+    }
+    console.log('Build complete');
+  }
+
+  // Check for stale session
+  if (existsSync(SESSION_FILE)) {
+    const session = JSON.parse(readFileSync(SESSION_FILE, 'utf-8'));
+    try {
+      await fetch(`http://localhost:${session.daemonPort}/health`);
+      console.log('TUI is already running. Run `close` first.');
+      return;
+    } catch {
+      // Stale session — clean up
+      try { process.kill(session.daemonPid); } catch {}
+      deleteSession();
+    }
+  }
+
+  // Fork daemon with stderr redirected to log file
+  const logFd = openSync(LOG_FILE, 'w');
+  const child = spawnProcess(process.execPath, [__filename, '--daemon'], {
+    detached: true,
+    stdio: ['ignore', 'ignore', logFd],
+  });
+  child.unref();
+
+  // Poll for session file (30s timeout)
+  const start = Date.now();
+  while (Date.now() - start < 30000) {
+    if (existsSync(SESSION_FILE)) {
+      const session = readSession();
+      console.log(`TUI launched (daemon PID ${session.daemonPid}, port ${session.daemonPort})`);
+      return;
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  // Timeout — print last 20 lines of daemon log
+  if (existsSync(LOG_FILE)) {
+    const logContent = readFileSync(LOG_FILE, 'utf-8');
+    const lines = logContent.split('\n');
+    const tail = lines.slice(-20).join('\n');
+    console.error('Daemon log (last 20 lines):\n' + tail);
+  }
+  throw new Error('Timeout: daemon did not start within 30 seconds');
+}
+
+async function cmdClose() {
+  if (!existsSync(SESSION_FILE)) {
+    console.log('Nothing to close');
+    return;
+  }
+
+  const session = readSession();
+  try {
+    await fetch(`http://localhost:${session.daemonPort}/shutdown`);
+  } catch {
+    try { process.kill(session.daemonPid); } catch {}
+  }
+
+  // Wait for session file deletion
+  const start = Date.now();
+  while (Date.now() - start < 10000) {
+    if (!existsSync(SESSION_FILE)) {
+      console.log('TUI closed');
+      return;
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  // Force cleanup
+  try { process.kill(session.daemonPid); } catch {}
+  deleteSession();
+  if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
+  console.log('TUI closed (forced)');
+}
+
+async function cmdText(parsed) {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'text', { row: parsed.row });
+  console.log(result.line);
+}
+
+async function cmdKey(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'key', { combo: parsed.combo });
+}
+
+async function cmdType(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'type', { text: parsed.text });
+}
+
+async function cmdWait(parsed) {
+  const session = readSession();
+  await sendToDaemon(session, 'wait', { text: parsed.text, timeout: parsed.timeout });
+  console.log('Found');
+}
+
+async function cmdScreenshot(parsed) {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'screenshot', { file: parsed.file });
+  console.log(result.path);
+}
+
+async function cmdRows() {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'rows', {});
+  console.log(result.size);
+}
+
+// ── Main dispatch ────────────────────────────────────────────────────
+
+async function main() {
+  // Daemon mode
+  if (process.argv.includes('--daemon')) {
+    await runDaemon();
+    return;
+  }
+
+  // Caller mode
+  const parsed = parseArgs(process.argv.slice(2));
+  switch (parsed.command) {
+    case 'launch': await cmdLaunch(parsed); break;
+    case 'close': await cmdClose(); break;
+    case 'text': await cmdText(parsed); break;
+    case 'key': await cmdKey(parsed); break;
+    case 'type': await cmdType(parsed); break;
+    case 'wait': await cmdWait(parsed); break;
+    case 'screenshot': await cmdScreenshot(parsed); break;
+    case 'rows': await cmdRows(); break;
+  }
+}
+
+// Entry guard: Windows case-insensitive path comparison
+if (process.argv[1] && resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()) {
+  main().catch(err => {
+    process.stderr.write(err.message + '\n');
+    process.exit(1);
+  });
+}

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -174,15 +174,6 @@ async function runDaemon() {
       return;
     }
 
-    // ctrl+shift+letter (best effort — same as ctrl+letter)
-    if (modifiers.shift && modifiers.ctrl) {
-      const code = lk.charCodeAt(0);
-      if (code >= 97 && code <= 122) {
-        term.write(String.fromCharCode(code - 96));
-        return;
-      }
-    }
-
     // Named keys
     const namedKeys = {
       enter: () => term.submit(),

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
@@ -45,15 +45,15 @@ describe('parseArgs', () => {
   });
 
   it('text with out-of-range row throws', () => {
-    assert.throws(() => parseArgs(['text', '30']), /Row 30 out of range/);
+    assert.throws(() => parseArgs(['text', '30']), /Row must be 0-29/);
   });
 
   it('text with negative row throws', () => {
-    assert.throws(() => parseArgs(['text', '-1']), /Row -1 out of range/);
+    assert.throws(() => parseArgs(['text', '-1']), /Row must be 0-29/);
   });
 
   it('text with missing row throws', () => {
-    assert.throws(() => parseArgs(['text']), /text requires a row number/);
+    assert.throws(() => parseArgs(['text']), /Usage: text <row>/);
   });
 
   // key
@@ -63,7 +63,7 @@ describe('parseArgs', () => {
   });
 
   it('key with missing combo throws', () => {
-    assert.throws(() => parseArgs(['key']), /key requires a key combo/);
+    assert.throws(() => parseArgs(['key']), /Usage: key <combo>/);
   });
 
   // type
@@ -73,7 +73,7 @@ describe('parseArgs', () => {
   });
 
   it('type with missing text throws', () => {
-    assert.throws(() => parseArgs(['type']), /type requires text/);
+    assert.throws(() => parseArgs(['type']), /Usage: type <text>/);
   });
 
   // wait
@@ -96,7 +96,7 @@ describe('parseArgs', () => {
   });
 
   it('wait with missing text throws', () => {
-    assert.throws(() => parseArgs(['wait']), /wait requires text/);
+    assert.throws(() => parseArgs(['wait']), /Usage: wait <text> \[timeout\]/);
   });
 
   // screenshot
@@ -106,7 +106,7 @@ describe('parseArgs', () => {
   });
 
   it('screenshot with missing file throws', () => {
-    assert.throws(() => parseArgs(['screenshot']), /screenshot requires a file path/);
+    assert.throws(() => parseArgs(['screenshot']), /Usage: screenshot <file>/);
   });
 
   // errors

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
@@ -79,7 +79,7 @@ describe('parseArgs', () => {
   // wait
   it('wait with text and default timeout', () => {
     const result = parseArgs(['wait', 'Loading']);
-    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 30000 });
+    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 10000 });
   });
 
   it('wait with text and custom timeout', () => {
@@ -87,9 +87,12 @@ describe('parseArgs', () => {
     assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 5000 });
   });
 
-  it('wait with zero timeout', () => {
-    const result = parseArgs(['wait', 'Loading', '0']);
-    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 0 });
+  it('wait with zero timeout throws', () => {
+    assert.throws(() => parseArgs(['wait', 'Loading', '0']), /Invalid timeout/);
+  });
+
+  it('wait with negative timeout throws', () => {
+    assert.throws(() => parseArgs(['wait', 'Loading', '-1']), /Invalid timeout/);
   });
 
   it('wait with missing text throws', () => {

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.test.mjs
@@ -1,0 +1,200 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { parseArgs, parseKeyCombo, ROWS, COLS } from './tui-verify.mjs';
+
+// ── parseArgs ────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  // launch
+  it('launch without --build', () => {
+    const result = parseArgs(['launch']);
+    assert.deepStrictEqual(result, { command: 'launch', build: false });
+  });
+
+  it('launch with --build', () => {
+    const result = parseArgs(['launch', '--build']);
+    assert.deepStrictEqual(result, { command: 'launch', build: true });
+  });
+
+  // close
+  it('close', () => {
+    const result = parseArgs(['close']);
+    assert.deepStrictEqual(result, { command: 'close' });
+  });
+
+  // rows
+  it('rows', () => {
+    const result = parseArgs(['rows']);
+    assert.deepStrictEqual(result, { command: 'rows' });
+  });
+
+  // text
+  it('text with valid row', () => {
+    const result = parseArgs(['text', '5']);
+    assert.deepStrictEqual(result, { command: 'text', row: 5 });
+  });
+
+  it('text with row 0', () => {
+    const result = parseArgs(['text', '0']);
+    assert.deepStrictEqual(result, { command: 'text', row: 0 });
+  });
+
+  it('text with row 29 (max)', () => {
+    const result = parseArgs(['text', '29']);
+    assert.deepStrictEqual(result, { command: 'text', row: 29 });
+  });
+
+  it('text with out-of-range row throws', () => {
+    assert.throws(() => parseArgs(['text', '30']), /Row 30 out of range/);
+  });
+
+  it('text with negative row throws', () => {
+    assert.throws(() => parseArgs(['text', '-1']), /Row -1 out of range/);
+  });
+
+  it('text with missing row throws', () => {
+    assert.throws(() => parseArgs(['text']), /text requires a row number/);
+  });
+
+  // key
+  it('key with combo', () => {
+    const result = parseArgs(['key', 'ctrl+c']);
+    assert.deepStrictEqual(result, { command: 'key', combo: 'ctrl+c' });
+  });
+
+  it('key with missing combo throws', () => {
+    assert.throws(() => parseArgs(['key']), /key requires a key combo/);
+  });
+
+  // type
+  it('type with text', () => {
+    const result = parseArgs(['type', 'hello world']);
+    assert.deepStrictEqual(result, { command: 'type', text: 'hello world' });
+  });
+
+  it('type with missing text throws', () => {
+    assert.throws(() => parseArgs(['type']), /type requires text/);
+  });
+
+  // wait
+  it('wait with text and default timeout', () => {
+    const result = parseArgs(['wait', 'Loading']);
+    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 30000 });
+  });
+
+  it('wait with text and custom timeout', () => {
+    const result = parseArgs(['wait', 'Loading', '5000']);
+    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 5000 });
+  });
+
+  it('wait with zero timeout', () => {
+    const result = parseArgs(['wait', 'Loading', '0']);
+    assert.deepStrictEqual(result, { command: 'wait', text: 'Loading', timeout: 0 });
+  });
+
+  it('wait with missing text throws', () => {
+    assert.throws(() => parseArgs(['wait']), /wait requires text/);
+  });
+
+  // screenshot
+  it('screenshot with file', () => {
+    const result = parseArgs(['screenshot', 'shot.json']);
+    assert.deepStrictEqual(result, { command: 'screenshot', file: 'shot.json' });
+  });
+
+  it('screenshot with missing file throws', () => {
+    assert.throws(() => parseArgs(['screenshot']), /screenshot requires a file path/);
+  });
+
+  // errors
+  it('unknown command throws', () => {
+    assert.throws(() => parseArgs(['explode']), /Unknown command: explode/);
+  });
+
+  it('empty args throws', () => {
+    assert.throws(() => parseArgs([]), /No command provided/);
+  });
+});
+
+// ── parseKeyCombo ────────────────────────────────────────────────────
+
+describe('parseKeyCombo', () => {
+  // Single named keys
+  it('enter', () => {
+    const result = parseKeyCombo('enter');
+    assert.deepStrictEqual(result, { key: 'enter', modifiers: {} });
+  });
+
+  it('tab', () => {
+    const result = parseKeyCombo('tab');
+    assert.deepStrictEqual(result, { key: 'tab', modifiers: {} });
+  });
+
+  it('escape', () => {
+    const result = parseKeyCombo('escape');
+    assert.deepStrictEqual(result, { key: 'escape', modifiers: {} });
+  });
+
+  it('up', () => {
+    const result = parseKeyCombo('up');
+    assert.deepStrictEqual(result, { key: 'up', modifiers: {} });
+  });
+
+  it('down', () => {
+    const result = parseKeyCombo('down');
+    assert.deepStrictEqual(result, { key: 'down', modifiers: {} });
+  });
+
+  it('F1', () => {
+    const result = parseKeyCombo('F1');
+    assert.deepStrictEqual(result, { key: 'F1', modifiers: {} });
+  });
+
+  it('f12 (case-insensitive)', () => {
+    const result = parseKeyCombo('f12');
+    assert.deepStrictEqual(result, { key: 'f12', modifiers: {} });
+  });
+
+  // Modifier combos
+  it('ctrl+letter', () => {
+    const result = parseKeyCombo('ctrl+c');
+    assert.deepStrictEqual(result, { key: 'c', modifiers: { ctrl: true } });
+  });
+
+  it('alt+letter', () => {
+    const result = parseKeyCombo('alt+x');
+    assert.deepStrictEqual(result, { key: 'x', modifiers: { alt: true } });
+  });
+
+  it('ctrl+shift+letter', () => {
+    const result = parseKeyCombo('ctrl+shift+a');
+    assert.deepStrictEqual(result, { key: 'a', modifiers: { ctrl: true, shift: true } });
+  });
+
+  // Errors
+  it('empty combo throws', () => {
+    assert.throws(() => parseKeyCombo(''), /Empty key combo/);
+  });
+
+  it('unknown modifier throws', () => {
+    assert.throws(() => parseKeyCombo('super+a'), /unknown modifier 'super'/);
+  });
+
+  // Single character
+  it('single character', () => {
+    const result = parseKeyCombo('a');
+    assert.deepStrictEqual(result, { key: 'a', modifiers: {} });
+  });
+});
+
+// ── Constants ────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('ROWS is 30', () => {
+    assert.strictEqual(ROWS, 30);
+  });
+
+  it('COLS is 120', () => {
+    assert.strictEqual(COLS, 120);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tui-verify.mjs` CLI tool for AI-driven TUI verification via PTY, mirroring `webview-cdp.mjs`'s daemon pattern
- Text-based primary workflow: read terminal rows, send keystrokes, wait for content — no PNG rendering needed
- Uses `@microsoft/tui-test` (already a dev dependency) for PTY spawn and terminal emulation
- Add `@tui-verify` skill, update `/verify tui` with interactive phases, add TUI Mode blind verifier to `/qa`
- 38 unit tests (node:test), smoke tested end-to-end on Windows 11

## Commands

| Command | Purpose |
|---------|---------|
| `launch [--build]` | Start TUI in PTY (optionally build first) |
| `close` | Kill PTY, clean up (idempotent) |
| `text <row>` | Read terminal row (0-29) |
| `key "<combo>"` | Send keystroke (tab, ctrl+q, alt+t, F1, etc.) |
| `type "<text>"` | Type text character by character |
| `wait "<text>" [ms]` | Poll until text appears (default 10s) |
| `screenshot <file>` | Dump serialize() as JSON |
| `rows` | Show dimensions (120x30) |

## Test plan

- [x] 38 unit tests pass (`node --test`)
- [x] `launch --build` starts TUI successfully
- [x] `wait "PPDS"` finds rendered text
- [x] `text 0` reads title bar correctly
- [x] `key "alt+t"` + `key "enter"` navigates menus
- [x] `key "alt+p"` opens profile selector
- [x] `wait "SQL Query"` finds screen after navigation
- [x] `text 50` returns proper error (row out of range)
- [x] `wait "NONEXISTENT" 2000` times out correctly
- [x] `screenshot $TEMP/...` writes JSON with view + shifts
- [x] `rows` returns `120x30`
- [x] `close` cleans up session + log files
- [x] Used tool to verify TDS status label feature (found bugs #580, #581)

🤖 Generated with [Claude Code](https://claude.com/claude-code)