### PR TITLE
feat(tui,mcp): add Solutions screen and MCP tools

### DIFF
--- a/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
@@ -1,0 +1,318 @@
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Cli.Tui.Testing;
+using PPDS.Cli.Tui.Testing.States;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// TUI screen for browsing Dataverse solutions and their components.
+/// </summary>
+internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<SolutionsScreenState>
+{
+    private readonly TextField _filterField;
+    private readonly CheckBox _managedCheckBox;
+    private readonly TableView _table;
+    private readonly Label _statusLabel;
+    private readonly FrameView _filterFrame;
+
+    private List<SolutionInfo> _allSolutions = [];
+    private List<SolutionInfo> _filteredSolutions = [];
+    private int? _lastComponentCount;
+    private bool _isLoading;
+    private string? _errorMessage;
+    private Dialog? _detailDialog;
+
+    public override string Title => "Solutions";
+
+    public SolutionsScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        _filterFrame = new FrameView("Filter")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = 3
+        };
+
+        _filterField = new TextField("")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(20)
+        };
+
+        _managedCheckBox = new CheckBox("Include Managed", true)
+        {
+            X = Pos.Right(_filterField) + 1,
+            Y = 0
+        };
+
+        _filterFrame.Add(_filterField, _managedCheckBox);
+
+        _table = new TableView
+        {
+            X = 0,
+            Y = Pos.Bottom(_filterFrame),
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            FullRowSelect = true,
+            Style = { ShowHorizontalHeaderOverline = false, ShowHorizontalHeaderUnderline = true }
+        };
+
+        _statusLabel = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_table),
+            Width = Dim.Fill(),
+            Height = 1,
+            Text = "Loading...",
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        _filterField.TextChanged += OnFilterTextChanged;
+        _managedCheckBox.Toggled += OnManagedToggled;
+        _table.CellActivated += OnCellActivated;
+
+        Content.Add(_filterFrame, _table, _statusLabel);
+
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadDataAsync(), "Solutions.InitialLoad");
+        }
+        else
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.R, "Refresh", () => ErrorService.FireAndForget(LoadDataAsync(), "Solutions.Refresh"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.O, "Open in Maker", OpenInMaker);
+    }
+
+    private async Task LoadDataAsync()
+    {
+        try
+        {
+            _isLoading = true;
+            _errorMessage = null;
+            _statusLabel.Text = "Loading solutions...";
+            Application.Refresh();
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<ISolutionService>();
+
+            var includeManaged = _managedCheckBox.Checked;
+            _allSolutions = await service.ListAsync(
+                filter: null,
+                includeManaged: includeManaged,
+                cancellationToken: ScreenCancellation);
+
+            _isLoading = false;
+            ApplyClientFilter();
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            _isLoading = false;
+            Application.MainLoop.Invoke(() =>
+            {
+                _errorMessage = ex.Message;
+                ErrorService.ReportError("Failed to load solutions", ex, "Solutions.Load");
+                _statusLabel.Text = "Error loading solutions";
+            });
+        }
+    }
+
+    private void ApplyClientFilter()
+    {
+        var filterText = _filterField.Text?.ToString() ?? "";
+
+        if (string.IsNullOrWhiteSpace(filterText))
+        {
+            _filteredSolutions = new List<SolutionInfo>(_allSolutions);
+        }
+        else
+        {
+            _filteredSolutions = _allSolutions
+                .Where(s => s.FriendlyName.Contains(filterText, StringComparison.OrdinalIgnoreCase)
+                    || s.UniqueName.Contains(filterText, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("Name", typeof(string));
+        dt.Columns.Add("Unique Name", typeof(string));
+        dt.Columns.Add("Version", typeof(string));
+        dt.Columns.Add("Publisher", typeof(string));
+        dt.Columns.Add("Managed", typeof(string));
+        dt.Columns.Add("Modified", typeof(string));
+
+        foreach (var sol in _filteredSolutions)
+        {
+            dt.Rows.Add(
+                sol.FriendlyName,
+                sol.UniqueName,
+                sol.Version ?? "\u2014",
+                sol.PublisherName ?? "\u2014",
+                sol.IsManaged ? "Yes" : "No",
+                sol.ModifiedOn?.ToString("g") ?? "\u2014");
+        }
+
+        Application.MainLoop.Invoke(() =>
+        {
+            _table.Table = dt;
+            var unmanaged = _filteredSolutions.Count(s => !s.IsManaged);
+            _statusLabel.Text = $"{_filteredSolutions.Count} solution{(_filteredSolutions.Count != 1 ? "s" : "")} \u2014 {unmanaged} unmanaged";
+        });
+    }
+
+    private void OnFilterTextChanged(NStack.ustring _)
+    {
+        ApplyClientFilter();
+    }
+
+    private void OnManagedToggled(bool _)
+    {
+        ErrorService.FireAndForget(LoadDataAsync(), "Solutions.ManagedToggle");
+    }
+
+    private void OnCellActivated(TableView.CellActivatedEventArgs args)
+    {
+        if (args.Row < 0 || args.Row >= _filteredSolutions.Count) return;
+        var solution = _filteredSolutions[args.Row];
+        ErrorService.FireAndForget(ShowComponentsDialogAsync(solution), "Solutions.ShowComponents");
+    }
+
+    private async Task ShowComponentsDialogAsync(SolutionInfo solution)
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<ISolutionService>();
+
+            var components = await service.GetComponentsAsync(solution.Id, cancellationToken: ScreenCancellation);
+            _lastComponentCount = components.Count;
+
+            var grouped = components
+                .GroupBy(c => c.ComponentTypeName)
+                .OrderBy(g => g.Key)
+                .ToList();
+
+            var lines = new List<string>
+            {
+                $"Solution: {solution.FriendlyName} ({solution.UniqueName})",
+                $"Version: {solution.Version ?? "\u2014"}",
+                $"Total Components: {components.Count}",
+                ""
+            };
+
+            foreach (var group in grouped)
+            {
+                lines.Add($"--- {group.Key} ({group.Count()}) ---");
+                foreach (var comp in group.OrderBy(c => c.DisplayName ?? c.LogicalName ?? c.ObjectId.ToString()))
+                {
+                    var name = comp.DisplayName ?? comp.LogicalName ?? comp.SchemaName ?? comp.ObjectId.ToString();
+                    lines.Add($"  {name}");
+                }
+                lines.Add("");
+            }
+
+            var text = string.Join(Environment.NewLine, lines);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                _detailDialog?.Dispose();
+
+                var textView = new TextView
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill(),
+                    ReadOnly = true,
+                    Text = text
+                };
+
+                _detailDialog = new Dialog(
+                    $"Components: {solution.FriendlyName}",
+                    new Button("Close", is_default: true))
+                {
+                    Width = Dim.Percent(80),
+                    Height = Dim.Percent(80)
+                };
+                _detailDialog.Add(textView);
+                Application.Run(_detailDialog);
+                _detailDialog.Dispose();
+                _detailDialog = null;
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load solution components", ex, "Solutions.Components");
+            });
+        }
+    }
+
+    private void OpenInMaker()
+    {
+        if (EnvironmentUrl == null)
+        {
+            ErrorService.ReportError("No environment URL available");
+            return;
+        }
+        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        {
+            Width = 60,
+            Height = 7
+        };
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/solutions" });
+        Application.Run(dialog);
+        dialog.Dispose();
+    }
+
+    /// <inheritdoc />
+    public SolutionsScreenState CaptureState()
+    {
+        string? selectedName = null;
+        string? selectedVersion = null;
+        bool? selectedIsManaged = null;
+
+        var selectedRow = _table.SelectedRow;
+        if (selectedRow >= 0 && selectedRow < _filteredSolutions.Count)
+        {
+            var sol = _filteredSolutions[selectedRow];
+            selectedName = sol.FriendlyName;
+            selectedVersion = sol.Version;
+            selectedIsManaged = sol.IsManaged;
+        }
+
+        return new SolutionsScreenState(
+            SolutionCount: _filteredSolutions.Count,
+            SelectedSolutionName: selectedName,
+            SelectedSolutionVersion: selectedVersion,
+            SelectedIsManaged: selectedIsManaged,
+            ComponentCount: _lastComponentCount,
+            IsLoading: _isLoading,
+            ShowManaged: _managedCheckBox.Checked,
+            FilterText: _filterField.Text?.ToString() ?? "",
+            ErrorMessage: _errorMessage);
+    }
+
+    protected override void OnDispose()
+    {
+        _filterField.TextChanged -= OnFilterTextChanged;
+        _managedCheckBox.Toggled -= OnManagedToggled;
+        _table.CellActivated -= OnCellActivated;
+        _detailDialog?.Dispose();
+    }
+}

