### PR TITLE
feat: Plugin Traces panel across all surfaces (Phase 2b)

### DIFF
--- a/docs/plans/2026-03-17-plugin-traces-panel.md
+++ b/docs/plans/2026-03-17-plugin-traces-panel.md
@@ -1,0 +1,1613 @@
+# Plugin Traces Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Plugin Traces panel across all 4 surfaces (Daemon RPC, VS Code extension, TUI, MCP delete tool), delivering the most complex panel in the panel-parity spec with multi-pane layout, rich filtering, timeline visualization, trace level management, and batch delete.
+
+**Architecture:** The domain service (`IPluginTraceService`) already exists with full CRUD + timeline + settings (552 lines). We add 6 RPC endpoints in the daemon, a VS Code webview panel with split pane, filter bar, and 5-tab detail area, a TUI screen with dialogs, and 1 new MCP delete tool. All surfaces call the same service methods (Constitution A1, A2).
+
+**Tech Stack:** C# (.NET 8), TypeScript (VS Code extension + webview), Terminal.Gui (TUI), StreamJsonRpc (RPC), ModelContextProtocol (MCP)
+
+**Spec:** `specs/panel-parity.md` — Panel 4 (Plugin Traces), Acceptance Criteria AC-PT-01 through AC-PT-15
+
+**Issues:** #342, #346, #585, #591
+
+---
+
+## Design Decisions
+
+### Purpose-built PluginTraceFilterBar (not shared)
+The existing `FilterBar<T>` is a client-side text search. Plugin Traces needs server-side filtering with 9+ typed controls (entity, message, plugin name, mode selector, exceptions toggle, date range, quick filter presets). This filter complexity is unique to Plugin Traces. If a pattern emerges across Phase 2c/2d panels, we can extract then. YAGNI.
+
+### Horizontal waterfall timeline
+The service already computes `OffsetPercent` and `WidthPercent` on `TimelineNode`. We render each trace as a row with a horizontal bar positioned/sized by these percentages, indented by depth, color-coded (red for exceptions, yellow for slow). Pure CSS/HTML, no canvas. Standard debugging visualization (browser DevTools, SQL plans).
+
+### CSS + drag handle for split pane
+Import Jobs uses a simple show/hide detail pane. Plugin Traces gets a true resizable splitter: a `div.resize-handle` between top (filter + table) and bottom (5-tab detail) panes. `mousedown`/`mousemove`/`mouseup` handlers adjust `flex-basis`. Split ratio persisted via `vscode.getState()`/`setState()`. ~40 lines of JS for significantly better debugging UX.
+
+### Delete via RPC not inline service
+The `pluginTraces/delete` RPC endpoint consolidates 3 delete modes (by IDs, by filter, by age) behind a single RPC method with optional parameters. The webview sends the mode + params; the RPC handler dispatches to the correct service method. This avoids 3 separate RPC endpoints for a single UI action.
+
+### Auto-refresh preserves selection
+Auto-refresh calls `pluginTraces/list` on interval, then does a targeted DOM update: new rows are inserted, removed rows are deleted, existing rows update in place. The selected row ID is preserved across refreshes. If the selected trace was deleted server-side, selection clears and detail pane shows a message.
+
+### TraceFilter DTO reused across RPC, webview, TUI
+A single `TraceFilterDto` shape is used in the RPC request, the webview filter bar state, and the TUI filter dialog. This ensures the filter contract is consistent across surfaces without duplicating filter logic.
+
+---
+
+## File Structure
+
+### Files to modify
+| File | Change |
+|------|--------|
+| `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` | Add 6 `pluginTraces/*` RPC methods + DTOs |
+| `src/PPDS.Extension/src/types.ts` | Add Plugin Traces response interfaces |
+| `src/PPDS.Extension/src/daemonClient.ts` | Add 6 `pluginTraces*` methods |
+| `src/PPDS.Extension/src/panels/webview/shared/message-types.ts` | Add Plugin Traces panel message types |
+| `src/PPDS.Extension/esbuild.js` | Add plugin-traces-panel JS + CSS entries |
+| `src/PPDS.Extension/src/extension.ts` | Register `ppds.openPluginTraces` + `ppds.openPluginTracesForEnv` commands |
+| `src/PPDS.Extension/src/views/toolsTreeView.ts` | Add Plugin Traces to the Tools tree |
+| `src/PPDS.Extension/package.json` | Add command contributions + menu items |
+| `src/PPDS.Cli/Tui/TuiShell.cs` | Add menu item to open Plugin Traces screen |
+
+### Files to create
+| File | Purpose |
+|------|---------|
+| `src/PPDS.Extension/src/panels/PluginTracesPanel.ts` | Host-side panel (extends WebviewPanelBase) |
+| `src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts` | Browser-side webview script |
+| `src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css` | Panel-specific CSS |
+| `src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs` | TUI screen (extends TuiScreenBase) |
+| `src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs` | TUI filter dialog |
+| `src/PPDS.Cli/Tui/Dialogs/PluginTraceDetailDialog.cs` | TUI detail dialog |
+| `src/PPDS.Cli/Tui/Dialogs/TraceTimelineDialog.cs` | TUI timeline dialog |
+| `src/PPDS.Cli/Tui/Dialogs/TraceLevelDialog.cs` | TUI trace level dialog |
+| `src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs` | TUI delete confirmation dialog |
+| `src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs` | MCP delete tool |
+| `src/PPDS.Extension/src/__tests__/panels/pluginTracesPanel.test.ts` | Unit tests for panel message types |
+
+---
+
+## Chunk 1: Data Layer — RPC Endpoints + DTOs
+
+### Task 1: Add Plugin Traces RPC DTOs
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` — Add DTOs at the bottom
+
+- [ ] **Step 1: Add Plugin Traces DTO classes**
+
+Add after the existing Import Jobs DTOs at the bottom of `RpcMethodHandler.cs`:
+
+```csharp
+// ── Plugin Traces DTOs ──────────────────────────────────────────────────────
+
+public class PluginTracesListResponse
+{
+    [JsonPropertyName("traces")]
+    public List<PluginTraceInfoDto> Traces { get; set; } = [];
+}
+
+public class PluginTracesGetResponse
+{
+    [JsonPropertyName("trace")]
+    public PluginTraceDetailDto Trace { get; set; } = null!;
+}
+
+public class PluginTracesTimelineResponse
+{
+    [JsonPropertyName("nodes")]
+    public List<TimelineNodeDto> Nodes { get; set; } = [];
+}
+
+public class PluginTracesDeleteResponse
+{
+    [JsonPropertyName("deletedCount")]
+    public int DeletedCount { get; set; }
+}
+
+public class PluginTracesTraceLevelResponse
+{
+    [JsonPropertyName("level")]
+    public string Level { get; set; } = "";
+
+    [JsonPropertyName("levelValue")]
+    public int LevelValue { get; set; }
+}
+
+public class PluginTracesSetTraceLevelResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+public class PluginTraceInfoDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("typeName")]
+    public string TypeName { get; set; } = "";
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("primaryEntity")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryEntity { get; set; }
+
+    [JsonPropertyName("mode")]
+    public string Mode { get; set; } = "";
+
+    [JsonPropertyName("operationType")]
+    public string OperationType { get; set; } = "";
+
+    [JsonPropertyName("depth")]
+    public int Depth { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    public string CreatedOn { get; set; } = "";
+
+    [JsonPropertyName("durationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DurationMs { get; set; }
+
+    [JsonPropertyName("hasException")]
+    public bool HasException { get; set; }
+
+    [JsonPropertyName("correlationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CorrelationId { get; set; }
+}
+
+public class PluginTraceDetailDto : PluginTraceInfoDto
+{
+    [JsonPropertyName("constructorDurationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ConstructorDurationMs { get; set; }
+
+    [JsonPropertyName("executionStartTime")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExecutionStartTime { get; set; }
+
+    [JsonPropertyName("exceptionDetails")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExceptionDetails { get; set; }
+
+    [JsonPropertyName("messageBlock")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageBlock { get; set; }
+
+    [JsonPropertyName("configuration")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Configuration { get; set; }
+
+    [JsonPropertyName("secureConfiguration")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SecureConfiguration { get; set; }
+
+    [JsonPropertyName("requestId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RequestId { get; set; }
+}
+
+public class TimelineNodeDto
+{
+    [JsonPropertyName("traceId")]
+    public string TraceId { get; set; } = "";
+
+    [JsonPropertyName("typeName")]
+    public string TypeName { get; set; } = "";
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("depth")]
+    public int Depth { get; set; }
+
+    [JsonPropertyName("durationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DurationMs { get; set; }
+
+    [JsonPropertyName("hasException")]
+    public bool HasException { get; set; }
+
+    [JsonPropertyName("offsetPercent")]
+    public double OffsetPercent { get; set; }
+
+    [JsonPropertyName("widthPercent")]
+    public double WidthPercent { get; set; }
+
+    [JsonPropertyName("hierarchyDepth")]
+    public int HierarchyDepth { get; set; }
+
+    [JsonPropertyName("children")]
+    public List<TimelineNodeDto> Children { get; set; } = [];
+}
+
+public class TraceFilterDto
+{
+    [JsonPropertyName("typeName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TypeName { get; set; }
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("primaryEntity")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryEntity { get; set; }
+
+    [JsonPropertyName("mode")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("hasException")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? HasException { get; set; }
+
+    [JsonPropertyName("correlationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CorrelationId { get; set; }
+
+    [JsonPropertyName("minDurationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MinDurationMs { get; set; }
+
+    [JsonPropertyName("startDate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StartDate { get; set; }
+
+    [JsonPropertyName("endDate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EndDate { get; set; }
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded (DTOs are standalone, no consumers yet).
+
+### Task 2: Add pluginTraces/list and pluginTraces/get RPC methods
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` — Add methods in a new `#region Plugin Traces`
+
+- [ ] **Step 1: Add mapper helpers and list/get methods**
+
+Add in the RPC handler class (after the Import Jobs region):
+
+```csharp
+#region Plugin Traces
+
+private static PluginTraceFilter? MapTraceFilterFromDto(TraceFilterDto? dto)
+{
+    if (dto == null) return null;
+
+    PluginTraceMode? mode = dto.Mode?.ToLowerInvariant() switch
+    {
+        "sync" or "synchronous" => PluginTraceMode.Synchronous,
+        "async" or "asynchronous" => PluginTraceMode.Asynchronous,
+        _ => null
+    };
+
+    return new PluginTraceFilter
+    {
+        TypeName = dto.TypeName,
+        MessageName = dto.MessageName,
+        PrimaryEntity = dto.PrimaryEntity,
+        Mode = mode,
+        HasException = dto.HasException,
+        CorrelationId = Guid.TryParse(dto.CorrelationId, out var cid) ? cid : null,
+        MinDurationMs = dto.MinDurationMs,
+        CreatedAfter = DateTime.TryParse(dto.StartDate, out var start) ? start : null,
+        CreatedBefore = DateTime.TryParse(dto.EndDate, out var end) ? end : null,
+    };
+}
+
+private static PluginTraceInfoDto MapTraceInfoToDto(PluginTraceInfo trace)
+{
+    return new PluginTraceInfoDto
+    {
+        Id = trace.Id.ToString(),
+        TypeName = trace.TypeName,
+        MessageName = trace.MessageName,
+        PrimaryEntity = trace.PrimaryEntity,
+        Mode = trace.Mode == PluginTraceMode.Synchronous ? "Sync" : "Async",
+        OperationType = trace.OperationType.ToString(),
+        Depth = trace.Depth,
+        CreatedOn = trace.CreatedOn.ToString("o"),
+        DurationMs = trace.DurationMs,
+        HasException = trace.HasException,
+        CorrelationId = trace.CorrelationId?.ToString(),
+    };
+}
+
+private static PluginTraceDetailDto MapTraceDetailToDto(PluginTraceDetail trace)
+{
+    var dto = new PluginTraceDetailDto
+    {
+        Id = trace.Id.ToString(),
+        TypeName = trace.TypeName,
+        MessageName = trace.MessageName,
+        PrimaryEntity = trace.PrimaryEntity,
+        Mode = trace.Mode == PluginTraceMode.Synchronous ? "Sync" : "Async",
+        OperationType = trace.OperationType.ToString(),
+        Depth = trace.Depth,
+        CreatedOn = trace.CreatedOn.ToString("o"),
+        DurationMs = trace.DurationMs,
+        HasException = trace.HasException,
+        CorrelationId = trace.CorrelationId?.ToString(),
+        ConstructorDurationMs = trace.ConstructorDurationMs,
+        ExecutionStartTime = trace.ExecutionStartTime?.ToString("o"),
+        ExceptionDetails = trace.ExceptionDetails,
+        MessageBlock = trace.MessageBlock,
+        Configuration = trace.Configuration,
+        SecureConfiguration = trace.SecureConfiguration,
+        RequestId = trace.RequestId?.ToString(),
+    };
+    return dto;
+}
+
+private static TimelineNodeDto MapTimelineNodeToDto(TimelineNode node)
+{
+    return new TimelineNodeDto
+    {
+        TraceId = node.Trace.Id.ToString(),
+        TypeName = node.Trace.TypeName,
+        MessageName = node.Trace.MessageName,
+        Depth = node.Trace.Depth,
+        DurationMs = node.Trace.DurationMs,
+        HasException = node.Trace.HasException,
+        OffsetPercent = node.OffsetPercent,
+        WidthPercent = node.WidthPercent,
+        HierarchyDepth = node.HierarchyDepth,
+        Children = node.Children.Select(MapTimelineNodeToDto).ToList(),
+    };
+}
+
+/// <summary>
+/// Lists plugin traces with optional filtering.
+/// Maps to: ppds plugin-traces list --json
+/// </summary>
+[JsonRpcMethod("pluginTraces/list")]
+public async Task<PluginTracesListResponse> PluginTracesListAsync(
+    TraceFilterDto? filter = null,
+    int top = 100,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        var domainFilter = MapTraceFilterFromDto(filter);
+        var traces = await service.ListAsync(domainFilter, top, ct);
+
+        return new PluginTracesListResponse
+        {
+            Traces = traces.Select(MapTraceInfoToDto).ToList()
+        };
+    }, cancellationToken);
+}
+
+/// <summary>
+/// Gets a single plugin trace with full detail.
+/// Maps to: ppds plugin-traces get --json
+/// </summary>
+[JsonRpcMethod("pluginTraces/get")]
+public async Task<PluginTracesGetResponse> PluginTracesGetAsync(
+    string id,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(id) || !Guid.TryParse(id, out var traceId))
+    {
+        throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            "The 'id' parameter must be a valid GUID");
+    }
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        var trace = await service.GetAsync(traceId, ct)
+            ?? throw new RpcException(
+                ErrorCodes.Operation.NotFound,
+                $"Plugin trace '{id}' not found");
+
+        return new PluginTracesGetResponse
+        {
+            Trace = MapTraceDetailToDto(trace)
+        };
+    }, cancellationToken);
+}
+
+#endregion
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+### Task 3: Add pluginTraces/timeline, delete, traceLevel, setTraceLevel RPC methods
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` — Add inside `#region Plugin Traces`
+
+- [ ] **Step 1: Add timeline method**
+
+Add inside the Plugin Traces region:
+
+```csharp
+/// <summary>
+/// Builds a timeline hierarchy from traces with the given correlation ID.
+/// Maps to: ppds plugin-traces timeline --json
+/// </summary>
+[JsonRpcMethod("pluginTraces/timeline")]
+public async Task<PluginTracesTimelineResponse> PluginTracesTimelineAsync(
+    string correlationId,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(correlationId) || !Guid.TryParse(correlationId, out var cid))
+    {
+        throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            "The 'correlationId' parameter must be a valid GUID");
+    }
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        var nodes = await service.BuildTimelineAsync(cid, ct);
+
+        return new PluginTracesTimelineResponse
+        {
+            Nodes = nodes.Select(MapTimelineNodeToDto).ToList()
+        };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 2: Add delete method**
+
+```csharp
+/// <summary>
+/// Deletes plugin traces by IDs or by age.
+/// Consolidates DeleteByIdsAsync and DeleteOlderThanAsync behind a single RPC.
+/// </summary>
+[JsonRpcMethod("pluginTraces/delete")]
+public async Task<PluginTracesDeleteResponse> PluginTracesDeleteAsync(
+    string[]? ids = null,
+    int? olderThanDays = null,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (ids == null && olderThanDays == null)
+    {
+        throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            "Either 'ids' or 'olderThanDays' must be provided");
+    }
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        int deletedCount;
+
+        if (ids != null && ids.Length > 0)
+        {
+            var guids = ids.Select(id =>
+            {
+                if (!Guid.TryParse(id, out var g))
+                    throw new RpcException(
+                        ErrorCodes.Validation.RequiredField,
+                        $"Invalid trace ID: '{id}'");
+                return g;
+            }).ToList();
+
+            deletedCount = await service.DeleteByIdsAsync(guids, cancellationToken: ct);
+        }
+        else if (olderThanDays.HasValue)
+        {
+            if (olderThanDays.Value < 1)
+                throw new RpcException(
+                    ErrorCodes.Validation.RequiredField,
+                    "olderThanDays must be >= 1");
+
+            deletedCount = await service.DeleteOlderThanAsync(
+                TimeSpan.FromDays(olderThanDays.Value),
+                cancellationToken: ct);
+        }
+        else
+        {
+            deletedCount = 0;
+        }
+
+        return new PluginTracesDeleteResponse { DeletedCount = deletedCount };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 3: Add traceLevel and setTraceLevel methods**
+
+```csharp
+/// <summary>
+/// Gets the current plugin trace logging level.
+/// </summary>
+[JsonRpcMethod("pluginTraces/traceLevel")]
+public async Task<PluginTracesTraceLevelResponse> PluginTracesTraceLevelAsync(
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        var settings = await service.GetSettingsAsync(ct);
+
+        return new PluginTracesTraceLevelResponse
+        {
+            Level = settings.SettingName,
+            LevelValue = (int)settings.Setting
+        };
+    }, cancellationToken);
+}
+
+/// <summary>
+/// Sets the plugin trace logging level.
+/// </summary>
+[JsonRpcMethod("pluginTraces/setTraceLevel")]
+public async Task<PluginTracesSetTraceLevelResponse> PluginTracesSetTraceLevelAsync(
+    string level,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(level))
+    {
+        throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            "The 'level' parameter is required");
+    }
+
+    var setting = level.ToLowerInvariant() switch
+    {
+        "off" => PluginTraceLogSetting.Off,
+        "exception" => PluginTraceLogSetting.Exception,
+        "all" => PluginTraceLogSetting.All,
+        _ => throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            $"Invalid trace level: '{level}'. Valid values: Off, Exception, All")
+    };
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        await service.SetSettingsAsync(setting, ct);
+
+        return new PluginTracesSetTraceLevelResponse { Success = true };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 4: Build to verify all 6 RPC methods**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+### Task 4: Add TypeScript response types
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/types.ts`
+
+- [ ] **Step 1: Add Plugin Traces TS interfaces**
+
+Add at the bottom of `types.ts`:
+
+```typescript
+// ── Plugin Traces ────────────────────────────────────────────────────────────
+
+export interface PluginTracesListResponse {
+    traces: PluginTraceInfoDto[];
+}
+
+export interface PluginTracesGetResponse {
+    trace: PluginTraceDetailDto;
+}
+
+export interface PluginTracesTimelineResponse {
+    nodes: TimelineNodeDto[];
+}
+
+export interface PluginTracesDeleteResponse {
+    deletedCount: number;
+}
+
+export interface PluginTracesTraceLevelResponse {
+    level: string;
+    levelValue: number;
+}
+
+export interface PluginTracesSetTraceLevelResponse {
+    success: boolean;
+}
+
+export interface PluginTraceInfoDto {
+    id: string;
+    typeName: string;
+    messageName: string | null;
+    primaryEntity: string | null;
+    mode: string;
+    operationType: string;
+    depth: number;
+    createdOn: string;
+    durationMs: number | null;
+    hasException: boolean;
+    correlationId: string | null;
+}
+
+export interface PluginTraceDetailDto extends PluginTraceInfoDto {
+    constructorDurationMs: number | null;
+    executionStartTime: string | null;
+    exceptionDetails: string | null;
+    messageBlock: string | null;
+    configuration: string | null;
+    secureConfiguration: string | null;
+    requestId: string | null;
+}
+
+export interface TimelineNodeDto {
+    traceId: string;
+    typeName: string;
+    messageName: string | null;
+    depth: number;
+    durationMs: number | null;
+    hasException: boolean;
+    offsetPercent: number;
+    widthPercent: number;
+    hierarchyDepth: number;
+    children: TimelineNodeDto[];
+}
+
+export interface TraceFilterDto {
+    typeName?: string;
+    messageName?: string;
+    primaryEntity?: string;
+    mode?: string;
+    hasException?: boolean;
+    correlationId?: string;
+    minDurationMs?: number;
+    startDate?: string;
+    endDate?: string;
+}
+```
+
+### Task 5: Add daemon client methods
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/daemonClient.ts`
+
+- [ ] **Step 1: Add imports for new response types**
+
+Add to the existing import from `./types.js`:
+
+```typescript
+import type {
+    // ... existing imports ...
+    PluginTracesListResponse,
+    PluginTracesGetResponse,
+    PluginTracesTimelineResponse,
+    PluginTracesDeleteResponse,
+    PluginTracesTraceLevelResponse,
+    PluginTracesSetTraceLevelResponse,
+    TraceFilterDto,
+} from './types.js';
+```
+
+- [ ] **Step 2: Add 6 pluginTraces methods**
+
+Add in the daemon client class (in a new `// ── Plugin Traces ──` section):
+
+```typescript
+// ── Plugin Traces ────────────────────────────────────────────────────────
+
+async pluginTracesList(filter?: TraceFilterDto, top?: number, environmentUrl?: string): Promise<PluginTracesListResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (filter !== undefined) params.filter = filter;
+    if (top !== undefined) params.top = top;
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling pluginTraces/list...');
+    const result = await this.connection!.sendRequest<PluginTracesListResponse>('pluginTraces/list', params);
+    this.log.debug(`Got ${result.traces.length} plugin traces`);
+    return result;
+}
+
+async pluginTracesGet(id: string, environmentUrl?: string): Promise<PluginTracesGetResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { id };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling pluginTraces/get for ${id}...`);
+    return await this.connection!.sendRequest<PluginTracesGetResponse>('pluginTraces/get', params);
+}
+
+async pluginTracesTimeline(correlationId: string, environmentUrl?: string): Promise<PluginTracesTimelineResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { correlationId };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling pluginTraces/timeline for ${correlationId}...`);
+    return await this.connection!.sendRequest<PluginTracesTimelineResponse>('pluginTraces/timeline', params);
+}
+
+async pluginTracesDelete(ids?: string[], olderThanDays?: number, environmentUrl?: string): Promise<PluginTracesDeleteResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (ids !== undefined) params.ids = ids;
+    if (olderThanDays !== undefined) params.olderThanDays = olderThanDays;
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling pluginTraces/delete...');
+    return await this.connection!.sendRequest<PluginTracesDeleteResponse>('pluginTraces/delete', params);
+}
+
+async pluginTracesTraceLevel(environmentUrl?: string): Promise<PluginTracesTraceLevelResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling pluginTraces/traceLevel...');
+    return await this.connection!.sendRequest<PluginTracesTraceLevelResponse>('pluginTraces/traceLevel', params);
+}
+
+async pluginTracesSetTraceLevel(level: string, environmentUrl?: string): Promise<PluginTracesSetTraceLevelResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { level };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling pluginTraces/setTraceLevel to ${level}...`);
+    return await this.connection!.sendRequest<PluginTracesSetTraceLevelResponse>('pluginTraces/setTraceLevel', params);
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd src/PPDS.Extension && npm run typecheck:all`
+Expected: No errors.
+
+### Task 6: Commit — Data Layer
+
+- [ ] **Step 1: Run quality gates**
+
+Run: `dotnet build PPDS.sln -v q && cd src/PPDS.Extension && npm run typecheck:all`
+Expected: All pass.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs \
+        src/PPDS.Extension/src/types.ts \
+        src/PPDS.Extension/src/daemonClient.ts
+git commit -m "feat(rpc): add pluginTraces/* RPC endpoints
+
+Add 6 RPC methods (list, get, timeline, delete, traceLevel, setTraceLevel)
+with DTOs, TypeScript response types, and daemon client methods.
+Addresses #342."
+```
+
+---
+
+## Chunk 2: VS Code Extension — Message Types + Panel Host
+
+### Task 7: Add message types
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/panels/webview/shared/message-types.ts`
+
+- [ ] **Step 1: Add Plugin Traces panel message unions**
+
+Add at the bottom of `message-types.ts`:
+
+```typescript
+// ── Plugin Traces Panel ──────────────────────────────────────────────────
+
+/** Plugin trace info as sent to the webview for table display. */
+export interface PluginTraceViewDto {
+    id: string;
+    typeName: string;
+    messageName: string | null;
+    primaryEntity: string | null;
+    mode: string;
+    operationType: string;
+    depth: number;
+    createdOn: string;
+    durationMs: number | null;
+    hasException: boolean;
+    correlationId: string | null;
+}
+
+/** Plugin trace detail for the detail pane. */
+export interface PluginTraceDetailViewDto extends PluginTraceViewDto {
+    constructorDurationMs: number | null;
+    executionStartTime: string | null;
+    exceptionDetails: string | null;
+    messageBlock: string | null;
+    configuration: string | null;
+    secureConfiguration: string | null;
+    requestId: string | null;
+}
+
+/** Timeline node for the waterfall visualization. */
+export interface TimelineNodeViewDto {
+    traceId: string;
+    typeName: string;
+    messageName: string | null;
+    depth: number;
+    durationMs: number | null;
+    hasException: boolean;
+    offsetPercent: number;
+    widthPercent: number;
+    hierarchyDepth: number;
+    children: TimelineNodeViewDto[];
+}
+
+/** Filter state sent from webview to host. */
+export interface TraceFilterViewDto {
+    typeName?: string;
+    messageName?: string;
+    primaryEntity?: string;
+    mode?: string;
+    hasException?: boolean;
+    correlationId?: string;
+    minDurationMs?: number;
+    startDate?: string;
+    endDate?: string;
+}
+
+/** Messages the Plugin Traces Panel webview sends to the extension host. */
+export type PluginTracesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'applyFilter'; filter: TraceFilterViewDto }
+    | { command: 'selectTrace'; id: string }
+    | { command: 'loadTimeline'; correlationId: string }
+    | { command: 'deleteTraces'; ids: string[] }
+    | { command: 'deleteOlderThan'; days: number }
+    | { command: 'requestTraceLevel' }
+    | { command: 'setTraceLevel'; level: string }
+    | { command: 'setAutoRefresh'; intervalSeconds: number | null }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Plugin Traces Panel webview. */
+export type PluginTracesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'tracesLoaded'; traces: PluginTraceViewDto[] }
+    | { command: 'traceDetailLoaded'; trace: PluginTraceDetailViewDto }
+    | { command: 'timelineLoaded'; nodes: TimelineNodeViewDto[] }
+    | { command: 'traceLevelLoaded'; level: string; levelValue: number }
+    | { command: 'deleteComplete'; deletedCount: number }
+    | { command: 'loading' }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd src/PPDS.Extension && npm run typecheck:all`
+Expected: No errors.
+
+### Task 8: Create PluginTracesPanel host class
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/PluginTracesPanel.ts`
+
+- [ ] **Step 1: Write the host-side panel**
+
+Create `src/PPDS.Extension/src/panels/PluginTracesPanel.ts` following the ImportJobsPanel pattern but with:
+- Auto-refresh timer (using `setInterval`/`clearInterval` disposed on panel close)
+- Filter state forwarded to RPC calls
+- Timeline loading from correlation ID
+- Delete operations with VS Code confirmation dialog
+- Trace level management with volume warning for "All"
+
+Key structure:
+
+```typescript
+import * as vscode from 'vscode';
+import type { DaemonClient } from '../daemonClient.js';
+import { handleAuthError } from '../utils/errorUtils.js';
+import { WebviewPanelBase } from './WebviewPanelBase.js';
+import { getNonce } from './webviewUtils.js';
+import { getEnvironmentPickerHtml, showEnvironmentPicker } from './environmentPicker.js';
+import type {
+    PluginTracesPanelWebviewToHost,
+    PluginTracesPanelHostToWebview,
+    TraceFilterViewDto,
+} from './webview/shared/message-types.js';
+import type { TraceFilterDto } from '../types.js';
+import { assertNever } from './webview/shared/assert-never.js';
+
+export class PluginTracesPanel extends WebviewPanelBase<
+    PluginTracesPanelWebviewToHost,
+    PluginTracesPanelHostToWebview
+> {
+    private static instances: PluginTracesPanel[] = [];
+    private static nextId = 1;
+    private readonly panelId: number;
+    private static readonly MAX_PANELS = 5;
+
+    private environmentUrl: string | undefined;
+    private environmentDisplayName: string | undefined;
+    private environmentType: string | null = null;
+    private environmentColor: string | null = null;
+    private environmentId: string | null = null;
+    private profileName: string | undefined;
+    private currentFilter: TraceFilterDto | undefined;
+    private autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+    // ... static show(), constructor, handleMessage(), dispose() ...
+    // Pattern identical to ImportJobsPanel with additions for:
+    // - applyFilter: stores filter, calls loadTraces()
+    // - selectTrace: calls daemon.pluginTracesGet(), posts traceDetailLoaded
+    // - loadTimeline: calls daemon.pluginTracesTimeline(), posts timelineLoaded
+    // - deleteTraces: shows vscode confirmation, calls daemon.pluginTracesDelete(), posts deleteComplete
+    // - deleteOlderThan: shows vscode confirmation with day count, calls daemon.pluginTracesDelete()
+    // - requestTraceLevel: calls daemon.pluginTracesTraceLevel(), posts traceLevelLoaded
+    // - setTraceLevel: if "All", shows volume warning first, then calls daemon.pluginTracesSetTraceLevel()
+    // - setAutoRefresh: clears existing timer, sets new interval or null
+}
+```
+
+Implement all message handlers following the `handleMessage` switch pattern from ImportJobsPanel. Key differences:
+- `applyFilter`: Convert `TraceFilterViewDto` to `TraceFilterDto` (identical shape), store as `this.currentFilter`, call `loadTraces()`
+- `deleteTraces`: Show `vscode.window.showWarningMessage` with "Delete" and "Cancel" options before calling RPC
+- `deleteOlderThan`: Show `vscode.window.showWarningMessage` with count of days
+- `setTraceLevel` with level "All": Show warning "Setting trace level to 'All' can generate significant log volume and impact performance. Continue?"
+- `setAutoRefresh`: `clearInterval` existing, `setInterval` with new value calling `loadTraces()`, null clears
+- `dispose()`: Clear auto-refresh timer, remove from instances
+
+HTML template includes:
+- Reconnect banner
+- Toolbar with buttons: Refresh, Auto-refresh dropdown, Delete dropdown, Trace Level dropdown, environment picker
+- Filter bar container
+- Content container (for data table)
+- Resize handle
+- Detail pane with 5 tabs (Details, Exception, Message Block, Configuration, Timeline)
+- Status bar
+
+CSS references: `shared.css` + `plugin-traces-panel.css`
+Script reference: `dist/plugin-traces-panel.js`
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd src/PPDS.Extension && npm run typecheck:all`
+Expected: No errors.
+
+### Task 9: Commit — Panel Host
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add src/PPDS.Extension/src/panels/webview/shared/message-types.ts \
+        src/PPDS.Extension/src/panels/PluginTracesPanel.ts
+git commit -m "feat(ext): add PluginTracesPanel host class with message types
+
+Split pane, filter forwarding, auto-refresh timer, delete confirmation,
+trace level management with volume warning, timeline loading."
+```
+
+---
+
+## Chunk 3: VS Code Extension — Webview Script + Styles
+
+### Task 10: Create plugin-traces-panel.css
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css`
+
+- [ ] **Step 1: Write panel styles**
+
+Create `plugin-traces-panel.css` with `@import './shared.css'` and sections for:
+
+1. **Data table** — Reuse `.data-table` pattern from `import-jobs-panel.css` with additions:
+   - `.trace-row-exception` — red tint background (`rgba(255, 0, 0, 0.08)`)
+   - `.trace-row-slow` — yellow tint background (`rgba(255, 200, 0, 0.08)`)
+   - `.trace-status-icon` — colored dot (red for exception, green for success)
+   - Column widths: Status 40px, Time 140px, Duration 80px, Plugin 200px, Entity 120px, Message 100px, Depth 50px, Mode 60px
+
+2. **Filter bar** — Collapsible section:
+   - `.filter-bar` — flex row with wrap, gap, border-bottom, padding
+   - `.filter-bar.collapsed` — `display: none` for content, toggle button visible
+   - `.filter-field` — flex column with label + input/select
+   - `.filter-field label` — small, uppercase, description foreground
+   - `.filter-field input, .filter-field select` — VS Code input styling
+   - `.quick-filters` — flex row of pill buttons
+   - `.quick-filter-pill` — rounded, small, badge-like
+   - `.quick-filter-pill.active` — highlighted with accent color
+   - `.filter-actions` — Clear All button
+
+3. **Split pane** — Resizable layout:
+   - `.panel-content` — flex column, flex: 1
+   - `.table-pane` — flex: 1 1 60%, min-height: 100px, overflow auto
+   - `.resize-handle` — height: 4px, cursor: row-resize, background on hover
+   - `.detail-pane` — flex: 0 0 auto, min-height: 100px, border-top
+
+4. **Detail tabs** — Tab bar + content:
+   - `.detail-tabs` — flex row, border-bottom
+   - `.detail-tab` — padding, cursor pointer, border-bottom transparent
+   - `.detail-tab.active` — border-bottom with accent color, bold
+   - `.detail-tab-content` — padding, overflow auto, max-height from split
+   - `.monospace-content` — `font-family: var(--vscode-editor-font-family)`, white-space pre-wrap
+
+5. **Timeline waterfall** — Horizontal bar chart:
+   - `.timeline-container` — flex column, padding
+   - `.timeline-row` — flex row, height: 28px, align-items center
+   - `.timeline-label` — width: 200px, ellipsis, padding-left by depth (indent)
+   - `.timeline-bar-container` — flex: 1, position relative, background: subtle
+   - `.timeline-bar` — position absolute, height: 20px, border-radius: 2px, min-width: 2px
+   - `.timeline-bar.exception` — red background
+   - `.timeline-bar.slow` — yellow/amber background
+   - `.timeline-bar.normal` — blue/accent background
+   - `.timeline-duration` — right-aligned text after bar
+   - `.timeline-header` — column headers (Plugin, Timeline)
+
+6. **Auto-refresh indicator** — small animated dot or text in toolbar
+
+### Task 11: Create plugin-traces-panel.ts webview script
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts`
+
+- [ ] **Step 1: Write the browser-side webview script**
+
+Create `plugin-traces-panel.ts` as an IIFE (same pattern as `import-jobs-panel.ts`) with these sections:
+
+1. **Setup** — Error handler, VS Code API, DOM refs
+2. **Filter bar controller** — Renders filter controls, collects values, emits `applyFilter`:
+   - Text inputs for: Entity, Message, Plugin Name
+   - Select for Mode: All / Sync / Async
+   - Checkbox for Exceptions Only
+   - Date inputs for Start/End
+   - Quick filter pills: Last Hour, Exceptions Only, Long Running (>1s)
+   - Clear All button
+   - Toggle collapse button
+   - On any filter change: debounce 300ms, collect filter object, post `applyFilter` message
+3. **Data table** — Reuse shared `DataTable<PluginTraceViewDto>` with columns:
+   - Status: colored dot icon (red exception, green success)
+   - Time: formatted `createdOn` timestamp
+   - Duration: `durationMs` with "ms" suffix, yellow highlight if >1000
+   - Plugin: `typeName` (truncated with title attribute)
+   - Entity: `primaryEntity` or "—"
+   - Message: `messageName` or "—"
+   - Depth: numeric
+   - Mode: "Sync" or "Async"
+   - Row CSS class: `trace-row-exception` if hasException, `trace-row-slow` if durationMs > 1000
+   - Row click → post `selectTrace` message
+4. **Split pane resize** — mousedown/mousemove/mouseup on `.resize-handle`:
+   - Track initial Y, compute delta, adjust flex-basis of table-pane and detail-pane
+   - Persist ratio via `vscode.getState()`/`setState()`
+   - Restore on load from `vscode.getState()`
+5. **Detail pane (5 tabs)** — Tab bar with click handlers:
+   - **Details tab**: Key-value pairs (Type, Message, Entity, Mode, Depth, Duration, Created, Correlation ID, Request ID)
+   - **Exception tab**: Monospace pre-formatted exception text, or "No exception" message
+   - **Message Block tab**: Monospace pre-formatted trace output, or "No message block"
+   - **Configuration tab**: Two sections — unsecured + secured config, both monospace
+   - **Timeline tab**: Waterfall visualization (renders on tab click, not on detail load)
+6. **Timeline renderer** — Flattens tree to rows, renders waterfall:
+   - For each node (recursive): render a `.timeline-row` with label indented by `hierarchyDepth`, bar positioned at `offsetPercent%` with width `widthPercent%`
+   - Color: red if hasException, yellow if durationMs > 1000, blue otherwise
+   - Duration label after bar
+   - Clickable rows → post `selectTrace` with traceId
+7. **Message handler** — Switch on incoming `command`:
+   - `updateEnvironment` → update toolbar attributes
+   - `tracesLoaded` → `dataTable.setItems()`, update status bar with count
+   - `traceDetailLoaded` → populate detail pane, show Details tab, show detail pane if hidden
+   - `timelineLoaded` → render waterfall in Timeline tab
+   - `traceLevelLoaded` → update trace level indicator in toolbar
+   - `deleteComplete` → show notification, refresh list
+   - `loading` → show loading state
+   - `error` → show error message
+   - `daemonReconnected` → show reconnect banner
+8. **Toolbar handlers** — Button click events:
+   - Refresh button → post `refresh`
+   - Auto-refresh select → post `setAutoRefresh` with seconds or null
+   - Delete button dropdown → selected IDs or older-than dialog
+   - Trace level button dropdown → Off/Exception/All options
+   - Environment picker button → post `requestEnvironmentList`
+9. **Keyboard shortcuts**:
+   - Escape → close detail pane or clear selection
+   - F5 → refresh
+
+- [ ] **Step 2: Typecheck (webview files excluded from main tsconfig but must be valid TS)**
+
+The webview scripts are bundled by esbuild which handles type checking implicitly. Verify by running the build.
+
+### Task 12: Update esbuild.js and extension registration
+
+**Files:**
+- Modify: `src/PPDS.Extension/esbuild.js`
+- Modify: `src/PPDS.Extension/src/extension.ts`
+- Modify: `src/PPDS.Extension/package.json`
+- Modify: `src/PPDS.Extension/src/views/toolsTreeView.ts` (if it exists, otherwise skip)
+
+- [ ] **Step 1: Add plugin-traces-panel to esbuild.js**
+
+In the panel webview scripts array, add:
+
+```javascript
+'src/panels/webview/plugin-traces-panel.ts'  // → dist/plugin-traces-panel.js
+```
+
+And in the CSS entries:
+
+```javascript
+'src/panels/styles/plugin-traces-panel.css'  // → dist/plugin-traces-panel.css
+```
+
+- [ ] **Step 2: Register commands in extension.ts**
+
+In the `registerPanelCommands()` function, add:
+
+```typescript
+context.subscriptions.push(
+    vscode.commands.registerCommand('ppds.openPluginTraces', () => {
+        PluginTracesPanel.show(context.extensionUri, daemon);
+    }),
+);
+```
+
+And for environment-specific opening:
+
+```typescript
+context.subscriptions.push(
+    vscode.commands.registerCommand('ppds.openPluginTracesForEnv', (envUrl: string, envDisplayName: string) => {
+        PluginTracesPanel.show(context.extensionUri, daemon, envUrl, envDisplayName);
+    }),
+);
+```
+
+- [ ] **Step 3: Add command contributions to package.json**
+
+In `contributes.commands`, add:
+
+```json
+{
+    "command": "ppds.openPluginTraces",
+    "title": "Plugin Traces",
+    "category": "PPDS"
+},
+{
+    "command": "ppds.openPluginTracesForEnv",
+    "title": "Open Plugin Traces",
+    "category": "PPDS"
+}
+```
+
+In the environment context menu (under `ppds.environments` submenu), add the Plugin Traces item following the Import Jobs pattern (group `env-tools@4`).
+
+- [ ] **Step 4: Add to tools tree view (if applicable)**
+
+If `src/PPDS.Extension/src/views/toolsTreeView.ts` exists and lists panels, add Plugin Traces entry.
+
+- [ ] **Step 5: Build extension**
+
+Run: `cd src/PPDS.Extension && npm run build`
+Expected: Build succeeded, `dist/plugin-traces-panel.js` and `dist/plugin-traces-panel.css` created.
+
+### Task 13: Commit — Webview + Extension Registration
+
+- [ ] **Step 1: Run quality gates**
+
+Run: `cd src/PPDS.Extension && npm run typecheck:all && npm run lint`
+Expected: All pass.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts \
+        src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css \
+        src/PPDS.Extension/esbuild.js \
+        src/PPDS.Extension/src/extension.ts \
+        src/PPDS.Extension/package.json
+git commit -m "feat(ext): add Plugin Traces webview with filter bar, split pane, timeline
+
+Filter bar with entity/message/plugin/mode/exceptions/date/quick filters.
+Resizable split pane with 5-tab detail (Details, Exception, Message Block,
+Configuration, Timeline). Horizontal waterfall timeline visualization.
+Auto-refresh with configurable interval. Delete with confirmation."
+```
+
+---
+
+## Chunk 4: Unit Tests
+
+### Task 14: Add panel message type tests
+
+**Files:**
+- Create: `src/PPDS.Extension/src/__tests__/panels/pluginTracesPanel.test.ts`
+
+- [ ] **Step 1: Write tests following importJobsPanel.test.ts pattern**
+
+Test suites:
+1. **WebviewToHost message types** — Verify all 13 command variants are valid discriminated union members
+2. **HostToWebview message types** — Verify all 9 command variants
+3. **PluginTraceViewDto required fields** — Verify required fields exist and types are correct
+4. **PluginTraceDetailViewDto extends PluginTraceViewDto** — Verify inheritance fields
+5. **TraceFilterViewDto** — Verify all filter fields are optional
+6. **TimelineNodeViewDto** — Verify children array and positioning fields
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd src/PPDS.Extension && npm run ext:test`
+Expected: All tests pass.
+
+### Task 15: Commit — Tests
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add src/PPDS.Extension/src/__tests__/panels/pluginTracesPanel.test.ts
+git commit -m "test(ext): add Plugin Traces panel message type tests
+
+Cover all 13 WebviewToHost and 9 HostToWebview message variants,
+view DTOs, filter DTO, and timeline node DTO."
+```
+
+---
+
+## Chunk 5: MCP Delete Tool
+
+### Task 16: Create PluginTracesDeleteTool
+
+**Files:**
+- Create: `src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs`
+
+- [ ] **Step 1: Write the MCP delete tool**
+
+Follow the pattern from `PluginTracesListTool.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Dataverse.Services;
+
+namespace PPDS.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class PluginTracesDeleteTool
+{
+    private readonly McpContext _context;
+
+    public PluginTracesDeleteTool(McpContext context)
+    {
+        _context = context;
+    }
+
+    [McpServerTool("ppds_plugin_traces_delete")]
+    [Description("Delete plugin trace logs. Provide either specific IDs or an age threshold (olderThanDays) for bulk cleanup.")]
+    public async Task<PluginTracesDeleteResult> ExecuteAsync(
+        [Description("Trace IDs to delete (array of GUIDs). Use for targeted deletion.")]
+        string[]? ids = null,
+        [Description("Delete all traces older than this many days. Use for bulk cleanup.")]
+        int? olderThanDays = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null && olderThanDays == null)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "Provide either 'ids' or 'olderThanDays'"
+            };
+        }
+
+        await using var sp = _context.CreateServiceProvider();
+        var service = sp.GetRequiredService<IPluginTraceService>();
+        int deletedCount;
+
+        if (ids != null && ids.Length > 0)
+        {
+            var guids = new List<Guid>();
+            foreach (var id in ids)
+            {
+                if (!Guid.TryParse(id, out var g))
+                    return new PluginTracesDeleteResult { Error = $"Invalid ID: '{id}'" };
+                guids.Add(g);
+            }
+            deletedCount = await service.DeleteByIdsAsync(guids, cancellationToken: cancellationToken);
+        }
+        else
+        {
+            if (olderThanDays!.Value < 1)
+                return new PluginTracesDeleteResult { Error = "olderThanDays must be >= 1" };
+
+            deletedCount = await service.DeleteOlderThanAsync(
+                TimeSpan.FromDays(olderThanDays.Value),
+                cancellationToken: cancellationToken);
+        }
+
+        return new PluginTracesDeleteResult { DeletedCount = deletedCount };
+    }
+}
+
+public class PluginTracesDeleteResult
+{
+    public int DeletedCount { get; set; }
+    public string? Error { get; set; }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build src/PPDS.Mcp/PPDS.Mcp.csproj -v q`
+Expected: Build succeeded.
+
+### Task 17: Commit — MCP Tool
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
+git commit -m "feat(mcp): add ppds_plugin_traces_delete tool
+
+Supports deletion by specific IDs or bulk cleanup by age threshold.
+Addresses AC-PT-14."
+```
+
+---
+
+## Chunk 6: TUI — PluginTracesScreen + Dialogs
+
+### Task 18: Create PluginTraceFilterDialog
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs`
+
+- [ ] **Step 1: Write filter dialog**
+
+Follow the `EnvironmentDetailsDialog` pattern for async dialogs, but with form controls:
+
+```csharp
+// Dialog with text fields for: TypeName, MessageName, PrimaryEntity
+// ComboBox for Mode (All, Synchronous, Asynchronous)
+// CheckBox for HasException
+// TextField for MinDurationMs
+// Apply and Cancel buttons
+// Returns a PluginTraceFilter on Apply, null on Cancel
+// Width: Dim.Percent(60), Height: 20
+```
+
+Key design:
+- Constructor takes optional `PluginTraceFilter` to pre-populate
+- `Filter` property returns the built filter (null if cancelled)
+- No async operations needed — this is a form dialog
+
+### Task 19: Create PluginTraceDetailDialog
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Dialogs/PluginTraceDetailDialog.cs`
+
+- [ ] **Step 1: Write detail dialog**
+
+Tabbed dialog showing trace detail:
+- TabView with 4 tabs: Details, Exception, Message Block, Configuration
+- Details tab: Label grid with key-value pairs (same fields as webview Details tab)
+- Exception tab: TextView with monospace content (read-only)
+- Message Block tab: TextView with monospace content (read-only)
+- Configuration tab: Two TextViews — unsecured and secured
+- Close button (Escape also closes)
+- Width: `Dim.Percent(80)`, Height: `Dim.Percent(80)`
+- Constructor takes `PluginTraceDetail` directly (no RPC — screen already fetched it)
+
+### Task 20: Create TraceTimelineDialog
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Dialogs/TraceTimelineDialog.cs`
+
+- [ ] **Step 1: Write timeline dialog**
+
+Text-based timeline visualization in a dialog:
+- Takes `List<TimelineNode>` in constructor
+- Renders a text-based waterfall:
+  - Each node: indent by depth, type name, message, duration, bar of `#` characters proportional to `WidthPercent`
+  - Exception nodes: colored red (Terminal.Gui color scheme)
+  - Slow nodes (>1s): colored yellow
+- ListView or TableView for scrollable output
+- Width: `Dim.Percent(90)`, Height: `Dim.Percent(80)`
+
+### Task 21: Create TraceLevelDialog
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Dialogs/TraceLevelDialog.cs`
+
+- [ ] **Step 1: Write trace level dialog**
+
+Simple selection dialog:
+- RadioGroup with 3 options: Off, Exception, All
+- Pre-selects current level (passed to constructor)
+- "All" option shows warning label: "Warning: 'All' can generate significant log volume"
+- Apply and Cancel buttons
+- `SelectedLevel` property returns choice (null if cancelled)
+- Width: 50, Height: 12
+
+### Task 22: Create TraceDeleteDialog
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs`
+
+- [ ] **Step 1: Write delete confirmation dialog**
+
+Confirmation dialog with options:
+- RadioGroup: "Delete selected traces", "Delete traces older than N days"
+- TextField for day count (only enabled when age option selected)
+- Shows count of selected traces (passed to constructor)
+- Confirm and Cancel buttons
+- `DeleteMode` enum: ByIds, ByAge
+- `Result` property: mode + day count (null if cancelled)
+- Width: 60, Height: 14
+
+### Task 23: Create PluginTracesScreen
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs`
+
+- [ ] **Step 1: Write the TUI screen**
+
+Follow `ImportJobsScreen` and `SolutionsScreen` patterns:
+
+```csharp
+public class PluginTracesScreen : TuiScreenBase
+{
+    public override string Title => "Plugin Traces";
+
+    // TableView with columns matching spec: Time, Duration, Plugin, Entity, Message, Depth, Mode, Status
+    // Status label for feedback messages
+    // Current filter (PluginTraceFilter?)
+    // Auto-cancel in-flight loads (like SolutionsScreen)
+
+    // RegisterHotkeys:
+    //   Ctrl+R → Refresh
+    //   Enter  → Open detail dialog for selected trace
+    //   Ctrl+F → Open filter dialog
+    //   Ctrl+T → Open timeline dialog (requires correlation ID from selected trace)
+    //   Ctrl+D → Open delete dialog
+    //   Ctrl+L → Open trace level dialog
+    //   Ctrl+E → Export (future, register but show "not implemented" for now)
+    //   Tab    → No-op in main screen (used in dialogs)
+
+    // LoadTracesAsync:
+    //   Calls IPluginTraceService.ListAsync with current filter
+    //   Populates TableView
+    //   Updates status label with count
+    //   Handles empty state
+
+    // Constructor:
+    //   Takes InteractiveSession
+    //   Resolves IPluginTraceService from session
+    //   Builds layout: TableView fills Content
+    //   Fires initial load
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+### Task 24: Register PluginTracesScreen in TuiShell
+
+**Files:**
+- Modify: `src/PPDS.Cli/Tui/TuiShell.cs`
+
+- [ ] **Step 1: Add menu item**
+
+In the Tools menu or equivalent navigation, add "Plugin Traces" entry that creates and navigates to a `PluginTracesScreen`.
+
+Follow the pattern from `NavigateToSolutions()` — show loading label, create screen in idle callback, call `NavigateTo()`.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+### Task 25: Commit — TUI
+
+- [ ] **Step 1: Run quality gates**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs \
+        src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs \
+        src/PPDS.Cli/Tui/Dialogs/PluginTraceDetailDialog.cs \
+        src/PPDS.Cli/Tui/Dialogs/TraceTimelineDialog.cs \
+        src/PPDS.Cli/Tui/Dialogs/TraceLevelDialog.cs \
+        src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs \
+        src/PPDS.Cli/Tui/TuiShell.cs
+git commit -m "feat(tui): add PluginTracesScreen with filter, detail, timeline, delete dialogs
+
+Split pane screen with TableView, 5 dialogs (filter, detail, timeline,
+trace level, delete confirmation), hotkey registration.
+Addresses #346."
+```
+
+---
+
+## Chunk 7: Quality Gates + Final Verification
+
+### Task 26: Full quality gates
+
+- [ ] **Step 1: .NET build**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded, 0 warnings.
+
+- [ ] **Step 2: .NET unit tests**
+
+Run: `dotnet test PPDS.sln --filter "Category!=Integration" -v q`
+Expected: All tests pass.
+
+- [ ] **Step 3: Extension typecheck**
+
+Run: `cd src/PPDS.Extension && npm run typecheck:all`
+Expected: No errors.
+
+- [ ] **Step 4: Extension lint**
+
+Run: `cd src/PPDS.Extension && npm run lint`
+Expected: No errors.
+
+- [ ] **Step 5: Extension unit tests**
+
+Run: `cd src/PPDS.Extension && npm run ext:test`
+Expected: All tests pass.
+
+- [ ] **Step 6: Extension build**
+
+Run: `cd src/PPDS.Extension && npm run build`
+Expected: Build succeeded, all dist files generated.
+
+### Task 27: Verification checklist
+
+- [ ] **AC-PT-01**: `pluginTraces/list` applies all filter combinations server-side — verify RPC method maps all TraceFilterDto fields to PluginTraceFilter
+- [ ] **AC-PT-02**: `pluginTraces/get` returns full detail — verify DTO includes exception, message block, configuration
+- [ ] **AC-PT-03**: `pluginTraces/timeline` returns hierarchical tree — verify recursive TimelineNodeDto mapping
+- [ ] **AC-PT-04**: `pluginTraces/delete` supports by IDs and by age — verify both code paths in RPC method
+- [ ] **AC-PT-05**: traceLevel and setTraceLevel read/write — verify both RPC methods work with all 3 levels
+- [ ] **AC-PT-06**: VS Code panel has filter bar, color-coded status, resizable detail — verify HTML structure and CSS
+- [ ] **AC-PT-07**: 5 detail tabs present — verify tab rendering in webview script
+- [ ] **AC-PT-08**: Timeline tab renders waterfall — verify horizontal bar positioning with offsetPercent/widthPercent
+- [ ] **AC-PT-09**: Quick filters apply correct filter combinations — verify Last Hour sets startDate, Exceptions Only sets hasException, Long Running sets minDurationMs
+- [ ] **AC-PT-10**: Auto-refresh preserves selection — verify selectedId maintained across tracesLoaded messages
+- [ ] **AC-PT-11**: Delete requires confirmation — verify vscode.window.showWarningMessage calls
+- [ ] **AC-PT-12**: Trace level "All" shows volume warning — verify warning message before setTraceLevel RPC
+- [ ] **AC-PT-13**: TUI PluginTracesScreen provides equivalent functionality — verify screen + 5 dialogs
+- [ ] **AC-PT-14**: MCP delete tool supports bulk cleanup — verify PluginTracesDeleteTool with ids and olderThanDays
+- [ ] **AC-PT-15**: "Trace level is Off" handled — verify informational message in tracesLoaded handler when list is empty and level is Off
+
+---
+
+## Acceptance Criteria Mapping
+
+| AC | Chunk | Task | Description |
+|----|-------|------|-------------|
+| AC-PT-01 | 1 | 2 | pluginTraces/list with all filter fields |
+| AC-PT-02 | 1 | 2 | pluginTraces/get with full detail DTO |
+| AC-PT-03 | 1 | 3 | pluginTraces/timeline with hierarchical nodes |
+| AC-PT-04 | 1 | 3 | pluginTraces/delete by IDs and by age |
+| AC-PT-05 | 1 | 3 | traceLevel + setTraceLevel RPC methods |
+| AC-PT-06 | 3 | 10-11 | VS Code panel with filter bar, colors, split pane |
+| AC-PT-07 | 3 | 11 | 5-tab detail pane |
+| AC-PT-08 | 3 | 11 | Timeline waterfall visualization |
+| AC-PT-09 | 3 | 11 | Quick filter presets |
+| AC-PT-10 | 2-3 | 8, 11 | Auto-refresh with selection preservation |
+| AC-PT-11 | 2 | 8 | Delete confirmation dialogs |
+| AC-PT-12 | 2 | 8 | Volume warning for trace level "All" |
+| AC-PT-13 | 6 | 18-24 | TUI screen + 5 dialogs |
+| AC-PT-14 | 5 | 16 | MCP delete tool |
+| AC-PT-15 | 3 | 11 | "Trace level Off" informational message |

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -2065,6 +2065,291 @@ public class RpcMethodHandler : IDisposable
     }
 
     #endregion
+
+    #region Plugin Traces
+
+    /// <summary>
+    /// Lists plugin trace logs with optional filtering.
+    /// Maps to: ppds plugintraces list --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/list")]
+    public async Task<PluginTracesListResponse> PluginTracesListAsync(
+        TraceFilterDto? filter = null,
+        int top = 100,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            var serviceFilter = MapTraceFilterFromDto(filter);
+            var traces = await traceService.ListAsync(serviceFilter, top, ct);
+
+            return new PluginTracesListResponse
+            {
+                Traces = traces.Select(MapTraceInfoToDto).ToList()
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a single plugin trace with full details.
+    /// Maps to: ppds plugintraces get --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/get")]
+    public async Task<PluginTracesGetResponse> PluginTracesGetAsync(
+        string id,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(id) || !Guid.TryParse(id, out var traceId))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'id' parameter must be a valid GUID");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            var trace = await traceService.GetAsync(traceId, ct)
+                ?? throw new RpcException(
+                    ErrorCodes.Operation.NotFound,
+                    $"Plugin trace '{id}' not found");
+
+            return new PluginTracesGetResponse
+            {
+                Trace = MapTraceDetailToDto(trace)
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds a timeline hierarchy from traces with the given correlation ID.
+    /// Maps to: ppds plugintraces timeline --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/timeline")]
+    public async Task<PluginTracesTimelineResponse> PluginTracesTimelineAsync(
+        string correlationId,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(correlationId) || !Guid.TryParse(correlationId, out var corrId))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'correlationId' parameter must be a valid GUID");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            var nodes = await traceService.BuildTimelineAsync(corrId, ct);
+
+            return new PluginTracesTimelineResponse
+            {
+                Nodes = nodes.Select(MapTimelineNodeToDto).ToList()
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Deletes plugin traces by IDs or by age.
+    /// Maps to: ppds plugintraces delete --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/delete")]
+    public async Task<PluginTracesDeleteResponse> PluginTracesDeleteAsync(
+        string[]? ids = null,
+        int? olderThanDays = null,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if ((ids == null || ids.Length == 0) && olderThanDays == null)
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "Either 'ids' or 'olderThanDays' must be provided");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            int deletedCount;
+
+            if (ids != null && ids.Length > 0)
+            {
+                var guids = new List<Guid>(ids.Length);
+                foreach (var idStr in ids)
+                {
+                    if (!Guid.TryParse(idStr, out var guid))
+                    {
+                        throw new RpcException(
+                            ErrorCodes.Validation.InvalidValue,
+                            $"The ID '{idStr}' is not a valid GUID");
+                    }
+                    guids.Add(guid);
+                }
+
+                deletedCount = await traceService.DeleteByIdsAsync(guids, cancellationToken: ct);
+            }
+            else
+            {
+                var olderThan = TimeSpan.FromDays(olderThanDays!.Value);
+                deletedCount = await traceService.DeleteOlderThanAsync(olderThan, cancellationToken: ct);
+            }
+
+            return new PluginTracesDeleteResponse
+            {
+                DeletedCount = deletedCount
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the current plugin trace logging level.
+    /// Maps to: ppds plugintraces tracelevel --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/traceLevel")]
+    public async Task<PluginTracesTraceLevelResponse> PluginTracesTraceLevelAsync(
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            var settings = await traceService.GetSettingsAsync(ct);
+
+            return new PluginTracesTraceLevelResponse
+            {
+                Level = settings.SettingName,
+                LevelValue = (int)settings.Setting
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sets the plugin trace logging level.
+    /// Maps to: ppds plugintraces settracelevel --json
+    /// </summary>
+    [JsonRpcMethod("pluginTraces/setTraceLevel")]
+    public async Task<PluginTracesSetTraceLevelResponse> PluginTracesSetTraceLevelAsync(
+        string level,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(level))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'level' parameter is required");
+        }
+
+        if (!Enum.TryParse<PluginTraceLogSetting>(level, ignoreCase: true, out var setting))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.InvalidValue,
+                $"Invalid trace level '{level}'. Valid values are: Off, Exception, All");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var traceService = sp.GetRequiredService<IPluginTraceService>();
+            await traceService.SetSettingsAsync(setting, ct);
+
+            return new PluginTracesSetTraceLevelResponse
+            {
+                Success = true
+            };
+        }, cancellationToken);
+    }
+
+    // ── Plugin Traces mapper helpers ────────────────────────────────────────
+
+    private static PluginTraceFilter? MapTraceFilterFromDto(TraceFilterDto? dto)
+    {
+        if (dto == null) return null;
+
+        PluginTraceMode? mode = null;
+        if (dto.Mode != null && Enum.TryParse<PluginTraceMode>(dto.Mode, ignoreCase: true, out var parsedMode))
+        {
+            mode = parsedMode;
+        }
+
+        return new PluginTraceFilter
+        {
+            TypeName = dto.TypeName,
+            MessageName = dto.MessageName,
+            PrimaryEntity = dto.PrimaryEntity,
+            Mode = mode,
+            HasException = dto.HasException,
+            CorrelationId = dto.CorrelationId != null && Guid.TryParse(dto.CorrelationId, out var corrId) ? corrId : null,
+            MinDurationMs = dto.MinDurationMs,
+            CreatedAfter = dto.StartDate != null ? DateTime.Parse(dto.StartDate, null, System.Globalization.DateTimeStyles.RoundtripKind) : null,
+            CreatedBefore = dto.EndDate != null ? DateTime.Parse(dto.EndDate, null, System.Globalization.DateTimeStyles.RoundtripKind) : null
+        };
+    }
+
+    private static PluginTraceInfoDto MapTraceInfoToDto(PluginTraceInfo trace)
+    {
+        return new PluginTraceInfoDto
+        {
+            Id = trace.Id.ToString(),
+            TypeName = trace.TypeName,
+            MessageName = trace.MessageName,
+            PrimaryEntity = trace.PrimaryEntity,
+            Mode = trace.Mode == PluginTraceMode.Synchronous ? "Sync" : "Async",
+            OperationType = trace.OperationType.ToString(),
+            Depth = trace.Depth,
+            CreatedOn = trace.CreatedOn.ToString("o"),
+            DurationMs = trace.DurationMs,
+            HasException = trace.HasException,
+            CorrelationId = trace.CorrelationId?.ToString()
+        };
+    }
+
+    private static PluginTraceDetailDto MapTraceDetailToDto(PluginTraceDetail detail)
+    {
+        return new PluginTraceDetailDto
+        {
+            Id = detail.Id.ToString(),
+            TypeName = detail.TypeName,
+            MessageName = detail.MessageName,
+            PrimaryEntity = detail.PrimaryEntity,
+            Mode = detail.Mode == PluginTraceMode.Synchronous ? "Sync" : "Async",
+            OperationType = detail.OperationType.ToString(),
+            Depth = detail.Depth,
+            CreatedOn = detail.CreatedOn.ToString("o"),
+            DurationMs = detail.DurationMs,
+            HasException = detail.HasException,
+            CorrelationId = detail.CorrelationId?.ToString(),
+            ConstructorDurationMs = detail.ConstructorDurationMs,
+            ExecutionStartTime = detail.ExecutionStartTime?.ToString("o"),
+            ExceptionDetails = detail.ExceptionDetails,
+            MessageBlock = detail.MessageBlock,
+            Configuration = detail.Configuration,
+            SecureConfiguration = detail.SecureConfiguration,
+            RequestId = detail.RequestId?.ToString()
+        };
+    }
+
+    private static TimelineNodeDto MapTimelineNodeToDto(TimelineNode node)
+    {
+        return new TimelineNodeDto
+        {
+            TraceId = node.Trace.Id.ToString(),
+            TypeName = node.Trace.TypeName,
+            MessageName = node.Trace.MessageName,
+            Depth = node.Trace.Depth,
+            DurationMs = node.Trace.DurationMs,
+            HasException = node.Trace.HasException,
+            OffsetPercent = node.OffsetPercent,
+            WidthPercent = node.WidthPercent,
+            HierarchyDepth = node.HierarchyDepth,
+            Children = node.Children.Select(MapTimelineNodeToDto).ToList()
+        };
+    }
+
+    #endregion
 }
 
 #region Response DTOs
@@ -3103,6 +3388,192 @@ public class ImportJobDetailDto : ImportJobInfoDto
     [JsonPropertyName("data")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Data { get; set; }
+}
+
+// ── Plugin Traces DTOs ──────────────────────────────────────────────────────
+
+public class PluginTracesListResponse
+{
+    [JsonPropertyName("traces")]
+    public List<PluginTraceInfoDto> Traces { get; set; } = [];
+}
+
+public class PluginTracesGetResponse
+{
+    [JsonPropertyName("trace")]
+    public PluginTraceDetailDto Trace { get; set; } = null!;
+}
+
+public class PluginTracesTimelineResponse
+{
+    [JsonPropertyName("nodes")]
+    public List<TimelineNodeDto> Nodes { get; set; } = [];
+}
+
+public class PluginTracesDeleteResponse
+{
+    [JsonPropertyName("deletedCount")]
+    public int DeletedCount { get; set; }
+}
+
+public class PluginTracesTraceLevelResponse
+{
+    [JsonPropertyName("level")]
+    public string Level { get; set; } = "";
+
+    [JsonPropertyName("levelValue")]
+    public int LevelValue { get; set; }
+}
+
+public class PluginTracesSetTraceLevelResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+public class PluginTraceInfoDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("typeName")]
+    public string TypeName { get; set; } = "";
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("primaryEntity")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryEntity { get; set; }
+
+    [JsonPropertyName("mode")]
+    public string Mode { get; set; } = "";
+
+    [JsonPropertyName("operationType")]
+    public string OperationType { get; set; } = "";
+
+    [JsonPropertyName("depth")]
+    public int Depth { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    public string CreatedOn { get; set; } = "";
+
+    [JsonPropertyName("durationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DurationMs { get; set; }
+
+    [JsonPropertyName("hasException")]
+    public bool HasException { get; set; }
+
+    [JsonPropertyName("correlationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CorrelationId { get; set; }
+}
+
+public class PluginTraceDetailDto : PluginTraceInfoDto
+{
+    [JsonPropertyName("constructorDurationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ConstructorDurationMs { get; set; }
+
+    [JsonPropertyName("executionStartTime")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExecutionStartTime { get; set; }
+
+    [JsonPropertyName("exceptionDetails")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExceptionDetails { get; set; }
+
+    [JsonPropertyName("messageBlock")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageBlock { get; set; }
+
+    [JsonPropertyName("configuration")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Configuration { get; set; }
+
+    [JsonPropertyName("secureConfiguration")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SecureConfiguration { get; set; }
+
+    [JsonPropertyName("requestId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RequestId { get; set; }
+}
+
+public class TimelineNodeDto
+{
+    [JsonPropertyName("traceId")]
+    public string TraceId { get; set; } = "";
+
+    [JsonPropertyName("typeName")]
+    public string TypeName { get; set; } = "";
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("depth")]
+    public int Depth { get; set; }
+
+    [JsonPropertyName("durationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DurationMs { get; set; }
+
+    [JsonPropertyName("hasException")]
+    public bool HasException { get; set; }
+
+    [JsonPropertyName("offsetPercent")]
+    public double OffsetPercent { get; set; }
+
+    [JsonPropertyName("widthPercent")]
+    public double WidthPercent { get; set; }
+
+    [JsonPropertyName("hierarchyDepth")]
+    public int HierarchyDepth { get; set; }
+
+    [JsonPropertyName("children")]
+    public List<TimelineNodeDto> Children { get; set; } = [];
+}
+
+public class TraceFilterDto
+{
+    [JsonPropertyName("typeName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TypeName { get; set; }
+
+    [JsonPropertyName("messageName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MessageName { get; set; }
+
+    [JsonPropertyName("primaryEntity")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryEntity { get; set; }
+
+    [JsonPropertyName("mode")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Mode { get; set; }
+
+    [JsonPropertyName("hasException")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? HasException { get; set; }
+
+    [JsonPropertyName("correlationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CorrelationId { get; set; }
+
+    [JsonPropertyName("minDurationMs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MinDurationMs { get; set; }
+
+    [JsonPropertyName("startDate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? StartDate { get; set; }
+
+    [JsonPropertyName("endDate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EndDate { get; set; }
 }
 
 #endregion

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -2154,21 +2154,22 @@ public class RpcMethodHandler : IDisposable
     }
 
     /// <summary>
-    /// Deletes plugin traces by IDs or by age.
+    /// Deletes plugin traces by IDs, by age, or by filter.
     /// Maps to: ppds plugintraces delete --json
     /// </summary>
     [JsonRpcMethod("pluginTraces/delete")]
     public async Task<PluginTracesDeleteResponse> PluginTracesDeleteAsync(
         string[]? ids = null,
         int? olderThanDays = null,
+        TraceFilterDto? filter = null,
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
-        if ((ids == null || ids.Length == 0) && olderThanDays == null)
+        if ((ids == null || ids.Length == 0) && olderThanDays == null && filter == null)
         {
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,
-                "Either 'ids' or 'olderThanDays' must be provided");
+                "One of 'ids', 'olderThanDays', or 'filter' must be provided");
         }
 
         return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
@@ -2192,10 +2193,15 @@ public class RpcMethodHandler : IDisposable
 
                 deletedCount = await traceService.DeleteByIdsAsync(guids, cancellationToken: ct);
             }
+            else if (olderThanDays != null)
+            {
+                var olderThan = TimeSpan.FromDays(olderThanDays.Value);
+                deletedCount = await traceService.DeleteOlderThanAsync(olderThan, cancellationToken: ct);
+            }
             else
             {
-                var olderThan = TimeSpan.FromDays(olderThanDays!.Value);
-                deletedCount = await traceService.DeleteOlderThanAsync(olderThan, cancellationToken: ct);
+                var domainFilter = MapTraceFilterFromDto(filter) ?? new PluginTraceFilter();
+                deletedCount = await traceService.DeleteByFilterAsync(domainFilter, cancellationToken: ct);
             }
 
             return new PluginTracesDeleteResponse

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -2165,12 +2165,13 @@ public class RpcMethodHandler : IDisposable
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
-        if ((ids == null || ids.Length == 0) && olderThanDays == null && filter == null)
-        {
-            throw new RpcException(
-                ErrorCodes.Validation.RequiredField,
-                "One of 'ids', 'olderThanDays', or 'filter' must be provided");
-        }
+        int modeCount = (ids != null && ids.Length > 0 ? 1 : 0)
+            + (olderThanDays.HasValue ? 1 : 0)
+            + (filter != null ? 1 : 0);
+        if (modeCount == 0)
+            throw new RpcException(ErrorCodes.Validation.RequiredField, "One of 'ids', 'olderThanDays', or 'filter' must be provided");
+        if (modeCount > 1)
+            throw new RpcException(ErrorCodes.Validation.RequiredField, "Only one of 'ids', 'olderThanDays', or 'filter' may be provided per call");
 
         return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
         {
@@ -2290,8 +2291,8 @@ public class RpcMethodHandler : IDisposable
             HasException = dto.HasException,
             CorrelationId = dto.CorrelationId != null && Guid.TryParse(dto.CorrelationId, out var corrId) ? corrId : null,
             MinDurationMs = dto.MinDurationMs,
-            CreatedAfter = dto.StartDate != null ? DateTime.Parse(dto.StartDate, null, System.Globalization.DateTimeStyles.RoundtripKind) : null,
-            CreatedBefore = dto.EndDate != null ? DateTime.Parse(dto.EndDate, null, System.Globalization.DateTimeStyles.RoundtripKind) : null
+            CreatedAfter = dto.StartDate != null && DateTime.TryParse(dto.StartDate, null, System.Globalization.DateTimeStyles.RoundtripKind, out var startDate) ? startDate : null,
+            CreatedBefore = dto.EndDate != null && DateTime.TryParse(dto.EndDate, null, System.Globalization.DateTimeStyles.RoundtripKind, out var endDate) ? endDate : null
         };
     }
 

--- a/src/PPDS.Cli/Tui/Dialogs/PluginTraceDetailDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/PluginTraceDetailDialog.cs
@@ -1,0 +1,168 @@
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog showing full details of a plugin trace log with tabbed sections.
+/// </summary>
+internal sealed class PluginTraceDetailDialog : TuiDialog
+{
+    /// <summary>
+    /// Creates a new plugin trace detail dialog.
+    /// </summary>
+    /// <param name="detail">The trace detail to display.</param>
+    /// <param name="session">Optional session for hotkey registry integration.</param>
+    public PluginTraceDetailDialog(PluginTraceDetail detail, InteractiveSession? session = null)
+        : base("Trace Detail", session)
+    {
+        Width = Dim.Percent(80);
+        Height = Dim.Percent(80);
+
+        var tabView = new TabView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(2)
+        };
+
+        // Details tab
+        var detailsView = new View
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        BuildDetailsTab(detailsView, detail);
+        tabView.AddTab(new TabView.Tab("Details", detailsView), andSelect: true);
+
+        // Exception tab
+        var exceptionView = new TextView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            ReadOnly = true,
+            Text = !string.IsNullOrEmpty(detail.ExceptionDetails) ? detail.ExceptionDetails : "No exception",
+            ColorScheme = TuiColorPalette.ReadOnlyText
+        };
+        tabView.AddTab(new TabView.Tab("Exception", exceptionView), andSelect: false);
+
+        // Message Block tab
+        var messageView = new TextView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            ReadOnly = true,
+            Text = !string.IsNullOrEmpty(detail.MessageBlock) ? detail.MessageBlock : "No message block",
+            ColorScheme = TuiColorPalette.ReadOnlyText
+        };
+        tabView.AddTab(new TabView.Tab("Message Block", messageView), andSelect: false);
+
+        // Configuration tab
+        var configView = new View
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+        BuildConfigTab(configView, detail);
+        tabView.AddTab(new TabView.Tab("Configuration", configView), andSelect: false);
+
+        // Close button
+        var closeButton = new Button("_Close")
+        {
+            X = Pos.Center(),
+            Y = Pos.AnchorEnd(1)
+        };
+        closeButton.Clicked += () => Application.RequestStop();
+
+        Add(tabView, closeButton);
+    }
+
+    private static void BuildDetailsTab(View container, PluginTraceDetail detail)
+    {
+        const int labelWidth = 18;
+        int row = 1;
+
+        AddDetailRow(container, "Type:", detail.TypeName, ref row, labelWidth);
+        AddDetailRow(container, "Message:", detail.MessageName ?? "\u2014", ref row, labelWidth);
+        AddDetailRow(container, "Entity:", detail.PrimaryEntity ?? "\u2014", ref row, labelWidth);
+        AddDetailRow(container, "Mode:", detail.Mode.ToString(), ref row, labelWidth);
+        AddDetailRow(container, "Operation:", detail.OperationType.ToString(), ref row, labelWidth);
+        AddDetailRow(container, "Depth:", detail.Depth.ToString(), ref row, labelWidth);
+        AddDetailRow(container, "Duration (ms):", detail.DurationMs?.ToString() ?? "\u2014", ref row, labelWidth);
+        AddDetailRow(container, "Created:", detail.CreatedOn.ToString("G"), ref row, labelWidth);
+        AddDetailRow(container, "Correlation ID:", detail.CorrelationId?.ToString() ?? "\u2014", ref row, labelWidth);
+        AddDetailRow(container, "Request ID:", detail.RequestId?.ToString() ?? "\u2014", ref row, labelWidth);
+        AddDetailRow(container, "Has Exception:", detail.HasException ? "Yes" : "No", ref row, labelWidth);
+    }
+
+    private static void AddDetailRow(View container, string label, string value, ref int row, int labelWidth)
+    {
+        container.Add(new Label(label)
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth,
+            ColorScheme = TuiColorPalette.TableHeader
+        });
+        container.Add(new Label(value)
+        {
+            X = labelWidth + 1,
+            Y = row,
+            Width = Dim.Fill(2)
+        });
+        row++;
+    }
+
+    private static void BuildConfigTab(View container, PluginTraceDetail detail)
+    {
+        var unsecuredLabel = new Label("Unsecured Configuration:")
+        {
+            X = 1,
+            Y = 1,
+            ColorScheme = TuiColorPalette.TableHeader
+        };
+        container.Add(unsecuredLabel);
+
+        var unsecuredText = new TextView
+        {
+            X = 1,
+            Y = 2,
+            Width = Dim.Fill(2),
+            Height = Dim.Percent(40),
+            ReadOnly = true,
+            Text = !string.IsNullOrEmpty(detail.Configuration) ? detail.Configuration : "(empty)",
+            ColorScheme = TuiColorPalette.ReadOnlyText
+        };
+        container.Add(unsecuredText);
+
+        var securedLabel = new Label("Secured Configuration:")
+        {
+            X = 1,
+            Y = Pos.Bottom(unsecuredText) + 1,
+            ColorScheme = TuiColorPalette.TableHeader
+        };
+        container.Add(securedLabel);
+
+        var securedText = new TextView
+        {
+            X = 1,
+            Y = Pos.Bottom(securedLabel),
+            Width = Dim.Fill(2),
+            Height = Dim.Fill(1),
+            ReadOnly = true,
+            Text = !string.IsNullOrEmpty(detail.SecureConfiguration) ? detail.SecureConfiguration : "(not available)",
+            ColorScheme = TuiColorPalette.ReadOnlyText
+        };
+        container.Add(securedText);
+    }
+}

--- a/src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs
@@ -134,7 +134,6 @@ internal sealed class PluginTraceFilterDialog : TuiDialog
             ColorScheme = TuiColorPalette.TextInput
         };
         Add(_minDurationField);
-        row += 2;
 
         // Buttons
         var applyButton = new Button("_Apply")
@@ -144,6 +143,13 @@ internal sealed class PluginTraceFilterDialog : TuiDialog
         };
         applyButton.Clicked += () =>
         {
+            var minDurText = _minDurationField.Text?.ToString()?.Trim();
+            if (!string.IsNullOrEmpty(minDurText) && !int.TryParse(minDurText, out _))
+            {
+                MessageBox.ErrorQuery("Invalid Input", "Min Duration must be a number.", "OK");
+                return;
+            }
+
             _applied = true;
             Application.RequestStop();
         };

--- a/src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/PluginTraceFilterDialog.cs
@@ -1,0 +1,205 @@
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog for filtering plugin trace logs by type, message, entity, mode, and duration.
+/// </summary>
+internal sealed class PluginTraceFilterDialog : TuiDialog
+{
+    private readonly TextField _typeNameField;
+    private readonly TextField _messageNameField;
+    private readonly TextField _primaryEntityField;
+    private readonly RadioGroup _modeGroup;
+    private readonly CheckBox _hasExceptionCheckBox;
+    private readonly TextField _minDurationField;
+    private bool _applied;
+
+    /// <summary>
+    /// Gets the built filter, or null if the dialog was cancelled.
+    /// </summary>
+    public PluginTraceFilter? Filter => _applied ? BuildFilter() : null;
+
+    /// <summary>
+    /// Creates a new plugin trace filter dialog.
+    /// </summary>
+    /// <param name="existingFilter">Optional existing filter to pre-populate fields.</param>
+    /// <param name="session">Optional session for hotkey registry integration.</param>
+    public PluginTraceFilterDialog(PluginTraceFilter? existingFilter = null, InteractiveSession? session = null)
+        : base("Filter Traces", session)
+    {
+        Width = Dim.Percent(60);
+        Height = 20;
+
+        const int labelWidth = 16;
+        int row = 1;
+
+        // Type Name
+        Add(new Label("Type Name:")
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth
+        });
+        _typeNameField = new TextField(existingFilter?.TypeName ?? "")
+        {
+            X = labelWidth + 1,
+            Y = row,
+            Width = Dim.Fill(2),
+            ColorScheme = TuiColorPalette.TextInput
+        };
+        Add(_typeNameField);
+        row++;
+
+        // Message Name
+        Add(new Label("Message Name:")
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth
+        });
+        _messageNameField = new TextField(existingFilter?.MessageName ?? "")
+        {
+            X = labelWidth + 1,
+            Y = row,
+            Width = Dim.Fill(2),
+            ColorScheme = TuiColorPalette.TextInput
+        };
+        Add(_messageNameField);
+        row++;
+
+        // Primary Entity
+        Add(new Label("Primary Entity:")
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth
+        });
+        _primaryEntityField = new TextField(existingFilter?.PrimaryEntity ?? "")
+        {
+            X = labelWidth + 1,
+            Y = row,
+            Width = Dim.Fill(2),
+            ColorScheme = TuiColorPalette.TextInput
+        };
+        Add(_primaryEntityField);
+        row += 2;
+
+        // Mode
+        Add(new Label("Mode:")
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth
+        });
+        _modeGroup = new RadioGroup(new NStack.ustring[] { "All", "Synchronous", "Asynchronous" })
+        {
+            X = labelWidth + 1,
+            Y = row,
+            DisplayMode = DisplayModeLayout.Horizontal
+        };
+        // Pre-select mode
+        if (existingFilter?.Mode == PluginTraceMode.Synchronous)
+            _modeGroup.SelectedItem = 1;
+        else if (existingFilter?.Mode == PluginTraceMode.Asynchronous)
+            _modeGroup.SelectedItem = 2;
+        else
+            _modeGroup.SelectedItem = 0;
+        Add(_modeGroup);
+        row += 2;
+
+        // Has Exception
+        _hasExceptionCheckBox = new CheckBox("Errors only", existingFilter?.HasException == true)
+        {
+            X = 1,
+            Y = row
+        };
+        Add(_hasExceptionCheckBox);
+        row += 2;
+
+        // Min Duration
+        Add(new Label("Min Duration (ms):")
+        {
+            X = 1,
+            Y = row,
+            Width = labelWidth + 2
+        });
+        _minDurationField = new TextField(existingFilter?.MinDurationMs?.ToString() ?? "")
+        {
+            X = labelWidth + 3,
+            Y = row,
+            Width = 10,
+            ColorScheme = TuiColorPalette.TextInput
+        };
+        Add(_minDurationField);
+        row += 2;
+
+        // Buttons
+        var applyButton = new Button("_Apply")
+        {
+            X = Pos.Center() - 10,
+            Y = Pos.AnchorEnd(1)
+        };
+        applyButton.Clicked += () =>
+        {
+            _applied = true;
+            Application.RequestStop();
+        };
+
+        var cancelButton = new Button("_Cancel")
+        {
+            X = Pos.Center() + 3,
+            Y = Pos.AnchorEnd(1)
+        };
+        cancelButton.Clicked += () =>
+        {
+            _applied = false;
+            Application.RequestStop();
+        };
+
+        Add(applyButton, cancelButton);
+    }
+
+    private PluginTraceFilter? BuildFilter()
+    {
+        var typeName = _typeNameField.Text?.ToString()?.Trim();
+        var messageName = _messageNameField.Text?.ToString()?.Trim();
+        var primaryEntity = _primaryEntityField.Text?.ToString()?.Trim();
+
+        PluginTraceMode? mode = _modeGroup.SelectedItem switch
+        {
+            1 => PluginTraceMode.Synchronous,
+            2 => PluginTraceMode.Asynchronous,
+            _ => null
+        };
+
+        bool? hasException = _hasExceptionCheckBox.Checked ? true : null;
+
+        int? minDuration = null;
+        var minDurText = _minDurationField.Text?.ToString()?.Trim();
+        if (!string.IsNullOrEmpty(minDurText) && int.TryParse(minDurText, out var parsed))
+        {
+            minDuration = parsed;
+        }
+
+        // Return null filter if nothing was specified
+        if (string.IsNullOrEmpty(typeName) && string.IsNullOrEmpty(messageName) &&
+            string.IsNullOrEmpty(primaryEntity) && mode == null &&
+            hasException == null && minDuration == null)
+        {
+            return null;
+        }
+
+        return new PluginTraceFilter
+        {
+            TypeName = string.IsNullOrEmpty(typeName) ? null : typeName,
+            MessageName = string.IsNullOrEmpty(messageName) ? null : messageName,
+            PrimaryEntity = string.IsNullOrEmpty(primaryEntity) ? null : primaryEntity,
+            Mode = mode,
+            HasException = hasException,
+            MinDurationMs = minDuration
+        };
+    }
+}

--- a/src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs
@@ -1,0 +1,125 @@
+using PPDS.Cli.Tui.Infrastructure;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog for confirming deletion of plugin traces.
+/// </summary>
+internal sealed class TraceDeleteDialog : TuiDialog
+{
+    private readonly RadioGroup _modeGroup;
+    private readonly TextField _dayCountField;
+    private bool _confirmed;
+
+    /// <summary>
+    /// Gets the delete result, or null if the dialog was cancelled.
+    /// </summary>
+    public TraceDeleteResult? Result => _confirmed ? BuildResult() : null;
+
+    /// <summary>
+    /// Creates a new trace delete dialog.
+    /// </summary>
+    /// <param name="selectedCount">Number of currently selected/loaded traces.</param>
+    /// <param name="session">Optional session for hotkey registry integration.</param>
+    public TraceDeleteDialog(int selectedCount, InteractiveSession? session = null)
+        : base("Delete Traces", session)
+    {
+        Width = 60;
+        Height = 14;
+
+        Add(new Label("Choose delete mode:")
+        {
+            X = 1,
+            Y = 1
+        });
+
+        _modeGroup = new RadioGroup(new NStack.ustring[]
+        {
+            $"Delete loaded traces ({selectedCount})",
+            "Delete traces older than N days"
+        })
+        {
+            X = 3,
+            Y = 3
+        };
+
+        var dayLabel = new Label("Days:")
+        {
+            X = 5,
+            Y = 6
+        };
+
+        _dayCountField = new TextField("30")
+        {
+            X = 11,
+            Y = 6,
+            Width = 8,
+            Enabled = false,
+            ColorScheme = TuiColorPalette.TextInput
+        };
+
+        _modeGroup.SelectedItemChanged += args =>
+        {
+            _dayCountField.Enabled = args.SelectedItem == 1;
+        };
+
+        var confirmButton = new Button("_Confirm")
+        {
+            X = Pos.Center() - 12,
+            Y = Pos.AnchorEnd(1)
+        };
+        confirmButton.Clicked += () =>
+        {
+            _confirmed = true;
+            Application.RequestStop();
+        };
+
+        var cancelButton = new Button("_Cancel")
+        {
+            X = Pos.Center() + 3,
+            Y = Pos.AnchorEnd(1)
+        };
+        cancelButton.Clicked += () =>
+        {
+            _confirmed = false;
+            Application.RequestStop();
+        };
+
+        Add(_modeGroup, dayLabel, _dayCountField, confirmButton, cancelButton);
+    }
+
+    private TraceDeleteResult? BuildResult()
+    {
+        if (_modeGroup.SelectedItem == 0)
+        {
+            return new TraceDeleteResult(TraceDeleteMode.ByIds, null);
+        }
+
+        var dayText = _dayCountField.Text?.ToString()?.Trim();
+        if (!string.IsNullOrEmpty(dayText) && int.TryParse(dayText, out var days) && days > 0)
+        {
+            return new TraceDeleteResult(TraceDeleteMode.ByAge, days);
+        }
+
+        // Invalid day count — treat as cancelled
+        return null;
+    }
+}
+
+/// <summary>
+/// Result from the trace delete dialog.
+/// </summary>
+internal sealed record TraceDeleteResult(TraceDeleteMode Mode, int? DayCount);
+
+/// <summary>
+/// Delete mode selection.
+/// </summary>
+internal enum TraceDeleteMode
+{
+    /// <summary>Delete traces by their IDs (loaded traces).</summary>
+    ByIds,
+
+    /// <summary>Delete traces older than a specified age.</summary>
+    ByAge
+}

--- a/src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/TraceDeleteDialog.cs
@@ -71,6 +71,16 @@ internal sealed class TraceDeleteDialog : TuiDialog
         };
         confirmButton.Clicked += () =>
         {
+            if (_modeGroup.SelectedItem == 1)
+            {
+                var dayText = _dayCountField.Text?.ToString()?.Trim();
+                if (string.IsNullOrEmpty(dayText) || !int.TryParse(dayText, out var days) || days <= 0)
+                {
+                    MessageBox.ErrorQuery("Invalid Input", "Day count must be a positive number.", "OK");
+                    return;
+                }
+            }
+
             _confirmed = true;
             Application.RequestStop();
         };

--- a/src/PPDS.Cli/Tui/Dialogs/TraceLevelDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/TraceLevelDialog.cs
@@ -1,0 +1,102 @@
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog for changing the plugin trace logging level.
+/// </summary>
+internal sealed class TraceLevelDialog : TuiDialog
+{
+    private readonly RadioGroup _levelGroup;
+    private readonly Label _warningLabel;
+    private bool _applied;
+
+    /// <summary>
+    /// Gets the selected trace level, or null if the dialog was cancelled.
+    /// </summary>
+    public PluginTraceLogSetting? SelectedLevel => _applied ? MapSelectedLevel() : null;
+
+    /// <summary>
+    /// Creates a new trace level dialog.
+    /// </summary>
+    /// <param name="currentLevel">The current trace logging level to pre-select.</param>
+    /// <param name="session">Optional session for hotkey registry integration.</param>
+    public TraceLevelDialog(PluginTraceLogSetting currentLevel, InteractiveSession? session = null)
+        : base("Plugin Trace Level", session)
+    {
+        Width = 50;
+        Height = 12;
+
+        Add(new Label("Select trace logging level:")
+        {
+            X = 1,
+            Y = 1
+        });
+
+        _levelGroup = new RadioGroup(new NStack.ustring[] { "Off", "Exception", "All" })
+        {
+            X = 3,
+            Y = 3
+        };
+
+        // Pre-select current level
+        _levelGroup.SelectedItem = currentLevel switch
+        {
+            PluginTraceLogSetting.Off => 0,
+            PluginTraceLogSetting.Exception => 1,
+            PluginTraceLogSetting.All => 2,
+            _ => 0
+        };
+
+        _warningLabel = new Label("Warning: 'All' can generate significant log volume")
+        {
+            X = 1,
+            Y = 6,
+            Width = Dim.Fill(2),
+            Visible = currentLevel == PluginTraceLogSetting.All,
+            ColorScheme = TuiColorPalette.Error
+        };
+
+        _levelGroup.SelectedItemChanged += args =>
+        {
+            _warningLabel.Visible = args.SelectedItem == 2;
+        };
+
+        var applyButton = new Button("_Apply")
+        {
+            X = Pos.Center() - 10,
+            Y = Pos.AnchorEnd(1)
+        };
+        applyButton.Clicked += () =>
+        {
+            _applied = true;
+            Application.RequestStop();
+        };
+
+        var cancelButton = new Button("_Cancel")
+        {
+            X = Pos.Center() + 3,
+            Y = Pos.AnchorEnd(1)
+        };
+        cancelButton.Clicked += () =>
+        {
+            _applied = false;
+            Application.RequestStop();
+        };
+
+        Add(_levelGroup, _warningLabel, applyButton, cancelButton);
+    }
+
+    private PluginTraceLogSetting MapSelectedLevel()
+    {
+        return _levelGroup.SelectedItem switch
+        {
+            0 => PluginTraceLogSetting.Off,
+            1 => PluginTraceLogSetting.Exception,
+            2 => PluginTraceLogSetting.All,
+            _ => PluginTraceLogSetting.Off
+        };
+    }
+}

--- a/src/PPDS.Cli/Tui/Dialogs/TraceTimelineDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/TraceTimelineDialog.cs
@@ -1,0 +1,88 @@
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Dialogs;
+
+/// <summary>
+/// Dialog showing a text-based waterfall timeline of plugin execution.
+/// </summary>
+internal sealed class TraceTimelineDialog : TuiDialog
+{
+    private const int BarMaxWidth = 40;
+
+    /// <summary>
+    /// Creates a new trace timeline dialog.
+    /// </summary>
+    /// <param name="nodes">The timeline nodes to display.</param>
+    /// <param name="session">Optional session for hotkey registry integration.</param>
+    public TraceTimelineDialog(List<TimelineNode> nodes, InteractiveSession? session = null)
+        : base("Execution Timeline", session)
+    {
+        Width = Dim.Percent(90);
+        Height = Dim.Percent(80);
+
+        var lines = BuildTimelineLines(nodes);
+
+        var listView = new ListView(lines)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(2),
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        var closeButton = new Button("_Close")
+        {
+            X = Pos.Center(),
+            Y = Pos.AnchorEnd(1)
+        };
+        closeButton.Clicked += () => Application.RequestStop();
+
+        Add(listView, closeButton);
+    }
+
+    private static List<string> BuildTimelineLines(List<TimelineNode> nodes)
+    {
+        var lines = new List<string>();
+        FlattenNodes(nodes, lines);
+
+        if (lines.Count == 0)
+        {
+            lines.Add("No timeline data available.");
+        }
+
+        return lines;
+    }
+
+    private static void FlattenNodes(IReadOnlyList<TimelineNode> nodes, List<string> lines)
+    {
+        foreach (var node in nodes)
+        {
+            var indent = new string(' ', node.HierarchyDepth * 2);
+            var typeName = TruncateText(node.Trace.TypeName, 30);
+            var message = node.Trace.MessageName ?? "";
+            var duration = node.Trace.DurationMs?.ToString() ?? "?";
+            var status = node.Trace.HasException ? " [ERR]" : "";
+
+            // Build proportional bar
+            var barWidth = Math.Max(1, (int)(node.WidthPercent / 100.0 * BarMaxWidth));
+            var bar = new string('\u2588', barWidth);
+
+            var line = $"{indent}{typeName} {message} ({duration}ms){status}  {bar}";
+            lines.Add(line);
+
+            if (node.Children.Count > 0)
+            {
+                FlattenNodes(node.Children, lines);
+            }
+        }
+    }
+
+    private static string TruncateText(string text, int maxLength)
+    {
+        if (text.Length <= maxLength) return text;
+        return text[..(maxLength - 3)] + "...";
+    }
+}

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -105,11 +105,27 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
             ct.ThrowIfCancellationRequested();
 
+            // Check trace level when no traces are found to give actionable guidance
+            PluginTraceLogSetting? traceSetting = null;
+            if (traces.Count == 0 && _currentFilter == null)
+            {
+                var settings = await service.GetSettingsAsync(ct);
+                traceSetting = settings.Setting;
+            }
+
             Application.MainLoop?.Invoke(() =>
             {
                 _traces = traces;
                 PopulateTable();
-                UpdateStatusLabel();
+
+                if (traceSetting == PluginTraceLogSetting.Off && _traces.Count == 0)
+                {
+                    _statusLabel.Text = "Plugin trace level is Off \u2014 no new traces are being recorded. Use Ctrl+L to change.";
+                }
+                else
+                {
+                    UpdateStatusLabel();
+                }
             });
         }
         catch (OperationCanceledException) { /* screen closing or superseded load */ }
@@ -178,6 +194,12 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
     private async Task ShowDetailDialogAsync(PluginTraceInfo trace)
     {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop?.Invoke(() => { _statusLabel.Text = "No environment connected"; });
+            return;
+        }
+
         try
         {
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
@@ -237,6 +259,12 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
     private async Task ShowTimelineAsync()
     {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop?.Invoke(() => { _statusLabel.Text = "No environment connected"; });
+            return;
+        }
+
         var selectedRow = _table.SelectedRow;
         if (selectedRow < 0 || selectedRow >= _traces.Count)
         {
@@ -306,6 +334,12 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
     private async Task ExecuteDeleteAsync(TraceDeleteResult deleteResult)
     {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop?.Invoke(() => { _statusLabel.Text = "No environment connected"; });
+            return;
+        }
+
         try
         {
             Application.MainLoop?.Invoke(() =>
@@ -350,6 +384,12 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
     private async Task ShowTraceLevelAsync()
     {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop?.Invoke(() => { _statusLabel.Text = "No environment connected"; });
+            return;
+        }
+
         try
         {
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -223,10 +223,16 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
                 _activeDialog?.Dispose();
                 _activeDialog = new PluginTraceDetailDialog(detail, Session);
-                Application.Run(_activeDialog);
-                _activeDialog.Dispose();
-                _activeDialog = null;
-                _isShowingDialog = false;
+                try
+                {
+                    Application.Run(_activeDialog);
+                }
+                finally
+                {
+                    _activeDialog.Dispose();
+                    _activeDialog = null;
+                    _isShowingDialog = false;
+                }
             });
         }
         catch (OperationCanceledException) { /* screen closing */ }
@@ -299,10 +305,16 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
                 _activeDialog?.Dispose();
                 _activeDialog = new TraceTimelineDialog(timeline, Session);
-                Application.Run(_activeDialog);
-                _activeDialog.Dispose();
-                _activeDialog = null;
-                _isShowingDialog = false;
+                try
+                {
+                    Application.Run(_activeDialog);
+                }
+                finally
+                {
+                    _activeDialog.Dispose();
+                    _activeDialog = null;
+                    _isShowingDialog = false;
+                }
             });
         }
         catch (OperationCanceledException) { /* screen closing */ }

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -1,0 +1,406 @@
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Tui.Dialogs;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// TUI screen for browsing and managing plugin trace logs.
+/// </summary>
+internal sealed class PluginTracesScreen : TuiScreenBase
+{
+    private readonly TableView _table;
+    private readonly Label _statusLabel;
+
+    private List<PluginTraceInfo> _traces = [];
+    private PluginTraceFilter? _currentFilter;
+    private CancellationTokenSource? _loadCts;
+    private Dialog? _activeDialog;
+    private bool _isShowingDialog;
+
+    public override string Title => "Plugin Traces";
+
+    public PluginTracesScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        _table = new TableView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            FullRowSelect = true,
+            Style = { ShowHorizontalHeaderOverline = false, ShowHorizontalHeaderUnderline = true }
+        };
+
+        _statusLabel = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_table),
+            Width = Dim.Fill(),
+            Height = 1,
+            Text = "Loading...",
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        _table.CellActivated += OnCellActivated;
+
+        Content.Add(_table, _statusLabel);
+
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadTracesAsync(), "PluginTraces.InitialLoad");
+        }
+        else
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.R, "Refresh", () =>
+            ErrorService.FireAndForget(LoadTracesAsync(), "PluginTraces.Refresh"));
+
+        RegisterHotkey(registry, Key.CtrlMask | Key.F, "Filter", ShowFilterDialog);
+
+        RegisterHotkey(registry, Key.CtrlMask | Key.T, "Timeline", () =>
+            ErrorService.FireAndForget(ShowTimelineAsync(), "PluginTraces.Timeline"));
+
+        RegisterHotkey(registry, Key.CtrlMask | Key.D, "Delete", ShowDeleteDialog);
+
+        RegisterHotkey(registry, Key.CtrlMask | Key.L, "Trace Level", () =>
+            ErrorService.FireAndForget(ShowTraceLevelAsync(), "PluginTraces.TraceLevel"));
+    }
+
+    private async Task LoadTracesAsync()
+    {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+            });
+            return;
+        }
+
+        // Cancel any in-flight load to prevent races
+        _loadCts?.Cancel();
+        _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        var ct = _loadCts.Token;
+
+        try
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                _statusLabel.Text = "Loading plugin traces...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var service = provider.GetRequiredService<IPluginTraceService>();
+
+            var traces = await service.ListAsync(filter: _currentFilter, cancellationToken: ct);
+
+            ct.ThrowIfCancellationRequested();
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                _traces = traces;
+                PopulateTable();
+                UpdateStatusLabel();
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing or superseded load */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load plugin traces", ex, "PluginTraces.Load");
+                _statusLabel.Text = "Error loading plugin traces";
+            });
+        }
+    }
+
+    private void PopulateTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("Time", typeof(string));
+        dt.Columns.Add("Duration (ms)", typeof(string));
+        dt.Columns.Add("Plugin", typeof(string));
+        dt.Columns.Add("Entity", typeof(string));
+        dt.Columns.Add("Message", typeof(string));
+        dt.Columns.Add("Depth", typeof(string));
+        dt.Columns.Add("Mode", typeof(string));
+        dt.Columns.Add("Status", typeof(string));
+
+        foreach (var trace in _traces)
+        {
+            dt.Rows.Add(
+                trace.CreatedOn.ToString("G"),
+                trace.DurationMs?.ToString() ?? "\u2014",
+                trace.TypeName,
+                trace.PrimaryEntity ?? "\u2014",
+                trace.MessageName ?? "\u2014",
+                trace.Depth.ToString(),
+                trace.Mode == PluginTraceMode.Synchronous ? "Sync" : "Async",
+                trace.HasException ? "Error" : "OK");
+        }
+
+        _table.Table = dt;
+    }
+
+    private void UpdateStatusLabel()
+    {
+        if (_traces.Count == 0)
+        {
+            _statusLabel.Text = _currentFilter != null
+                ? "No traces match the current filter."
+                : "No plugin traces found.";
+            return;
+        }
+
+        var errors = _traces.Count(t => t.HasException);
+        var statusParts = new List<string> { $"{_traces.Count} trace{(_traces.Count != 1 ? "s" : "")}" };
+        if (errors > 0) statusParts.Add($"{errors} with errors");
+        if (_currentFilter != null) statusParts.Add("filtered");
+        _statusLabel.Text = string.Join(" \u2014 ", statusParts);
+    }
+
+    private void OnCellActivated(TableView.CellActivatedEventArgs args)
+    {
+        if (_isShowingDialog) return;
+        if (args.Row < 0 || args.Row >= _traces.Count) return;
+        var trace = _traces[args.Row];
+        ErrorService.FireAndForget(ShowDetailDialogAsync(trace), "PluginTraces.ShowDetail");
+    }
+
+    private async Task ShowDetailDialogAsync(PluginTraceInfo trace)
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IPluginTraceService>();
+
+            var detail = await service.GetAsync(trace.Id, ScreenCancellation);
+
+            if (detail == null)
+            {
+                Application.MainLoop?.Invoke(() =>
+                {
+                    ErrorService.ReportError("Trace not found. It may have been deleted.");
+                });
+                return;
+            }
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                if (_isShowingDialog) return;
+                _isShowingDialog = true;
+
+                _activeDialog?.Dispose();
+                _activeDialog = new PluginTraceDetailDialog(detail, Session);
+                Application.Run(_activeDialog);
+                _activeDialog.Dispose();
+                _activeDialog = null;
+                _isShowingDialog = false;
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load trace details", ex, "PluginTraces.Detail");
+            });
+        }
+    }
+
+    private void ShowFilterDialog()
+    {
+        if (_isShowingDialog) return;
+        _isShowingDialog = true;
+
+        using var dialog = new PluginTraceFilterDialog(_currentFilter, Session);
+        Application.Run(dialog);
+
+        _isShowingDialog = false;
+
+        // dialog.Filter is null if cancelled, also null if all fields empty (clears filter)
+        if (dialog.Filter != _currentFilter)
+        {
+            _currentFilter = dialog.Filter;
+            ErrorService.FireAndForget(LoadTracesAsync(), "PluginTraces.FilterApply");
+        }
+    }
+
+    private async Task ShowTimelineAsync()
+    {
+        var selectedRow = _table.SelectedRow;
+        if (selectedRow < 0 || selectedRow >= _traces.Count)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("No trace selected. Select a trace to view its timeline.");
+            });
+            return;
+        }
+
+        var trace = _traces[selectedRow];
+        if (trace.CorrelationId == null || trace.CorrelationId == Guid.Empty)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Selected trace has no correlation ID.");
+            });
+            return;
+        }
+
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IPluginTraceService>();
+
+            var timeline = await service.BuildTimelineAsync(trace.CorrelationId.Value, ScreenCancellation);
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                if (_isShowingDialog) return;
+                _isShowingDialog = true;
+
+                _activeDialog?.Dispose();
+                _activeDialog = new TraceTimelineDialog(timeline, Session);
+                Application.Run(_activeDialog);
+                _activeDialog.Dispose();
+                _activeDialog = null;
+                _isShowingDialog = false;
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to build timeline", ex, "PluginTraces.Timeline");
+            });
+        }
+    }
+
+    private void ShowDeleteDialog()
+    {
+        if (_isShowingDialog) return;
+        _isShowingDialog = true;
+
+        using var dialog = new TraceDeleteDialog(_traces.Count, Session);
+        Application.Run(dialog);
+
+        _isShowingDialog = false;
+
+        var result = dialog.Result;
+        if (result != null)
+        {
+            ErrorService.FireAndForget(ExecuteDeleteAsync(result), "PluginTraces.Delete");
+        }
+    }
+
+    private async Task ExecuteDeleteAsync(TraceDeleteResult deleteResult)
+    {
+        try
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                _statusLabel.Text = "Deleting traces...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IPluginTraceService>();
+
+            int deletedCount;
+
+            if (deleteResult.Mode == TraceDeleteMode.ByIds)
+            {
+                var ids = _traces.Select(t => t.Id).ToList();
+                deletedCount = await service.DeleteByIdsAsync(ids, cancellationToken: ScreenCancellation);
+            }
+            else
+            {
+                var olderThan = TimeSpan.FromDays(deleteResult.DayCount!.Value);
+                deletedCount = await service.DeleteOlderThanAsync(olderThan, cancellationToken: ScreenCancellation);
+            }
+
+            // Reload after deletion
+            await LoadTracesAsync();
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                _statusLabel.Text = $"Deleted {deletedCount} trace{(deletedCount != 1 ? "s" : "")}. {_traces.Count} remaining.";
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to delete traces", ex, "PluginTraces.Delete");
+                _statusLabel.Text = "Error deleting traces";
+            });
+        }
+    }
+
+    private async Task ShowTraceLevelAsync()
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IPluginTraceService>();
+
+            var settings = await service.GetSettingsAsync(ScreenCancellation);
+
+            PluginTraceLogSetting? selectedLevel = null;
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                if (_isShowingDialog) return;
+                _isShowingDialog = true;
+
+                using var dialog = new TraceLevelDialog(settings.Setting, Session);
+                Application.Run(dialog);
+
+                selectedLevel = dialog.SelectedLevel;
+                _isShowingDialog = false;
+            });
+
+            if (selectedLevel.HasValue && selectedLevel.Value != settings.Setting)
+            {
+                Application.MainLoop?.Invoke(() =>
+                {
+                    _statusLabel.Text = $"Setting trace level to {selectedLevel.Value}...";
+                });
+
+                await service.SetSettingsAsync(selectedLevel.Value, ScreenCancellation);
+
+                Application.MainLoop?.Invoke(() =>
+                {
+                    _statusLabel.Text = $"Trace level set to {selectedLevel.Value}.";
+                });
+            }
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to change trace level", ex, "PluginTraces.TraceLevel");
+            });
+        }
+    }
+
+    protected override void OnDispose()
+    {
+        _table.CellActivated -= OnCellActivated;
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        _activeDialog?.Dispose();
+    }
+}

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -281,6 +281,7 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             new("SQL Query", "Run SQL queries against Dataverse", () => NavigateToSqlQuery()),
             new("Solutions", "Browse Dataverse solutions", () => NavigateToSolutions()),
             new("Import Jobs", "View solution import jobs", () => NavigateToImportJobs()),
+            new("Plugin Traces", "Browse plugin trace logs", () => NavigateToPluginTraces()),
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Environment Details...", "View organization and connection info",
                 hasEnvironment ? () => ShowEnvironmentDetails() : (Action?)null),
@@ -479,6 +480,31 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             _contentArea.Remove(loadingLabel);
 
             var screen = new ImportJobsScreen(_session);
+            NavigateTo(screen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToPluginTraces()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Plugin Traces...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new PluginTracesScreen(_session);
             NavigateTo(screen);
 
             return false;

--- a/src/PPDS.Extension/esbuild.js
+++ b/src/PPDS.Extension/esbuild.js
@@ -78,6 +78,18 @@ const builds = [
         outfile: 'dist/import-jobs-panel.js',
         logLevel: 'warning',
     },
+    // Plugin Traces panel webview (browser, IIFE)
+    {
+        entryPoints: ['src/panels/webview/plugin-traces-panel.ts'],
+        bundle: true,
+        format: 'iife',
+        minify: production,
+        sourcemap: !production,
+        sourcesContent: false,
+        platform: 'browser',
+        outfile: 'dist/plugin-traces-panel.js',
+        logLevel: 'warning',
+    },
     // ── Panel CSS bundles ────────────────────────────────────────────────────
     {
         entryPoints: ['src/panels/styles/query-panel.css'],
@@ -99,6 +111,14 @@ const builds = [
         bundle: true,
         minify: production,
         outfile: 'dist/import-jobs-panel.css',
+        logLevel: 'warning',
+    },
+    // Plugin Traces panel CSS
+    {
+        entryPoints: ['src/panels/styles/plugin-traces-panel.css'],
+        bundle: true,
+        minify: production,
+        outfile: 'dist/plugin-traces-panel.css',
         logLevel: 'warning',
     },
 ];

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -237,6 +237,17 @@
         "icon": "$(history)"
       },
       {
+        "command": "ppds.openPluginTraces",
+        "title": "Plugin Traces",
+        "category": "PPDS",
+        "icon": "$(debug-stackframe)"
+      },
+      {
+        "command": "ppds.openPluginTracesForEnv",
+        "title": "Open Plugin Traces",
+        "icon": "$(debug-stackframe)"
+      },
+      {
         "command": "ppds.copyEnvironmentUrl",
         "title": "Copy URL",
         "icon": "$(copy)"
@@ -365,6 +376,11 @@
           "command": "ppds.openImportJobsForEnv",
           "when": "view == ppds.profiles && viewItem == environment",
           "group": "env-tools@3"
+        },
+        {
+          "command": "ppds.openPluginTracesForEnv",
+          "when": "view == ppds.profiles && viewItem == environment",
+          "group": "env-tools@4"
         },
         {
           "command": "ppds.openInMaker",

--- a/src/PPDS.Extension/src/__tests__/panels/pluginTracesPanel.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/pluginTracesPanel.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+
+import type {
+    PluginTracesPanelWebviewToHost,
+    PluginTracesPanelHostToWebview,
+    PluginTraceViewDto,
+    PluginTraceDetailViewDto,
+    TraceFilterViewDto,
+    TimelineNodeViewDto,
+} from '../../panels/webview/shared/message-types.js';
+
+describe('PluginTracesPanel message types', () => {
+    describe('WebviewToHost', () => {
+        it('covers all commands', () => {
+            const messages: PluginTracesPanelWebviewToHost[] = [
+                { command: 'ready' },
+                { command: 'refresh' },
+                { command: 'applyFilter', filter: { typeName: 'MyPlugin', hasException: true } },
+                { command: 'selectTrace', id: 'trace-1' },
+                { command: 'loadTimeline', correlationId: 'corr-1' },
+                { command: 'deleteTraces', ids: ['id-1', 'id-2'] },
+                { command: 'deleteOlderThan', days: 30 },
+                { command: 'requestTraceLevel' },
+                { command: 'setTraceLevel', level: 'All' },
+                { command: 'setAutoRefresh', intervalSeconds: 10 },
+                { command: 'setAutoRefresh', intervalSeconds: null },
+                { command: 'requestEnvironmentList' },
+                { command: 'copyToClipboard', text: 'copied text' },
+                { command: 'webviewError', error: 'something broke', stack: 'Error\n  at ...' },
+            ];
+            expect(messages).toHaveLength(14);
+        });
+
+        it('webviewError stack is optional', () => {
+            const msg: PluginTracesPanelWebviewToHost = {
+                command: 'webviewError',
+                error: 'test error',
+            };
+            expect(msg.command).toBe('webviewError');
+        });
+    });
+
+    describe('HostToWebview', () => {
+        it('covers all commands', () => {
+            const messages: PluginTracesPanelHostToWebview[] = [
+                { command: 'updateEnvironment', name: 'dev', envType: 'Sandbox', envColor: '#00ff00' },
+                { command: 'tracesLoaded', traces: [] },
+                {
+                    command: 'traceDetailLoaded',
+                    trace: {
+                        id: 't-1',
+                        typeName: 'MyPlugin',
+                        messageName: 'Create',
+                        primaryEntity: 'account',
+                        mode: 'Synchronous',
+                        operationType: 'Plugin',
+                        depth: 1,
+                        createdOn: '2026-03-17T00:00:00Z',
+                        durationMs: 42,
+                        hasException: false,
+                        correlationId: 'corr-1',
+                        constructorDurationMs: 5,
+                        executionStartTime: '2026-03-17T00:00:00Z',
+                        exceptionDetails: null,
+                        messageBlock: '{"key":"value"}',
+                        configuration: null,
+                        secureConfiguration: null,
+                        requestId: 'req-1',
+                    },
+                },
+                { command: 'timelineLoaded', nodes: [] },
+                { command: 'traceLevelLoaded', level: 'All', levelValue: 2 },
+                { command: 'deleteComplete', deletedCount: 5 },
+                { command: 'loading' },
+                { command: 'error', message: 'something went wrong' },
+                { command: 'daemonReconnected' },
+            ];
+            expect(messages).toHaveLength(9);
+        });
+
+        it('updateEnvironment accepts null envType and envColor', () => {
+            const msg: PluginTracesPanelHostToWebview = {
+                command: 'updateEnvironment',
+                name: 'test',
+                envType: null,
+                envColor: null,
+            };
+            expect(msg.command).toBe('updateEnvironment');
+        });
+    });
+
+    describe('PluginTraceViewDto', () => {
+        it('has all required fields with correct types', () => {
+            const dto: PluginTraceViewDto = {
+                id: '00000000-0000-0000-0000-000000000001',
+                typeName: 'Contoso.Plugins.AccountCreate',
+                messageName: 'Create',
+                primaryEntity: 'account',
+                mode: 'Synchronous',
+                operationType: 'Plugin',
+                depth: 1,
+                createdOn: '2026-03-17T12:00:00Z',
+                durationMs: 150,
+                hasException: false,
+                correlationId: 'abc-123',
+            };
+            expect(dto.id).toBe('00000000-0000-0000-0000-000000000001');
+            expect(dto.typeName).toBe('Contoso.Plugins.AccountCreate');
+            expect(dto.depth).toBe(1);
+            expect(dto.hasException).toBe(false);
+            expect(dto.durationMs).toBe(150);
+        });
+
+        it('handles null fields gracefully', () => {
+            const dto: PluginTraceViewDto = {
+                id: '00000000-0000-0000-0000-000000000002',
+                typeName: 'SomePlugin',
+                messageName: null,
+                primaryEntity: null,
+                mode: 'Asynchronous',
+                operationType: 'Plugin',
+                depth: 2,
+                createdOn: '2026-03-17T12:00:00Z',
+                durationMs: null,
+                hasException: true,
+                correlationId: null,
+            };
+            expect(dto.messageName).toBeNull();
+            expect(dto.primaryEntity).toBeNull();
+            expect(dto.durationMs).toBeNull();
+            expect(dto.correlationId).toBeNull();
+        });
+    });
+
+    describe('PluginTraceDetailViewDto', () => {
+        it('extends PluginTraceViewDto with additional fields', () => {
+            const detail: PluginTraceDetailViewDto = {
+                // Base PluginTraceViewDto fields
+                id: 'detail-1',
+                typeName: 'Contoso.Plugins.AccountCreate',
+                messageName: 'Create',
+                primaryEntity: 'account',
+                mode: 'Synchronous',
+                operationType: 'Plugin',
+                depth: 1,
+                createdOn: '2026-03-17T12:00:00Z',
+                durationMs: 200,
+                hasException: true,
+                correlationId: 'corr-abc',
+                // Extended fields
+                constructorDurationMs: 10,
+                executionStartTime: '2026-03-17T12:00:01Z',
+                exceptionDetails: 'NullReferenceException: Object reference not set',
+                messageBlock: '{"Target":{"Id":"..."}}',
+                configuration: '<config>value</config>',
+                secureConfiguration: null,
+                requestId: 'req-xyz',
+            };
+            expect(detail.constructorDurationMs).toBe(10);
+            expect(detail.exceptionDetails).toContain('NullReferenceException');
+            expect(detail.secureConfiguration).toBeNull();
+            expect(detail.requestId).toBe('req-xyz');
+        });
+
+        it('handles all-null extended fields', () => {
+            const detail: PluginTraceDetailViewDto = {
+                id: 'detail-2',
+                typeName: 'SomePlugin',
+                messageName: null,
+                primaryEntity: null,
+                mode: 'Asynchronous',
+                operationType: 'Plugin',
+                depth: 1,
+                createdOn: '2026-03-17T12:00:00Z',
+                durationMs: null,
+                hasException: false,
+                correlationId: null,
+                constructorDurationMs: null,
+                executionStartTime: null,
+                exceptionDetails: null,
+                messageBlock: null,
+                configuration: null,
+                secureConfiguration: null,
+                requestId: null,
+            };
+            expect(detail.constructorDurationMs).toBeNull();
+            expect(detail.executionStartTime).toBeNull();
+            expect(detail.exceptionDetails).toBeNull();
+            expect(detail.messageBlock).toBeNull();
+            expect(detail.configuration).toBeNull();
+            expect(detail.requestId).toBeNull();
+        });
+    });
+
+    describe('TraceFilterViewDto', () => {
+        it('all fields are optional', () => {
+            const emptyFilter: TraceFilterViewDto = {};
+            expect(emptyFilter).toEqual({});
+        });
+
+        it('accepts any combination of filter fields', () => {
+            const partial: TraceFilterViewDto = {
+                typeName: 'MyPlugin',
+                hasException: true,
+                minDurationMs: 100,
+            };
+            expect(partial.typeName).toBe('MyPlugin');
+            expect(partial.hasException).toBe(true);
+            expect(partial.minDurationMs).toBe(100);
+        });
+
+        it('accepts all filter fields', () => {
+            const full: TraceFilterViewDto = {
+                typeName: 'Contoso.Plugins.AccountCreate',
+                messageName: 'Create',
+                primaryEntity: 'account',
+                mode: 'Synchronous',
+                hasException: false,
+                correlationId: 'corr-1',
+                minDurationMs: 50,
+                startDate: '2026-03-01T00:00:00Z',
+                endDate: '2026-03-17T23:59:59Z',
+            };
+            expect(full.startDate).toBe('2026-03-01T00:00:00Z');
+            expect(full.endDate).toBe('2026-03-17T23:59:59Z');
+        });
+    });
+
+    describe('TimelineNodeViewDto', () => {
+        it('has all required fields including children array', () => {
+            const node: TimelineNodeViewDto = {
+                traceId: 'trace-1',
+                typeName: 'Contoso.Plugins.AccountCreate',
+                messageName: 'Create',
+                depth: 1,
+                durationMs: 200,
+                hasException: false,
+                offsetPercent: 0,
+                widthPercent: 100,
+                hierarchyDepth: 0,
+                children: [],
+            };
+            expect(node.traceId).toBe('trace-1');
+            expect(node.offsetPercent).toBe(0);
+            expect(node.widthPercent).toBe(100);
+            expect(node.hierarchyDepth).toBe(0);
+            expect(node.children).toHaveLength(0);
+        });
+
+        it('supports nested children', () => {
+            const tree: TimelineNodeViewDto = {
+                traceId: 'parent-1',
+                typeName: 'ParentPlugin',
+                messageName: 'Create',
+                depth: 1,
+                durationMs: 500,
+                hasException: false,
+                offsetPercent: 0,
+                widthPercent: 100,
+                hierarchyDepth: 0,
+                children: [
+                    {
+                        traceId: 'child-1',
+                        typeName: 'ChildPlugin',
+                        messageName: 'Update',
+                        depth: 2,
+                        durationMs: 150,
+                        hasException: false,
+                        offsetPercent: 10,
+                        widthPercent: 30,
+                        hierarchyDepth: 1,
+                        children: [
+                            {
+                                traceId: 'grandchild-1',
+                                typeName: 'GrandchildPlugin',
+                                messageName: null,
+                                depth: 3,
+                                durationMs: null,
+                                hasException: true,
+                                offsetPercent: 15,
+                                widthPercent: 10,
+                                hierarchyDepth: 2,
+                                children: [],
+                            },
+                        ],
+                    },
+                ],
+            };
+            expect(tree.children).toHaveLength(1);
+            expect(tree.children[0].children).toHaveLength(1);
+            expect(tree.children[0].children[0].hasException).toBe(true);
+            expect(tree.children[0].children[0].durationMs).toBeNull();
+        });
+    });
+});

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -40,6 +40,13 @@ import type {
     SchemaAttributesResponse,
     ImportJobsListResponse,
     ImportJobsGetResponse,
+    PluginTracesListResponse,
+    PluginTracesGetResponse,
+    PluginTracesTimelineResponse,
+    PluginTracesDeleteResponse,
+    PluginTracesTraceLevelResponse,
+    PluginTracesSetTraceLevelResponse,
+    TraceFilterDto,
 } from './types.js';
 
 // Re-export AuthWhoResponse for profileCommands.ts convenience
@@ -730,6 +737,90 @@ export class DaemonClient implements vscode.Disposable {
         this.log.info(`Calling importJobs/get for ${id}...`);
         const result = await this.connection!.sendRequest<ImportJobsGetResponse>('importJobs/get', params);
         this.log.debug(`Got import job detail: ${result.job.solutionName}`);
+
+        return result;
+    }
+
+    // ── Plugin Traces ─────────────────────────────────────────────────────────
+
+    async pluginTracesList(filter?: TraceFilterDto, top?: number, environmentUrl?: string): Promise<PluginTracesListResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = {};
+        if (filter !== undefined) params.filter = filter;
+        if (top !== undefined) params.top = top;
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info('Calling pluginTraces/list...');
+        const result = await this.connection!.sendRequest<PluginTracesListResponse>('pluginTraces/list', params);
+        this.log.debug(`Got ${result.traces.length} plugin traces`);
+
+        return result;
+    }
+
+    async pluginTracesGet(id: string, environmentUrl?: string): Promise<PluginTracesGetResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = { id };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info(`Calling pluginTraces/get for ${id}...`);
+        const result = await this.connection!.sendRequest<PluginTracesGetResponse>('pluginTraces/get', params);
+        this.log.debug(`Got plugin trace detail: ${result.trace.typeName}`);
+
+        return result;
+    }
+
+    async pluginTracesTimeline(correlationId: string, environmentUrl?: string): Promise<PluginTracesTimelineResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = { correlationId };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info(`Calling pluginTraces/timeline for ${correlationId}...`);
+        const result = await this.connection!.sendRequest<PluginTracesTimelineResponse>('pluginTraces/timeline', params);
+        this.log.debug(`Got ${result.nodes.length} timeline nodes`);
+
+        return result;
+    }
+
+    async pluginTracesDelete(ids?: string[], olderThanDays?: number, environmentUrl?: string): Promise<PluginTracesDeleteResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = {};
+        if (ids !== undefined) params.ids = ids;
+        if (olderThanDays !== undefined) params.olderThanDays = olderThanDays;
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info('Calling pluginTraces/delete...');
+        const result = await this.connection!.sendRequest<PluginTracesDeleteResponse>('pluginTraces/delete', params);
+        this.log.debug(`Deleted ${result.deletedCount} plugin traces`);
+
+        return result;
+    }
+
+    async pluginTracesTraceLevel(environmentUrl?: string): Promise<PluginTracesTraceLevelResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = {};
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info('Calling pluginTraces/traceLevel...');
+        const result = await this.connection!.sendRequest<PluginTracesTraceLevelResponse>('pluginTraces/traceLevel', params);
+        this.log.debug(`Trace level: ${result.level} (${result.levelValue})`);
+
+        return result;
+    }
+
+    async pluginTracesSetTraceLevel(level: string, environmentUrl?: string): Promise<PluginTracesSetTraceLevelResponse> {
+        await this.ensureConnected();
+
+        const params: Record<string, unknown> = { level };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.info(`Calling pluginTraces/setTraceLevel with level=${level}...`);
+        const result = await this.connection!.sendRequest<PluginTracesSetTraceLevelResponse>('pluginTraces/setTraceLevel', params);
+        this.log.debug(`Set trace level success: ${result.success}`);
 
         return result;
     }

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -19,6 +19,7 @@ import { DataverseCompletionProvider } from './providers/completionProvider.js';
 import { QueryPanel } from './panels/QueryPanel.js';
 import { SolutionsPanel } from './panels/SolutionsPanel.js';
 import { ImportJobsPanel } from './panels/ImportJobsPanel.js';
+import { PluginTracesPanel } from './panels/PluginTracesPanel.js';
 import { migrateLegacyState } from './migration/legacyState.js';
 import { registerDebugCommands } from './commands/debugCommands.js';
 import { DaemonStatusBar } from './daemonStatusBar.js';
@@ -66,6 +67,9 @@ function registerPanelCommands(
         }),
         vscode.commands.registerCommand('ppds.openImportJobs', () => {
             ImportJobsPanel.show(context.extensionUri, client);
+        }),
+        vscode.commands.registerCommand('ppds.openPluginTraces', () => {
+            PluginTracesPanel.show(context.extensionUri, client);
         }),
         vscode.commands.registerCommand('ppds.openQueryInNotebook', (sql?: string) => {
             void openQueryInNotebook(sql ?? '');
@@ -262,6 +266,12 @@ export function activate(context: vscode.ExtensionContext): void {
             ImportJobsPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
         })),
 
+        // Open Plugin Traces targeting this environment
+        vscode.commands.registerCommand('ppds.openPluginTracesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
+            if (!item?.envUrl) return;
+            PluginTracesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+        })),
+
         // Copy environment URL to clipboard
         vscode.commands.registerCommand('ppds.copyEnvironmentUrl', async (item: { envUrl: string }) => {
             if (!item?.envUrl) return;
@@ -366,6 +376,7 @@ export function activate(context: vscode.ExtensionContext): void {
         queryPanels: () => QueryPanel.instanceCount,
         solutionsPanels: () => SolutionsPanel.instanceCount,
         importJobsPanels: () => ImportJobsPanel.instanceCount,
+        pluginTracesPanels: () => PluginTracesPanel.instanceCount,
     });
 
     // Register environment selection command for notebooks

--- a/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
@@ -402,30 +402,65 @@ export class PluginTracesPanel extends WebviewPanelBase<PluginTracesPanelWebview
     </select>
     <vscode-button id="delete-btn" appearance="secondary" title="Delete traces">Delete</vscode-button>
     <vscode-button id="trace-level-btn" appearance="secondary" title="View/change trace level">Trace Level</vscode-button>
+    <span id="trace-level-indicator" class="trace-level-indicator"></span>
     <span class="toolbar-spacer"></span>
     ${getEnvironmentPickerHtml()}
 </div>
 
-<div id="filter-bar"></div>
+<div id="filter-bar" class="filter-bar">
+    <button id="filter-toggle-btn" class="filter-toggle-btn">Filters &#x25BC;</button>
+    <div class="filter-fields">
+        <div class="filter-field">
+            <label>Entity</label>
+            <input type="text" id="filter-entity" placeholder="Entity name..." />
+        </div>
+        <div class="filter-field">
+            <label>Message</label>
+            <input type="text" id="filter-message" placeholder="Message name..." />
+        </div>
+        <div class="filter-field">
+            <label>Plugin</label>
+            <input type="text" id="filter-plugin" placeholder="Plugin type..." />
+        </div>
+        <div class="filter-field">
+            <label>Mode</label>
+            <select id="filter-mode">
+                <option value="">All</option>
+                <option value="Sync">Sync</option>
+                <option value="Async">Async</option>
+            </select>
+        </div>
+        <div class="filter-field">
+            <label>&nbsp;</label>
+            <label><input type="checkbox" id="filter-exceptions" /> Exceptions only</label>
+        </div>
+    </div>
+    <div class="quick-filters">
+        <span id="qf-last-hour" class="quick-filter-pill">Last Hour</span>
+        <span id="qf-exceptions" class="quick-filter-pill">Exceptions Only</span>
+        <span id="qf-long-running" class="quick-filter-pill">Long Running</span>
+        <button id="qf-clear-all" class="filter-toggle-btn">Clear All</button>
+    </div>
+</div>
 
 <div class="panel-content">
     <div id="table-pane" class="table-pane">
         <div class="empty-state" id="empty-state">Loading plugin traces...</div>
     </div>
-    <div class="resize-handle"></div>
-    <div id="detail-pane" class="detail-pane" style="display: none;">
+    <div id="resize-handle" class="resize-handle"></div>
+    <div id="detail-pane" class="detail-pane">
         <div class="detail-tabs-bar">
             <button class="detail-tab active" data-tab="details">Details</button>
             <button class="detail-tab" data-tab="exception">Exception</button>
             <button class="detail-tab" data-tab="message-block">Message Block</button>
-            <button class="detail-tab" data-tab="configuration">Configuration</button>
+            <button class="detail-tab" data-tab="config">Configuration</button>
             <button class="detail-tab" data-tab="timeline">Timeline</button>
         </div>
         <div class="detail-tab-content" id="tab-details"></div>
-        <div class="detail-tab-content" id="tab-exception" style="display: none;"></div>
-        <div class="detail-tab-content" id="tab-message-block" style="display: none;"></div>
-        <div class="detail-tab-content" id="tab-configuration" style="display: none;"></div>
-        <div class="detail-tab-content" id="tab-timeline" style="display: none;"></div>
+        <div class="detail-tab-content" id="tab-exception"></div>
+        <div class="detail-tab-content" id="tab-message-block"></div>
+        <div class="detail-tab-content" id="tab-config"></div>
+        <div class="detail-tab-content" id="tab-timeline"></div>
     </div>
 </div>
 

--- a/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
@@ -1,0 +1,440 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient } from '../daemonClient.js';
+import type { TraceFilterDto } from '../types.js';
+import { handleAuthError } from '../utils/errorUtils.js';
+
+import { WebviewPanelBase } from './WebviewPanelBase.js';
+import { getNonce } from './webviewUtils.js';
+import { getEnvironmentPickerHtml, showEnvironmentPicker } from './environmentPicker.js';
+import type {
+    PluginTracesPanelWebviewToHost,
+    PluginTracesPanelHostToWebview,
+    PluginTraceViewDto,
+    PluginTraceDetailViewDto,
+    TimelineNodeViewDto,
+} from './webview/shared/message-types.js';
+import { assertNever } from './webview/shared/assert-never.js';
+
+export class PluginTracesPanel extends WebviewPanelBase<PluginTracesPanelWebviewToHost, PluginTracesPanelHostToWebview> {
+    private static instances: PluginTracesPanel[] = [];
+    private static nextId = 1;
+    private readonly panelId: number;
+
+    private static readonly MAX_PANELS = 5;
+
+    private environmentUrl: string | undefined;
+    private environmentDisplayName: string | undefined;
+    private environmentType: string | null = null;
+    private environmentColor: string | null = null;
+    private profileName: string | undefined;
+
+    private currentFilter: TraceFilterDto | undefined;
+    private autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+    /**
+     * Returns the number of open PluginTracesPanel instances.
+     * Used by diagnostic commands for panel state inspection.
+     */
+    static get instanceCount(): number {
+        return PluginTracesPanel.instances.length;
+    }
+
+    static show(extensionUri: vscode.Uri, daemon: DaemonClient, envUrl?: string, envDisplayName?: string): PluginTracesPanel {
+        if (PluginTracesPanel.instances.length >= PluginTracesPanel.MAX_PANELS) {
+            const oldest = PluginTracesPanel.instances[0];
+            oldest.panel?.reveal();
+            return oldest;
+        }
+        const panel = new PluginTracesPanel(extensionUri, daemon, envUrl, envDisplayName);
+        return panel;
+    }
+
+    private constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly daemon: DaemonClient,
+        initialEnvUrl?: string,
+        initialEnvDisplayName?: string,
+    ) {
+        super();
+
+        if (initialEnvUrl) {
+            this.environmentUrl = initialEnvUrl;
+            this.environmentDisplayName = initialEnvDisplayName ?? initialEnvUrl;
+        }
+
+        this.panelId = PluginTracesPanel.nextId++;
+        PluginTracesPanel.instances.push(this);
+
+        const panel = vscode.window.createWebviewPanel(
+            'ppds.pluginTraces',
+            `Plugin Traces #${this.panelId}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: false,
+                localResourceRoots: [
+                    vscode.Uri.joinPath(extensionUri, 'node_modules'),
+                    vscode.Uri.joinPath(extensionUri, 'dist'),
+                ],
+            }
+        );
+
+        panel.webview.html = this.getHtmlContent(panel.webview);
+        this.initPanel(panel);
+        this.subscribeToDaemonReconnect(this.daemon);
+    }
+
+    protected async handleMessage(message: PluginTracesPanelWebviewToHost): Promise<void> {
+        switch (message.command) {
+            case 'ready':
+                await this.initialize();
+                break;
+            case 'refresh':
+                await this.loadTraces();
+                break;
+            case 'applyFilter':
+                this.currentFilter = message.filter;
+                await this.loadTraces();
+                break;
+            case 'selectTrace':
+                await this.loadTraceDetail(message.id);
+                break;
+            case 'loadTimeline':
+                await this.loadTimeline(message.correlationId);
+                break;
+            case 'deleteTraces':
+                await this.confirmAndDeleteByIds(message.ids);
+                break;
+            case 'deleteOlderThan':
+                await this.confirmAndDeleteByAge(message.days);
+                break;
+            case 'requestTraceLevel':
+                await this.loadTraceLevel();
+                break;
+            case 'setTraceLevel':
+                await this.setTraceLevel(message.level);
+                break;
+            case 'setAutoRefresh':
+                this.setupAutoRefresh(message.intervalSeconds);
+                break;
+            case 'requestEnvironmentList':
+                await this.handleEnvironmentPicker();
+                break;
+            case 'copyToClipboard':
+                await vscode.env.clipboard.writeText(message.text);
+                break;
+            case 'webviewError':
+                this.logWebviewError(message.error, message.stack);
+                break;
+            default:
+                assertNever(message);
+        }
+    }
+
+    protected override onDaemonReconnected(): void {
+        void this.loadTraces();
+    }
+
+    override dispose(): void {
+        if (this.autoRefreshTimer !== null) {
+            clearInterval(this.autoRefreshTimer);
+            this.autoRefreshTimer = null;
+        }
+        const idx = PluginTracesPanel.instances.indexOf(this);
+        if (idx >= 0) PluginTracesPanel.instances.splice(idx, 1);
+        super.dispose();
+    }
+
+    private async initialize(): Promise<void> {
+        try {
+            const who = await this.daemon.authWho();
+            this.profileName = who.name ?? `Profile ${who.index}`;
+            if (!this.environmentUrl && who.environment?.url) {
+                this.environmentUrl = who.environment.url;
+                this.environmentDisplayName = who.environment.displayName || who.environment.url;
+            }
+            this.environmentType = who.environment?.type ?? null;
+            if (this.environmentUrl) {
+                try {
+                    const config = await this.daemon.envConfigGet(this.environmentUrl);
+                    this.environmentColor = config.resolvedColor ?? null;
+                } catch {
+                    this.environmentColor = null;
+                }
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: this.environmentDisplayName ?? 'No environment', envType: this.environmentType, envColor: this.environmentColor });
+            await this.loadTraces();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to initialize: ${msg}` });
+        }
+    }
+
+    private async handleEnvironmentPicker(): Promise<void> {
+        const result = await showEnvironmentPicker(this.daemon, this.environmentUrl);
+        if (result) {
+            this.environmentUrl = result.url;
+            this.environmentDisplayName = result.displayName;
+            this.environmentType = result.type;
+            try {
+                const config = await this.daemon.envConfigGet(result.url);
+                this.environmentColor = config.resolvedColor ?? null;
+            } catch {
+                this.environmentColor = null;
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: result.type, envColor: this.environmentColor });
+            await this.loadTraces();
+        }
+    }
+
+    private updatePanelTitle(): void {
+        if (!this.panel) return;
+        const context = [this.profileName, this.environmentDisplayName].filter(Boolean).join(' \u00B7 ');
+        const suffix = PluginTracesPanel.instances.length > 1 ? ` ${this.panelId}` : '';
+        this.panel.title = context ? `${context} \u2014 Plugin Traces${suffix}` : `Plugin Traces${suffix}`;
+    }
+
+    private async loadTraces(isRetry = false): Promise<void> {
+        try {
+            this.postMessage({ command: 'loading' });
+            const result = await this.daemon.pluginTracesList(this.currentFilter, undefined, this.environmentUrl);
+
+            const traces: PluginTraceViewDto[] = result.traces.map(t => ({
+                id: t.id,
+                typeName: t.typeName,
+                messageName: t.messageName,
+                primaryEntity: t.primaryEntity,
+                mode: t.mode,
+                operationType: t.operationType,
+                depth: t.depth,
+                createdOn: t.createdOn,
+                durationMs: t.durationMs,
+                hasException: t.hasException,
+                correlationId: t.correlationId,
+            }));
+
+            this.postMessage({ command: 'tracesLoaded', traces });
+
+            // Also check trace level to inform the user if tracing is Off
+            void this.loadTraceLevel();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+
+            if (await handleAuthError(this.daemon, error, isRetry, () => this.loadTraces(true))) {
+                return;
+            }
+
+            this.postMessage({ command: 'error', message: msg });
+        }
+    }
+
+    private async loadTraceDetail(id: string): Promise<void> {
+        try {
+            const result = await this.daemon.pluginTracesGet(id, this.environmentUrl);
+            const t = result.trace;
+            const trace: PluginTraceDetailViewDto = {
+                id: t.id,
+                typeName: t.typeName,
+                messageName: t.messageName,
+                primaryEntity: t.primaryEntity,
+                mode: t.mode,
+                operationType: t.operationType,
+                depth: t.depth,
+                createdOn: t.createdOn,
+                durationMs: t.durationMs,
+                hasException: t.hasException,
+                correlationId: t.correlationId,
+                constructorDurationMs: t.constructorDurationMs,
+                executionStartTime: t.executionStartTime,
+                exceptionDetails: t.exceptionDetails,
+                messageBlock: t.messageBlock,
+                configuration: t.configuration,
+                secureConfiguration: t.secureConfiguration,
+                requestId: t.requestId,
+            };
+            this.postMessage({ command: 'traceDetailLoaded', trace });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load trace detail: ${msg}` });
+        }
+    }
+
+    private async loadTimeline(correlationId: string): Promise<void> {
+        try {
+            const result = await this.daemon.pluginTracesTimeline(correlationId, this.environmentUrl);
+            const mapNodes = (nodes: typeof result.nodes): TimelineNodeViewDto[] =>
+                nodes.map(n => ({
+                    traceId: n.traceId,
+                    typeName: n.typeName,
+                    messageName: n.messageName,
+                    depth: n.depth,
+                    durationMs: n.durationMs,
+                    hasException: n.hasException,
+                    offsetPercent: n.offsetPercent,
+                    widthPercent: n.widthPercent,
+                    hierarchyDepth: n.hierarchyDepth,
+                    children: mapNodes(n.children),
+                }));
+            this.postMessage({ command: 'timelineLoaded', nodes: mapNodes(result.nodes) });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load timeline: ${msg}` });
+        }
+    }
+
+    private async confirmAndDeleteByIds(ids: string[]): Promise<void> {
+        const confirm = await vscode.window.showWarningMessage(
+            `Delete ${ids.length} trace(s)?`,
+            { modal: true },
+            'Delete',
+        );
+        if (confirm !== 'Delete') return;
+
+        try {
+            const result = await this.daemon.pluginTracesDelete(ids, undefined, this.environmentUrl);
+            this.postMessage({ command: 'deleteComplete', deletedCount: result.deletedCount });
+            await this.loadTraces();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to delete traces: ${msg}` });
+        }
+    }
+
+    private async confirmAndDeleteByAge(days: number): Promise<void> {
+        const confirm = await vscode.window.showWarningMessage(
+            `Delete all traces older than ${days} day(s)?`,
+            { modal: true },
+            'Delete',
+        );
+        if (confirm !== 'Delete') return;
+
+        try {
+            const result = await this.daemon.pluginTracesDelete(undefined, days, this.environmentUrl);
+            this.postMessage({ command: 'deleteComplete', deletedCount: result.deletedCount });
+            await this.loadTraces();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to delete traces: ${msg}` });
+        }
+    }
+
+    private async loadTraceLevel(): Promise<void> {
+        try {
+            const result = await this.daemon.pluginTracesTraceLevel(this.environmentUrl);
+            this.postMessage({ command: 'traceLevelLoaded', level: result.level, levelValue: result.levelValue });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load trace level: ${msg}` });
+        }
+    }
+
+    private async setTraceLevel(level: string): Promise<void> {
+        if (level === 'All') {
+            const confirm = await vscode.window.showWarningMessage(
+                "Setting trace level to 'All' generates significant log volume and may impact performance. Continue?",
+                'Set to All',
+                'Cancel',
+            );
+            if (confirm !== 'Set to All') return;
+        }
+
+        try {
+            await this.daemon.pluginTracesSetTraceLevel(level, this.environmentUrl);
+            await this.loadTraceLevel();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to set trace level: ${msg}` });
+        }
+    }
+
+    private setupAutoRefresh(seconds: number | null): void {
+        if (this.autoRefreshTimer !== null) {
+            clearInterval(this.autoRefreshTimer);
+            this.autoRefreshTimer = null;
+        }
+        if (seconds !== null && seconds > 0) {
+            this.autoRefreshTimer = setInterval(() => {
+                void this.loadTraces();
+            }, seconds * 1000);
+        }
+    }
+
+    getHtmlContent(webview: vscode.Webview): string {
+        const toolkitUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist', 'toolkit.min.js')
+        ).toString();
+        const panelJsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'plugin-traces-panel.js')
+        ).toString();
+        const panelCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'plugin-traces-panel.css')
+        ).toString();
+        const nonce = getNonce();
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- 'unsafe-inline' is required by @vscode/webview-ui-toolkit for dynamic styles -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="${panelCssUri}">
+    <script type="module" nonce="${nonce}" src="${toolkitUri}"></script>
+</head>
+<body>
+
+<div id="reconnect-banner" style="display:none; background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-foreground); padding: 6px 12px; text-align: center; font-size: 12px;">
+    Connection restored. Data may be stale. <a href="#" id="reconnect-refresh" style="color: var(--vscode-textLink-foreground);">Refresh</a>
+</div>
+
+<div class="toolbar">
+    <vscode-button id="refresh-btn" appearance="secondary" title="Refresh plugin traces">Refresh</vscode-button>
+    <select id="auto-refresh-select" title="Auto-refresh interval">
+        <option value="">Off</option>
+        <option value="5">5s</option>
+        <option value="15">15s</option>
+        <option value="30">30s</option>
+        <option value="60">1m</option>
+        <option value="300">5m</option>
+    </select>
+    <vscode-button id="delete-btn" appearance="secondary" title="Delete traces">Delete</vscode-button>
+    <vscode-button id="trace-level-btn" appearance="secondary" title="View/change trace level">Trace Level</vscode-button>
+    <span class="toolbar-spacer"></span>
+    ${getEnvironmentPickerHtml()}
+</div>
+
+<div id="filter-bar"></div>
+
+<div class="panel-content">
+    <div id="table-pane" class="table-pane">
+        <div class="empty-state" id="empty-state">Loading plugin traces...</div>
+    </div>
+    <div class="resize-handle"></div>
+    <div id="detail-pane" class="detail-pane" style="display: none;">
+        <div class="detail-tabs-bar">
+            <button class="detail-tab active" data-tab="details">Details</button>
+            <button class="detail-tab" data-tab="exception">Exception</button>
+            <button class="detail-tab" data-tab="message-block">Message Block</button>
+            <button class="detail-tab" data-tab="configuration">Configuration</button>
+            <button class="detail-tab" data-tab="timeline">Timeline</button>
+        </div>
+        <div class="detail-tab-content" id="tab-details"></div>
+        <div class="detail-tab-content" id="tab-exception" style="display: none;"></div>
+        <div class="detail-tab-content" id="tab-message-block" style="display: none;"></div>
+        <div class="detail-tab-content" id="tab-configuration" style="display: none;"></div>
+        <div class="detail-tab-content" id="tab-timeline" style="display: none;"></div>
+    </div>
+</div>
+
+<div class="status-bar">
+    <span id="status-text">Loading...</span>
+</div>
+
+<script nonce="${nonce}" src="${panelJsUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
@@ -1,0 +1,386 @@
+@import './shared.css';
+
+/* ── Filter Bar ─────────────────────────────────────────────────── */
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    align-items: flex-end;
+}
+
+.filter-bar.collapsed .filter-fields {
+    display: none;
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.filter-field label {
+    font-size: 10px;
+    text-transform: uppercase;
+    color: var(--vscode-descriptionForeground);
+    letter-spacing: 0.5px;
+}
+
+.filter-field input,
+.filter-field select {
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 3px 6px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
+    min-width: 100px;
+}
+
+.filter-field input:focus,
+.filter-field select:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+}
+
+.quick-filters {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-left: 8px;
+}
+
+.quick-filter-pill {
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    cursor: pointer;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.quick-filter-pill.active {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+}
+
+.filter-actions {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-left: auto;
+}
+
+.filter-toggle-btn {
+    cursor: pointer;
+    font-size: 11px;
+    color: var(--vscode-textLink-foreground);
+    background: none;
+    border: none;
+    padding: 2px 4px;
+}
+
+/* ── Split Pane ─────────────────────────────────────────────────── */
+.panel-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+}
+
+.table-pane {
+    flex: 1 1 60%;
+    min-height: 100px;
+    overflow: auto;
+}
+
+.resize-handle {
+    height: 4px;
+    cursor: row-resize;
+    background: transparent;
+    flex-shrink: 0;
+}
+
+.resize-handle:hover,
+.resize-handle.active {
+    background: var(--vscode-focusBorder);
+}
+
+.detail-pane {
+    flex: 0 0 40%;
+    min-height: 100px;
+    border-top: 1px solid var(--vscode-panel-border);
+    overflow: hidden;
+    display: none;
+    flex-direction: column;
+}
+
+.detail-pane.visible {
+    display: flex;
+}
+
+/* ── Data Table ─────────────────────────────────────────────────── */
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-size: 12px;
+}
+
+.data-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.data-table th {
+    background: var(--vscode-editor-background);
+    color: var(--vscode-foreground);
+    font-weight: 600;
+    text-align: left;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    user-select: none;
+}
+
+.data-table th.sortable {
+    cursor: pointer;
+}
+
+.data-table th.sortable:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.data-table td {
+    padding: 3px 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-bottom: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.12));
+}
+
+.data-table-row {
+    cursor: pointer;
+}
+
+.data-table-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.data-table-row:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.data-table-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* Color-coded rows */
+.trace-row-exception {
+    background: rgba(255, 0, 0, 0.08);
+}
+
+.trace-row-exception:hover {
+    background: rgba(255, 0, 0, 0.15);
+}
+
+.trace-row-slow {
+    background: rgba(255, 200, 0, 0.08);
+}
+
+.trace-row-slow:hover {
+    background: rgba(255, 200, 0, 0.15);
+}
+
+/* Status icon */
+.trace-status-icon {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.trace-status-icon.exception {
+    background: var(--vscode-testing-iconFailed, #f44336);
+}
+
+.trace-status-icon.success {
+    background: var(--vscode-testing-iconPassed, #4caf50);
+}
+
+/* Column widths */
+.col-status { width: 40px; }
+.col-time { width: 140px; }
+.col-duration { width: 80px; }
+.col-plugin { width: 200px; }
+.col-entity { width: 120px; }
+.col-message { width: 100px; }
+.col-depth { width: 50px; }
+.col-mode { width: 60px; }
+
+/* ── Detail Tabs ─────────────────────────────────────────────────── */
+.detail-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    flex-shrink: 0;
+}
+
+.detail-tab {
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 12px;
+    border-bottom: 2px solid transparent;
+    color: var(--vscode-descriptionForeground);
+    background: none;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+}
+
+.detail-tab:hover {
+    color: var(--vscode-foreground);
+}
+
+.detail-tab.active {
+    color: var(--vscode-foreground);
+    border-bottom-color: var(--vscode-focusBorder);
+    font-weight: 600;
+}
+
+.detail-tab-content {
+    display: none;
+    padding: 12px;
+    overflow: auto;
+    flex: 1;
+}
+
+.detail-tab-content.active {
+    display: block;
+}
+
+.monospace-content {
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size, 13px);
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.5;
+}
+
+.detail-kv {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    gap: 4px 12px;
+    font-size: 12px;
+}
+
+.detail-kv-label {
+    color: var(--vscode-descriptionForeground);
+    font-weight: 600;
+}
+
+/* ── Timeline Waterfall ─────────────────────────────────────────── */
+.timeline-container {
+    padding: 8px;
+}
+
+.timeline-header {
+    display: flex;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--vscode-descriptionForeground);
+    padding: 4px 0;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    margin-bottom: 4px;
+}
+
+.timeline-header-label {
+    width: 200px;
+    padding-left: 8px;
+}
+
+.timeline-header-bar {
+    flex: 1;
+    text-align: center;
+}
+
+.timeline-row {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    cursor: pointer;
+}
+
+.timeline-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.timeline-label {
+    width: 200px;
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.timeline-bar-container {
+    flex: 1;
+    position: relative;
+    height: 20px;
+    background: rgba(128, 128, 128, 0.05);
+    border-radius: 2px;
+}
+
+.timeline-bar {
+    position: absolute;
+    height: 18px;
+    top: 1px;
+    border-radius: 2px;
+    min-width: 2px;
+}
+
+.timeline-bar.normal {
+    background: var(--vscode-progressBar-background, #0078d4);
+}
+
+.timeline-bar.exception {
+    background: var(--vscode-testing-iconFailed, #f44336);
+}
+
+.timeline-bar.slow {
+    background: #ffa726;
+}
+
+.timeline-duration {
+    font-size: 10px;
+    color: var(--vscode-descriptionForeground);
+    margin-left: 4px;
+    white-space: nowrap;
+}
+
+/* ── Toolbar extras ─────────────────────────────────────────────── */
+.toolbar select {
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 2px 4px;
+    font-size: 12px;
+}
+
+.trace-level-indicator {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+}
+
+.auto-refresh-active {
+    color: var(--vscode-testing-iconPassed, #4caf50);
+}

--- a/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
@@ -226,7 +226,7 @@
 .col-mode { width: 60px; }
 
 /* ── Detail Tabs ─────────────────────────────────────────────────── */
-.detail-tabs {
+.detail-tabs-bar {
     display: flex;
     border-bottom: 1px solid var(--vscode-panel-border);
     flex-shrink: 0;
@@ -383,4 +383,61 @@
 
 .auto-refresh-active {
     color: var(--vscode-testing-iconPassed, #4caf50);
+}
+
+/* ── Delete Dropdown ───────────────────────────────────────────── */
+.delete-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 10;
+    min-width: 180px;
+    background: var(--vscode-menu-background, var(--vscode-editor-background));
+    border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border));
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    padding: 4px 0;
+}
+
+.delete-dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 12px;
+    text-align: left;
+    background: none;
+    border: none;
+    color: var(--vscode-menu-foreground, var(--vscode-foreground));
+    cursor: pointer;
+    font-family: var(--vscode-font-family);
+}
+
+.delete-dropdown-item:hover {
+    background: var(--vscode-menu-selectionBackground, var(--vscode-list-hoverBackground));
+    color: var(--vscode-menu-selectionForeground, var(--vscode-foreground));
+}
+
+.delete-older-dialog {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    background: var(--vscode-menu-background, var(--vscode-editor-background));
+    border: 1px solid var(--vscode-menu-border, var(--vscode-panel-border));
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    font-size: 12px;
+    white-space: nowrap;
+}
+
+.delete-older-dialog input[type="number"] {
+    width: 60px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    padding: 3px 6px;
+    font-size: 12px;
+    font-family: var(--vscode-font-family);
 }

--- a/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
@@ -1,0 +1,624 @@
+// plugin-traces-panel.ts
+// External webview script for the Plugin Traces panel.
+// Built by esbuild as IIFE for browser, loaded via <script src="...">.
+
+import { escapeHtml, escapeAttr } from './shared/dom-utils.js';
+import type {
+    PluginTracesPanelWebviewToHost,
+    PluginTracesPanelHostToWebview,
+    PluginTraceViewDto,
+    PluginTraceDetailViewDto,
+    TimelineNodeViewDto,
+    TraceFilterViewDto,
+} from './shared/message-types.js';
+import { assertNever } from './shared/assert-never.js';
+import { getVsCodeApi } from './shared/vscode-api.js';
+import { installErrorHandler } from './shared/error-handler.js';
+import { DataTable } from './shared/data-table.js';
+
+const vscode = getVsCodeApi<PluginTracesPanelWebviewToHost>();
+installErrorHandler((msg) => vscode.postMessage(msg as PluginTracesPanelWebviewToHost));
+
+// ── DOM element references ──────────────────────────────────────────────
+const filterBar = document.getElementById('filter-bar') as HTMLElement;
+const tablePane = document.getElementById('table-pane') as HTMLElement;
+const detailPane = document.getElementById('detail-pane') as HTMLElement;
+const statusText = document.getElementById('status-text') as HTMLElement;
+const refreshBtn = document.getElementById('refresh-btn') as HTMLElement;
+const deleteBtn = document.getElementById('delete-btn') as HTMLElement;
+const traceLevelBtn = document.getElementById('trace-level-btn') as HTMLElement;
+const traceLevelIndicator = document.getElementById('trace-level-indicator') as HTMLElement;
+const autoRefreshSelect = document.getElementById('auto-refresh-select') as HTMLSelectElement;
+
+// Detail pane tabs
+const detailTabs = document.querySelectorAll<HTMLElement>('.detail-tab');
+const detailTabContents = document.querySelectorAll<HTMLElement>('.detail-tab-content');
+const detailTabDetails = document.getElementById('tab-details') as HTMLElement;
+const detailTabException = document.getElementById('tab-exception') as HTMLElement;
+const detailTabMessageBlock = document.getElementById('tab-message-block') as HTMLElement;
+const detailTabConfig = document.getElementById('tab-config') as HTMLElement;
+const detailTabTimeline = document.getElementById('tab-timeline') as HTMLElement;
+
+// ── Environment picker ──────────────────────────────────────────────────
+const envPickerBtn = document.getElementById('env-picker-btn') as HTMLElement;
+const envPickerName = document.getElementById('env-picker-name') as HTMLElement;
+envPickerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'requestEnvironmentList' });
+});
+function updateEnvironmentDisplay(name: string | null): void {
+    envPickerName.textContent = name || 'No environment';
+}
+
+// ── Filter bar controller ───────────────────────────────────────────────
+const filterEntity = document.getElementById('filter-entity') as HTMLInputElement;
+const filterMessage = document.getElementById('filter-message') as HTMLInputElement;
+const filterPlugin = document.getElementById('filter-plugin') as HTMLInputElement;
+const filterMode = document.getElementById('filter-mode') as HTMLSelectElement;
+const filterExceptions = document.getElementById('filter-exceptions') as HTMLInputElement;
+
+let filterDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function collectFilter(): TraceFilterViewDto {
+    const filter: TraceFilterViewDto = {};
+    if (filterEntity.value.trim()) filter.primaryEntity = filterEntity.value.trim();
+    if (filterMessage.value.trim()) filter.messageName = filterMessage.value.trim();
+    if (filterPlugin.value.trim()) filter.typeName = filterPlugin.value.trim();
+    if (filterMode.value && filterMode.value !== 'All') filter.mode = filterMode.value;
+    if (filterExceptions.checked) filter.hasException = true;
+
+    // Merge active quick filter state
+    const lastHourPill = document.getElementById('qf-last-hour') as HTMLElement;
+    const longRunningPill = document.getElementById('qf-long-running') as HTMLElement;
+    if (lastHourPill.classList.contains('active')) {
+        filter.startDate = new Date(Date.now() - 3600000).toISOString();
+    }
+    if (longRunningPill.classList.contains('active')) {
+        filter.minDurationMs = 1000;
+    }
+    return filter;
+}
+
+function applyFilterDebounced(): void {
+    if (filterDebounceTimer) clearTimeout(filterDebounceTimer);
+    filterDebounceTimer = setTimeout(() => {
+        vscode.postMessage({ command: 'applyFilter', filter: collectFilter() });
+    }, 300);
+}
+
+filterEntity.addEventListener('input', applyFilterDebounced);
+filterMessage.addEventListener('input', applyFilterDebounced);
+filterPlugin.addEventListener('input', applyFilterDebounced);
+filterMode.addEventListener('change', applyFilterDebounced);
+filterExceptions.addEventListener('change', () => {
+    // Sync the Exceptions Only pill with the checkbox
+    const exPill = document.getElementById('qf-exceptions') as HTMLElement;
+    if (filterExceptions.checked) {
+        exPill.classList.add('active');
+    } else {
+        exPill.classList.remove('active');
+    }
+    applyFilterDebounced();
+});
+
+// Quick filter pills
+const qfLastHour = document.getElementById('qf-last-hour') as HTMLElement;
+const qfExceptions = document.getElementById('qf-exceptions') as HTMLElement;
+const qfLongRunning = document.getElementById('qf-long-running') as HTMLElement;
+const qfClearAll = document.getElementById('qf-clear-all') as HTMLElement;
+
+qfLastHour.addEventListener('click', () => {
+    qfLastHour.classList.toggle('active');
+    applyFilterDebounced();
+});
+
+qfExceptions.addEventListener('click', () => {
+    qfExceptions.classList.toggle('active');
+    filterExceptions.checked = qfExceptions.classList.contains('active');
+    applyFilterDebounced();
+});
+
+qfLongRunning.addEventListener('click', () => {
+    qfLongRunning.classList.toggle('active');
+    applyFilterDebounced();
+});
+
+qfClearAll.addEventListener('click', () => {
+    filterEntity.value = '';
+    filterMessage.value = '';
+    filterPlugin.value = '';
+    filterMode.value = 'All';
+    filterExceptions.checked = false;
+    qfLastHour.classList.remove('active');
+    qfExceptions.classList.remove('active');
+    qfLongRunning.classList.remove('active');
+    vscode.postMessage({ command: 'applyFilter', filter: {} });
+});
+
+// Filter collapse toggle
+const filterToggleBtn = document.getElementById('filter-toggle-btn') as HTMLElement;
+filterToggleBtn.addEventListener('click', () => {
+    filterBar.classList.toggle('collapsed');
+    filterToggleBtn.textContent = filterBar.classList.contains('collapsed') ? 'Show Filters' : 'Hide Filters';
+});
+
+// ── Format duration helper ──────────────────────────────────────────────
+function formatDuration(ms: number | null): string {
+    if (ms === null || ms === undefined) return '\u2014';
+    if (ms < 1000) return ms + 'ms';
+    return (ms / 1000).toFixed(2) + 's';
+}
+
+function formatDateTime(isoString: string | null | undefined): string {
+    if (!isoString) return '';
+    try {
+        return new Date(isoString).toLocaleString(undefined, {
+            year: 'numeric', month: 'short', day: 'numeric',
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+        });
+    } catch {
+        return isoString;
+    }
+}
+
+// ── DataTable setup ─────────────────────────────────────────────────────
+let selectedTraceId: string | null = null;
+let currentTraces: PluginTraceViewDto[] = [];
+
+const table = new DataTable<PluginTraceViewDto>({
+    container: tablePane,
+    columns: [
+        {
+            key: 'status',
+            label: '',
+            render: (item) => '<span class="trace-status-icon ' + escapeAttr(item.hasException ? 'exception' : 'success') + '"></span>',
+            className: '40px',
+            sortable: false,
+        },
+        {
+            key: 'createdOn',
+            label: 'Time',
+            render: (item) => escapeHtml(formatDateTime(item.createdOn)),
+            className: '140px',
+        },
+        {
+            key: 'durationMs',
+            label: 'Duration',
+            render: (item) => {
+                const text = escapeHtml(formatDuration(item.durationMs));
+                if (item.durationMs !== null && item.durationMs > 1000) {
+                    return '<span style="color: var(--vscode-editorWarning-foreground, #cca700);">' + text + '</span>';
+                }
+                return text;
+            },
+            className: '80px',
+        },
+        {
+            key: 'typeName',
+            label: 'Plugin',
+            render: (item) => '<span title="' + escapeAttr(item.typeName) + '">' + escapeHtml(item.typeName) + '</span>',
+            className: '200px',
+        },
+        {
+            key: 'primaryEntity',
+            label: 'Entity',
+            render: (item) => escapeHtml(item.primaryEntity || '\u2014'),
+            className: '120px',
+        },
+        {
+            key: 'messageName',
+            label: 'Message',
+            render: (item) => escapeHtml(item.messageName || '\u2014'),
+            className: '100px',
+        },
+        {
+            key: 'depth',
+            label: 'Depth',
+            render: (item) => escapeHtml(String(item.depth)),
+            className: '50px',
+        },
+        {
+            key: 'mode',
+            label: 'Mode',
+            render: (item) => escapeHtml(item.mode),
+            className: '60px',
+        },
+    ],
+    getRowId: (item) => item.id,
+    onRowClick: (item) => {
+        selectedTraceId = item.id;
+        vscode.postMessage({ command: 'selectTrace', id: item.id });
+    },
+    defaultSortKey: 'createdOn',
+    defaultSortDirection: 'desc',
+    statusEl: statusText,
+    formatStatus: (items) => {
+        const exceptions = items.filter(t => t.hasException).length;
+        const parts = [items.length + ' trace' + (items.length !== 1 ? 's' : '')];
+        if (exceptions > 0) parts.push(exceptions + ' exception' + (exceptions !== 1 ? 's' : ''));
+        return parts.join(' \u2014 ');
+    },
+    emptyMessage: 'No plugin traces found',
+});
+
+function applyRowClasses(): void {
+    tablePane.querySelectorAll<HTMLElement>('.data-table-row').forEach(row => {
+        const id = row.dataset.id;
+        const item = currentTraces.find(t => t.id === id);
+        if (!item) return;
+        if (item.hasException) row.classList.add('trace-row-exception');
+        if (item.durationMs !== null && item.durationMs > 1000) row.classList.add('trace-row-slow');
+    });
+}
+
+// ── Split pane resize ───────────────────────────────────────────────────
+const resizeHandle = document.getElementById('resize-handle') as HTMLElement;
+
+interface SplitState {
+    tableBasis: string;
+    detailBasis: string;
+}
+
+function restoreSplitState(): void {
+    const state = vscode.getState() as { split?: SplitState } | null;
+    if (state?.split) {
+        tablePane.style.flexBasis = state.split.tableBasis;
+        detailPane.style.flexBasis = state.split.detailBasis;
+    }
+}
+
+restoreSplitState();
+
+resizeHandle.addEventListener('mousedown', (e: MouseEvent) => {
+    e.preventDefault();
+    resizeHandle.classList.add('active');
+    const startY = e.clientY;
+    const tablePaneRect = tablePane.getBoundingClientRect();
+    const detailPaneRect = detailPane.getBoundingClientRect();
+    const startTableHeight = tablePaneRect.height;
+    const startDetailHeight = detailPaneRect.height;
+
+    function onMouseMove(ev: MouseEvent): void {
+        const delta = ev.clientY - startY;
+        const newTableHeight = Math.max(100, startTableHeight + delta);
+        const newDetailHeight = Math.max(100, startDetailHeight - delta);
+        tablePane.style.flexBasis = newTableHeight + 'px';
+        detailPane.style.flexBasis = newDetailHeight + 'px';
+    }
+
+    function onMouseUp(): void {
+        resizeHandle.classList.remove('active');
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        // Persist split ratio
+        const currentState = (vscode.getState() as Record<string, unknown>) || {};
+        vscode.setState({
+            ...currentState,
+            split: {
+                tableBasis: tablePane.style.flexBasis,
+                detailBasis: detailPane.style.flexBasis,
+            },
+        });
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+});
+
+// ── Detail pane tab switching ───────────────────────────────────────────
+let currentDetail: PluginTraceDetailViewDto | null = null;
+
+function activateTab(tabName: string): void {
+    detailTabs.forEach(t => {
+        if (t.dataset.tab === tabName) {
+            t.classList.add('active');
+        } else {
+            t.classList.remove('active');
+        }
+    });
+    detailTabContents.forEach(c => {
+        if (c.id === 'tab-' + tabName) {
+            c.classList.add('active');
+        } else {
+            c.classList.remove('active');
+        }
+    });
+
+    // Load timeline on tab activation
+    if (tabName === 'timeline' && currentDetail?.correlationId) {
+        vscode.postMessage({ command: 'loadTimeline', correlationId: currentDetail.correlationId });
+    }
+}
+
+detailTabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+        const tabName = tab.dataset.tab;
+        if (tabName) activateTab(tabName);
+    });
+});
+
+// ── Detail pane render functions ────────────────────────────────────────
+function renderDetailsTab(trace: PluginTraceDetailViewDto): void {
+    const kvPairs: [string, string][] = [
+        ['Type', trace.typeName],
+        ['Message', trace.messageName || '\u2014'],
+        ['Entity', trace.primaryEntity || '\u2014'],
+        ['Mode', trace.mode],
+        ['Operation', trace.operationType],
+        ['Depth', String(trace.depth)],
+        ['Duration', formatDuration(trace.durationMs)],
+        ['Created', formatDateTime(trace.createdOn)],
+        ['Correlation ID', trace.correlationId || '\u2014'],
+        ['Request ID', trace.requestId || '\u2014'],
+        ['Constructor', formatDuration(trace.constructorDurationMs)],
+        ['Execution Start', formatDateTime(trace.executionStartTime)],
+    ];
+
+    let html = '<div class="detail-kv">';
+    for (const [label, value] of kvPairs) {
+        html += '<span class="detail-kv-label">' + escapeHtml(label) + '</span>';
+        html += '<span>' + escapeHtml(value) + '</span>';
+    }
+    html += '</div>';
+    detailTabDetails.innerHTML = html;
+}
+
+function renderExceptionTab(trace: PluginTraceDetailViewDto): void {
+    detailTabException.innerHTML = '';
+    const pre = document.createElement('pre');
+    pre.className = 'monospace-content';
+    pre.textContent = trace.exceptionDetails || 'No exception';
+    detailTabException.appendChild(pre);
+}
+
+function renderMessageBlockTab(trace: PluginTraceDetailViewDto): void {
+    detailTabMessageBlock.innerHTML = '';
+    const pre = document.createElement('pre');
+    pre.className = 'monospace-content';
+    pre.textContent = trace.messageBlock || 'No message block';
+    detailTabMessageBlock.appendChild(pre);
+}
+
+function renderConfigTab(trace: PluginTraceDetailViewDto): void {
+    detailTabConfig.innerHTML = '';
+
+    const unsecuredLabel = document.createElement('h4');
+    unsecuredLabel.textContent = 'Unsecured Configuration';
+    unsecuredLabel.style.marginTop = '0';
+    detailTabConfig.appendChild(unsecuredLabel);
+
+    const unsecuredPre = document.createElement('pre');
+    unsecuredPre.className = 'monospace-content';
+    unsecuredPre.textContent = trace.configuration || 'No configuration';
+    detailTabConfig.appendChild(unsecuredPre);
+
+    const securedLabel = document.createElement('h4');
+    securedLabel.textContent = 'Secured Configuration';
+    detailTabConfig.appendChild(securedLabel);
+
+    const securedPre = document.createElement('pre');
+    securedPre.className = 'monospace-content';
+    securedPre.textContent = trace.secureConfiguration || 'No secured configuration';
+    detailTabConfig.appendChild(securedPre);
+}
+
+// ── Timeline waterfall renderer ─────────────────────────────────────────
+interface FlatTimelineRow {
+    node: TimelineNodeViewDto;
+}
+
+function flattenTimeline(nodes: TimelineNodeViewDto[]): FlatTimelineRow[] {
+    const rows: FlatTimelineRow[] = [];
+    function walk(nodeList: TimelineNodeViewDto[]): void {
+        for (const node of nodeList) {
+            rows.push({ node });
+            if (node.children && node.children.length > 0) {
+                walk(node.children);
+            }
+        }
+    }
+    walk(nodes);
+    return rows;
+}
+
+function renderTimeline(nodes: TimelineNodeViewDto[]): void {
+    const rows = flattenTimeline(nodes);
+
+    if (rows.length === 0) {
+        detailTabTimeline.innerHTML = '<div class="empty-state">' + escapeHtml('No timeline data available') + '</div>';
+        return;
+    }
+
+    let html = '<div class="timeline-container">';
+    html += '<div class="timeline-header">';
+    html += '<span class="timeline-header-label">' + escapeHtml('Plugin') + '</span>';
+    html += '<span class="timeline-header-bar">' + escapeHtml('Duration') + '</span>';
+    html += '</div>';
+
+    for (const row of rows) {
+        const n = row.node;
+        const paddingLeft = n.hierarchyDepth * 16;
+        const labelText = escapeHtml(n.typeName + ' / ' + (n.messageName || '\u2014'));
+        const barClass = n.hasException ? 'exception' : (n.durationMs !== null && n.durationMs > 1000 ? 'slow' : 'normal');
+        const durationText = escapeHtml(n.durationMs !== null ? n.durationMs + 'ms' : '\u2014');
+
+        html += '<div class="timeline-row">';
+        html += '<span class="timeline-label" style="padding-left: ' + escapeAttr(String(paddingLeft)) + 'px;" title="' + escapeAttr(n.typeName) + '">' + labelText + '</span>';
+        html += '<div class="timeline-bar-container">';
+        html += '<div class="timeline-bar ' + escapeAttr(barClass) + '" style="left: ' + escapeAttr(String(n.offsetPercent)) + '%; width: ' + escapeAttr(String(n.widthPercent)) + '%;"></div>';
+        html += '</div>';
+        html += '<span class="timeline-duration">' + durationText + '</span>';
+        html += '</div>';
+    }
+
+    html += '</div>';
+    detailTabTimeline.innerHTML = html;
+}
+
+// ── Message handler ─────────────────────────────────────────────────────
+window.addEventListener('message', (event: MessageEvent<PluginTracesPanelHostToWebview>) => {
+    const msg = event.data;
+    // VS Code sends internal messages that lack 'command' — ignore them
+    if (!msg || typeof msg !== 'object' || !('command' in msg)) return;
+
+    switch (msg.command) {
+        case 'updateEnvironment':
+            updateEnvironmentDisplay(msg.name);
+            {
+                const toolbar = document.querySelector('.toolbar');
+                if (toolbar) {
+                    if (msg.envType) {
+                        toolbar.setAttribute('data-env-type', msg.envType.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-type');
+                    }
+                    if (msg.envColor) {
+                        toolbar.setAttribute('data-env-color', msg.envColor.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-color');
+                    }
+                }
+            }
+            break;
+
+        case 'tracesLoaded':
+            currentTraces = msg.traces;
+            {
+                const previousSelectedId = selectedTraceId;
+                table.setItems(msg.traces);
+                applyRowClasses();
+                // Preserve selection if the trace still exists
+                if (previousSelectedId) {
+                    const stillExists = msg.traces.some(t => t.id === previousSelectedId);
+                    if (stillExists) {
+                        selectedTraceId = previousSelectedId;
+                        const row = tablePane.querySelector<HTMLElement>('[data-id="' + CSS.escape(previousSelectedId) + '"]');
+                        if (row) {
+                            row.classList.add('selected');
+                        }
+                    } else {
+                        selectedTraceId = null;
+                    }
+                }
+            }
+            {
+                const reconnectBanner = document.getElementById('reconnect-banner');
+                if (reconnectBanner) reconnectBanner.style.display = 'none';
+            }
+            break;
+
+        case 'traceDetailLoaded':
+            currentDetail = msg.trace;
+            renderDetailsTab(msg.trace);
+            renderExceptionTab(msg.trace);
+            renderMessageBlockTab(msg.trace);
+            renderConfigTab(msg.trace);
+            // Clear timeline tab — will be loaded on click
+            detailTabTimeline.innerHTML = '<div class="empty-state">' + escapeHtml('Click the Timeline tab to load execution chain') + '</div>';
+            // Show detail pane and select Details tab
+            detailPane.classList.add('visible');
+            activateTab('details');
+            break;
+
+        case 'timelineLoaded':
+            renderTimeline(msg.nodes);
+            break;
+
+        case 'traceLevelLoaded':
+            traceLevelIndicator.textContent = msg.level;
+            if (msg.levelValue === 0) {
+                traceLevelIndicator.title = 'Trace level is Off \u2014 no new traces will be recorded';
+                traceLevelIndicator.style.opacity = '0.6';
+            } else {
+                traceLevelIndicator.title = 'Trace level: ' + msg.level;
+                traceLevelIndicator.style.opacity = '1';
+            }
+            break;
+
+        case 'deleteComplete':
+            statusText.textContent = msg.deletedCount + ' trace' + (msg.deletedCount !== 1 ? 's' : '') + ' deleted';
+            setTimeout(() => {
+                vscode.postMessage({ command: 'refresh' });
+            }, 1000);
+            break;
+
+        case 'loading':
+            tablePane.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading plugin traces...</div></div>';
+            statusText.textContent = 'Loading...';
+            break;
+
+        case 'error':
+            tablePane.innerHTML = '<div class="error-state">' + escapeHtml(msg.message) + '</div>';
+            statusText.textContent = 'Error';
+            break;
+
+        case 'daemonReconnected':
+            {
+                const banner = document.getElementById('reconnect-banner');
+                if (banner) banner.style.display = '';
+            }
+            break;
+
+        default:
+            assertNever(msg);
+    }
+});
+
+// ── Toolbar handlers ────────────────────────────────────────────────────
+refreshBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'refresh' });
+});
+
+autoRefreshSelect.addEventListener('change', () => {
+    const value = autoRefreshSelect.value;
+    const interval = value === 'off' ? null : parseInt(value, 10);
+    vscode.postMessage({ command: 'setAutoRefresh', intervalSeconds: interval });
+
+    // Visual indicator for active auto-refresh
+    if (interval !== null) {
+        autoRefreshSelect.classList.add('auto-refresh-active');
+    } else {
+        autoRefreshSelect.classList.remove('auto-refresh-active');
+    }
+});
+
+deleteBtn.addEventListener('click', () => {
+    const selId = table.getSelectedId();
+    if (selId) {
+        vscode.postMessage({ command: 'deleteTraces', ids: [selId] });
+    }
+});
+
+traceLevelBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'requestTraceLevel' });
+});
+
+// Reconnect banner refresh
+const reconnectRefresh = document.getElementById('reconnect-refresh');
+if (reconnectRefresh) {
+    reconnectRefresh.addEventListener('click', (e) => {
+        e.preventDefault();
+        const banner = document.getElementById('reconnect-banner');
+        if (banner) banner.style.display = 'none';
+        vscode.postMessage({ command: 'refresh' });
+    });
+}
+
+// ── Keyboard shortcuts ──────────────────────────────────────────────────
+document.addEventListener('keydown', (e) => {
+    // Escape = hide detail pane and clear selection
+    if (e.key === 'Escape' && detailPane.classList.contains('visible')) {
+        detailPane.classList.remove('visible');
+        table.clearSelection();
+        selectedTraceId = null;
+        currentDetail = null;
+    }
+
+    // F5 = refresh
+    if (e.key === 'F5') {
+        e.preventDefault();
+        vscode.postMessage({ command: 'refresh' });
+    }
+});
+
+// ── Ready signal ────────────────────────────────────────────────────────
+vscode.postMessage({ command: 'ready' });

--- a/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/plugin-traces-panel.ts
@@ -126,7 +126,7 @@ qfClearAll.addEventListener('click', () => {
     filterEntity.value = '';
     filterMessage.value = '';
     filterPlugin.value = '';
-    filterMode.value = 'All';
+    filterMode.value = '';
     filterExceptions.checked = false;
     qfLastHour.classList.remove('active');
     qfExceptions.classList.remove('active');
@@ -570,7 +570,7 @@ refreshBtn.addEventListener('click', () => {
 
 autoRefreshSelect.addEventListener('change', () => {
     const value = autoRefreshSelect.value;
-    const interval = value === 'off' ? null : parseInt(value, 10);
+    const interval = value ? parseInt(value, 10) : null;
     vscode.postMessage({ command: 'setAutoRefresh', intervalSeconds: interval });
 
     // Visual indicator for active auto-refresh
@@ -581,10 +581,68 @@ autoRefreshSelect.addEventListener('change', () => {
     }
 });
 
+// ── Delete dropdown menu ─────────────────────────────────────────────────
+const deleteDropdown = document.createElement('div');
+deleteDropdown.className = 'delete-dropdown';
+deleteDropdown.style.display = 'none';
+deleteDropdown.innerHTML = [
+    '<button class="delete-dropdown-item" id="delete-selected">Delete selected</button>',
+    '<button class="delete-dropdown-item" id="delete-older-than">Delete older than...</button>',
+].join('');
+deleteBtn.parentElement!.style.position = 'relative';
+deleteBtn.insertAdjacentElement('afterend', deleteDropdown);
+
 deleteBtn.addEventListener('click', () => {
+    const isVisible = deleteDropdown.style.display !== 'none';
+    deleteDropdown.style.display = isVisible ? 'none' : '';
+});
+
+document.getElementById('delete-selected')!.addEventListener('click', () => {
+    deleteDropdown.style.display = 'none';
     const selId = table.getSelectedId();
     if (selId) {
         vscode.postMessage({ command: 'deleteTraces', ids: [selId] });
+    }
+});
+
+// Inline input for "Delete older than" (prompt() is unavailable in webviews)
+const deleteOlderDialog = document.createElement('div');
+deleteOlderDialog.className = 'delete-older-dialog';
+deleteOlderDialog.style.display = 'none';
+deleteOlderDialog.innerHTML = [
+    '<label>Delete traces older than</label>',
+    '<input type="number" id="delete-older-days" min="1" value="7" />',
+    '<label>day(s)</label>',
+    '<button id="delete-older-confirm" class="delete-dropdown-item">Delete</button>',
+    '<button id="delete-older-cancel" class="delete-dropdown-item">Cancel</button>',
+].join(' ');
+deleteBtn.parentElement!.appendChild(deleteOlderDialog);
+
+document.getElementById('delete-older-than')!.addEventListener('click', () => {
+    deleteDropdown.style.display = 'none';
+    deleteOlderDialog.style.display = '';
+    const daysInput = document.getElementById('delete-older-days') as HTMLInputElement;
+    daysInput.value = '7';
+    daysInput.focus();
+});
+
+document.getElementById('delete-older-confirm')!.addEventListener('click', () => {
+    const daysInput = document.getElementById('delete-older-days') as HTMLInputElement;
+    const days = parseInt(daysInput.value, 10);
+    deleteOlderDialog.style.display = 'none';
+    if (!isNaN(days) && days > 0) {
+        vscode.postMessage({ command: 'deleteOlderThan', days });
+    }
+});
+
+document.getElementById('delete-older-cancel')!.addEventListener('click', () => {
+    deleteOlderDialog.style.display = 'none';
+});
+
+// Close dropdown when clicking elsewhere
+document.addEventListener('click', (e) => {
+    if (!deleteBtn.contains(e.target as Node) && !deleteDropdown.contains(e.target as Node)) {
+        deleteDropdown.style.display = 'none';
     }
 });
 

--- a/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
@@ -129,3 +129,86 @@ export type ImportJobsPanelHostToWebview =
     | { command: 'loading' }
     | { command: 'error'; message: string }
     | { command: 'daemonReconnected' };
+
+// ── Plugin Traces Panel ──────────────────────────────────────────────────
+
+/** Plugin trace info as sent to the webview for table display. */
+export interface PluginTraceViewDto {
+    id: string;
+    typeName: string;
+    messageName: string | null;
+    primaryEntity: string | null;
+    mode: string;
+    operationType: string;
+    depth: number;
+    createdOn: string;
+    durationMs: number | null;
+    hasException: boolean;
+    correlationId: string | null;
+}
+
+/** Plugin trace detail for the detail pane. */
+export interface PluginTraceDetailViewDto extends PluginTraceViewDto {
+    constructorDurationMs: number | null;
+    executionStartTime: string | null;
+    exceptionDetails: string | null;
+    messageBlock: string | null;
+    configuration: string | null;
+    secureConfiguration: string | null;
+    requestId: string | null;
+}
+
+/** Timeline node for the waterfall visualization. */
+export interface TimelineNodeViewDto {
+    traceId: string;
+    typeName: string;
+    messageName: string | null;
+    depth: number;
+    durationMs: number | null;
+    hasException: boolean;
+    offsetPercent: number;
+    widthPercent: number;
+    hierarchyDepth: number;
+    children: TimelineNodeViewDto[];
+}
+
+/** Filter state sent from webview to host. */
+export interface TraceFilterViewDto {
+    typeName?: string;
+    messageName?: string;
+    primaryEntity?: string;
+    mode?: string;
+    hasException?: boolean;
+    correlationId?: string;
+    minDurationMs?: number;
+    startDate?: string;
+    endDate?: string;
+}
+
+/** Messages the Plugin Traces Panel webview sends to the extension host. */
+export type PluginTracesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'applyFilter'; filter: TraceFilterViewDto }
+    | { command: 'selectTrace'; id: string }
+    | { command: 'loadTimeline'; correlationId: string }
+    | { command: 'deleteTraces'; ids: string[] }
+    | { command: 'deleteOlderThan'; days: number }
+    | { command: 'requestTraceLevel' }
+    | { command: 'setTraceLevel'; level: string }
+    | { command: 'setAutoRefresh'; intervalSeconds: number | null }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Plugin Traces Panel webview. */
+export type PluginTracesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'tracesLoaded'; traces: PluginTraceViewDto[] }
+    | { command: 'traceDetailLoaded'; trace: PluginTraceDetailViewDto }
+    | { command: 'timelineLoaded'; nodes: TimelineNodeViewDto[] }
+    | { command: 'traceLevelLoaded'; level: string; levelValue: number }
+    | { command: 'deleteComplete'; deletedCount: number }
+    | { command: 'loading' }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -317,3 +317,79 @@ export interface ImportJobInfoDto {
 export interface ImportJobDetailDto extends ImportJobInfoDto {
     data: string | null;
 }
+
+// ── Plugin Traces ────────────────────────────────────────────────────────────
+
+export interface PluginTracesListResponse {
+    traces: PluginTraceInfoDto[];
+}
+
+export interface PluginTracesGetResponse {
+    trace: PluginTraceDetailDto;
+}
+
+export interface PluginTracesTimelineResponse {
+    nodes: TimelineNodeDto[];
+}
+
+export interface PluginTracesDeleteResponse {
+    deletedCount: number;
+}
+
+export interface PluginTracesTraceLevelResponse {
+    level: string;
+    levelValue: number;
+}
+
+export interface PluginTracesSetTraceLevelResponse {
+    success: boolean;
+}
+
+export interface PluginTraceInfoDto {
+    id: string;
+    typeName: string;
+    messageName: string | null;
+    primaryEntity: string | null;
+    mode: string;
+    operationType: string;
+    depth: number;
+    createdOn: string;
+    durationMs: number | null;
+    hasException: boolean;
+    correlationId: string | null;
+}
+
+export interface PluginTraceDetailDto extends PluginTraceInfoDto {
+    constructorDurationMs: number | null;
+    executionStartTime: string | null;
+    exceptionDetails: string | null;
+    messageBlock: string | null;
+    configuration: string | null;
+    secureConfiguration: string | null;
+    requestId: string | null;
+}
+
+export interface TimelineNodeDto {
+    traceId: string;
+    typeName: string;
+    messageName: string | null;
+    depth: number;
+    durationMs: number | null;
+    hasException: boolean;
+    offsetPercent: number;
+    widthPercent: number;
+    hierarchyDepth: number;
+    children: TimelineNodeDto[];
+}
+
+export interface TraceFilterDto {
+    typeName?: string;
+    messageName?: string;
+    primaryEntity?: string;
+    mode?: string;
+    hasException?: boolean;
+    correlationId?: string;
+    minDurationMs?: number;
+    startDate?: string;
+    endDate?: string;
+}

--- a/src/PPDS.Extension/src/views/toolsTreeView.ts
+++ b/src/PPDS.Extension/src/views/toolsTreeView.ts
@@ -38,6 +38,7 @@ export class ToolsTreeDataProvider
         { label: 'Notebooks', commandId: 'ppds.openNotebooks', icon: 'notebook' },
         { label: 'Solutions', commandId: 'ppds.openSolutions', icon: 'package' },
         { label: 'Import Jobs', commandId: 'ppds.openImportJobs', icon: 'history' },
+        { label: 'Plugin Traces', commandId: 'ppds.openPluginTraces', icon: 'debug-stackframe' },
         { label: 'Show Logs', commandId: 'ppds.showLogs', icon: 'output', alwaysEnabled: true },
     ];
 

--- a/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
+++ b/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
@@ -25,34 +25,40 @@ public sealed class PluginTracesDeleteTool
     }
 
     /// <summary>
-    /// Deletes plugin trace logs by specific IDs or by age threshold.
+    /// Deletes plugin trace logs by specific IDs, by age threshold, or by filter criteria.
     /// </summary>
     /// <param name="ids">Trace IDs to delete (array of GUID strings).</param>
     /// <param name="olderThanDays">Delete all traces older than this many days.</param>
+    /// <param name="typeName">Delete traces matching this plugin type name.</param>
+    /// <param name="messageName">Delete traces matching this message name.</param>
+    /// <param name="primaryEntity">Delete traces matching this entity logical name.</param>
+    /// <param name="errorsOnly">Delete only traces with exceptions.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Result with count of deleted traces.</returns>
     [McpServerTool(Name = "ppds_plugin_traces_delete")]
-    [Description("Delete plugin trace logs. Provide either specific IDs for targeted deletion, or olderThanDays for bulk cleanup. Exactly one parameter must be specified.")]
+    [Description("Delete plugin trace logs. Provide specific IDs for targeted deletion, olderThanDays for age-based cleanup, or filter parameters (typeName, messageName, primaryEntity, errorsOnly) for criteria-based deletion. Priority: ids > olderThanDays > filter.")]
     public async Task<PluginTracesDeleteResult> ExecuteAsync(
         [Description("Trace IDs to delete (array of GUID strings from ppds_plugin_traces_list)")]
         string[]? ids = null,
         [Description("Delete all traces older than this many days (minimum 1). Use for bulk cleanup.")]
         int? olderThanDays = null,
+        [Description("Delete traces matching this plugin type name")]
+        string? typeName = null,
+        [Description("Delete traces matching this message name (e.g., 'Create', 'Update')")]
+        string? messageName = null,
+        [Description("Delete traces matching this entity logical name (e.g., 'account')")]
+        string? primaryEntity = null,
+        [Description("Delete only traces that have exceptions")]
+        bool? errorsOnly = null,
         CancellationToken cancellationToken = default)
     {
-        if (ids == null && olderThanDays == null)
-        {
-            return new PluginTracesDeleteResult
-            {
-                Error = "At least one parameter is required: provide 'ids' for targeted deletion or 'olderThanDays' for bulk cleanup."
-            };
-        }
+        var hasFilter = typeName != null || messageName != null || primaryEntity != null || errorsOnly == true;
 
-        if (ids != null && olderThanDays != null)
+        if (ids == null && olderThanDays == null && !hasFilter)
         {
             return new PluginTracesDeleteResult
             {
-                Error = "Provide only one of 'ids' or 'olderThanDays', not both."
+                Error = "At least one parameter is required: provide 'ids' for targeted deletion, 'olderThanDays' for age-based cleanup, or filter parameters (typeName, messageName, primaryEntity, errorsOnly) for criteria-based deletion."
             };
         }
 
@@ -64,7 +70,12 @@ public sealed class PluginTracesDeleteTool
             return await DeleteByIdsAsync(traceService, ids, cancellationToken).ConfigureAwait(false);
         }
 
-        return await DeleteOlderThanAsync(traceService, olderThanDays!.Value, cancellationToken).ConfigureAwait(false);
+        if (olderThanDays != null)
+        {
+            return await DeleteOlderThanAsync(traceService, olderThanDays.Value, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await DeleteByFilterAsync(traceService, typeName, messageName, primaryEntity, errorsOnly, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<PluginTracesDeleteResult> DeleteByIdsAsync(
@@ -117,6 +128,30 @@ public sealed class PluginTracesDeleteTool
 
         var olderThan = TimeSpan.FromDays(olderThanDays);
         var deletedCount = await traceService.DeleteOlderThanAsync(olderThan, progress: null, cancellationToken).ConfigureAwait(false);
+
+        return new PluginTracesDeleteResult
+        {
+            DeletedCount = deletedCount
+        };
+    }
+
+    private static async Task<PluginTracesDeleteResult> DeleteByFilterAsync(
+        IPluginTraceService traceService,
+        string? typeName,
+        string? messageName,
+        string? primaryEntity,
+        bool? errorsOnly,
+        CancellationToken cancellationToken)
+    {
+        var filter = new PluginTraceFilter
+        {
+            TypeName = typeName,
+            MessageName = messageName,
+            PrimaryEntity = primaryEntity,
+            HasException = errorsOnly == true ? true : null
+        };
+
+        var deletedCount = await traceService.DeleteByFilterAsync(filter, progress: null, cancellationToken).ConfigureAwait(false);
 
         return new PluginTracesDeleteResult
         {

--- a/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
+++ b/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
@@ -1,0 +1,145 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that deletes plugin trace logs.
+/// </summary>
+[McpServerToolType]
+public sealed class PluginTracesDeleteTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginTracesDeleteTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public PluginTracesDeleteTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Deletes plugin trace logs by specific IDs or by age threshold.
+    /// </summary>
+    /// <param name="ids">Trace IDs to delete (array of GUID strings).</param>
+    /// <param name="olderThanDays">Delete all traces older than this many days.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result with count of deleted traces.</returns>
+    [McpServerTool(Name = "ppds_plugin_traces_delete")]
+    [Description("Delete plugin trace logs. Provide either specific IDs for targeted deletion, or olderThanDays for bulk cleanup. Exactly one parameter must be specified.")]
+    public async Task<PluginTracesDeleteResult> ExecuteAsync(
+        [Description("Trace IDs to delete (array of GUID strings from ppds_plugin_traces_list)")]
+        string[]? ids = null,
+        [Description("Delete all traces older than this many days (minimum 1). Use for bulk cleanup.")]
+        int? olderThanDays = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids == null && olderThanDays == null)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "At least one parameter is required: provide 'ids' for targeted deletion or 'olderThanDays' for bulk cleanup."
+            };
+        }
+
+        if (ids != null && olderThanDays != null)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "Provide only one of 'ids' or 'olderThanDays', not both."
+            };
+        }
+
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var traceService = serviceProvider.GetRequiredService<IPluginTraceService>();
+
+        if (ids != null)
+        {
+            return await DeleteByIdsAsync(traceService, ids, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await DeleteOlderThanAsync(traceService, olderThanDays!.Value, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<PluginTracesDeleteResult> DeleteByIdsAsync(
+        IPluginTraceService traceService,
+        string[] ids,
+        CancellationToken cancellationToken)
+    {
+        if (ids.Length == 0)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "The 'ids' array must contain at least one trace ID."
+            };
+        }
+
+        var guids = new List<Guid>(ids.Length);
+        foreach (var id in ids)
+        {
+            if (!Guid.TryParse(id, out var guid))
+            {
+                return new PluginTracesDeleteResult
+                {
+                    Error = $"Invalid trace ID format: '{id}'. Expected a GUID."
+                };
+            }
+
+            guids.Add(guid);
+        }
+
+        var deletedCount = await traceService.DeleteByIdsAsync(guids, progress: null, cancellationToken).ConfigureAwait(false);
+
+        return new PluginTracesDeleteResult
+        {
+            DeletedCount = deletedCount
+        };
+    }
+
+    private static async Task<PluginTracesDeleteResult> DeleteOlderThanAsync(
+        IPluginTraceService traceService,
+        int olderThanDays,
+        CancellationToken cancellationToken)
+    {
+        if (olderThanDays < 1)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "The 'olderThanDays' parameter must be at least 1."
+            };
+        }
+
+        var olderThan = TimeSpan.FromDays(olderThanDays);
+        var deletedCount = await traceService.DeleteOlderThanAsync(olderThan, progress: null, cancellationToken).ConfigureAwait(false);
+
+        return new PluginTracesDeleteResult
+        {
+            DeletedCount = deletedCount
+        };
+    }
+}
+
+/// <summary>
+/// Result of the plugin_traces_delete tool.
+/// </summary>
+public sealed class PluginTracesDeleteResult
+{
+    /// <summary>
+    /// Number of traces deleted.
+    /// </summary>
+    [JsonPropertyName("deletedCount")]
+    public int DeletedCount { get; set; }
+
+    /// <summary>
+    /// Error message if the operation failed validation.
+    /// </summary>
+    [JsonPropertyName("error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Error { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
+++ b/src/PPDS.Mcp/Tools/PluginTracesDeleteTool.cs
@@ -36,7 +36,7 @@ public sealed class PluginTracesDeleteTool
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Result with count of deleted traces.</returns>
     [McpServerTool(Name = "ppds_plugin_traces_delete")]
-    [Description("Delete plugin trace logs. Provide specific IDs for targeted deletion, olderThanDays for age-based cleanup, or filter parameters (typeName, messageName, primaryEntity, errorsOnly) for criteria-based deletion. Priority: ids > olderThanDays > filter.")]
+    [Description("Delete plugin trace logs. Provide exactly one mode: specific IDs for targeted deletion, olderThanDays for age-based cleanup, or filter parameters (typeName, messageName, primaryEntity, errorsOnly) for criteria-based deletion.")]
     public async Task<PluginTracesDeleteResult> ExecuteAsync(
         [Description("Trace IDs to delete (array of GUID strings from ppds_plugin_traces_list)")]
         string[]? ids = null,
@@ -54,11 +54,23 @@ public sealed class PluginTracesDeleteTool
     {
         var hasFilter = typeName != null || messageName != null || primaryEntity != null || errorsOnly == true;
 
-        if (ids == null && olderThanDays == null && !hasFilter)
+        int modeCount = (ids != null && ids.Length > 0 ? 1 : 0)
+            + (olderThanDays.HasValue ? 1 : 0)
+            + (hasFilter ? 1 : 0);
+
+        if (modeCount == 0)
         {
             return new PluginTracesDeleteResult
             {
                 Error = "At least one parameter is required: provide 'ids' for targeted deletion, 'olderThanDays' for age-based cleanup, or filter parameters (typeName, messageName, primaryEntity, errorsOnly) for criteria-based deletion."
+            };
+        }
+
+        if (modeCount > 1)
+        {
+            return new PluginTracesDeleteResult
+            {
+                Error = "Only one deletion mode may be used per call: 'ids', 'olderThanDays', or filter parameters (typeName, messageName, primaryEntity, errorsOnly)."
             };
         }
 


### PR DESCRIPTION
## Summary

- Implement Plugin Traces panel (Phase 2b of panel-parity spec) across all 4 surfaces: Daemon RPC, VS Code extension, TUI, and MCP
- Add 6 RPC endpoints (`pluginTraces/list`, `get`, `timeline`, `delete`, `traceLevel`, `setTraceLevel`) with full DTO mapping
- Create VS Code webview panel with filter bar (entity/message/plugin/mode/exceptions/date range + quick filters), resizable split pane, 5-tab detail view (Details, Exception, Message Block, Configuration, Timeline), horizontal waterfall timeline visualization, auto-refresh, delete with confirmation, trace level management with volume warning
- Create TUI `PluginTracesScreen` with TableView + 5 dialogs (filter, detail, timeline, trace level, delete confirmation)
- Add `ppds_plugin_traces_delete` MCP tool supporting deletion by IDs, by filter, and by age
- All surfaces handle "trace level is Off" with informational messaging

## Test plan

- [x] .NET build: 0 errors, 0 warnings
- [x] .NET unit tests: 10,225+ passing across net8.0/net9.0/net10.0
- [x] TypeScript typecheck: clean (host + webview configs)
- [x] ESLint: 0 errors
- [x] Extension unit tests: 244 passing (16 test files)
- [x] Pre-commit hooks pass on all commits
- [x] Impartial code review: 3 critical + 7 important findings, all fixed
- [ ] Manual: Open Plugin Traces panel, verify filter bar renders with all controls
- [ ] Manual: Select trace → detail pane opens with 5 tabs
- [ ] Manual: Click Timeline tab → waterfall renders with correct positioning
- [ ] Manual: Auto-refresh at 5s interval preserves selection
- [ ] Manual: Delete selected trace with confirmation dialog
- [ ] Manual: Set trace level to All → volume warning shown
- [ ] Manual: TUI Plugin Traces screen via Tools menu

Closes #342, #346
Related: #585, #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)