### PR TITLE
fix: use py launcher instead of python for hook scripts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -199,7 +199,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/pre-commit-validate.py",
+            "command": "py .claude/hooks/pre-commit-validate.py",
             "timeout": 120
           }
         ]
@@ -209,7 +209,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/pr-gate.py",
+            "command": "py .claude/hooks/pr-gate.py",
             "timeout": 30
           }
         ]
@@ -221,7 +221,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/post-commit-state.py",
+            "command": "py .claude/hooks/post-commit-state.py",
             "timeout": 10
           }
         ]
@@ -232,7 +232,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/session-start-workflow.py",
+            "command": "py .claude/hooks/session-start-workflow.py",
             "timeout": 10
           }
         ]
@@ -243,7 +243,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python .claude/hooks/session-stop-workflow.py",
+            "command": "py .claude/hooks/session-stop-workflow.py",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary

- All 5 hook scripts in `.claude/settings.json` used `python` as the command, which on Windows redirects to the Microsoft Store alias instead of the actual Python installation
- Changed to `py` (Windows Python launcher) which correctly resolves to the installed Python

## Test plan

- [x] Confirmed `py --version` returns Python 3.14.3
- [ ] Verify SessionStart hook fires on new session
- [ ] Verify Stop hook fires on session end

🤖 Generated with [Claude Code](https://claude.com/claude-code)