### PR TITLE
QA: Extension & TUI comprehensive sweep with fixes

### DIFF
--- a/docs/qa/2026-03-16-extension-tui-qa-sweep.md
+++ b/docs/qa/2026-03-16-extension-tui-qa-sweep.md
@@ -1,0 +1,192 @@
+# Extension & TUI QA Sweep — 2026-03-16
+
+Comprehensive QA pass before scaling out panel implementation. Covers code integrity, interactive verification, parity comparison, and bug fixes.
+
+## Summary
+
+| Category | Findings | Fixed | Deferred |
+|----------|----------|-------|----------|
+| Bugs (GH issues) | 3 | 3 (#580, #581, #361) | 0 |
+| Bugs (discovered) | 2 | 2 (startup race, unnamed profile status bar) | 0 |
+| Silent errors | 7 | 7 (all logging now) | 0 |
+| Architecture | 0 violations | — | — |
+| Dead code | 1 (EnvironmentDetailsDialog unwired) | 1 (wired to Tools menu) | 0 |
+| MCP guardrails | Missing | Added (session locking, allowlist, DML guard) | 0 |
+| Constitution | Missing session laws | Added (SS1, SS2) | 0 |
+
+## Commits on `qa/extension-tui-sweep`
+
+1. `e144529` — fix: TDS keybinding conflict, tools state race, silent error logging
+2. `8399399` — feat: TDS status fix, environment details dialog, profile status bar
+3. `71e20e6` — feat(mcp): session locking, environment allowlist, and DML guard
+4. `e9555fc` — fix(ext): profile status bar shows name for unnamed profiles
+
+## Phase 1 — Code Integrity Audit
+
+### Extension Architecture: CLEAN
+
+- All Dataverse operations route through daemon JSON-RPC — no service bypasses
+- Webview → Host → Daemon → Application Services chain is correct
+- No direct query construction or business logic in extension code
+- All 62 commands have working handlers
+
+### TUI Architecture: CLEAN
+
+- All operations route through Application Services — no direct Dataverse calls
+- TDS toggle implementation correctly scoped to SqlQueryScreen
+- HotkeyRegistry priority (Dialog > Screen > Global) is correct
+- Status bar is fully interactive with mouse event handling
+
+### Error Handling
+
+**Fixed — 7 silent catches now log:**
+- `extension.ts:200` — refreshToolsState catch (was silently disabling tools tree)
+- `daemonClient.ts:819` — heartbeat error (was discarding error details)
+- `QueryPanel.ts:154` — IntelliSense failure
+- `QueryPanel.ts:223,269` — environment color fetch (2 locations)
+- `SolutionsPanel.ts:150,173` — environment color fetch (2 locations)
+
+## Phase 2 — Bug Fixes
+
+### #580 — TDS Keybinding Conflict (FIXED)
+
+**Root cause:** Terminals send the same keycode for `Ctrl+T` and `Ctrl+Shift+T`. The global-scope `Ctrl+T` (new tab) always matched before the screen-scope `Ctrl+Shift+T` (TDS toggle).
+
+**Fix:** Changed TDS toggle to `F10`. Added comment documenting the terminal limitation. `SqlQueryScreen.cs:350`
+
+### #581 — TDS Menu Toggle Status Label (FIXED)
+
+**Root cause:** Terminal.Gui 1.x doesn't auto-repaint labels when their Text property changes via a menu item callback. The subsequent `NotifyMenuChanged()` → `RebuildMenuBar()` redraws the menu bar but doesn't propagate to the `_statusLabel` in the content area.
+
+**Fix:** Added `_statusLabel.SetNeedsDisplay()` after setting text in `ToggleTdsEndpoint()`. `SqlQueryScreen.cs:861`
+
+### #361 — Extension Profile Status Bar (IMPLEMENTED)
+
+**Design decision:** Profile indicator only (not environment). Environment context is per-panel and already shown in panel toolbars. Adding environment to the global status bar would be ambiguous with multiple panels open.
+
+**Implementation:** `profileStatusBar.ts` — 72 lines. Shows `$(account) ProfileName`, click to switch via `ppds.listProfiles`. Hidden when daemon not ready. Refreshes on `onDidChangeState`, `onDidReconnect`, and profile commands.
+
+### Startup Race — "(no profile)" Bug (FIXED)
+
+**Root cause:** `refreshToolsState()` was called immediately at extension activation, before the daemon finished starting. The daemon `authList()` call failed, the silent catch set `hasActiveProfile(false)`, and nothing ever retried.
+
+**Fix:** Removed the immediate call. Added `client.onDidChangeState('ready')` listener that triggers `refreshToolsState()` + `profileTreeProvider.refresh()` when daemon becomes available. Also added `activeProfileIndex` fallback check.
+
+### Unnamed Profile Status Bar (FIXED)
+
+**Root cause:** `activeProfile` in the `auth/list` response is the profile's `Name` property, which is null for profiles created without an explicit name. The profile status bar only checked this field.
+
+**Fix:** Fall back to `profiles.find(p => p.isActive)` and display `Profile ${index}` for unnamed profiles. Found during visual QA via `@webview-cdp`.
+
+## Phase 3 — Interactive Verification
+
+### Extension (via @webview-cdp)
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| Profile status bar | PASS | Shows "Profile 2", click to switch |
+| Tools tree (no profile) | PASS | No "(no profile)" suffix when profile active |
+| Profiles tree | PASS | Shows 2 profiles, green checkmark on active |
+| Data Explorer panel | PASS | Query execution, results table, filter, export, history |
+| Data Explorer toolbar | PASS | Execute, Export, History, env picker present |
+| Environment picker | PASS | Shows "DEV" with dropdown |
+| SQL syntax highlighting | PASS | Keywords highlighted in editor |
+| Query results | PASS | 5 rows, columns, Load More, execution time |
+| Filter results | PASS | Typed "Test" → "Showing 8 of 10 rows", correctly filters across all columns |
+| Load More | PASS | Loaded 10 → 20 rows with paging cookie, status updates correctly |
+| Query history | PASS | Shows previous queries with timestamps, row counts, execution times |
+| "..." overflow menu | PASS | Shows Load Query, Open in Notebook, Explain Query, TDS Read Replica |
+| Error handling | PASS | Bad table name shows red error banner with Dataverse error message, status = "Error" |
+| Multi-panel | PASS | Multiple Data Explorer panels open simultaneously with independent state |
+| Toolbar env color | PARTIAL | `data-env-color="green"` set but `data-env-type` is null (type not configured for this environment) |
+| Daemon status bar | PASS | Shows checkmark + "PPDS" when ready |
+
+### TUI (code audit — interactive testing deferred to user)
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| TDS toggle (F10) | FIXED | New keybinding, menu shortcut text updated |
+| TDS menu toggle | FIXED | SetNeedsDisplay ensures label repaints |
+| Environment Details dialog | WIRED | Available via Tools > Environment Details |
+| Status bar | VERIFIED (code) | Interactive profile/env selectors, color-coded |
+| All dialogs reachable | VERIFIED (code) | 14/16 wired; DeviceCodeDialog used by ProfileCreation |
+
+## Phase 4 — Parity Comparison
+
+### Feature Matrix
+
+| Feature | TUI | Extension | Notes |
+|---------|-----|-----------|-------|
+| Profile selection | Status bar click (Alt+P) | Sidebar tree + quick pick | Extension is better — more discoverable |
+| Environment selection | Status bar click (Alt+E) | Per-panel picker | Extension is better — per-panel scoping |
+| Environment details | Tools > Environment Details | Not implemented | TUI ahead — Extension could add as command |
+| Environment config | Tools > Configure Environment | Not implemented (panel-level) | TUI ahead |
+| Query execution | F5, menu | Execute button | Parity |
+| FetchXML preview | Ctrl+Shift+F / F9 | Toolbar button | Parity |
+| Query history | Ctrl+Shift+H / F8 | History button | Parity |
+| Export | Ctrl+E | Export dropdown | Parity |
+| TDS toggle | F10, menu | "..." > TDS Read Replica | Parity |
+| Filter results | / key | Filter bar | Extension is better — always visible |
+| Execution plan | Ctrl+Shift+E / F7 | "..." > Explain Query | Parity |
+| Multi-tab/panel | Ctrl+T tabs | Multiple panel instances | Parity (different paradigms) |
+| Keyboard shortcuts dialog | F1 | N/A (VS Code native) | Different by design |
+| Solutions browser | Not implemented | Solutions panel | Extension ahead |
+| Status bar profile | Full interactive bar | New profile indicator | TUI is richer but Extension is appropriate for VS Code |
+
+### UX Assessment
+
+**Extension strengths:**
+- Per-panel environment scoping is excellent for multi-env workflows
+- Toolbar buttons are discoverable without memorizing hotkeys
+- Profile status bar is clean and unobtrusive
+- Tab title shows profile + environment context
+
+**Extension gaps:**
+- No TDS toggle (planned for query parity)
+- No environment details command
+- No execution plan viewer in toolbar (may be under "..." menu)
+- Environment type detection not working for all environments (`data-env-type` was null)
+
+**TUI strengths:**
+- Rich interactive status bar (click to switch profile/env)
+- Comprehensive keyboard shortcuts for everything
+- F-key alternatives for Linux terminal compatibility
+- Environment details dialog is well-built
+
+**TUI gaps:**
+- No solutions browser (planned in panel-parity spec)
+- Single query screen (vs Extension's unlimited panels)
+- Tab-based multi-env is less flexible than Extension's per-panel model
+
+### Recommendation
+
+The two UIs are appropriately different. The Extension leverages VS Code's visual paradigm (panels, toolbars, sidebars). The TUI leverages terminal efficiency (hotkeys, menus, status bar). Don't try to make them identical — make them each excellent in their paradigm.
+
+## Phase 5 — MCP Session Guardrails
+
+Added to protect AI agents from accidental cross-environment operations:
+
+- **Session locking:** Profile and environment resolved once at first tool invocation
+- **`--profile`/`--environment`:** Lock to specific profile/env at startup
+- **`--read-only`:** Disable all DML (INSERT/UPDATE/DELETE)
+- **`--allowed-env`:** Restrict `ppds_env_select` to allowlisted URLs only
+- **Constitution laws SS1/SS2:** Codified session independence across all surfaces
+
+## Tooling Gaps Discovered
+
+### webview-cdp multi-panel targeting
+
+When multiple webview panels from the same extension are open, `--ext` targets the first match in DOM order, not the visible/focused one. The `connect` command shows targets by URL hash only — no panel titles, no indication of which is active.
+
+**Impact:** Testing multi-panel scenarios requires manual `--target N` guessing.
+
+**Proposed fix:** `connect` should show panel titles; `--ext` should prefer the focused webview; consider `--target active` flag.
+
+## Items NOT Fixed (Future Work)
+
+- Environment type detection for toolbar color borders — needs investigation into why `data-env-type` is null when environment has a configured type
+- TDS toggle in Extension Data Explorer — already accessible via "..." > TDS Read Replica menu
+- Environment details command in Extension — low priority, could be added as a command
+- webview-cdp multi-panel targeting improvements
+- Per-environment DML permissions in MCP — deferred to future iteration
+- MCP audit logging — deferred

--- a/docs/qa/2026-03-16-extension-tui-qa-sweep.md
+++ b/docs/qa/2026-03-16-extension-tui-qa-sweep.md
@@ -160,8 +160,11 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 
 **TUI gaps:**
 - No solutions browser (planned in panel-parity spec)
-- Single query screen (vs Extension's unlimited panels)
+- Single query screen type (vs Extension's unlimited panels)
 - Tab-based multi-env is less flexible than Extension's per-panel model
+- Unnamed SPN profiles show raw application ID in selectors (Extension shows "Profile N" fallback)
+- Keyboard shortcuts dialog doesn't scroll to show screen-specific bindings
+- "Background operation failed" error on splash before profile selection
 
 ### Recommendation
 
@@ -198,21 +201,45 @@ When multiple webview panels from the same extension are open, `--ext` targets t
 
 Total MCP tests: 58 passed, 3 skipped (pre-existing).
 
-## TUI Verification
+## TUI Interactive Verification (via tui-verify)
 
-Code audit confirmed all fixes compile and integrate correctly:
-- F10 keybinding registered in SqlQueryScreen (replaces Ctrl+Shift+T)
-- SetNeedsDisplay added to ToggleTdsEndpoint
-- EnvironmentDetailsDialog wired in TuiShell Tools menu
-- KeyboardShortcutsDialog reads bindings dynamically (auto-shows F10)
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Splash screen | PASS | Title, menu bar, status bar all render correctly |
+| Profile selector (Alt+P) | PASS | Shows all profiles with identity, select works |
+| Environment auto-populate | PASS | Environment loads from profile default |
+| Status bar | PASS | Shows "Profile: [2] ... Environment: PPDS Demo - Dev [DEV]" with clickable selectors |
+| SQL Query screen | PASS | Opens via Tools menu, tab bar shows env name |
+| Query execution (F5) | PASS | "Returned 100 rows in 552ms via Dataverse" |
+| Results table | PASS | Virtual table with accountid, name columns, row count footer |
+| **F10 TDS toggle** | **PASS** | Status changes to "Mode: TDS Read Replica (read-only, slight delay)", toggles back to "Mode: Dataverse (real-time)" |
+| **Query menu TDS toggle** | **PASS** | Menu selection updates status label immediately (#581 fix verified) |
+| Query menu items | PASS | All items present with correct shortcuts — F10 shown for TDS (not Ctrl+Shift+T) |
+| Tab management (Ctrl+T/W) | PASS | New tab opens, close tab works, tab bar updates |
+| **Environment Details dialog** | **PASS** | Shows URL, unique name, version, org ID, user ID, business unit ID, connected as — all loaded via connection pool |
+| Tools menu | PASS | SQL Query, Environment Details, Configure Environment — all present with descriptions |
+| FetchXML preview (F9) | PASS | Shows transpiled XML with proper formatting |
+| History (F8) | PASS | Search box, timestamped queries with row counts |
+| Keyboard shortcuts (F1) | PASS | Shows global bindings dynamically. Note: screen-specific bindings (F5-F10) may not be visible without scrolling — minor UX issue |
+| About dialog | PASS | Version, tagline, docs URL, GitHub URL |
+| Help menu | PASS | About, Keyboard Shortcuts items present |
 
-TUI snapshot test infrastructure has a pre-existing dependency issue (`@microsoft/tui-test` package resolution error). Not from our changes — needs separate investigation.
+### TUI UX Notes
+
+- Profile selector shows application ID for unnamed SPN profiles (e.g., `[2] (3b039cb2-...)`) — functional but not pretty. Extension shows "Profile 2" via index fallback, which is cleaner.
+- Keyboard shortcuts dialog doesn't scroll well — global bindings fill the visible area, screen-specific bindings (F5, F7, F8, F9, F10) require scrolling that doesn't seem to work with the current dialog layout.
+- "Background operation failed" error on splash screen before profile selection — appears to be an update check that runs before auth is configured. Non-blocking but noisy.
+
+TUI snapshot test infrastructure has a pre-existing dependency issue (`@microsoft/tui-test` not installed in worktree `node_modules`). Fixed by running `npm install` in the test directory. The engine warning (Node 22 vs required <21) is a known compatibility gap.
 
 ## Items NOT Fixed (Future Work)
 
 - **BUG: Environment type border not rendering** — Panel toolbar `data-env-type` is null because QueryPanel/SolutionsPanel use `auth/who → environment.type` (which returns null) instead of `env/config/get → resolvedType` (which returns "Development"). Fix: use resolvedType from envConfigGet response.
 - Environment details command in Extension — low priority, TUI has it
 - webview-cdp multi-panel targeting improvements
-- TUI snapshot test infrastructure dependency fix
+- TUI: Unnamed SPN profiles show raw application ID in profile selector (should use name or "Profile N" fallback)
+- TUI: Keyboard shortcuts dialog doesn't scroll to screen-specific bindings
+- TUI: "Background operation failed" error on splash before profile selection (update check without auth)
+- TUI snapshot test infrastructure — works after `npm install` but has Node engine warning
 - Per-environment DML permissions in MCP — deferred
 - MCP audit logging — deferred

--- a/docs/qa/2026-03-16-extension-tui-qa-sweep.md
+++ b/docs/qa/2026-03-16-extension-tui-qa-sweep.md
@@ -166,6 +166,24 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 - Keyboard shortcuts dialog doesn't scroll to show screen-specific bindings
 - "Background operation failed" error on splash before profile selection
 
+### Profile Management Comparison
+
+| Feature | TUI | Extension |
+|---------|-----|-----------|
+| Profile selector | Dialog with list + 7 action buttons (Select, Create, Rename, Delete, Details, Clear All, Cancel) | Tree view + context menu items |
+| Profile creation | Single-screen form: auth method radios, env URL field, Start Authentication button | 3-step wizard: method → name → authenticate |
+| Profile naming | Not available during creation | Step 2 of wizard (optional for user auth, required for SPN) |
+| Device code display | Inline dialog with code and verification URL | VS Code notification with "Open Browser" and "Copy Code" buttons |
+| Environment selector | Dialog with discovered list, details preview, manual URL entry, 4 buttons | Tree view under each profile + "Enter URL manually" item |
+| Env discovery | Shows helpful message for SPN profiles ("not supported for ClientSecret") | Only shows discovered envs for active profile |
+| Context menus | Profile: 7 dialog buttons; Environment: 4 dialog buttons | Profile: 7 context menu items; Environment: 9 context menu items |
+
+**Key differences:**
+- TUI profile creation has **no name field** — profiles can only be named via Rename after creation. Extension has naming in the wizard. This explains the unnamed profile issue we've been seeing.
+- Extension's 3-step wizard is more guided; TUI's single-screen form is faster for experienced users.
+- Extension has more environment context menu actions (Open in Maker, Open in Dynamics, Test Connection, Copy URL) that TUI doesn't have.
+- TUI's environment selector has a **Details preview pane** inline — you can see env details without opening a separate dialog. Extension requires expanding the tree.
+
 ### Recommendation
 
 The two UIs are appropriately different. The Extension leverages VS Code's visual paradigm (panels, toolbars, sidebars). The TUI leverages terminal efficiency (hotkeys, menus, status bar). Don't try to make them identical — make them each excellent in their paradigm.
@@ -240,6 +258,9 @@ TUI snapshot test infrastructure has a pre-existing dependency issue (`@microsof
 - TUI: Unnamed SPN profiles show raw application ID in profile selector (should use name or "Profile N" fallback)
 - TUI: Keyboard shortcuts dialog doesn't scroll to screen-specific bindings
 - TUI: "Background operation failed" error on splash before profile selection (update check without auth)
+- TUI: Profile creation dialog has no name field — profiles must be renamed after creation
+- TUI: Environment selector could add "Open in Maker" / "Open in Dynamics" actions (Extension has them)
+- Extension: Environment context menu could add "Details" action (TUI has it inline)
 - TUI snapshot test infrastructure — works after `npm install` but has Node engine warning
 - Per-environment DML permissions in MCP — deferred
 - MCP audit logging — deferred

--- a/docs/qa/2026-03-16-extension-tui-qa-sweep.md
+++ b/docs/qa/2026-03-16-extension-tui-qa-sweep.md
@@ -98,8 +98,15 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 | "..." overflow menu | PASS | Shows Load Query, Open in Notebook, Explain Query, TDS Read Replica |
 | Error handling | PASS | Bad table name shows red error banner with Dataverse error message, status = "Error" |
 | Multi-panel | PASS | Multiple Data Explorer panels open simultaneously with independent state |
-| Toolbar env color | PARTIAL | `data-env-color="green"` set but `data-env-type` is null (type not configured for this environment) |
+| FetchXML toggle | PASS | SQL→FetchXML converts query correctly, FetchXML→SQL round-trips cleanly with reformatting |
+| Export dropdown | PASS | Shows CSV, TSV, JSON, Copy to Clipboard, Save Query |
+| Copy to Clipboard | PASS | Shows "Copied 5 rows to clipboard" notification |
+| Explain Query | PASS | Opens "Execution Plan" document with FetchXmlScanNode tree and FetchXML source |
+| Solutions panel | PASS | Lists 8 solutions (4 managed, 4 unmanaged), filter bar, env picker |
+| Solution drill-down | PASS | Expands to show component types with counts (Entity, Plugin Assembly, etc.) |
+| Toolbar env color | BUG | `data-env-color="green"` renders correctly, but `data-env-type` is null despite daemon returning type=Development. Root cause: panel uses `auth/who → environment.type` (null) instead of `env/config/get → resolvedType` (correct). The type-based top border doesn't render. |
 | Daemon status bar | PASS | Shows checkmark + "PPDS" when ready |
+| Extension logs | CLEAN | No PPDS errors in any session. All errors from GitHub Copilot (expected in test instance). |
 
 ### TUI (code audit — interactive testing deferred to user)
 
@@ -142,10 +149,8 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 - Tab title shows profile + environment context
 
 **Extension gaps:**
-- No TDS toggle (planned for query parity)
-- No environment details command
-- No execution plan viewer in toolbar (may be under "..." menu)
-- Environment type detection not working for all environments (`data-env-type` was null)
+- Environment type border not rendering (data source mismatch — uses auth/who instead of env/config/get)
+- No environment details command (TUI has it under Tools menu)
 
 **TUI strengths:**
 - Rich interactive status bar (click to switch profile/env)
@@ -182,11 +187,32 @@ When multiple webview panels from the same extension are open, `--ext` targets t
 
 **Proposed fix:** `connect` should show panel titles; `--ext` should prefer the focused webview; consider `--target active` flag.
 
+## MCP Guardrail Verification
+
+18 new unit tests covering:
+- **McpSessionOptions.Parse:** All CLI arg combinations (--profile, --environment, --read-only, --allowed-env)
+- **McpSessionOptions.IsEnvironmentAllowed:** Empty list, matching URL, non-matching, trailing slash normalization, case insensitivity
+- **McpToolContext.IsReadOnly:** Default false, true when configured
+- **McpToolContext.ValidateEnvironmentSwitch:** Throws on no allowlist, throws on non-allowed URL, succeeds on allowed
+- **McpToolContext.EnvironmentUrlOverride:** Default null, returns configured value
+
+Total MCP tests: 58 passed, 3 skipped (pre-existing).
+
+## TUI Verification
+
+Code audit confirmed all fixes compile and integrate correctly:
+- F10 keybinding registered in SqlQueryScreen (replaces Ctrl+Shift+T)
+- SetNeedsDisplay added to ToggleTdsEndpoint
+- EnvironmentDetailsDialog wired in TuiShell Tools menu
+- KeyboardShortcutsDialog reads bindings dynamically (auto-shows F10)
+
+TUI snapshot test infrastructure has a pre-existing dependency issue (`@microsoft/tui-test` package resolution error). Not from our changes — needs separate investigation.
+
 ## Items NOT Fixed (Future Work)
 
-- Environment type detection for toolbar color borders — needs investigation into why `data-env-type` is null when environment has a configured type
-- TDS toggle in Extension Data Explorer — already accessible via "..." > TDS Read Replica menu
-- Environment details command in Extension — low priority, could be added as a command
+- **BUG: Environment type border not rendering** — Panel toolbar `data-env-type` is null because QueryPanel/SolutionsPanel use `auth/who → environment.type` (which returns null) instead of `env/config/get → resolvedType` (which returns "Development"). Fix: use resolvedType from envConfigGet response.
+- Environment details command in Extension — low priority, TUI has it
 - webview-cdp multi-panel targeting improvements
-- Per-environment DML permissions in MCP — deferred to future iteration
+- TUI snapshot test infrastructure dependency fix
+- Per-environment DML permissions in MCP — deferred
 - MCP audit logging — deferred

--- a/docs/qa/2026-03-16-extension-tui-qa-sweep.md
+++ b/docs/qa/2026-03-16-extension-tui-qa-sweep.md
@@ -7,7 +7,7 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 | Category | Findings | Fixed | Deferred |
 |----------|----------|-------|----------|
 | Bugs (GH issues) | 3 | 3 (#580, #581, #361) | 0 |
-| Bugs (discovered) | 2 | 2 (startup race, unnamed profile status bar) | 0 |
+| Bugs (discovered) | 3 | 3 (startup race, unnamed profile status bar, env type border) | 0 |
 | Silent errors | 7 | 7 (all logging now) | 0 |
 | Architecture | 0 violations | — | — |
 | Dead code | 1 (EnvironmentDetailsDialog unwired) | 1 (wired to Tools menu) | 0 |
@@ -104,7 +104,7 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 | Explain Query | PASS | Opens "Execution Plan" document with FetchXmlScanNode tree and FetchXML source |
 | Solutions panel | PASS | Lists 8 solutions (4 managed, 4 unmanaged), filter bar, env picker |
 | Solution drill-down | PASS | Expands to show component types with counts (Entity, Plugin Assembly, etc.) |
-| Toolbar env color | BUG | `data-env-color="green"` renders correctly, but `data-env-type` is null despite daemon returning type=Development. Root cause: panel uses `auth/who → environment.type` (null) instead of `env/config/get → resolvedType` (correct). The type-based top border doesn't render. |
+| Toolbar env color | FIXED | Both borders now render: green top border (env type = development) and green left border (custom color). Fixed by falling back to `env/config/get → resolvedType` when `auth/who → environment.type` is null. |
 | Daemon status bar | PASS | Shows checkmark + "PPDS" when ready |
 | Extension logs | CLEAN | No PPDS errors in any session. All errors from GitHub Copilot (expected in test instance). |
 
@@ -149,7 +149,6 @@ Comprehensive QA pass before scaling out panel implementation. Covers code integ
 - Tab title shows profile + environment context
 
 **Extension gaps:**
-- Environment type border not rendering (data source mismatch — uses auth/who instead of env/config/get)
 - No environment details command (TUI has it under Tools menu)
 
 **TUI strengths:**
@@ -252,7 +251,7 @@ TUI snapshot test infrastructure has a pre-existing dependency issue (`@microsof
 
 ## Items NOT Fixed (Future Work)
 
-- **BUG: Environment type border not rendering** — Panel toolbar `data-env-type` is null because QueryPanel/SolutionsPanel use `auth/who → environment.type` (which returns null) instead of `env/config/get → resolvedType` (which returns "Development"). Fix: use resolvedType from envConfigGet response.
+- ~~Environment type border not rendering~~ — **Fixed** in commit `35ee5be`. Panels now fall back to `env/config/get → resolvedType` when `auth/who → environment.type` is null.
 - Environment details command in Extension — low priority, TUI has it
 - webview-cdp multi-panel targeting improvements
 - TUI: Unnamed SPN profiles show raw application ID in profile selector (should use name or "Profile N" fallback)

--- a/specs/CONSTITUTION.md
+++ b/specs/CONSTITUTION.md
@@ -36,6 +36,12 @@ Non-negotiable principles. Every spec, plan, implementation, and review MUST com
 
 **I3.** Every spec must have numbered acceptance criteria (AC-01, AC-02, ...) before implementation begins. No ACs = no implementation.
 
+## Session Laws
+
+**SS1.** Running sessions are independent — changing the active profile or environment in one surface (CLI, TUI, Extension, MCP) does not affect other running surfaces. The persisted active profile is a default for new sessions, not a live binding.
+
+**SS2.** MCP sessions are locked at startup — the profile and environment are captured when the server starts and cannot be changed by external profile switches. Environment switching within a session is controlled by the `--allowed-env` allowlist; if no allowlist is configured, the session is locked to its initial environment.
+
 ## Security Laws
 
 **S1.** Never render untrusted data via `innerHTML` — use `textContent` or a proper escaping pipeline. Mixed escaped/unescaped data in the same structure is an architectural flaw, not a minor issue.

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -84,6 +84,70 @@ The MCP (Model Context Protocol) server exposes Power Platform/Dataverse capabil
 
 ---
 
+## Session Configuration
+
+### Command-Line Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--profile <name>` | Lock to a specific profile (default: current active) |
+| `--environment <url>` | Lock to a specific environment (default: profile's default) |
+| `--read-only` | Disable all DML operations |
+| `--allowed-env <url>` | Repeatable. Restrict environment switching to these URLs only |
+
+### Session Isolation Model
+
+- Profile and environment are resolved once at first tool invocation
+- External profile changes (CLI, TUI, Extension) do not affect the MCP session
+- `ppds_env_select` is restricted to the `--allowed-env` allowlist (or disabled if no allowlist)
+
+See also: [CONSTITUTION.md — Session Laws](./CONSTITUTION.md#session-laws)
+
+### Example Configurations
+
+**Development (permissive):**
+
+```json
+{
+  "command": "ppds-mcp-server",
+  "args": ["--profile", "Dev"]
+}
+```
+
+**Multi-environment (restricted):**
+
+```json
+{
+  "command": "ppds-mcp-server",
+  "args": [
+    "--profile", "Dev",
+    "--environment", "https://contoso-dev.crm.dynamics.com",
+    "--allowed-env", "https://contoso-dev.crm.dynamics.com",
+    "--allowed-env", "https://contoso-test.crm.dynamics.com"
+  ]
+}
+```
+
+**Production read-only:**
+
+```json
+{
+  "command": "ppds-mcp-server",
+  "args": [
+    "--profile", "Prod",
+    "--read-only"
+  ]
+}
+```
+
+### Security Model
+
+- Configuration is set by the user at MCP client configuration time
+- The AI agent cannot modify the allowlist or read-only flag
+- If no args are provided, the safest defaults apply: current active profile, its default environment, no switching, DML allowed
+
+---
+
 ## Specification
 
 ### Core Requirements

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -89,7 +89,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Filter Results", "/", ShowFilter),
             new("", "", () => {}, null, null, Key.Null), // Separator
-            new(_useTdsEndpoint ? "\u2713 TDS Read Replica" : "  TDS Read Replica", "Ctrl+Shift+T", ToggleTdsEndpoint),
+            new(_useTdsEndpoint ? "\u2713 TDS Read Replica" : "  TDS Read Replica", "F10", ToggleTdsEndpoint),
         })
     };
 
@@ -347,7 +347,9 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         });
         RegisterHotkey(registry, Key.F5, "Execute query", () => _ = ExecuteQueryAsync());
         RegisterHotkey(registry, Key.CtrlMask | Key.ShiftMask | Key.F, "Show FetchXML", ShowFetchXmlDialog);
-        RegisterHotkey(registry, Key.CtrlMask | Key.ShiftMask | Key.T, "Toggle TDS Endpoint", ToggleTdsEndpoint);
+        // F10 instead of Ctrl+Shift+T: terminals cannot distinguish Ctrl+T from Ctrl+Shift+T
+        // (they send the same keycode), so the global Ctrl+T (new tab) always wins. See #580.
+        RegisterHotkey(registry, Key.F10, "Toggle TDS Endpoint", ToggleTdsEndpoint);
         // F-key alternatives for Linux compatibility (Ctrl+Shift combos don't work on Linux terminals)
         RegisterHotkey(registry, Key.F7, "Show execution plan", ShowExecutionPlanDialog);
         RegisterHotkey(registry, Key.F8, "Query history", ShowHistoryDialog);

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -858,6 +858,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         _statusLabel.Text = _useTdsEndpoint
             ? "Mode: TDS Read Replica (read-only, slight delay)"
             : "Mode: Dataverse (real-time)";
+        _statusLabel.SetNeedsDisplay();
         NotifyMenuChanged();
     }
 

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -279,6 +279,9 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         menuItems.Add(new MenuBarItem("_Tools", new MenuItem[]
         {
             new("SQL Query", "Run SQL queries against Dataverse", () => NavigateToSqlQuery()),
+            new("", "", () => {}, null, null, Key.Null), // Separator
+            new("Environment Details...", "View organization and connection info",
+                hasEnvironment ? () => ShowEnvironmentDetails() : (Action?)null),
             new("Configure Environment...", "Configure label, type, and color",
                 hasEnvironment ? () => ShowEnvironmentConfig() : (Action?)null),
         }));
@@ -527,6 +530,20 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         {
             _session.NotifyConfigChanged();
         }
+    }
+
+    private void ShowEnvironmentDetails()
+    {
+        var url = _session.CurrentEnvironmentUrl;
+        if (string.IsNullOrEmpty(url))
+        {
+            MessageBox.ErrorQuery("No Environment", "Please connect to an environment first.", "OK");
+            return;
+        }
+
+        var displayName = _session.CurrentEnvironmentDisplayName;
+        using var dialog = new EnvironmentDetailsDialog(_session, url, displayName);
+        Application.Run(dialog);
     }
 
     /// <summary>

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -816,8 +816,9 @@ export class DaemonClient implements vscode.Disposable {
             // TODO: Consider a lightweight health/ping endpoint
             this.connection.sendRequest('auth/list').then(() => {
                 this._heartbeatFailures = 0;
-            }).catch(() => {
+            }).catch((err: unknown) => {
                 this._heartbeatFailures++;
+                this.log.debug(`Heartbeat error: ${err instanceof Error ? err.message : String(err)}`);
                 this.log.warn(`Heartbeat failed (${this._heartbeatFailures}/${DaemonClient.HEARTBEAT_MAX_FAILURES}) — daemon may be unresponsive`);
                 if (this._heartbeatFailures >= DaemonClient.HEARTBEAT_MAX_FAILURES) {
                     this.log.warn('Max consecutive heartbeat failures reached — killing daemon');

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -20,6 +20,7 @@ import { SolutionsPanel } from './panels/SolutionsPanel.js';
 import { migrateLegacyState } from './migration/legacyState.js';
 import { registerDebugCommands } from './commands/debugCommands.js';
 import { DaemonStatusBar } from './daemonStatusBar.js';
+import { ProfileStatusBar } from './profileStatusBar.js';
 
 let daemonClient: DaemonClient | undefined;
 let logChannel: vscode.LogOutputChannel | undefined;
@@ -113,6 +114,10 @@ export function activate(context: vscode.ExtensionContext): void {
     // ── Daemon Status Bar ────────────────────────────────────────────
     const statusBar = new DaemonStatusBar(client);
     context.subscriptions.push(statusBar);
+
+    // ── Profile Status Bar ───────────────────────────────────────────
+    const profileStatusBar = new ProfileStatusBar(client);
+    context.subscriptions.push(profileStatusBar);
 
     // ── Virtual Document Provider (EXPLAIN output) ────────────────────
     const explainProvider = new ExplainDocumentProvider();
@@ -216,7 +221,7 @@ export function activate(context: vscode.ExtensionContext): void {
     );
 
     // ── Profile Commands ────────────────────────────────────────────────
-    registerProfileCommands(context, client, () => { profileTreeProvider.refresh(); refreshToolsState(); });
+    registerProfileCommands(context, client, () => { profileTreeProvider.refresh(); refreshToolsState(); profileStatusBar.refresh(); });
 
     // ── Environment Commands (tree context menu) ────────────────────────
     context.subscriptions.push(

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -196,12 +196,24 @@ export function activate(context: vscode.ExtensionContext): void {
     // Sync tools tree disabled state with profile availability
     const refreshToolsState = (): void => {
         void client.authList().then(result => {
-            toolsTreeProvider.setHasActiveProfile(result.activeProfile !== null);
-        }).catch(() => {
+            toolsTreeProvider.setHasActiveProfile(
+                result.activeProfile !== null || result.activeProfileIndex !== null);
+        }).catch((err: unknown) => {
+            logChannel?.warn(`Failed to refresh tools state: ${err instanceof Error ? err.message : String(err)}`);
             toolsTreeProvider.setHasActiveProfile(false);
         });
     };
-    refreshToolsState();
+
+    // Refresh tools state when daemon becomes ready (fixes startup race where
+    // the initial call fires before the daemon is connected)
+    context.subscriptions.push(
+        client.onDidChangeState(state => {
+            if (state === 'ready') {
+                refreshToolsState();
+                profileTreeProvider.refresh();
+            }
+        }),
+    );
 
     // ── Profile Commands ────────────────────────────────────────────────
     registerProfileCommands(context, client, () => { profileTreeProvider.refresh(); refreshToolsState(); });

--- a/src/PPDS.Extension/src/panels/QueryPanel.ts
+++ b/src/PPDS.Extension/src/panels/QueryPanel.ts
@@ -222,12 +222,15 @@ export class QueryPanel extends WebviewPanelBase<QueryPanelWebviewToHost, QueryP
                     try {
                         const config = await this.daemon.envConfigGet(env.url);
                         this.environmentColor = config.resolvedColor ?? null;
+                        if (!this.environmentType && config.resolvedType) {
+                            this.environmentType = config.resolvedType;
+                        }
                     } catch (err) {
                         // eslint-disable-next-line no-console -- non-critical: color accent unavailable
                         console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                         this.environmentColor = null;
                     }
-                    this.postMessage({ command: 'updateEnvironment', name: env.displayName, url: env.url, envType: env.type, envColor: this.environmentColor });
+                    this.postMessage({ command: 'updateEnvironment', name: env.displayName, url: env.url, envType: this.environmentType, envColor: this.environmentColor });
                     this.updateTitle();
                 }
                 break;
@@ -271,6 +274,9 @@ export class QueryPanel extends WebviewPanelBase<QueryPanelWebviewToHost, QueryP
             try {
                 const config = await this.daemon.envConfigGet(this.environmentUrl);
                 this.environmentColor = config.resolvedColor ?? null;
+                if (!this.environmentType && config.resolvedType) {
+                    this.environmentType = config.resolvedType;
+                }
             } catch (err) {
                 // eslint-disable-next-line no-console -- non-critical: color accent unavailable
                 console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/PPDS.Extension/src/panels/QueryPanel.ts
+++ b/src/PPDS.Extension/src/panels/QueryPanel.ts
@@ -151,7 +151,9 @@ export class QueryPanel extends WebviewPanelBase<QueryPanelWebviewToHost, QueryP
                         language: message.language,
                     });
                     this.postMessage({ command: 'completionResult', requestId, items: result.items });
-                } catch {
+                } catch (err) {
+                    // eslint-disable-next-line no-console -- non-critical: IntelliSense unavailable
+                    console.warn(`[PPDS] IntelliSense error: ${err instanceof Error ? err.message : String(err)}`);
                     this.postMessage({ command: 'completionResult', requestId, items: [] });
                 }
                 break;
@@ -220,7 +222,9 @@ export class QueryPanel extends WebviewPanelBase<QueryPanelWebviewToHost, QueryP
                     try {
                         const config = await this.daemon.envConfigGet(env.url);
                         this.environmentColor = config.resolvedColor ?? null;
-                    } catch {
+                    } catch (err) {
+                        // eslint-disable-next-line no-console -- non-critical: color accent unavailable
+                        console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                         this.environmentColor = null;
                     }
                     this.postMessage({ command: 'updateEnvironment', name: env.displayName, url: env.url, envType: env.type, envColor: this.environmentColor });
@@ -259,14 +263,17 @@ export class QueryPanel extends WebviewPanelBase<QueryPanelWebviewToHost, QueryP
                 this.environmentDisplayName = who.environment.displayName;
             }
             this.environmentType = who.environment?.type ?? null;
-        } catch {
-            // No active profile or environment
+        } catch (err) {
+            // eslint-disable-next-line no-console -- expected when no profile is active
+            console.debug(`[PPDS] initEnvironment: ${err instanceof Error ? err.message : String(err)}`);
         }
         if (this.environmentUrl) {
             try {
                 const config = await this.daemon.envConfigGet(this.environmentUrl);
                 this.environmentColor = config.resolvedColor ?? null;
-            } catch {
+            } catch (err) {
+                // eslint-disable-next-line no-console -- non-critical: color accent unavailable
+                console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                 this.environmentColor = null;
             }
         }

--- a/src/PPDS.Extension/src/panels/SolutionsPanel.ts
+++ b/src/PPDS.Extension/src/panels/SolutionsPanel.ts
@@ -147,7 +147,9 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
                 try {
                     const config = await this.daemon.envConfigGet(this.environmentUrl);
                     this.environmentColor = config.resolvedColor ?? null;
-                } catch {
+                } catch (err) {
+                    // eslint-disable-next-line no-console -- non-critical: color accent unavailable
+                    console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                     this.environmentColor = null;
                 }
             }
@@ -170,7 +172,9 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
             try {
                 const config = await this.daemon.envConfigGet(result.url);
                 this.environmentColor = config.resolvedColor ?? null;
-            } catch {
+            } catch (err) {
+                // eslint-disable-next-line no-console -- non-critical: color accent unavailable
+                console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                 this.environmentColor = null;
             }
             this.updatePanelTitle();

--- a/src/PPDS.Extension/src/panels/SolutionsPanel.ts
+++ b/src/PPDS.Extension/src/panels/SolutionsPanel.ts
@@ -147,6 +147,9 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
                 try {
                     const config = await this.daemon.envConfigGet(this.environmentUrl);
                     this.environmentColor = config.resolvedColor ?? null;
+                    if (!this.environmentType) {
+                        this.environmentType = config.resolvedType ?? null;
+                    }
                 } catch (err) {
                     // eslint-disable-next-line no-console -- non-critical: color accent unavailable
                     console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
@@ -172,13 +175,16 @@ export class SolutionsPanel extends WebviewPanelBase<SolutionsPanelWebviewToHost
             try {
                 const config = await this.daemon.envConfigGet(result.url);
                 this.environmentColor = config.resolvedColor ?? null;
+                if (!this.environmentType && config.resolvedType) {
+                    this.environmentType = config.resolvedType;
+                }
             } catch (err) {
                 // eslint-disable-next-line no-console -- non-critical: color accent unavailable
                 console.warn(`[PPDS] Failed to fetch environment color: ${err instanceof Error ? err.message : String(err)}`);
                 this.environmentColor = null;
             }
             this.updatePanelTitle();
-            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: result.type, envColor: this.environmentColor });
+            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: this.environmentType, envColor: this.environmentColor });
             await this.loadSolutions();
         }
     }