--- a/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
@@ -24,6 +24,11 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
     private bool _isLoading;
     private string? _errorMessage;
     private Dialog? _detailDialog;
+    private CancellationTokenSource? _loadCts;
+    private object? _filterDebounceToken;
+    private bool _isShowingDetail;
+
+    private const int FilterDebounceMs = 300;
 
     public override string Title => "Solutions";
 
@@ -97,31 +102,44 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
 
     private async Task LoadDataAsync()
     {
+        // Cancel any in-flight load to prevent races from rapid toggle
+        _loadCts?.Cancel();
+        _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        var ct = _loadCts.Token;
+
         try
         {
-            _isLoading = true;
-            _errorMessage = null;
-            _statusLabel.Text = "Loading solutions...";
-            Application.Refresh();
+            Application.MainLoop.Invoke(() =>
+            {
+                _isLoading = true;
+                _errorMessage = null;
+                _statusLabel.Text = "Loading solutions...";
+            });
 
-            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
             var service = provider.GetRequiredService<ISolutionService>();
 
             var includeManaged = _managedCheckBox.Checked;
-            _allSolutions = await service.ListAsync(
+            var solutions = await service.ListAsync(
                 filter: null,
                 includeManaged: includeManaged,
-                cancellationToken: ScreenCancellation);
+                cancellationToken: ct);
 
-            _isLoading = false;
-            ApplyClientFilter();
-        }
-        catch (OperationCanceledException) { /* screen closing */ }
-        catch (Exception ex)
-        {
-            _isLoading = false;
+            ct.ThrowIfCancellationRequested();
+
             Application.MainLoop.Invoke(() =>
             {
+                _allSolutions = solutions;
+                _isLoading = false;
+                ApplyClientFilterOnUiThread();
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing or superseded load */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _isLoading = false;
                 _errorMessage = ex.Message;
                 ErrorService.ReportError("Failed to load solutions", ex, "Solutions.Load");
                 _statusLabel.Text = "Error loading solutions";
@@ -129,7 +147,10 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
         }
     }
 
-    private void ApplyClientFilter()
+    /// <summary>
+    /// Applies client-side filtering. Must be called on the UI thread.
+    /// </summary>
+    private void ApplyClientFilterOnUiThread()
     {
         var filterText = _filterField.Text?.ToString() ?? "";
 
@@ -164,17 +185,32 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
                 sol.ModifiedOn?.ToString("g") ?? "\u2014");
         }
 
-        Application.MainLoop.Invoke(() =>
-        {
-            _table.Table = dt;
-            var unmanaged = _filteredSolutions.Count(s => !s.IsManaged);
-            _statusLabel.Text = $"{_filteredSolutions.Count} solution{(_filteredSolutions.Count != 1 ? "s" : "")} \u2014 {unmanaged} unmanaged";
-        });
+        _table.Table = dt;
+        var unmanaged = _filteredSolutions.Count(s => !s.IsManaged);
+        _statusLabel.Text = $"{_filteredSolutions.Count} solution{(_filteredSolutions.Count != 1 ? "s" : "")} \u2014 {unmanaged} unmanaged";
     }
 
     private void OnFilterTextChanged(NStack.ustring _)
     {
-        ApplyClientFilter();
+        // Cancel any pending debounce timer
+        if (_filterDebounceToken != null && Application.MainLoop != null)
+        {
+            Application.MainLoop.RemoveTimeout(_filterDebounceToken);
+            _filterDebounceToken = null;
+        }
+
+        // Schedule debounced filter application
+        if (Application.MainLoop != null)
+        {
+            _filterDebounceToken = Application.MainLoop.AddTimeout(
+                TimeSpan.FromMilliseconds(FilterDebounceMs),
+                _ =>
+                {
+                    _filterDebounceToken = null;
+                    ApplyClientFilterOnUiThread();
+                    return false; // do not repeat
+                });
+        }
     }
 
     private void OnManagedToggled(bool _)
