### PR TITLE
fix: resolve QA findings from issues #594-#603

### DIFF
--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -11,10 +11,17 @@ import sys
 
 def main():
     # Read stdin (Claude Code sends JSON with tool info)
+    # Parse command to check if this is actually a gh pr create command
+    command = ""
     try:
-        json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
+        hook_input = json.load(sys.stdin)
+        command = hook_input.get("tool_input", {}).get("command", "")
+    except (json.JSONDecodeError, EOFError, AttributeError):
         pass
+
+    # Only enforce on gh pr create — skip all other Bash commands
+    if "gh pr create" not in command:
+        sys.exit(0)
 
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,7 +205,7 @@
         ]
       },
       {
-        "matcher": "Bash(gh pr create:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/src/PPDS.Cli/Services/Profile/ProfileService.cs
+++ b/src/PPDS.Cli/Services/Profile/ProfileService.cs
@@ -24,6 +24,7 @@ public sealed class ProfileService : IProfileService
     private readonly ProfileStore _store;
     private readonly ILogger<ProfileService> _logger;
     private readonly Func<ISecureCredentialStore> _credentialStoreFactory;
+    private readonly EnvironmentConfigStore? _envConfigStore;
 
     /// <summary>
     /// Creates a new profile service.
@@ -35,14 +36,19 @@ public sealed class ProfileService : IProfileService
     /// <see cref="NativeCredentialStore"/> directly (production default).
     /// Pass a custom factory in tests to avoid requiring a configured GCM credential store.
     /// </param>
+    /// <param name="envConfigStore">
+    /// Optional environment config store for cleaning up orphaned environment configs on profile deletion.
+    /// </param>
     public ProfileService(
         ProfileStore store,
         ILogger<ProfileService> logger,
-        Func<ISecureCredentialStore>? credentialStoreFactory = null)
+        Func<ISecureCredentialStore>? credentialStoreFactory = null,
+        EnvironmentConfigStore? envConfigStore = null)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _credentialStoreFactory = credentialStoreFactory ?? (() => new NativeCredentialStore());
+        _envConfigStore = envConfigStore;
     }
 
     /// <inheritdoc />
@@ -97,6 +103,9 @@ public sealed class ProfileService : IProfileService
             return false;
         }
 
+        // Capture environment URL before removal for orphan cleanup
+        var deletedEnvUrl = profile.Environment?.Url;
+
         // Clean up stored credentials for this profile (only if no other profiles share them)
         await CleanupCredentialsAsync(collection, profile, cancellationToken);
 
@@ -104,6 +113,19 @@ public sealed class ProfileService : IProfileService
         await _store.SaveAsync(collection, cancellationToken);
 
         _logger.LogInformation("Deleted profile {ProfileIdentifier}", profile.DisplayIdentifier);
+
+        // Clean up orphaned environment configs (if no remaining profile references the URL)
+        if (_envConfigStore != null && !string.IsNullOrEmpty(deletedEnvUrl))
+        {
+            var isUrlStillReferenced = collection.All.Any(p =>
+                string.Equals(p.Environment?.Url?.TrimEnd('/'), deletedEnvUrl.TrimEnd('/'), StringComparison.OrdinalIgnoreCase));
+
+            if (!isUrlStillReferenced)
+            {
+                await _envConfigStore.RemoveConfigAsync(deletedEnvUrl, cancellationToken);
+                _logger.LogInformation("Cleaned up orphaned environment config for {Url}", deletedEnvUrl);
+            }
+        }
 
         return true;
     }

--- a/src/PPDS.Cli/Services/ProfileResolutionService.cs
+++ b/src/PPDS.Cli/Services/ProfileResolutionService.cs
@@ -1,4 +1,5 @@
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Tui.Infrastructure;
 
 namespace PPDS.Cli.Services;
 
@@ -24,9 +25,9 @@ public sealed class ProfileResolutionService
                         nameof(configs));
 
                 if (_labelIndex.ContainsKey(config.Label))