--- a/src/PPDS.Extension/src/profileStatusBar.ts
+++ b/src/PPDS.Extension/src/profileStatusBar.ts
@@ -43,7 +43,13 @@ export class ProfileStatusBar implements vscode.Disposable {
      */
     refresh(): void {
         void this.client.authList().then(result => {
-            const name = result.activeProfile;
+            // activeProfile is the Name field which may be null for unnamed profiles.
+            // Fall back to finding the active profile in the list by isActive flag.
+            let name = result.activeProfile;
+            if (!name && result.activeProfileIndex !== null) {
+                const active = result.profiles.find(p => p.isActive);
+                name = active?.name ?? (active ? `Profile ${active.index}` : null);
+            }
             this.statusBarItem.text = name
                 ? `$(account) ${name}`
                 : '$(account) No profile';

--- a/src/PPDS.Extension/src/profileStatusBar.ts
+++ b/src/PPDS.Extension/src/profileStatusBar.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient, DaemonState } from './daemonClient.js';
+
+/**
+ * Status bar item that shows the currently active authentication profile.
+ * Hidden when the daemon is not ready. Clicking it opens the profile quick pick
+ * (`ppds.listProfiles`) to switch profiles.
+ */
+export class ProfileStatusBar implements vscode.Disposable {
+    private readonly statusBarItem: vscode.StatusBarItem;
+    private readonly disposables: vscode.Disposable[] = [];
+    private readonly client: DaemonClient;
+
+    constructor(client: DaemonClient) {
+        this.client = client;
+
+        this.statusBarItem = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Left,
+            49, // Just right of the daemon status bar (priority 50)
+        );
+        this.statusBarItem.command = 'ppds.listProfiles';
+        this.statusBarItem.tooltip = 'PPDS: Click to switch profile';
+
+        // Start hidden — shown when daemon becomes ready
+        this.updateForState(client.state);
+
+        this.disposables.push(
+            client.onDidChangeState(state => this.updateForState(state)),
+            client.onDidReconnect(() => this.refresh()),
+            this.statusBarItem,
+        );
+
+        // If already ready, fetch profile immediately
+        if (client.state === 'ready') {
+            this.refresh();
+        }
+    }
+
+    /**
+     * Fetches the current active profile from the daemon and updates the
+     * status bar text. Safe to call at any time — errors are swallowed.
+     */
+    refresh(): void {
+        void this.client.authList().then(result => {
+            const name = result.activeProfile;
+            this.statusBarItem.text = name
+                ? `$(account) ${name}`
+                : '$(account) No profile';
+        }).catch(() => {
+            // Daemon not ready or call failed — leave text as-is
+        });
+    }
+
+    private updateForState(state: DaemonState): void {
+        if (state === 'ready') {
+            this.statusBarItem.show();
+            this.refresh();
+        } else {
+            this.statusBarItem.hide();
+        }
+    }
+
+    dispose(): void {
+        for (const d of this.disposables) d.dispose();
+    }
+}

--- a/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
+++ b/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
@@ -1,0 +1,74 @@
+namespace PPDS.Mcp.Infrastructure;
+
+/// <summary>
+/// Configuration options for an MCP server session.
+/// Parsed from command-line arguments at startup.
+/// </summary>
+public sealed class McpSessionOptions
+{
+    /// <summary>
+    /// Lock the session to a specific profile name.
+    /// If null, uses the active profile at first tool invocation.
+    /// </summary>
+    public string? Profile { get; set; }
+
+    /// <summary>
+    /// Lock the session to a specific environment URL.
+    /// If null, uses the profile's default environment.
+    /// </summary>
+    public string? Environment { get; set; }
+
+    /// <summary>
+    /// When true, all DML operations (INSERT, UPDATE, DELETE) are rejected.
+    /// </summary>
+    public bool ReadOnly { get; set; }
+
+    /// <summary>
+    /// Allowed environment URLs for ppds_env_select. If empty, environment
+    /// switching is disabled (locked to the initial environment).
+    /// </summary>
+    public List<string> AllowedEnvironments { get; set; } = new();
+
+    /// <summary>
+    /// Checks whether the given URL is in the allowed environments list.
+    /// </summary>
+    public bool IsEnvironmentAllowed(string url)
+    {
+        if (AllowedEnvironments.Count == 0)
+            return false; // No allowlist = no switching
+
+        var normalized = url.TrimEnd('/').ToLowerInvariant();
+        return AllowedEnvironments.Any(e =>
+            e.TrimEnd('/').Equals(normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Parses command-line arguments into session options.
+    /// Unknown args are passed through to the host builder.
+    /// </summary>
+    public static McpSessionOptions Parse(string[] args)
+    {
+        var options = new McpSessionOptions();
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--profile" when i + 1 < args.Length:
+                    options.Profile = args[++i];
+                    break;
+                case "--environment" when i + 1 < args.Length:
+                    options.Environment = args[++i];
+                    break;
+                case "--read-only":
+                    options.ReadOnly = true;
+                    break;
+                case "--allowed-env" when i + 1 < args.Length:
+                    options.AllowedEnvironments.Add(args[++i]);
+                    break;
+            }
+        }
+
+        return options;
+    }
+}

--- a/src/PPDS.Mcp/Infrastructure/McpToolContext.cs
+++ b/src/PPDS.Mcp/Infrastructure/McpToolContext.cs
@@ -27,6 +27,9 @@ public sealed class McpToolContext
     private readonly ProfileStore _profileStore;
     private readonly ISecureCredentialStore _credentialStore;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly McpSessionOptions _sessionOptions;
+    private AuthProfile? _lockedProfile;
+    private readonly SemaphoreSlim _lockGate = new(1, 1);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpToolContext"/> class.
@@ -34,17 +37,41 @@ public sealed class McpToolContext
     /// <param name="poolManager">The connection pool manager.</param>
     /// <param name="profileStore">The profile store for loading/saving auth profiles.</param>
     /// <param name="credentialStore">The secure credential store.</param>
+    /// <param name="sessionOptions">Session configuration options.</param>
     /// <param name="loggerFactory">Optional logger factory.</param>
     public McpToolContext(
         IMcpConnectionPoolManager poolManager,
         ProfileStore profileStore,
         ISecureCredentialStore credentialStore,
+        McpSessionOptions sessionOptions,
         ILoggerFactory? loggerFactory = null)
     {
         _poolManager = poolManager ?? throw new ArgumentNullException(nameof(poolManager));
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
         _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+        _sessionOptions = sessionOptions ?? throw new ArgumentNullException(nameof(sessionOptions));
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+    }
+
+    /// <summary>Whether DML operations are disabled for this session.</summary>
+    public bool IsReadOnly => _sessionOptions.ReadOnly;
+
+    /// <summary>The overridden environment URL, if specified via --environment.</summary>
+    public string? EnvironmentUrlOverride => _sessionOptions.Environment;
+
+    /// <summary>
+    /// Validates whether switching to the given environment URL is allowed.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">If the environment is not in the allowlist.</exception>
+    public void ValidateEnvironmentSwitch(string environmentUrl)
+    {
+        if (!_sessionOptions.IsEnvironmentAllowed(environmentUrl))
+        {
+            var msg = _sessionOptions.AllowedEnvironments.Count == 0
+                ? "Environment switching is disabled for this MCP session. The session is locked to the initial environment."
+                : $"Environment '{environmentUrl}' is not in the allowed list. Allowed: {string.Join(", ", _sessionOptions.AllowedEnvironments)}";
+            throw new InvalidOperationException(msg);
+        }
     }
 
     /// <summary>
@@ -55,14 +82,39 @@ public sealed class McpToolContext
     /// <exception cref="InvalidOperationException">Thrown if no profile is active.</exception>
     public async Task<AuthProfile> GetActiveProfileAsync(CancellationToken cancellationToken = default)
     {
-        var store = _profileStore;
-        var collection = await store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        // Session locking: resolve the profile once, then reuse for the session
+        if (_lockedProfile != null)
+            return _lockedProfile;
 
-        var profile = collection.ActiveProfile
-            ?? throw new InvalidOperationException(
-                "No active profile configured. Run 'ppds auth create' to create a profile.");
+        await _lockGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_lockedProfile != null)
+                return _lockedProfile;
 
-        return profile;
+            var collection = await _profileStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+
+            AuthProfile? profile;
+            if (_sessionOptions.Profile != null)
+            {
+                profile = collection.GetByNameOrIndex(_sessionOptions.Profile)
+                    ?? throw new InvalidOperationException(
+                        $"Profile '{_sessionOptions.Profile}' not found. Available profiles: {string.Join(", ", collection.All.Select(p => p.Name ?? $"Profile {p.Index}"))}");
+            }
+            else
+            {
+                profile = collection.ActiveProfile
+                    ?? throw new InvalidOperationException(
+                        "No active profile configured. Run 'ppds auth create' to create a profile.");
+            }
+
+            _lockedProfile = profile;
+            return profile;
+        }
+        finally
+        {
+            _lockGate.Release();
+        }
     }
 
     /// <summary>
@@ -88,16 +140,14 @@ public sealed class McpToolContext
     {
         var profile = await GetActiveProfileAsync(cancellationToken).ConfigureAwait(false);
 
-        if (profile.Environment == null)
-        {
-            throw new InvalidOperationException(
+        var environmentUrl = _sessionOptions.Environment ?? profile.Environment?.Url
+            ?? throw new InvalidOperationException(
                 "No environment selected. Run 'ppds env select <url>' to select an environment.");
-        }
 
         var profileName = profile.Name ?? profile.DisplayIdentifier;
         return await _poolManager.GetOrCreatePoolAsync(
             new[] { profileName },
-            profile.Environment.Url,
+            environmentUrl,
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -118,11 +168,13 @@ public sealed class McpToolContext
     {
         var profile = await GetActiveProfileAsync(cancellationToken).ConfigureAwait(false);
 
-        if (profile.Environment == null)
-        {
-            throw new InvalidOperationException(
+        var environmentUrl = _sessionOptions.Environment ?? profile.Environment?.Url
+            ?? throw new InvalidOperationException(
                 "No environment selected. Run 'ppds env select <url>' to select an environment.");
-        }
+
+        var environmentDisplayName = _sessionOptions.Environment != null
+            ? _sessionOptions.Environment
+            : profile.Environment?.DisplayName;
 
         var sources = new List<IConnectionSource>();
 
@@ -130,10 +182,10 @@ public sealed class McpToolContext
         {
             var source = new ProfileConnectionSource(
                 profile,
-                profile.Environment.Url,
+                environmentUrl,
                 maxPoolSize: 52,
                 deviceCodeCallback: null,
-                environmentDisplayName: profile.Environment.DisplayName,
+                environmentDisplayName: environmentDisplayName,
                 credentialStore: _credentialStore);
 
             var adapter = new ProfileConnectionSourceAdapter(source);

--- a/src/PPDS.Mcp/Program.cs
+++ b/src/PPDS.Mcp/Program.cs
@@ -10,6 +10,9 @@ using PPDS.Mcp.Infrastructure;
 // Redirect all console output to stderr before any logging occurs.
 Console.SetOut(Console.Error);
 
+// Parse session options before building the host.
+var sessionOptions = McpSessionOptions.Parse(args);
+
 var builder = Host.CreateApplicationBuilder(args);
 
 // Configure logging to stderr only (stdout is reserved for MCP protocol messages).
@@ -27,6 +30,7 @@ builder.Services.AddMcpServer()
     .WithToolsFromAssembly();
 
 // Register MCP infrastructure.
+builder.Services.AddSingleton(sessionOptions);
 builder.Services.AddSingleton<IMcpConnectionPoolManager, McpConnectionPoolManager>();
 builder.Services.AddSingleton<McpToolContext>();
 

--- a/src/PPDS.Mcp/Tools/EnvSelectTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvSelectTool.cs
@@ -60,6 +60,9 @@ public sealed class EnvSelectTool
 
         var resolved = result.Environment!;
 
+        // Validate environment switch against session allowlist
+        _context.ValidateEnvironmentSwitch(resolved.Url);
+
         // Invalidate cached pool for the old environment.
         if (profile.Environment != null)
         {

--- a/src/PPDS.Mcp/Tools/QueryFetchTool.cs
+++ b/src/PPDS.Mcp/Tools/QueryFetchTool.cs
@@ -54,6 +54,7 @@ public sealed class QueryFetchTool
         await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
         var queryExecutor = serviceProvider.GetRequiredService<IQueryExecutor>();
 
+        // FetchXML is inherently read-only — no DML guard needed.
         var result = await queryExecutor.ExecuteFetchXmlAsync(
             query,
             pageNumber: null,

--- a/src/PPDS.Mcp/Tools/QuerySqlTool.cs
+++ b/src/PPDS.Mcp/Tools/QuerySqlTool.cs
@@ -62,6 +62,13 @@ public sealed class QuerySqlTool
             throw new InvalidOperationException($"SQL parse error: {ex.Message}", ex);
         }
 
+        // Block DML operations in read-only sessions.
+        if (_context.IsReadOnly && stmt is not SelectStatement)
+        {
+            throw new InvalidOperationException(
+                "DML operations (INSERT, UPDATE, DELETE) are disabled. This MCP session was started with --read-only.");
+        }
+
         // Apply row limit.
         if (stmt is SelectStatement selectStmt
             && selectStmt.QueryExpression is QuerySpecification querySpec)

--- a/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
@@ -1,0 +1,250 @@
+using FluentAssertions;
+using PPDS.Mcp.Infrastructure;
+using Xunit;
+
+namespace PPDS.Mcp.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="McpSessionOptions"/>.
+/// </summary>
+public sealed class McpSessionOptionsTests
+{
+    #region Parse Tests
+
+    [Fact]
+    public void Parse_WithProfileFlag_SetsProfile()
+    {
+        // Arrange
+        var args = new[] { "--profile", "Dev" };
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.Profile.Should().Be("Dev");
+    }
+
+    [Fact]
+    public void Parse_WithEnvironmentFlag_SetsEnvironment()
+    {
+        // Arrange
+        var args = new[] { "--environment", "https://org.crm.dynamics.com" };
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.Environment.Should().Be("https://org.crm.dynamics.com");
+    }
+
+    [Fact]
+    public void Parse_WithReadOnlyFlag_SetsReadOnly()
+    {
+        // Arrange
+        var args = new[] { "--read-only" };
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.ReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_WithMultipleAllowedEnv_AddsAllUrls()
+    {
+        // Arrange
+        var args = new[]
+        {
+            "--allowed-env", "https://dev.crm.dynamics.com",
+            "--allowed-env", "https://test.crm.dynamics.com",
+            "--allowed-env", "https://prod.crm.dynamics.com"
+        };
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.AllowedEnvironments.Should().HaveCount(3);
+        options.AllowedEnvironments.Should().ContainInOrder(
+            "https://dev.crm.dynamics.com",
+            "https://test.crm.dynamics.com",
+            "https://prod.crm.dynamics.com");
+    }
+
+    [Fact]
+    public void Parse_WithNoArgs_ReturnsDefaults()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.Profile.Should().BeNull();
+        options.Environment.Should().BeNull();
+        options.ReadOnly.Should().BeFalse();
+        options.AllowedEnvironments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_WithCombinedArgs_SetsAllFields()
+    {
+        // Arrange
+        var args = new[]
+        {
+            "--profile", "Production",
+            "--environment", "https://prod.crm.dynamics.com",
+            "--read-only",
+            "--allowed-env", "https://prod.crm.dynamics.com",
+            "--allowed-env", "https://staging.crm.dynamics.com"
+        };
+
+        // Act
+        var options = McpSessionOptions.Parse(args);
+
+        // Assert
+        options.Profile.Should().Be("Production");
+        options.Environment.Should().Be("https://prod.crm.dynamics.com");
+        options.ReadOnly.Should().BeTrue();
+        options.AllowedEnvironments.Should().HaveCount(2);
+        options.AllowedEnvironments.Should().Contain("https://prod.crm.dynamics.com");
+        options.AllowedEnvironments.Should().Contain("https://staging.crm.dynamics.com");
+    }
+
+    #endregion
+
+    #region IsEnvironmentAllowed Tests
+
+    [Fact]
+    public void IsEnvironmentAllowed_EmptyList_ReturnsFalse()
+    {
+        // Arrange
+        var options = new McpSessionOptions();
+
+        // Act
+        var result = options.IsEnvironmentAllowed("https://org.crm.dynamics.com");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_MatchingUrl_ReturnsTrue()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://dev.crm.dynamics.com",
+                "https://prod.crm.dynamics.com"
+            }
+        };
+
+        // Act
+        var result = options.IsEnvironmentAllowed("https://prod.crm.dynamics.com");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_NonMatchingUrl_ReturnsFalse()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://dev.crm.dynamics.com",
+                "https://prod.crm.dynamics.com"
+            }
+        };
+
+        // Act
+        var result = options.IsEnvironmentAllowed("https://staging.crm.dynamics.com");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_TrailingSlashNormalization_MatchesRegardless()
+    {
+        // Arrange - allowlist has URL without trailing slash
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://org.crm.dynamics.com"
+            }
+        };
+
+        // Act - query with trailing slash
+        var result = options.IsEnvironmentAllowed("https://org.crm.dynamics.com/");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_TrailingSlashInAllowlist_MatchesWithout()
+    {
+        // Arrange - allowlist has URL with trailing slash
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://org.crm.dynamics.com/"
+            }
+        };
+
+        // Act - query without trailing slash
+        var result = options.IsEnvironmentAllowed("https://org.crm.dynamics.com");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_CaseInsensitive_Matches()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://ORG.CRM.DYNAMICS.COM"
+            }
+        };
+
+        // Act
+        var result = options.IsEnvironmentAllowed("https://org.crm.dynamics.com");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsEnvironmentAllowed_CaseInsensitive_UpperCaseQuery()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://org.crm.dynamics.com"
+            }
+        };
+
+        // Act
+        var result = options.IsEnvironmentAllowed("HTTPS://ORG.CRM.DYNAMICS.COM");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Mcp.Tests/Infrastructure/McpToolContextTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/McpToolContextTests.cs
@@ -19,7 +19,7 @@ public sealed class McpToolContextTests
     public void Constructor_NullPoolManager_ThrowsArgumentNullException()
     {
         // Act
-        var act = () => new McpToolContext(null!, new ProfileStore(), new Mock<ISecureCredentialStore>().Object);
+        var act = () => new McpToolContext(null!, new ProfileStore(), new Mock<ISecureCredentialStore>().Object, new McpSessionOptions());
 
         // Assert
         act.Should().Throw<ArgumentNullException>()
@@ -33,7 +33,8 @@ public sealed class McpToolContextTests
         var act = () => new McpToolContext(
             new Mock<IMcpConnectionPoolManager>().Object,
             null!,
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
 
         // Assert
         act.Should().Throw<ArgumentNullException>()
@@ -47,7 +48,8 @@ public sealed class McpToolContextTests
         var act = () => new McpToolContext(
             new Mock<IMcpConnectionPoolManager>().Object,
             new ProfileStore(),
-            null!);
+            null!,
+            new McpSessionOptions());
 
         // Assert
         act.Should().Throw<ArgumentNullException>()
@@ -64,7 +66,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
 
         // Assert
         context.Should().NotBeNull();
@@ -81,6 +84,7 @@ public sealed class McpToolContextTests
             mockPoolManager.Object,
             new ProfileStore(),
             new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions(),
             loggerFactory: null);
 
         // Assert
@@ -99,7 +103,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var environmentUrl = "https://org.crm.dynamics.com";
 
         // Act
@@ -119,7 +124,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var environmentUrl = "https://org.crm.dynamics.com/with/trailing/slash/";
 
         // Act
@@ -145,7 +151,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
 
         // Act
         Func<Task> act = () => context.GetActiveProfileAsync();
@@ -168,7 +175,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
 
         // Act
         Func<Task> act = () => context.GetPoolAsync();
@@ -191,7 +199,8 @@ public sealed class McpToolContextTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
 
         // Act
         Func<Task> act = () => context.CreateServiceProviderAsync();

--- a/tests/PPDS.Mcp.Tests/Infrastructure/McpToolContextTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/McpToolContextTests.cs
@@ -188,6 +188,140 @@ public sealed class McpToolContextTests
 
     #endregion
 
+    #region Session Options Tests
+
+    [Fact]
+    public void IsReadOnly_DefaultOptions_ReturnsFalse()
+    {
+        // Arrange
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
+
+        // Act & Assert
+        context.IsReadOnly.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsReadOnly_ReadOnlyOptionTrue_ReturnsTrue()
+    {
+        // Arrange
+        var options = new McpSessionOptions { ReadOnly = true };
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            options);
+
+        // Act & Assert
+        context.IsReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateEnvironmentSwitch_NoAllowlistConfigured_ThrowsInvalidOperationException()
+    {
+        // Arrange - empty allowlist means switching is disabled
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
+
+        // Act
+        var act = () => context.ValidateEnvironmentSwitch("https://org.crm.dynamics.com");
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Environment switching is disabled*");
+    }
+
+    [Fact]
+    public void ValidateEnvironmentSwitch_UrlNotInAllowlist_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://dev.crm.dynamics.com",
+                "https://test.crm.dynamics.com"
+            }
+        };
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            options);
+
+        // Act
+        var act = () => context.ValidateEnvironmentSwitch("https://prod.crm.dynamics.com");
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not in the allowed list*");
+    }
+
+    [Fact]
+    public void ValidateEnvironmentSwitch_UrlInAllowlist_Succeeds()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            AllowedEnvironments = new List<string>
+            {
+                "https://dev.crm.dynamics.com",
+                "https://test.crm.dynamics.com"
+            }
+        };
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            options);
+
+        // Act
+        var act = () => context.ValidateEnvironmentSwitch("https://dev.crm.dynamics.com");
+
+        // Assert - should not throw
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void EnvironmentUrlOverride_DefaultOptions_ReturnsNull()
+    {
+        // Arrange
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
+
+        // Act & Assert
+        context.EnvironmentUrlOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public void EnvironmentUrlOverride_WithEnvironmentConfigured_ReturnsUrl()
+    {
+        // Arrange
+        var options = new McpSessionOptions
+        {
+            Environment = "https://prod.crm.dynamics.com"
+        };
+        var context = new McpToolContext(
+            new Mock<IMcpConnectionPoolManager>().Object,
+            new ProfileStore(),
+            new Mock<ISecureCredentialStore>().Object,
+            options);
+
+        // Act & Assert
+        context.EnvironmentUrlOverride.Should().Be("https://prod.crm.dynamics.com");
+    }
+
+    #endregion
+
     #region CreateServiceProviderAsync Tests
 
     [Fact(Skip = "Requires no profiles.json to exist - tested via integration tests")]

--- a/tests/PPDS.Mcp.Tests/Tools/DataSchemaToolTests.cs
+++ b/tests/PPDS.Mcp.Tests/Tools/DataSchemaToolTests.cs
@@ -38,7 +38,8 @@ public sealed class DataSchemaToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new DataSchemaTool(context);
 
         // Act
@@ -58,7 +59,8 @@ public sealed class DataSchemaToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new DataSchemaTool(context);
 
         // Act
@@ -77,7 +79,8 @@ public sealed class DataSchemaToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new DataSchemaTool(context);
 
         // Act

--- a/tests/PPDS.Mcp.Tests/Tools/QueryFetchToolTests.cs
+++ b/tests/PPDS.Mcp.Tests/Tools/QueryFetchToolTests.cs
@@ -38,7 +38,8 @@ public sealed class QueryFetchToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QueryFetchTool(context);
 
         // Act
@@ -58,7 +59,8 @@ public sealed class QueryFetchToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QueryFetchTool(context);
 
         // Act
@@ -77,7 +79,8 @@ public sealed class QueryFetchToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QueryFetchTool(context);
 
         // Act

--- a/tests/PPDS.Mcp.Tests/Tools/QuerySqlToolTests.cs
+++ b/tests/PPDS.Mcp.Tests/Tools/QuerySqlToolTests.cs
@@ -38,7 +38,8 @@ public sealed class QuerySqlToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QuerySqlTool(context);
 
         // Act
@@ -58,7 +59,8 @@ public sealed class QuerySqlToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QuerySqlTool(context);
 
         // Act
@@ -77,7 +79,8 @@ public sealed class QuerySqlToolTests
         var context = new McpToolContext(
             mockPoolManager.Object,
             new ProfileStore(),
-            new Mock<ISecureCredentialStore>().Object);
+            new Mock<ISecureCredentialStore>().Object,
+            new McpSessionOptions());
         var tool = new QuerySqlTool(context);
 
         // Act


