### PR TITLE
fix: add commit frequency instruction to workflow

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -78,9 +78,19 @@ When external reviews (Gemini, etc.) are complete:
 1. Evaluate against constitution and codebase patterns
 2. If valid (mechanical issue, real bug, correct suggestion) → fix it
 3. If invalid (conflicts with our patterns, misunderstands codebase) → dismiss with rationale
-4. **Reply to EACH comment individually on the PR** with the action taken:
+4. **Reply directly to EACH review comment** (not a top-level PR comment):
+   ```bash
+   # Get review comments
+   gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {id, path, body}'
+
+   # Reply to a specific comment (threads the reply under the original)
+   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."
+   ```
+   Reply text:
    - Fixed: "Fixed in {commit SHA} — {brief description}"
    - Dismissed: "Not applicable — {rationale referencing constitution/pattern}"
+
+   Do NOT use `gh pr comment` — that creates a top-level comment, not a threaded reply.
 
 **Push fixes as a new commit:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,23 +78,23 @@ TUI-first multi-interface platform. All business logic in Application Services, 
 2. If UI/output changed → /verify for affected surface
 3. /pr when ready
 
-### Enforcement
-Steps 5-8 are enforced by hooks. The PR gate hook will block `gh pr create` if incomplete. Run /status to check.
+### Commits and enforcement
+Commit after each GitHub issue fixed or plan task completed — don't ask, just do it. One commit per fix.
+Steps 5-8 enforced by hooks. PR gate blocks `gh pr create` if incomplete. Run /status to check.
 
 ### STOP conditions
 - DO NOT skip steps 5-8 because "tests pass." Tests are necessary, not sufficient.
 - DO NOT declare work complete without visual verification of affected surfaces.
 
 ### Autonomy scope
-"Don't ask, just do it" applies to: committing, running gates, verification, QA, review, triaging external review comments (fix valid, dismiss invalid with rationale).
-"Don't ask, just do it" does NOT apply to: skipping workflow steps, filing/closing issues, creating PRs without passing gates.
-After external review: respond to EACH comment individually on the PR with action taken. Include summary in PR status report.
+"Don't ask, just do it" applies to: committing, gates, verification, QA, review, triaging review comments. Does NOT apply to: skipping workflow steps, filing/closing issues, PRs without passing gates.
+After external review: respond to EACH PR comment individually with action taken. Include summary in status report.
 
 ## Git Hooks
 
-Pre-commit hook in `scripts/hooks/` runs `typecheck:all` and `eslint --quiet` (errors only) on extension TS changes. Auto-configured by `npm install` via `prepare` script. Manual setup: `git config core.hooksPath scripts/hooks`.
+Pre-commit hook (`scripts/hooks/`) runs `typecheck:all` + `eslint --quiet` on extension TS changes. Auto-configured by `npm install`. Manual: `git config core.hooksPath scripts/hooks`.
 
 ## Gotchas
 
 - VS Code `LogOutputChannel` writes to `exthost/<extId>/Name.log`, NOT `N-Name.log`
-- Agent research summaries may be wrong — read code yourself before stating codebase behavior as fact
+- Agent research summaries may be wrong — read code yourself before stating facts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Steps 5-8 enforced by hooks. PR gate blocks `gh pr create` if incomplete. Run /s
 - DO NOT declare work complete without visual verification of affected surfaces.
 
 ### Autonomy scope
-"Don't ask, just do it" applies to: committing, gates, verification, QA, review, triaging review comments. Does NOT apply to: skipping workflow steps, filing/closing issues, PRs without passing gates.
+"Don't ask, just do it" applies to: committing, gates, verification, QA, review, triaging review comments (fix valid, dismiss invalid w/ rationale). Does NOT apply to: skipping workflow steps, filing/closing issues, PRs without passing gates.
 After external review: respond to EACH PR comment individually with action taken. Include summary in status report.
 
 ## Git Hooks


### PR DESCRIPTION
## Summary
- Add "Commit after each GitHub issue fixed or plan task completed" to CLAUDE.md workflow section
- Prevents AI from batching multiple fixes into one commit, which breaks bisecting and reverting
- Tightened other sections to stay within 100-line governance limit

## Motivation
Observed in active session: AI fixing 8 issues without committing between them. If bugs touch the same files, the history becomes unusable.

## Test plan
- [ ] Verify CLAUDE.md is exactly 100 lines
- [ ] Start new session, fix multiple issues — verify AI commits after each one

🤖 Generated with [Claude Code](https://claude.com/claude-code)