-                    throw new ArgumentException(
-                        $"Duplicate environment label '{config.Label}'. Each environment must have a unique label.",
-                        nameof(configs));
+                {
+                    TuiDebugLog.Log($"Warning: Duplicate environment label '{config.Label}' — using last occurrence");
+                }
 
                 _labelIndex[config.Label] = config;
             }

--- a/src/PPDS.Cli/Tui/Dialogs/EnvironmentSelectorDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/EnvironmentSelectorDialog.cs
@@ -70,7 +70,7 @@ internal sealed class EnvironmentSelectorDialog : TuiDialog, ITuiStateCapture<En
         _configService = session?.EnvironmentConfigService;
 
         Width = 72;
-        Height = 28;
+        Height = 30;
 
         // Filter field
         var filterLabel = new Label("Filter:")
@@ -192,36 +192,51 @@ internal sealed class EnvironmentSelectorDialog : TuiDialog, ITuiStateCapture<En
             Visible = false
         };
 
-        // Buttons
+        // Buttons - Row 1 (primary actions)
         _selectButton = new Button("_Select")
         {
             X = Pos.Center() - 25,
-            Y = Pos.AnchorEnd(1)
+            Y = Pos.AnchorEnd(2)
         };
         _selectButton.Clicked += OnSelectClicked;
 
         var detailsButton = new Button("De_tails")
         {
             X = Pos.Center() - 10,
-            Y = Pos.AnchorEnd(1)
+            Y = Pos.AnchorEnd(2)
         };
         detailsButton.Clicked += OnDetailsClicked;
 
         var configButton = new Button("Con_figure")
         {
             X = Pos.Center() + 5,
-            Y = Pos.AnchorEnd(1)
+            Y = Pos.AnchorEnd(2)
         };
         configButton.Clicked += OnConfigureClicked;
 
         var cancelButton = new Button("_Cancel")
         {
             X = Pos.Center() + 18,
-            Y = Pos.AnchorEnd(1)
+            Y = Pos.AnchorEnd(2)
         };
         cancelButton.Clicked += () => { Application.RequestStop(); };
 
-        Add(filterLabel, _filterField, listFrame, previewFrame, urlLabel, _urlField, _spinner, _statusLabel, _selectButton, detailsButton, configButton, cancelButton);
+        // Buttons - Row 2 (browser actions)
+        var makerButton = new Button("Open in _Maker")
+        {
+            X = Pos.Center() - 20,
+            Y = Pos.AnchorEnd(1)
+        };
+        makerButton.Clicked += OnOpenInMakerClicked;
+
+        var dynamicsButton = new Button("Open in D_ynamics")
+        {
+            X = Pos.Center() + 2,
+            Y = Pos.AnchorEnd(1)
+        };
+        dynamicsButton.Clicked += OnOpenInDynamicsClicked;
+
+        Add(filterLabel, _filterField, listFrame, previewFrame, urlLabel, _urlField, _spinner, _statusLabel, _selectButton, detailsButton, configButton, cancelButton, makerButton, dynamicsButton);
 
         // Defer loading until dialog is visible to ensure spinner renders
         Loaded += () =>
@@ -453,6 +468,61 @@ internal sealed class EnvironmentSelectorDialog : TuiDialog, ITuiStateCapture<En
             {
                 UpdatePreviewPanel(_filteredEnvironments[_listView.SelectedItem]);
             }