### PR DESCRIPTION
## Summary

Comprehensive QA sweep of Extension, TUI, and MCP surfaces before scaling out panel implementation. Covers code integrity audit, interactive verification of every feature, parity comparison, and bug fixes.

- Fix #580: TDS keybinding conflict — change from Ctrl+Shift+T to F10 (terminal limitation)
- Fix #581: TDS menu toggle status label — add SetNeedsDisplay() for Terminal.Gui repaint
- Close #361: Extension profile status bar — shows active profile name, click to switch
- Fix startup race where tools tree showed "(no profile)" permanently
- Fix env type toolbar border — use resolvedType from env config instead of auth/who
- Fix 7 silent error catches across Extension panels and daemon client
- Wire EnvironmentDetailsDialog to TUI Tools menu
- Add MCP session locking, --read-only, --allowed-env, DML guard
- Add Constitution Session Laws (SS1, SS2)
- Add 18 MCP guardrail unit tests
- QA findings document with full parity comparison

## Issues Filed from Findings

- #594 TUI: unnamed SPN profile display
- #595 TUI: keyboard shortcuts dialog scrolling
- #596 TUI: splash screen error before profile selection
- #597 TUI: environment selector missing Open in Maker/Dynamics
- #598 webview-cdp: multi-panel targeting
- #599 Extension: environment details command
- #600 TUI: solutions browser screen

## Test plan

- [x] Extension typecheck + 225 unit tests passing
- [x] CLI build clean (0 warnings, 0 errors)
- [x] MCP 58 tests passing (18 new)
- [x] Extension verified via @webview-cdp: query, filter, Load More, export, history, FetchXML toggle, explain, error handling, solutions drill-down, env type border, profile status bar
- [x] TUI verified via @tui-verify: F10 toggle, menu toggle, query execution, all menus, Environment Details dialog, profile selector, environment selector
- [x] Pre-commit hooks pass (typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)