@@ -184,8 +220,10 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
 
     private void OnCellActivated(TableView.CellActivatedEventArgs args)
     {
-        if (args.Row < 0 || args.Row >= _filteredSolutions.Count) return;
-        var solution = _filteredSolutions[args.Row];
+        if (_isShowingDetail) return;
+        var solutions = _filteredSolutions;
+        if (args.Row < 0 || args.Row >= solutions.Count) return;
+        var solution = solutions[args.Row];
         ErrorService.FireAndForget(ShowComponentsDialogAsync(solution), "Solutions.ShowComponents");
     }
 
@@ -227,7 +265,8 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
 
             Application.MainLoop.Invoke(() =>
             {
-                _detailDialog?.Dispose();
+                if (_isShowingDetail) return;
+                _isShowingDetail = true;
 
                 var textView = new TextView
                 {
@@ -250,6 +289,7 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
                 Application.Run(_detailDialog);
                 _detailDialog.Dispose();
                 _detailDialog = null;
+                _isShowingDetail = false;
             });
         }
         catch (OperationCanceledException) { /* screen closing */ }
@@ -313,6 +353,12 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
         _filterField.TextChanged -= OnFilterTextChanged;
         _managedCheckBox.Toggled -= OnManagedToggled;
         _table.CellActivated -= OnCellActivated;
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        if (_filterDebounceToken != null)
+        {
+            Application.MainLoop?.RemoveTimeout(_filterDebounceToken);
+        }
         _detailDialog?.Dispose();
     }
 }