+        }
+    }
+
+    private void OnOpenInMakerClicked()
+    {
+        var env = GetSelectedEnvironment();
+        if (env == null) return;
+
+        string url;
+        if (!string.IsNullOrWhiteSpace(env.EnvironmentId))
+        {
+            url = $"https://make.powerapps.com/environments/{env.EnvironmentId}/solutions";
+        }
+        else
+        {
+            MessageBox.Query("Environment ID Unavailable",
+                "The environment ID is not available for this environment.\nOpening Maker Portal home instead.", "OK");
+            url = "https://make.powerapps.com";
+        }
+
+        OpenUrl(url);
+    }
+
+    private void OnOpenInDynamicsClicked()
+    {
+        var env = GetSelectedEnvironment();
+        if (env == null) return;
+
+        var url = env.Url.TrimEnd('/');
+        OpenUrl(url);
+    }
+
+    private EnvironmentSummary? GetSelectedEnvironment()
+    {
+        if (_listView.SelectedItem >= 0 && _listView.SelectedItem < _filteredEnvironments.Count)
+        {
+            return _filteredEnvironments[_listView.SelectedItem];
+        }
+
+        MessageBox.Query("No Environment", "Please select an environment first.", "OK");
+        return null;
+    }
+
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url)
+            {
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            MessageBox.ErrorQuery("Error", $"Failed to open browser: {ex.Message}", "OK");
         }
     }
 

--- a/src/PPDS.Cli/Tui/Dialogs/KeyboardShortcutsDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/KeyboardShortcutsDialog.cs
@@ -39,12 +39,15 @@ internal sealed class KeyboardShortcutsDialog : TuiDialog, ITuiStateCapture<Keyb
         Width = 55;
         Height = Math.Min(lineCount + 6, 30); // +6 for border, padding, button
 
-        var content = new Label(text)
+        var content = new TextView
         {
             X = 1,
             Y = 1,
             Width = Dim.Fill() - 2,
-            Height = Dim.Fill() - 2
+            Height = Dim.Fill() - 2,
+            ReadOnly = true,
+            Text = text,
+            ColorScheme = TuiColorPalette.Default
         };
 
         var closeButton = new Button("_OK")

--- a/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ProfileSelectorDialog.cs
@@ -1,3 +1,4 @@
+using PPDS.Auth.Profiles;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Services.Profile;
 using PPDS.Cli.Tui.Infrastructure;
@@ -192,8 +193,7 @@ internal sealed class ProfileSelectorDialog : TuiDialog, ITuiStateCapture<Profil
 
             foreach (var profile in _profiles)
             {
-                var envHint = profile.EnvironmentName != null ? $" [{profile.EnvironmentName}]" : "";
-                items.Add($"{profile.DisplayIdentifier} ({profile.Identity}){envHint}");
+                items.Add(FormatProfileDisplay(profile));
             }
 
             _listView.SetSource(items);
@@ -461,6 +461,39 @@ internal sealed class ProfileSelectorDialog : TuiDialog, ITuiStateCapture<Profil
             ProfileWasDeleted = true;
             Application.RequestStop();
         }
+    }
+
+    private static bool IsServicePrincipal(AuthMethod method) => method is
+        AuthMethod.ClientSecret or AuthMethod.CertificateFile or
+        AuthMethod.CertificateStore or AuthMethod.GitHubFederated or
+        AuthMethod.AzureDevOpsFederated or AuthMethod.ManagedIdentity;
+
+    private static string FormatProfileDisplay(ProfileSummary profile)
+    {
+        var envHint = profile.EnvironmentName != null ? $" [{profile.EnvironmentName}]" : "";
+
+        if (profile.Name != null)
+        {
+            // Named profile: [2] MyProfile (user@domain.com) [Contoso Dev]
+            return $"{profile.DisplayIdentifier} ({profile.Identity}){envHint}";
+        }
+
+        if (IsServicePrincipal(profile.AuthMethod))
+        {
+            // Unnamed SPN: [2] SPN · Contoso Dev  or  [2] SPN · 3b039cb2
+            var hint = profile.EnvironmentName ?? TruncateId(profile.Identity);
+            return $"[{profile.Index}] SPN \u00b7 {hint}";
+        }
+
+        // Unnamed interactive: [2] user@domain.com [Contoso Dev]
+        return $"[{profile.Index}] {profile.Identity}{envHint}";
+    }
+
+    private static string TruncateId(string identity)
+    {
+        // Truncate GUIDs to first 8 chars for readability
+        var dashIndex = identity.IndexOf('-');
+        return dashIndex > 0 ? identity[..dashIndex] : identity;
     }
 
     /// <inheritdoc />

--- a/src/PPDS.Cli/Tui/InteractiveSession.cs
+++ b/src/PPDS.Cli/Tui/InteractiveSession.cs
@@ -126,7 +126,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
         _envConfigService = new EnvironmentConfigService(_envConfigStore);
 
         // Initialize lazy service instances (thread-safe by default)
-        _profileService = new Lazy<IProfileService>(() => new ProfileService(_profileStore, NullLogger<ProfileService>.Instance));
+        _profileService = new Lazy<IProfileService>(() => new ProfileService(_profileStore, NullLogger<ProfileService>.Instance, envConfigStore: _envConfigStore));
         _environmentService = new Lazy<IEnvironmentService>(() => new EnvironmentService(_profileStore, NullLogger<EnvironmentService>.Instance));
         _themeService = new Lazy<ITuiThemeService>(() => new TuiThemeService(_envConfigService));
         _errorService = new Lazy<ITuiErrorService>(() => new TuiErrorService());
@@ -147,9 +147,6 @@ internal sealed class InteractiveSession : IAsyncDisposable
         // Pre-load environment config so sync-over-async calls in UI thread are cache hits
         var envConfigs = await _envConfigStore.LoadAsync(cancellationToken).ConfigureAwait(false);
 
-        // Build label resolver for cross-environment queries ([LABEL].entity syntax)
-        _profileResolutionService = new ProfileResolutionService(envConfigs.Environments);
-
         var collection = await _profileStore.LoadAsync(cancellationToken).ConfigureAwait(false);
         var profile = string.IsNullOrEmpty(_profileName)
             ? collection.ActiveProfile
@@ -157,18 +154,28 @@ internal sealed class InteractiveSession : IAsyncDisposable
 
         TuiDebugLog.Log($"Loaded profile: {profile?.DisplayIdentifier ?? "(none)"}, AuthMethod: {profile?.AuthMethod}");
 
+        if (profile == null)
+        {
+            TuiDebugLog.Log("No active profile — skipping initialization. User will select a profile.");
+            return;
+        }
+
+        // Build label resolver for cross-environment queries ([LABEL].entity syntax)
+        // Only needed when we have a profile that can actually execute queries
+        _profileResolutionService = new ProfileResolutionService(envConfigs.Environments);
+
         // Set the identity for status bar display
-        CurrentProfileIdentity = profile?.IdentityDisplay;
+        CurrentProfileIdentity = profile.IdentityDisplay;
 
         // If using active profile (no explicit name specified), update _profileName
         // so CurrentProfileName returns the actual profile name instead of null
-        if (string.IsNullOrEmpty(_profileName) && profile != null)
+        if (string.IsNullOrEmpty(_profileName))
         {
             _profileName = profile.Name ?? collection.ActiveProfileName ?? $"[{profile.Index}]";
             TuiDebugLog.Log($"Using active profile: {_profileName}");
         }
 