--- a/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SolutionsScreen.cs
@@ -102,6 +102,16 @@ internal sealed class SolutionsScreen : TuiScreenBase, ITuiStateCapture<Solution
 
     private async Task LoadDataAsync()
     {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _isLoading = false;
+                _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+            });
+            return;
+        }
+
         // Cancel any in-flight load to prevent races from rapid toggle
         _loadCts?.Cancel();
         _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Testing/States/SolutionsScreenState.cs
+++ b/src/PPDS.Cli/Tui/Testing/States/SolutionsScreenState.cs
@@ -1,0 +1,24 @@
+namespace PPDS.Cli.Tui.Testing.States;
+
+/// <summary>
+/// Captures the state of the SolutionsScreen for testing.
+/// </summary>
+/// <param name="SolutionCount">Number of solutions currently displayed.</param>
+/// <param name="SelectedSolutionName">Friendly name of the selected solution.</param>
+/// <param name="SelectedSolutionVersion">Version of the selected solution.</param>
+/// <param name="SelectedIsManaged">Whether the selected solution is managed.</param>
+/// <param name="ComponentCount">Number of components in the selected solution (null if no detail loaded).</param>
+/// <param name="IsLoading">Whether data is currently loading.</param>
+/// <param name="ShowManaged">Whether the "Include Managed" checkbox is checked.</param>
+/// <param name="FilterText">Current text in the filter field.</param>
+/// <param name="ErrorMessage">Error message if loading failed (null if no error).</param>
+public sealed record SolutionsScreenState(
+    int SolutionCount,
+    string? SelectedSolutionName,
+    string? SelectedSolutionVersion,
+    bool? SelectedIsManaged,
+    int? ComponentCount,
+    bool IsLoading,
+    bool ShowManaged,
+    string? FilterText,
+    string? ErrorMessage);

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -279,6 +279,7 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
         menuItems.Add(new MenuBarItem("_Tools", new MenuItem[]
         {
             new("SQL Query", "Run SQL queries against Dataverse", () => NavigateToSqlQuery()),
+            new("Solutions", "Browse Dataverse solutions", () => NavigateToSolutions()),
             new("Import Jobs", "View solution import jobs", () => NavigateToImportJobs()),
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Environment Details...", "View organization and connection info",
@@ -429,6 +430,31 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
 
             var sqlScreen = new SqlQueryScreen(_deviceCodeCallback, _session, environmentUrl, displayName);
             NavigateTo(sqlScreen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToSolutions()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Solutions...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new SolutionsScreen(_session);
+            NavigateTo(screen);
 
             return false;
         });

--- a/src/PPDS.Mcp/Tools/SolutionsComponentsTool.cs
+++ b/src/PPDS.Mcp/Tools/SolutionsComponentsTool.cs
@@ -1,0 +1,154 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that gets components for a Dataverse solution.
+/// </summary>
+[McpServerToolType]
+public sealed class SolutionsComponentsTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SolutionsComponentsTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public SolutionsComponentsTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Gets the components of a specific solution.
+    /// </summary>
+    /// <param name="solutionId">The solution ID (GUID).</param>
+    /// <param name="componentType">Optional filter by component type code.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Solution components grouped by type.</returns>
+    [McpServerTool(Name = "ppds_solutions_components")]
+    [Description("Get components of a Dataverse solution. Returns entities, workflows, plugins, and other components. Use the solution id from ppds_solutions_list. Optionally filter by component type code.")]
+    public async Task<SolutionsComponentsResult> ExecuteAsync(
+        [Description("The solution ID (GUID) from ppds_solutions_list")]
+        string solutionId,
+        [Description("Optional component type code to filter by (e.g., 1 = Entity, 26 = View, 29 = Workflow)")]
+        int? componentType = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(solutionId, out var id))
+        {
+            throw new ArgumentException($"Invalid solution ID: '{solutionId}'. Must be a valid GUID.");
+        }
+
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<ISolutionService>();
+
+        var components = await service.GetComponentsAsync(
+            id,
+            componentType: componentType,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new SolutionsComponentsResult
+        {
+            SolutionId = solutionId,
+            TotalCount = components.Count,
+            Components = components.Select(c => new ComponentDto
+            {
+                Id = c.Id.ToString(),
+                ObjectId = c.ObjectId.ToString(),
+                ComponentType = c.ComponentType,
+                ComponentTypeName = c.ComponentTypeName,
+                DisplayName = c.DisplayName,
+                LogicalName = c.LogicalName,
+                SchemaName = c.SchemaName,
+                IsMetadata = c.IsMetadata
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the solutions_components tool.
+/// </summary>
+public sealed class SolutionsComponentsResult
+{
+    /// <summary>
+    /// The solution ID that was queried.
+    /// </summary>
+    [JsonPropertyName("solutionId")]
+    public string SolutionId { get; set; } = "";
+
+    /// <summary>
+    /// Total number of components.
+    /// </summary>
+    [JsonPropertyName("totalCount")]
+    public int TotalCount { get; set; }
+
+    /// <summary>
+    /// List of solution components.
+    /// </summary>
+    [JsonPropertyName("components")]
+    public List<ComponentDto> Components { get; set; } = [];
+}
+
+/// <summary>
+/// A solution component.
+/// </summary>
+public sealed class ComponentDto
+{
+    /// <summary>
+    /// Component record ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    /// <summary>
+    /// The object ID of the component (e.g., entity ID, workflow ID).
+    /// </summary>
+    [JsonPropertyName("objectId")]
+    public string ObjectId { get; set; } = "";
+
+    /// <summary>
+    /// Component type code.
+    /// </summary>
+    [JsonPropertyName("componentType")]
+    public int ComponentType { get; set; }
+
+    /// <summary>
+    /// Human-readable component type name.
+    /// </summary>
+    [JsonPropertyName("componentTypeName")]
+    public string ComponentTypeName { get; set; } = "";
+
+    /// <summary>
+    /// Display name of the component.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Logical name of the component.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LogicalName { get; set; }
+
+    /// <summary>
+    /// Schema name of the component.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SchemaName { get; set; }
+
+    /// <summary>
+    /// Whether this is a metadata component.
+    /// </summary>
+    [JsonPropertyName("isMetadata")]
+    public bool IsMetadata { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/SolutionsListTool.cs
+++ b/src/PPDS.Mcp/Tools/SolutionsListTool.cs
@@ -1,0 +1,136 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that lists Dataverse solutions.
+/// </summary>
+[McpServerToolType]
+public sealed class SolutionsListTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SolutionsListTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public SolutionsListTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Lists Dataverse solutions for the current environment.
+    /// </summary>
+    /// <param name="filter">Optional filter by solution name.</param>
+    /// <param name="includeManaged">Include managed solutions (default false).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of solution summaries.</returns>
+    [McpServerTool(Name = "ppds_solutions_list")]
+    [Description("List Dataverse solutions for the current environment. Shows solution name, version, publisher, and managed status. Use includeManaged to also show managed (system) solutions.")]
+    public async Task<SolutionsListResult> ExecuteAsync(
+        [Description("Optional filter by solution name (friendly name or unique name)")]
+        string? filter = null,
+        [Description("Include managed solutions in the results (default false)")]
+        bool includeManaged = false,
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<ISolutionService>();
+
+        var solutions = await service.ListAsync(
+            filter: filter,
+            includeManaged: includeManaged,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new SolutionsListResult
+        {
+            Solutions = solutions.Select(s => new SolutionSummary
+            {
+                Id = s.Id.ToString(),
+                UniqueName = s.UniqueName,
+                FriendlyName = s.FriendlyName,
+                Version = s.Version,
+                IsManaged = s.IsManaged,
+                PublisherName = s.PublisherName,
+                ModifiedOn = s.ModifiedOn?.ToString("o"),
+                InstalledOn = s.InstalledOn?.ToString("o")
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the solutions_list tool.
+/// </summary>
+public sealed class SolutionsListResult
+{
+    /// <summary>
+    /// List of solution summaries.
+    /// </summary>
+    [JsonPropertyName("solutions")]
+    public List<SolutionSummary> Solutions { get; set; } = [];
+}
+
+/// <summary>
+/// Summary information about a Dataverse solution.
+/// </summary>
+public sealed class SolutionSummary
+{
+    /// <summary>
+    /// Solution ID (use with ppds_solutions_components for details).
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    /// <summary>
+    /// Solution unique name.
+    /// </summary>
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    /// <summary>
+    /// Solution display name.
+    /// </summary>
+    [JsonPropertyName("friendlyName")]
+    public string FriendlyName { get; set; } = "";
+
+    /// <summary>
+    /// Solution version string.
+    /// </summary>
+    [JsonPropertyName("version")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Whether the solution is managed.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Publisher name.
+    /// </summary>
+    [JsonPropertyName("publisherName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PublisherName { get; set; }
+
+    /// <summary>
+    /// When the solution was last modified (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+
+    /// <summary>
+    /// When the solution was installed (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("installedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? InstalledOn { get; set; }
+}


### PR DESCRIPTION
## Summary
- Add TUI `SolutionsScreen` for browsing Dataverse solutions with filter, managed toggle, and component detail dialog
- Add MCP tools `ppds_solutions_list` and `ppds_solutions_components` for AI agent access to solution data
- Register "Solutions" in TuiShell Tools menu between SQL Query and Import Jobs

## Test Plan
- [x] .NET build succeeds (0 errors, 0 warnings)
- [x] All unit tests pass (5,829 passed across 3 TFMs)
- [x] TUI snapshot tests pass (12/12)
- [x] TUI interactive verification via PTY — menu, table, filter, components dialog
- [x] MCP tool verification via Inspector — list, components, error handling
- [x] Blind QA: TUI (8/8 checks) and MCP (6/6 checks)

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: TUI, MCP)
- [x] /qa completed (surfaces: TUI, MCP)
- [x] /review completed (findings: 13 — 4 critical fixed, 1 important fixed, 4 suggestions deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)