-        if (profile?.Environment?.Url != null)
+        if (profile.Environment?.Url != null)
         {
             _activeEnvironmentUrl = profile.Environment.Url;
             _activeEnvironmentDisplayName = profile.Environment.DisplayName;

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -200,6 +200,12 @@
         "icon": "$(link-external)"
       },
       {
+        "command": "ppds.environmentDetails",
+        "title": "Environment Details",
+        "category": "PPDS",
+        "icon": "$(info)"
+      },
+      {
         "command": "ppds.testConnection",
         "title": "Test Connection",
         "icon": "$(plug)"
@@ -369,6 +375,11 @@
           "command": "ppds.openInDynamics",
           "when": "view == ppds.profiles && viewItem == environment",
           "group": "env-open@2"
+        },
+        {
+          "command": "ppds.environmentDetails",
+          "when": "view == ppds.profiles && viewItem == environment",
+          "group": "env-open@3"
         },
         {
           "command": "ppds.configureEnvironment",

--- a/src/PPDS.Extension/src/commands/environmentDetailsCommand.ts
+++ b/src/PPDS.Extension/src/commands/environmentDetailsCommand.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient } from '../daemonClient.js';
+import type { EnvironmentTreeItem } from '../views/profileTreeView.js';
+
+/**
+ * Registers the environment details command.
+ *
+ * Shows WhoAmI-based environment details (URL, version, org ID, user ID,
+ * connected as) via an information message. Accepts an optional
+ * EnvironmentTreeItem from the tree context menu, falling back to the
+ * active profile's environment.
+ */
+export function registerEnvironmentDetailsCommand(
+    context: vscode.ExtensionContext,
+    daemonClient: DaemonClient,
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ppds.environmentDetails', async (item?: EnvironmentTreeItem) => {
+            try {
+                // Guard: ensure an environment is available
+                if (!item?.envUrl) {
+                    const who = await daemonClient.authWho();
+                    if (!who.environment?.url) {
+                        vscode.window.showInformationMessage('No environment selected.');
+                        return;
+                    }
+                }
+
+                const details = await daemonClient.envWho();
+
+                const lines = [
+                    `Environment: ${details.organizationName} (${details.url})`,
+                    `Unique Name: ${details.uniqueName}`,
+                    `Version: ${details.version}`,
+                    `Organization ID: ${details.organizationId}`,
+                    `User ID: ${details.userId}`,
+                    `Business Unit ID: ${details.businessUnitId}`,
+                    `Connected As: ${details.connectedAs}`,
+                ];
+
+                if (details.environmentType) {
+                    lines.push(`Type: ${details.environmentType}`);
+                }
+
+                await vscode.window.showInformationMessage(
+                    lines.join('\n'),
+                    { modal: true },
+                    'Copy to Clipboard',
+                ).then(selection => {
+                    if (selection === 'Copy to Clipboard') {
+                        void vscode.env.clipboard.writeText(lines.join('\n'));
+                    }
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Failed to get environment details: ${message}`);
+            }
+        }),
+    );
+}

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -7,6 +7,7 @@ import { ToolsTreeDataProvider } from './views/toolsTreeView.js';
 import { registerProfileCommands } from './commands/profileCommands.js';
 import { registerEnvironmentConfigCommand } from './commands/environmentConfigCommand.js';
 import { registerBrowserCommands } from './commands/browserCommands.js';
+import { registerEnvironmentDetailsCommand } from './commands/environmentDetailsCommand.js';
 import { ExplainDocumentProvider } from './providers/explainDocumentProvider.js';
 import { DataverseNotebookSerializer } from './notebooks/DataverseNotebookSerializer.js';
 import { DataverseNotebookController } from './notebooks/DataverseNotebookController.js';
@@ -356,6 +357,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // ── Browser Commands ──────────────────────────────────────────────
     registerBrowserCommands(context, client);
+
+    // ── Environment Details Command ─────────────────────────────────
+    registerEnvironmentDetailsCommand(context, client);
 
     // ── Debug / Diagnostic Commands ──────────────────────────────────
     registerDebugCommands(context, client, profileTreeProvider, extensionState, {

--- a/src/PPDS.Extension/tools/webview-cdp.mjs
+++ b/src/PPDS.Extension/tools/webview-cdp.mjs
@@ -89,7 +89,10 @@ export function parseArgs(argv) {
   let target, ext, right = false, page = false;
   const args = [];
   for (let i = 0; i < rest.length; i++) {
-    if (rest[i] === '--target' && i + 1 < rest.length) { target = parseInt(rest[++i], 10); }
+    if (rest[i] === '--target' && i + 1 < rest.length) {
+      const val = rest[++i];
+      target = val === 'active' ? 'active' : parseInt(val, 10);
+    }
     else if (rest[i] === '--ext' && i + 1 < rest.length) { ext = rest[++i]; }
     else if (rest[i] === '--right') { right = true; }
     else if (rest[i] === '--page') { page = true; }
@@ -239,7 +242,40 @@ async function runDaemon(workspace) {
 
     if (candidates.length === 0) throw new Error('No webview found. Open a panel first.');
 
-    const idx = targetIndex ?? 0;
+    // --target active: find the visible/focused webview
+    if (targetIndex === 'active') {
+      const visibleFrames = [];
+      for (const frame of candidates) {
+        try {
+          const isVisible = await frame.evaluate(() => document.visibilityState === 'visible');
+          if (isVisible) visibleFrames.push(frame);
+        } catch { /* skip detached frames */ }
+      }
+      if (visibleFrames.length === 0) throw new Error('No visible webview found. Focus a webview panel first.');
+      if (visibleFrames.length > 1) throw new Error(`Multiple visible webviews found (${visibleFrames.length}). Use --target <index> to disambiguate.`);
+      return visibleFrames[0];
+    }
+
+    // When no explicit --target is specified and multiple candidates exist,
+    // prefer visible frames (sort visible first, then DOM order)
+    if (targetIndex == null && candidates.length > 1) {
+      const visibility = [];
+      for (const frame of candidates) {
+        try {
+          const isVisible = await frame.evaluate(() => document.visibilityState === 'visible');
+          visibility.push(isVisible);
+        } catch {
+          visibility.push(false);
+        }
+      }
+      // If exactly one is visible, use it; otherwise keep DOM order
+      const visibleIndices = visibility.reduce((acc, v, i) => v ? [...acc, i] : acc, []);
+      if (visibleIndices.length === 1) {
+        return candidates[visibleIndices[0]];
+      }
+    }
+
+    const idx = typeof targetIndex === 'number' ? targetIndex : 0;
     if (idx < 0 || idx >= candidates.length)
       throw new Error(`Target index ${idx} out of range (found ${candidates.length} webviews)`);
 
@@ -376,7 +412,37 @@ async function runDaemon(workspace) {
           // Extension ID is in the parent (wrapper) frame's URL
           const parentUrl = frame.parentFrame()?.url() || '';
           const extMatch = parentUrl.match(/extensionId=([^&]*)/);
-          targets.push({ ext: extMatch?.[1] || 'unknown', src: url });
+          // Check visibility
+          let visible = false;
+          try {
+            visible = await frame.evaluate(() => document.visibilityState === 'visible');
+          } catch { /* skip */ }
+          // Extract panel title from VS Code tab bar via main page
+          let title = null;
+          try {
+            // webview ID is in the URL: vscode-webview://<id>/...
+            const webviewId = new URL(url).hostname;
+            title = await page.evaluate((wvId) => {
+              // VS Code tab elements have data-resource-name or aria-label with panel title
+              const tabs = document.querySelectorAll('.tab');
+              for (const tab of tabs) {
+                const label = tab.getAttribute('aria-label') || '';
+                const resourceUri = tab.querySelector('.label-name')?.getAttribute('data-resource-name') || '';
+                // Check if this tab's resource references the webview ID
+                if (label.includes(wvId) || resourceUri.includes(wvId)) {
+                  return tab.querySelector('.label-name')?.textContent?.trim() || label;
+                }
+              }
+              // Fallback: try matching via active tab's webview container
+              return null;
+            }, webviewId);
+          } catch { /* title extraction is best-effort */ }
+          targets.push({
+            ext: extMatch?.[1] || 'unknown',
+            src: url,
+            title: title || '(unknown)',
+            visible,
+          });
         }
         return { targets };
       }
@@ -669,7 +735,8 @@ async function cmdConnect() {
   }
   console.log(`Found ${result.targets.length} webview target(s):`);
   result.targets.forEach((t, i) => {
-    console.log(`  ${i}: ${t.ext} — ${t.src.substring(0, 80)}`);
+    const activeMarker = t.visible ? ' *' : '';
+    console.log(`  ${i}: ${t.ext} — ${t.title}${activeMarker}`);
   });
 }
 

--- a/src/PPDS.Extension/tools/webview-cdp.test.mjs
+++ b/src/PPDS.Extension/tools/webview-cdp.test.mjs
@@ -78,9 +78,19 @@ describe('parseArgs', () => {
     expect(result).toEqual({ command: 'eval', args: ['document.title'], page: true, target: undefined, ext: undefined });
   });
 
-  it('parses --target flag', () => {
+  it('parses --target with numeric index', () => {
     const result = parseArgs(['eval', '1+1', '--target', '2']);
     expect(result).toEqual({ command: 'eval', args: ['1+1'], page: false, target: 2, ext: undefined });
+  });
+
+  it('parses --target active', () => {
+    const result = parseArgs(['eval', '1+1', '--target', 'active']);
+    expect(result).toEqual({ command: 'eval', args: ['1+1'], page: false, target: 'active', ext: undefined });
+  });
+
+  it('parses --target active with --ext', () => {
+    const result = parseArgs(['click', '#btn', '--target', 'active', '--ext', 'ppds']);
+    expect(result).toEqual({ command: 'click', args: ['#btn'], page: false, right: false, target: 'active', ext: 'ppds' });
   });
 
   it('parses --ext flag on interaction commands', () => {

--- a/tests/PPDS.Cli.Tests/Services/ProfileResolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ProfileResolutionServiceTests.cs
@@ -78,14 +78,20 @@ public class ProfileResolutionServiceTests
     }
 
     [Fact]
-    public void Constructor_DuplicateLabels_ThrowsArgumentException()
+    public void Constructor_DuplicateLabels_UsesLastWriteWins()
     {
         var configs = new[]
         {
             new EnvironmentConfig { Label = "UAT", Url = "https://uat.crm.dynamics.com/" },
             new EnvironmentConfig { Label = "uat", Url = "https://uat2.crm.dynamics.com/" }
         };
-        var act = () => new ProfileResolutionService(configs);
-        act.Should().Throw<ArgumentException>().WithMessage("*Duplicate*uat*");
+
+        // Should not throw — last-write-wins prevents TUI crash on orphaned configs
+        var service = new ProfileResolutionService(configs);
+
+        // The second config (uat2) should win
+        var resolved = service.ResolveByLabel("UAT");
+        resolved.Should().NotBeNull();
+        resolved!.Url.Should().Be("https://uat2.crm.dynamics.com/");
     }
 }


### PR DESCRIPTION
## Summary

Batch fix for 8 issues found during the Extension & TUI QA sweep (#601):

- **#594** — Unnamed SPN profiles now show "SPN · env-name" instead of raw GUIDs in profile selectors
- **#595** — Keyboard shortcuts dialog uses scrollable TextView so screen-specific bindings are accessible
- **#596** — TUI no longer crashes on splash when no profile is selected (defers initialization)
- **#597** — Environment selector adds "Open in Maker" / "Open in Dynamics" browser action buttons
- **#598** — webview-cdp supports `--target active` for visibility-based panel targeting; listing shows title + visibility
- **#599** — New `ppds.environmentDetails` command shows WhoAmI info in a modal with copy-to-clipboard
- **#602** — Duplicate environment labels use last-write-wins instead of crashing TUI initialization
- **#603** — Profile deletion cleans up orphaned environment configs when no remaining profile references the URL

## Test plan

- [x] `dotnet build PPDS.sln` — 0 warnings, 0 errors
- [x] `dotnet test --filter "Category!=Integration"` — 2,149 tests passing
- [x] `npm run typecheck:all` — clean
- [x] `npm run ext:test` — 231 tests passing (including 2 new `--target active` tests)
- [x] Pre-commit hooks pass (typecheck + lint)

Closes #594, closes #595, closes #596, closes #597, closes #598, closes #599, closes #602, closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)