### PR TITLE
feat(panel): add Metadata Browser panel (Phase 2c)

### DIFF
--- a/docs/plans/2026-03-17-metadata-browser-panel.md
+++ b/docs/plans/2026-03-17-metadata-browser-panel.md
@@ -1,0 +1,984 @@
+# Metadata Browser Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the Metadata Browser panel across all 4 surfaces (Daemon RPC, VS Code extension, TUI, MCP), providing entity/attribute/relationship/key/privilege/choices browsing with a split-pane layout.
+
+**Architecture:** The domain service (`IMetadataService`) already exists with full entity metadata retrieval. We replace the stub `schema/*` RPC endpoints with richer `metadata/*` endpoints, add a VS Code webview panel with a split-pane layout (entity list + 5-tab detail), a TUI screen with SplitterView, and one new MCP tool. All surfaces call the same service methods (Constitution A1, A2).
+
+**Tech Stack:** C# (.NET 8), TypeScript (VS Code extension + webview), Terminal.Gui (TUI), StreamJsonRpc (RPC), ModelContextProtocol (MCP)
+
+**Spec:** `specs/panel-parity.md` — Panel 5 (Metadata Browser), Acceptance Criteria AC-MB-01 through AC-MB-10
+
+**Issues:** #338, #347, #354, #590
+
+---
+
+## Design Decisions
+
+### Replace `schema/*` with `metadata/*` RPC endpoints
+The existing `schema/entities` and `schema/attributes` RPC methods are unused stubs — the IntelliSense pipeline uses `query/complete` which calls `ICachedMetadataProvider` server-side, not through RPC. The new `metadata/entities` and `metadata/entity` endpoints return richer payloads and serve the panel. The old `schema/*` methods, their DTOs (`SchemaEntitiesResponse`, `EntitySummaryDto`, `SchemaAttributesResponse`, `AttributeSummaryDto`), the TypeScript client wrappers (`schemaEntities()`, `schemaAttributes()`), and their TypeScript interfaces are removed.
+
+### Single `GetEntityAsync()` call for entity detail
+`metadata/entity` uses a single `IMetadataService.GetEntityAsync()` call with all EntityFilters (Entity | Attributes | Relationships | Privileges). One round-trip, atomic response, already implemented and tested. Keys are included in `EntityFilters.Entity` automatically. No parallel decomposition needed — the service layer has individual methods (`GetAttributesAsync`, etc.) for IntelliSense, but the panel doesn't use them.
+
+### Global option sets via `includeGlobalOptionSets` flag
+`metadata/entity` accepts an optional `includeGlobalOptionSets` parameter (default `false`). When `true`, the server inspects the entity's attributes for `isGlobalOptionSet: true`, extracts the distinct option set names, calls `GetOptionSetAsync()` for each in parallel, and returns them in a `globalOptionSets` array alongside the entity detail. This avoids a client-side bounce (the client would need the attribute list first to know which option sets to request).
+
+### Choices tab shows both entity-scoped and global option sets
+The Choices tab has two sections: (1) entity-scoped choice attributes with their inline option values (filtered from the attributes array where `options?.length > 0`), and (2) global option sets used by this entity's attributes (from the `globalOptionSets` response array). The old metadata browser showed both.
+
+### Flat DOM list for entity list (no virtual scrolling)
+500+ entity `<div>` rows is trivially small for modern browsers. Client-side search filters with `display: none`. Virtual scrolling would be over-engineering for a simple text list.
+
+### Reuse DataTable component for detail tabs
+Attributes tab (400+ rows) benefits from existing sort and status bar. DataTable is proven and avoids building a second table component. Nested scrolling managed with proper CSS containment.
+
+---
+
+## File Structure
+
+### Files to modify
+| File | Change |
+|------|--------|
+| `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` | Remove `schema/*` methods + DTOs; add `metadata/entities` and `metadata/entity` RPC methods + DTOs |
+| `src/PPDS.Dataverse/Metadata/IMetadataService.cs` | Add `GetEntityWithGlobalOptionSetsAsync()` method |
+| `src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs` | Implement `GetEntityWithGlobalOptionSetsAsync()` |
+| `src/PPDS.Extension/src/types.ts` | Remove `Schema*` interfaces; add `Metadata*` interfaces |
+| `src/PPDS.Extension/src/daemonClient.ts` | Remove `schemaEntities()`/`schemaAttributes()`; add `metadataEntities()`/`metadataEntity()` |
+| `src/PPDS.Extension/src/panels/webview/shared/message-types.ts` | Add Metadata Browser panel message types |
+| `src/PPDS.Extension/esbuild.js` | Add metadata-browser-panel JS + CSS entries |
+| `src/PPDS.Extension/src/extension.ts` | Register `ppds.openMetadataBrowser` command |
+| `src/PPDS.Extension/src/views/toolsTreeView.ts` | Add Metadata Browser to the Tools tree |
+| `src/PPDS.Extension/package.json` | Add command contributions + menu items |
+| `src/PPDS.Cli/Tui/TuiShell.cs` | Add menu item + NavigateToMetadataBrowser() method |
+
+### Files to create
+| File | Purpose |
+|------|---------|
+| `src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts` | Host-side panel (extends WebviewPanelBase) |
+| `src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts` | Browser-side webview script |
+| `src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css` | Panel-specific CSS |
+| `src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs` | TUI screen (extends TuiScreenBase) |
+| `src/PPDS.Mcp/Tools/MetadataEntitiesListTool.cs` | MCP tool: `ppds_metadata_entities` |
+| `src/PPDS.Extension/src/__tests__/panels/metadataBrowserPanel.test.ts` | Unit tests for panel message handling |
+
+### Files to delete
+| File | Reason |
+|------|--------|
+| (none — removals are inline edits to existing files) | |
+
+---
+
+## Chunk 1: Service Layer — Global Option Set Aggregation
+
+### Task 1: Add `GetEntityWithGlobalOptionSetsAsync` to IMetadataService
+
+**Files:**
+- Modify: `src/PPDS.Dataverse/Metadata/IMetadataService.cs`
+
+- [ ] **Step 1: Add the new method to the interface**
+
+Add after `GetEntityAsync` (line 41):
+
+```csharp
+/// <summary>
+/// Gets full metadata for a specific entity, optionally including
+/// global option set values for picklist attributes.
+/// </summary>
+/// <param name="logicalName">The entity logical name.</param>
+/// <param name="includeGlobalOptionSets">If true, fetches values for any global option sets used by picklist attributes.</param>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>Full entity metadata with optional global option sets.</returns>
+Task<(EntityMetadataDto Entity, IReadOnlyList<OptionSetMetadataDto> GlobalOptionSets)> GetEntityWithGlobalOptionSetsAsync(
+    string logicalName,
+    bool includeGlobalOptionSets = false,
+    CancellationToken cancellationToken = default);
+```
+
+### Task 2: Implement `GetEntityWithGlobalOptionSetsAsync` in DataverseMetadataService
+
+**Files:**
+- Modify: `src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs`
+
+- [ ] **Step 1: Implement the method**
+
+Add after `GetEntityAsync` (around line 152):
+
+```csharp
+/// <inheritdoc />
+public async Task<(EntityMetadataDto Entity, IReadOnlyList<OptionSetMetadataDto> GlobalOptionSets)> GetEntityWithGlobalOptionSetsAsync(
+    string logicalName,
+    bool includeGlobalOptionSets = false,
+    CancellationToken cancellationToken = default)
+{
+    var entity = await GetEntityAsync(
+        logicalName,
+        includeAttributes: true,
+        includeRelationships: true,
+        includeKeys: true,
+        includePrivileges: true,
+        cancellationToken: cancellationToken);
+
+    if (!includeGlobalOptionSets)
+    {
+        return (entity, Array.Empty<OptionSetMetadataDto>());
+    }
+
+    // Extract distinct global option set names from picklist attributes
+    var globalOptionSetNames = entity.Attributes
+        .Where(a => a.IsGlobalOptionSet && !string.IsNullOrEmpty(a.OptionSetName))
+        .Select(a => a.OptionSetName!)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    if (globalOptionSetNames.Count == 0)
+    {
+        return (entity, Array.Empty<OptionSetMetadataDto>());
+    }
+
+    // Fetch all global option sets in parallel
+    var optionSetTasks = globalOptionSetNames.Select(name =>
+        GetOptionSetAsync(name, cancellationToken));
+    var optionSets = await Task.WhenAll(optionSetTasks).ConfigureAwait(false);
+
+    return (entity, optionSets);
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build src/PPDS.Dataverse/PPDS.Dataverse.csproj -v q`
+Expected: Build succeeded.
+
+---
+
+## Chunk 2: RPC Layer — Replace `schema/*` with `metadata/*`
+
+### Task 3: Remove `schema/*` RPC methods and DTOs
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Remove the `#region Schema Methods` block**
+
+Remove lines 779-841 (the `SchemaEntitiesAsync` and `SchemaAttributesAsync` methods and their `#region`).
+
+- [ ] **Step 2: Remove Schema DTO classes**
+
+Remove from the DTO section at end of file (lines 2848-2884):
+- `SchemaEntitiesResponse`
+- `EntitySummaryDto`
+- `SchemaAttributesResponse`
+- `AttributeSummaryDto`
+
+### Task 4: Add `metadata/entities` RPC method
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Add `metadata/entities` method**
+
+Add in a new `#region Metadata Methods` section (where Schema Methods was):
+
+```csharp
+#region Metadata Methods
+
+/// <summary>
+/// Lists all entities in the environment with summary metadata.
+/// Replaces schema/entities with richer payload for Metadata Browser panel.
+/// </summary>
+[JsonRpcMethod("metadata/entities")]
+public async Task<MetadataEntitiesResponse> MetadataEntitiesAsync(
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var metadataService = sp.GetRequiredService<IMetadataService>();
+        var entities = await metadataService.GetEntitiesAsync(cancellationToken: ct);
+
+        return new MetadataEntitiesResponse
+        {
+            Entities = entities.Select(MapEntitySummaryToDto).ToList()
+        };
+    }, cancellationToken);
+}
+
+private static MetadataEntitySummaryDto MapEntitySummaryToDto(EntitySummary e) => new()
+{
+    LogicalName = e.LogicalName,
+    SchemaName = e.SchemaName,
+    DisplayName = e.DisplayName,
+    IsCustomEntity = e.IsCustomEntity,
+    IsManaged = e.IsManaged,
+    OwnershipType = e.OwnershipType,
+    ObjectTypeCode = e.ObjectTypeCode,
+    Description = e.Description
+};
+```
+
+### Task 5: Add `metadata/entity` RPC method
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Add `metadata/entity` method**
+
+Add after `metadata/entities` in the same region:
+
+```csharp
+/// <summary>
+/// Gets full metadata for a single entity including attributes, relationships,
+/// keys, privileges, and optionally global option set values.
+/// </summary>
+[JsonRpcMethod("metadata/entity")]
+public async Task<MetadataEntityResponse> MetadataEntityAsync(
+    string logicalName,
+    bool includeGlobalOptionSets = false,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(logicalName))
+    {
+        throw new RpcException(
+            ErrorCodes.Validation.RequiredField,
+            "The 'logicalName' parameter is required");
+    }
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var metadataService = sp.GetRequiredService<IMetadataService>();
+        var (entity, globalOptionSets) = await metadataService
+            .GetEntityWithGlobalOptionSetsAsync(logicalName, includeGlobalOptionSets, ct);
+
+        return new MetadataEntityResponse
+        {
+            Entity = MapEntityMetadataToDto(entity, globalOptionSets)
+        };
+    }, cancellationToken);
+}
+
+#endregion
+```
+
+- [ ] **Step 2: Add entity detail mapping helpers**
+
+Add private mapping methods for entity detail DTO construction. These map from the existing `EntityMetadataDto`, `AttributeMetadataDto`, `RelationshipMetadataDto`, `ManyToManyRelationshipDto`, `EntityKeyDto`, `PrivilegeDto`, and `OptionSetMetadataDto` domain models to the wire DTOs.
+
+The mapper should be straightforward field-by-field copying — the domain models already have the right shape. Key fields to include:
+
+**Attributes:** logicalName, displayName, schemaName, attributeType, isPrimaryId, isPrimaryName, isCustomAttribute, requiredLevel, maxLength, minValue, maxValue, precision, targets (for lookups), optionSetName, isGlobalOptionSet, options (inline OptionValueDto list), format, dateTimeBehavior, sourceType, isSecured, isValidForGrid, isValidForForm, description, autoNumberFormat
+
+**Relationships (1:N/N:1):** schemaName, relationshipType, referencedEntity, referencedAttribute, referencingEntity, referencingAttribute, cascadeAssign, cascadeDelete, cascadeMerge, cascadeReparent, cascadeShare, cascadeUnshare, isHierarchical
+
+**ManyToMany:** schemaName, entity1LogicalName, entity1IntersectAttribute, entity2LogicalName, entity2IntersectAttribute, intersectEntityName
+
+**Keys:** schemaName, logicalName, displayName, keyAttributes, entityKeyIndexStatus, isManaged
+
+**Privileges:** privilegeId, name, privilegeType, canBeLocal, canBeDeep, canBeGlobal, canBeBasic
+
+**Global option sets:** name, displayName, optionSetType, isGlobal, options (value, label, color, description)
+
+### Task 6: Add Metadata RPC DTOs
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Add DTO classes at end of file**
+
+Add response and detail DTO classes following the existing pattern (`[JsonPropertyName]` attributes, `[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]` for nullable fields):
+
+- `MetadataEntitiesResponse` — `{ entities: MetadataEntitySummaryDto[] }`
+- `MetadataEntitySummaryDto` — logicalName, schemaName, displayName, isCustomEntity, isManaged, ownershipType, objectTypeCode, description
+- `MetadataEntityResponse` — `{ entity: MetadataEntityDetailDto }`
+- `MetadataEntityDetailDto` — all summary fields + attributes[], oneToManyRelationships[], manyToOneRelationships[], manyToManyRelationships[], keys[], privileges[], globalOptionSets[]
+- `MetadataAttributeDto` — attribute wire format
+- `MetadataRelationshipDto` — 1:N/N:1 wire format
+- `MetadataManyToManyDto` — N:N wire format
+- `MetadataKeyDto` — alternate key wire format
+- `MetadataPrivilegeDto` — privilege wire format
+- `MetadataOptionSetDto` — global option set wire format
+- `MetadataOptionValueDto` — option value wire format (value, label, color, description)
+
+- [ ] **Step 2: Build full solution**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded. No downstream breaks — the `query/complete` endpoint uses `ICachedMetadataProvider` directly, not through the removed `schema/*` RPC methods.
+
+---
+
+## Chunk 3: TypeScript Client — Wire Types + Daemon Client
+
+### Task 7: Update TypeScript types
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/types.ts`
+
+- [ ] **Step 1: Replace Schema interfaces with Metadata interfaces**
+
+Remove the `// ── Schema` section (lines 271-293: `SchemaEntitiesResponse`, `EntitySummaryDto`, `SchemaAttributesResponse`, `AttributeSummaryDto`).
+
+Add a `// ── Metadata` section with TypeScript interfaces mirroring the C# DTOs:
+
+```typescript
+// ── Metadata ─────────────────────────────────────────────────────────────────
+
+export interface MetadataEntitiesResponse {
+    entities: MetadataEntitySummaryDto[];
+}
+
+export interface MetadataEntitySummaryDto {
+    logicalName: string;
+    schemaName: string;
+    displayName: string;
+    isCustomEntity: boolean;
+    isManaged: boolean;
+    ownershipType: string | null;
+    objectTypeCode: number;
+    description: string | null;
+}
+
+export interface MetadataEntityResponse {
+    entity: MetadataEntityDetailDto;
+}
+
+export interface MetadataEntityDetailDto extends MetadataEntitySummaryDto {
+    primaryIdAttribute: string | null;
+    primaryNameAttribute: string | null;
+    entitySetName: string | null;
+    isActivity: boolean;
+    attributes: MetadataAttributeDto[];
+    oneToManyRelationships: MetadataRelationshipDto[];
+    manyToOneRelationships: MetadataRelationshipDto[];
+    manyToManyRelationships: MetadataManyToManyDto[];
+    keys: MetadataKeyDto[];
+    privileges: MetadataPrivilegeDto[];
+    globalOptionSets: MetadataOptionSetDto[];
+}
+
+export interface MetadataAttributeDto {
+    logicalName: string;
+    displayName: string | null;
+    schemaName: string | null;
+    attributeType: string;
+    isPrimaryId: boolean;
+    isPrimaryName: boolean;
+    isCustomAttribute: boolean;
+    requiredLevel: string | null;
+    maxLength: number | null;
+    minValue: number | null;
+    maxValue: number | null;
+    precision: number | null;
+    targets: string[] | null;
+    optionSetName: string | null;
+    isGlobalOptionSet: boolean;
+    options: MetadataOptionValueDto[] | null;
+    format: string | null;
+    dateTimeBehavior: string | null;
+    sourceType: number | null;
+    isSecured: boolean;
+    description: string | null;
+}
+
+export interface MetadataRelationshipDto {
+    schemaName: string;
+    relationshipType: string;
+    referencedEntity: string | null;
+    referencedAttribute: string | null;
+    referencingEntity: string | null;
+    referencingAttribute: string | null;
+    cascadeAssign: string | null;
+    cascadeDelete: string | null;
+    cascadeMerge: string | null;
+    cascadeReparent: string | null;
+    cascadeShare: string | null;
+    cascadeUnshare: string | null;
+    isHierarchical: boolean;
+}
+
+export interface MetadataManyToManyDto {
+    schemaName: string;
+    entity1LogicalName: string | null;
+    entity1IntersectAttribute: string | null;
+    entity2LogicalName: string | null;
+    entity2IntersectAttribute: string | null;
+    intersectEntityName: string | null;
+}
+
+export interface MetadataKeyDto {
+    schemaName: string;
+    logicalName: string;
+    displayName: string | null;
+    keyAttributes: string[];
+    entityKeyIndexStatus: string | null;
+    isManaged: boolean;
+}
+
+export interface MetadataPrivilegeDto {
+    privilegeId: string;
+    name: string;
+    privilegeType: string;
+    canBeLocal: boolean;
+    canBeDeep: boolean;
+    canBeGlobal: boolean;
+    canBeBasic: boolean;
+}
+
+export interface MetadataOptionSetDto {
+    name: string;
+    displayName: string | null;
+    optionSetType: string;
+    isGlobal: boolean;
+    options: MetadataOptionValueDto[];
+}
+
+export interface MetadataOptionValueDto {
+    value: number;
+    label: string;
+    color: string | null;
+    description: string | null;
+}
+```
+
+### Task 8: Update daemon client
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/daemonClient.ts`
+
+- [ ] **Step 1: Replace schema methods with metadata methods**
+
+Remove `schemaEntities()` and `schemaAttributes()` (lines 737-768).
+
+Add in their place:
+
+```typescript
+// ── Metadata ────────────────────────────────────────────────────────────
+
+async metadataEntities(environmentUrl?: string): Promise<MetadataEntitiesResponse> {
+    await this.ensureConnected();
+
+    const params: Record<string, unknown> = {};
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+    this.log.debug('Calling metadata/entities...');
+    const result = await this.connection!.sendRequest<MetadataEntitiesResponse>(
+        'metadata/entities',
+        params
+    );
+    this.log.debug(`Got ${result.entities.length} entities`);
+
+    return result;
+}
+
+async metadataEntity(
+    logicalName: string,
+    includeGlobalOptionSets = false,
+    environmentUrl?: string,
+): Promise<MetadataEntityResponse> {
+    await this.ensureConnected();
+
+    const params: Record<string, unknown> = { logicalName, includeGlobalOptionSets };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+    this.log.debug(`Calling metadata/entity for "${logicalName}"...`);
+    const result = await this.connection!.sendRequest<MetadataEntityResponse>(
+        'metadata/entity',
+        params
+    );
+    this.log.debug(`Got entity "${logicalName}" with ${result.entity.attributes.length} attributes`);
+
+    return result;
+}
+```
+
+- [ ] **Step 2: Update imports in daemonClient.ts**
+
+Add `MetadataEntitiesResponse`, `MetadataEntityResponse` to the import from `./types.js`.
+
+- [ ] **Step 3: Build extension to verify**
+
+Run: `cd src/PPDS.Extension && npm run build`
+Expected: Build succeeded. If any TS code referenced `schemaEntities`/`schemaAttributes`, compiler will flag it — fix those callers.
+
+---
+
+## Chunk 4: VS Code Extension — Metadata Browser Panel
+
+### Task 9: Add message types
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/panels/webview/shared/message-types.ts`
+
+- [ ] **Step 1: Add Metadata Browser message types**
+
+Add at end of file:
+
+```typescript
+// ── Metadata Browser Panel ─────────────────────────────────────────────
+
+/** Entity summary as sent to the webview for the entity list. */
+export interface MetadataEntityViewDto {
+    logicalName: string;
+    schemaName: string;
+    displayName: string;
+    isCustomEntity: boolean;
+    isManaged: boolean;
+    ownershipType: string | null;
+    objectTypeCode: number;
+    description: string | null;
+}
+
+/** Messages the Metadata Browser Panel webview sends to the extension host. */
+export type MetadataBrowserPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectEntity'; logicalName: string }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker'; entityLogicalName?: string }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Metadata Browser Panel webview. */
+export type MetadataBrowserPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'entitiesLoaded'; entities: MetadataEntityViewDto[] }
+    | { command: 'entityDetailLoaded'; entity: import('../../../types.js').MetadataEntityDetailDto }
+    | { command: 'entityDetailLoading'; logicalName: string }
+    | { command: 'loading' }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+```
+
+### Task 10: Create MetadataBrowserPanel host class
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts`
+
+- [ ] **Step 1: Create the panel class**
+
+Follow the ImportJobsPanel pattern:
+- Extend `WebviewPanelBase<MetadataBrowserPanelWebviewToHost, MetadataBrowserPanelHostToWebview>`
+- Static `show()` factory with MAX_PANELS = 5
+- `handleMessage()` switch on commands:
+  - `ready` → load entity list via `daemon.metadataEntities(envUrl)`
+  - `refresh` → invalidate and reload entity list
+  - `selectEntity` → call `daemon.metadataEntity(logicalName, true, envUrl)`, send `entityDetailLoaded`
+  - `requestEnvironmentList` → show environment picker
+  - `openInMaker` → open entity in Power Apps Maker (`/entities/{objectTypeCode}/details`)
+  - `copyToClipboard` → write to clipboard
+  - `webviewError` → log error
+- `onDaemonReconnected()` → reload entity list
+- `getHtmlContent()` → CSP-safe HTML with split-pane layout structure
+
+Key differences from ImportJobsPanel:
+- The panel caches the entity list client-side (in a class member) to avoid re-fetching on every entity selection
+- Entity detail is fetched on demand when an entity is selected
+- `includeGlobalOptionSets: true` passed to get choices data
+
+### Task 11: Create metadata-browser-panel webview script
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts`
+
+- [ ] **Step 1: Implement the webview script**
+
+Structure:
+1. **Left pane — Entity list:**
+   - Render all entities as `<div class="entity-row">` inside a scrollable container
+   - Each row shows: icon (custom entity = `◆`, system = `○`), display name, logical name
+   - FilterBar component for client-side search (searches displayName + logicalName + schemaName)
+   - Click handler sends `selectEntity` message with logicalName
+   - Selected entity highlighted with `.selected` CSS class
+
+2. **Right pane — Tabbed detail:**
+   - 5 tab buttons: Attributes, Relationships, Keys, Privileges, Choices
+   - Each tab renders a DataTable when active
+   - Tab content stored in memory, rendered on tab switch (avoid re-creating DataTable on each click)
+
+3. **Tab: Attributes**
+   - DataTable columns: Name (logicalName), Display Name, Type, Required, Custom, Max Length, Description
+   - Sort by logicalName ascending default
+   - Status bar: "X attributes"
+
+4. **Tab: Relationships**
+   - DataTable columns: Schema Name, Type (1:N/N:1/N:N), Related Entity, Lookup Field, Cascade Delete
+   - Combine oneToManyRelationships + manyToOneRelationships + manyToManyRelationships into one table
+   - For N:N: Related Entity shows the other entity, Lookup Field shows intersect entity
+   - Sort by schemaName ascending default
+
+5. **Tab: Keys**
+   - DataTable columns: Display Name, Schema Name, Key Attributes (comma-separated), Index Status
+   - Sort by schemaName ascending default
+
+6. **Tab: Privileges**
+   - DataTable columns: Name, Type (Create/Read/Write/Delete/Assign/Share/Append/AppendTo), Local, Deep, Global, Basic
+   - Scope columns render checkmarks (✓/—)
+   - Sort by name ascending default
+
+7. **Tab: Choices**
+   - Two sections with headers:
+     - "Entity Choices" — filter attributes where `options?.length > 0 && !isGlobalOptionSet`, render DataTable: Attribute Name, Option Set Name, Values (count)
+       - Click row to expand/show values inline or in sub-table
+     - "Global Option Sets" — from `entity.globalOptionSets`, render DataTable: Name, Display Name, Type, Values (count)
+       - Click row to expand/show values
+   - Each expanded section shows value table: Value (int), Label, Color (swatch), Description
+
+### Task 12: Create metadata-browser-panel CSS
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css`
+
+- [ ] **Step 1: Create panel styles**
+
+Import shared.css, then define:
+- `.split-pane` — flexbox row, 100% height
+- `.entity-list-pane` — fixed width (280px), left side, overflow-y auto, border-right
+- `.entity-detail-pane` — flex: 1, right side
+- `.entity-row` — padding, cursor pointer, hover/selected states
+- `.entity-row.selected` — background highlight using VS Code theme vars
+- `.entity-row .entity-icon` — inline icon span
+- `.entity-search` — input at top of left pane, full width
+- `.tab-bar` — flex row of tab buttons, bottom border
+- `.tab-button` — padding, border-bottom transparent, cursor pointer
+- `.tab-button.active` — border-bottom with accent color
+- `.tab-content` — flex: 1, overflow hidden, contains DataTable
+- `.choices-section-header` — section header for Entity Choices / Global Option Sets
+- `.color-swatch` — small inline color indicator for option set colors
+
+### Task 13: Register panel in build and extension
+
+**Files:**
+- Modify: `src/PPDS.Extension/esbuild.js`
+- Modify: `src/PPDS.Extension/src/extension.ts`
+- Modify: `src/PPDS.Extension/src/views/toolsTreeView.ts`
+- Modify: `src/PPDS.Extension/package.json`
+
+- [ ] **Step 1: Add esbuild entries**
+
+Add after the Import Jobs panel entries in esbuild.js:
+
+```javascript
+// Metadata Browser panel webview (browser, IIFE)
+{
+    entryPoints: ['src/panels/webview/metadata-browser-panel.ts'],
+    bundle: true,
+    format: 'iife',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'browser',
+    outfile: 'dist/metadata-browser-panel.js',
+    logLevel: 'warning',
+},
+```
+
+```javascript
+// Metadata Browser panel CSS
+{
+    entryPoints: ['src/panels/styles/metadata-browser-panel.css'],
+    bundle: true,
+    minify: production,
+    outfile: 'dist/metadata-browser-panel.css',
+    logLevel: 'warning',
+},
+```
+
+- [ ] **Step 2: Register command in extension.ts**
+
+Add to `registerPanelCommands()`:
+
+```typescript
+vscode.commands.registerCommand('ppds.openMetadataBrowser', () => {
+    MetadataBrowserPanel.show(context.extensionUri, client);
+}),
+```
+
+Add import for `MetadataBrowserPanel`.
+
+- [ ] **Step 3: Add to Tools tree view**
+
+In `toolsTreeView.ts`, add to the `tools` array:
+
+```typescript
+{ label: 'Metadata Browser', commandId: 'ppds.openMetadataBrowser', icon: 'symbol-class' },
+```
+
+- [ ] **Step 4: Add package.json contributions**
+
+Add command and menu contributions following the Import Jobs pattern:
+
+```json
+{
+    "command": "ppds.openMetadataBrowser",
+    "title": "Open Metadata Browser",
+    "category": "PPDS",
+    "icon": "$(symbol-class)"
+}
+```
+
+Add environment context menu entry:
+```json
+{
+    "command": "ppds.openMetadataBrowserForEnv",
+    "when": "view == ppds.profiles && viewItem == environment",
+    "group": "env-tools@4"
+}
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd src/PPDS.Extension && npm run build`
+Expected: Build succeeded with new panel JS + CSS in dist/.
+
+---
+
+## Chunk 5: TUI Screen — MetadataExplorerScreen
+
+### Task 14: Create MetadataExplorerScreen
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs`
+
+- [ ] **Step 1: Create the screen class**
+
+Extend `TuiScreenBase`. Layout:
+- **Left pane:** FrameView titled "Entities" containing:
+  - TextField for search (top, full width)
+  - ListView of entity names (below search, fills remaining space)
+  - Client-side filtering on TextField.TextChanged (debounced 300ms)
+- **SplitterView:** Vertical resize between left and right panes
+- **Right pane:** FrameView titled "Details" containing:
+  - Tab bar (Label buttons: Attributes | Relationships | Keys | Privileges | Choices)
+  - TableView below tab bar showing the active tab's data
+
+Key behaviors:
+- On entity selection (ListView.SelectedItemChanged): call `IMetadataService.GetEntityWithGlobalOptionSetsAsync()` via the session's service provider, populate right pane
+- Tab switching updates the TableView data source
+- Loading indicator while fetching entity detail
+- Handle empty states ("Select an entity to view details", "No attributes", etc.)
+
+Hotkeys:
+- `Ctrl+R`: Refresh (clear all caches, reload entity list)
+- `Ctrl+F`: Focus search field
+- `Tab`: Cycle detail tabs (Attributes → Relationships → Keys → Privileges → Choices → Attributes)
+- `Enter`: Select entity (if entity list focused)
+- `Ctrl+O`: Open in Maker (launch browser URL)
+
+### Task 15: Register screen in TuiShell
+
+**Files:**
+- Modify: `src/PPDS.Cli/Tui/TuiShell.cs`
+
+- [ ] **Step 1: Add Tools menu entry**
+
+Add after the Import Jobs menu item (around line 283):
+
+```csharp
+new("Metadata Browser", "Browse entity metadata", () => NavigateToMetadataBrowser()),
+```
+
+- [ ] **Step 2: Add NavigateToMetadataBrowser method**
+
+Add after `NavigateToImportJobs()` (around line 486):
+
+```csharp
+private void NavigateToMetadataBrowser()
+{
+    HideSplash();
+
+    var loadingLabel = new Label("Loading Metadata Browser...")
+    {
+        X = Pos.Center(),
+        Y = Pos.Center()
+    };
+    _contentArea.Add(loadingLabel);
+    _contentArea.Title = "Loading";
+
+    Application.Refresh();
+
+    Application.MainLoop?.AddIdle(() =>
+    {
+        _contentArea.Remove(loadingLabel);
+
+        var screen = new MetadataExplorerScreen(_session);
+        NavigateTo(screen);
+
+        return false;
+    });
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build PPDS.sln -v q`
+Expected: Build succeeded.
+
+---
+
+## Chunk 6: MCP Tool — `ppds_metadata_entities`
+
+### Task 16: Create MetadataEntitiesListTool
+
+**Files:**
+- Create: `src/PPDS.Mcp/Tools/MetadataEntitiesListTool.cs`
+
+- [ ] **Step 1: Create the MCP tool**
+
+Follow the ImportJobsListTool pattern:
+
+```csharp
+[McpServerToolType]
+public sealed class MetadataEntitiesListTool
+{
+    private readonly McpToolContext _context;
+
+    public MetadataEntitiesListTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    [McpServerTool(Name = "ppds_metadata_entities")]
+    [Description("Lists all entities (tables) in the connected Dataverse environment. Returns entity logical names, display names, schema names, and ownership type. Use this to discover available entities before querying with ppds_metadata_entity for full details.")]
+    public async Task<MetadataEntitiesResult> ExecuteAsync(
+        [Description("If true, only return custom entities (not system entities).")] bool customOnly = false,
+        [Description("Optional filter pattern to match entity logical names. Supports * wildcard (e.g., 'account*', '*custom*').")] string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context
+            .CreateServiceProviderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var metadataService = serviceProvider
+            .GetRequiredService<IMetadataService>();
+
+        var entities = await metadataService
+            .GetEntitiesAsync(customOnly, filter, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new MetadataEntitiesResult
+        {
+            Entities = entities.Select(e => new EntityListItem
+            {
+                LogicalName = e.LogicalName,
+                DisplayName = e.DisplayName,
+                SchemaName = e.SchemaName,
+                IsCustomEntity = e.IsCustomEntity,
+                IsManaged = e.IsManaged,
+                OwnershipType = e.OwnershipType,
+                Description = e.Description
+            }).ToList()
+        };
+    }
+}
+
+public sealed class MetadataEntitiesResult
+{
+    [JsonPropertyName("entityCount")]
+    public int EntityCount => Entities.Count;
+
+    [JsonPropertyName("entities")]
+    public List<EntityListItem> Entities { get; set; } = [];
+}
+
+public sealed class EntityListItem
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("ownershipType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OwnershipType { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}
+```
+
+- [ ] **Step 2: Build MCP project**
+
+Run: `dotnet build src/PPDS.Mcp/PPDS.Mcp.csproj -v q`
+Expected: Build succeeded. Tool auto-discovered via `[McpServerToolType]` attribute.
+
+---
+
+## Chunk 7: Cleanup + Tests
+
+### Task 17: Remove stale TypeScript test references
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/__tests__/daemonClient.test.ts`
+
+- [ ] **Step 1: Remove or update schema-related tests**
+
+Remove tests for `schemaEntities()` and `schemaAttributes()`. Add tests for `metadataEntities()` and `metadataEntity()` following the same mock pattern used by import job tests.
+
+### Task 18: Add panel unit tests
+
+**Files:**
+- Create: `src/PPDS.Extension/src/__tests__/panels/metadataBrowserPanel.test.ts`
+
+- [ ] **Step 1: Write unit tests for message handling**
+
+Test cases:
+- `ready` command triggers entity list load
+- `selectEntity` command triggers entity detail load with `includeGlobalOptionSets: true`
+- `refresh` command reloads entity list
+- Error handling when daemon call fails
+- Multiple `selectEntity` calls — latest wins (stale response protection)
+
+### Task 19: Final build + test
+
+- [ ] **Step 1: Full .NET build**
+
+Run: `dotnet build PPDS.sln -v q`
+
+- [ ] **Step 2: .NET unit tests**
+
+Run: `dotnet test PPDS.sln --filter "Category!=Integration" -v q`
+
+- [ ] **Step 3: Extension build**
+
+Run: `cd src/PPDS.Extension && npm run build`
+
+- [ ] **Step 4: Extension type check**
+
+Run: `cd src/PPDS.Extension && npx tsc --noEmit`
+
+- [ ] **Step 5: Extension lint**
+
+Run: `cd src/PPDS.Extension && npx eslint src --quiet`
+
+- [ ] **Step 6: Extension unit tests**
+
+Run: `cd src/PPDS.Extension && npm run ext:test`
+
+---
+
+## Acceptance Criteria Mapping
+
+| AC | Criterion | Chunk/Task | Verification |
+|----|-----------|------------|--------------|
+| AC-MB-01 | `metadata/entities` returns all entity definitions with summary fields | Chunk 2, Task 4 | RPC test or manual daemon call |
+| AC-MB-02 | `metadata/entity` returns full detail (attributes, relationships, keys, privileges) in one call | Chunk 2, Task 5 | RPC test or manual daemon call |
+| AC-MB-03 | VS Code panel displays entity list with search/filter and tabbed detail pane | Chunk 4, Tasks 10-12 | ext-verify screenshot |
+| AC-MB-04 | Search/filter box filters entity list as user types (client-side) | Chunk 4, Task 11 | ext-verify interaction |
+| AC-MB-05 | Attributes tab shows type-specific metadata | Chunk 4, Task 11 | ext-verify screenshot |
+| AC-MB-06 | Relationships tab shows 1:N and N:N with cascade configuration | Chunk 4, Task 11 | ext-verify screenshot |
+| AC-MB-07 | Entity list cached with configurable TTL; refresh clears cache | Chunk 4, Task 10 | Verify refresh behavior |
+| AC-MB-08 | TUI MetadataExplorerScreen provides equivalent split pane with tab cycling | Chunk 5, Task 14 | tui-verify PTY interaction |
+| AC-MB-09 | MCP ppds_metadata_entities returns entity list for AI discovery | Chunk 6, Task 16 | MCP Inspector test |
+| AC-MB-10 | Handles large schemas (500+ entities) without UI lag | Chunk 4, Task 11 | ext-verify with real env |

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -776,66 +776,217 @@ public class RpcMethodHandler : IDisposable
 
     #endregion
 
-    #region Schema Methods
+    #region Metadata Methods
 
     /// <summary>
     /// Lists all entities in the environment with summary metadata.
-    /// Used by VS Code extension for IntelliSense entity completion.
+    /// Used by the Metadata Browser panel in VS Code.
     /// </summary>
-    [JsonRpcMethod("schema/entities")]
-    public async Task<SchemaEntitiesResponse> SchemaEntitiesAsync(
+    [JsonRpcMethod("metadata/entities")]
+    public async Task<MetadataEntitiesResponse> MetadataEntitiesAsync(
+        string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
-        return await WithActiveProfileAsync(async (sp, ct) =>
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
         {
-            var metadataProvider = sp.GetRequiredService<ICachedMetadataProvider>();
-            var entities = await metadataProvider.GetEntitiesAsync(ct);
+            var metadataService = sp.GetRequiredService<IMetadataService>();
+            var entities = await metadataService.GetEntitiesAsync(cancellationToken: ct);
 
-            return new SchemaEntitiesResponse
+            return new MetadataEntitiesResponse
             {
-                Entities = entities.Select(e => new EntitySummaryDto
-                {
-                    LogicalName = e.LogicalName,
-                    DisplayName = e.DisplayName,
-                    IsCustom = e.IsCustomEntity
-                }).ToList()
+                Entities = entities.Select(MapEntitySummaryToRpc).ToList()
             };
         }, cancellationToken);
     }
 
     /// <summary>
-    /// Lists attributes for a specific entity.
-    /// Used by VS Code extension for IntelliSense attribute completion.
+    /// Gets full metadata for a specific entity including attributes, relationships,
+    /// keys, privileges, and optionally global option set values.
+    /// Used by the Metadata Browser panel in VS Code.
     /// </summary>
-    [JsonRpcMethod("schema/attributes")]
-    public async Task<SchemaAttributesResponse> SchemaAttributesAsync(
-        string entity,
+    [JsonRpcMethod("metadata/entity")]
+    public async Task<MetadataEntityResponse> MetadataEntityAsync(
+        string logicalName,
+        bool includeGlobalOptionSets = false,
+        string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(entity))
+        if (string.IsNullOrWhiteSpace(logicalName))
         {
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,
-                "The 'entity' parameter is required");
+                "The 'logicalName' parameter is required");
         }
 
-        return await WithActiveProfileAsync(async (sp, ct) =>
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
         {
-            var metadataProvider = sp.GetRequiredService<ICachedMetadataProvider>();
-            var attributes = await metadataProvider.GetAttributesAsync(entity, ct);
+            var metadataService = sp.GetRequiredService<IMetadataService>();
+            var (entity, globalOptionSets) = await metadataService.GetEntityWithGlobalOptionSetsAsync(
+                logicalName,
+                includeGlobalOptionSets,
+                ct);
 
-            return new SchemaAttributesResponse
+            return new MetadataEntityResponse
             {
-                EntityName = entity,
-                Attributes = attributes.Select(a => new AttributeSummaryDto
-                {
-                    LogicalName = a.LogicalName,
-                    DisplayName = a.DisplayName,
-                    DataType = a.AttributeType,
-                    IsCustom = a.IsCustomAttribute
-                }).ToList()
+                Entity = MapEntityDetailToRpc(entity, globalOptionSets)
             };
         }, cancellationToken);
+    }
+
+    private static MetadataEntitySummaryDto MapEntitySummaryToRpc(EntitySummary e)
+    {
+        return new MetadataEntitySummaryDto
+        {
+            LogicalName = e.LogicalName,
+            SchemaName = e.SchemaName,
+            DisplayName = e.DisplayName,
+            IsCustomEntity = e.IsCustomEntity,
+            IsManaged = e.IsManaged,
+            OwnershipType = e.OwnershipType,
+            ObjectTypeCode = e.ObjectTypeCode,
+            Description = e.Description
+        };
+    }
+
+    private static MetadataEntityDetailDto MapEntityDetailToRpc(
+        EntityMetadataDto entity,
+        IReadOnlyList<OptionSetMetadataDto> globalOptionSets)
+    {
+        return new MetadataEntityDetailDto
+        {
+            LogicalName = entity.LogicalName,
+            SchemaName = entity.SchemaName,
+            DisplayName = entity.DisplayName,
+            IsCustomEntity = entity.IsCustomEntity,
+            IsManaged = entity.IsManaged,
+            OwnershipType = entity.OwnershipType,
+            ObjectTypeCode = entity.ObjectTypeCode,
+            Description = entity.Description,
+            PrimaryIdAttribute = entity.PrimaryIdAttribute,
+            PrimaryNameAttribute = entity.PrimaryNameAttribute,
+            EntitySetName = entity.EntitySetName,
+            IsActivity = entity.IsActivity,
+            Attributes = entity.Attributes.Select(MapAttributeToRpc).ToList(),
+            OneToManyRelationships = entity.OneToManyRelationships.Select(MapRelationshipToRpc).ToList(),
+            ManyToOneRelationships = entity.ManyToOneRelationships.Select(MapRelationshipToRpc).ToList(),
+            ManyToManyRelationships = entity.ManyToManyRelationships.Select(MapManyToManyToRpc).ToList(),
+            Keys = entity.Keys.Select(MapKeyToRpc).ToList(),
+            Privileges = entity.Privileges.Select(MapPrivilegeToRpc).ToList(),
+            GlobalOptionSets = globalOptionSets.Select(MapOptionSetToRpc).ToList()
+        };
+    }
+
+    private static MetadataAttributeDto MapAttributeToRpc(AttributeMetadataDto a)
+    {
+        return new MetadataAttributeDto
+        {
+            LogicalName = a.LogicalName,
+            DisplayName = a.DisplayName,
+            SchemaName = a.SchemaName,
+            AttributeType = a.AttributeType,
+            AttributeTypeName = a.AttributeTypeName,
+            IsPrimaryId = a.IsPrimaryId,
+            IsPrimaryName = a.IsPrimaryName,
+            IsCustomAttribute = a.IsCustomAttribute,
+            RequiredLevel = a.RequiredLevel,
+            MaxLength = a.MaxLength,
+            MinValue = a.MinValue,
+            MaxValue = a.MaxValue,
+            Precision = a.Precision,
+            Targets = a.Targets,
+            OptionSetName = a.OptionSetName,
+            IsGlobalOptionSet = a.IsGlobalOptionSet,
+            Options = a.Options?.Select(MapOptionValueToRpc).ToList(),
+            Format = a.Format,
+            DateTimeBehavior = a.DateTimeBehavior,
+            SourceType = a.SourceType,
+            IsSecured = a.IsSecured,
+            Description = a.Description,
+            AutoNumberFormat = a.AutoNumberFormat
+        };
+    }
+
+    private static MetadataRelationshipDto MapRelationshipToRpc(RelationshipMetadataDto r)
+    {
+        return new MetadataRelationshipDto
+        {
+            SchemaName = r.SchemaName,
+            RelationshipType = r.RelationshipType,
+            ReferencedEntity = r.ReferencedEntity,
+            ReferencedAttribute = r.ReferencedAttribute,
+            ReferencingEntity = r.ReferencingEntity,
+            ReferencingAttribute = r.ReferencingAttribute,
+            CascadeAssign = r.CascadeAssign,
+            CascadeDelete = r.CascadeDelete,
+            CascadeMerge = r.CascadeMerge,
+            CascadeReparent = r.CascadeReparent,
+            CascadeShare = r.CascadeShare,
+            CascadeUnshare = r.CascadeUnshare,
+            IsHierarchical = r.IsHierarchical
+        };
+    }
+
+    private static MetadataManyToManyDto MapManyToManyToRpc(ManyToManyRelationshipDto r)
+    {
+        return new MetadataManyToManyDto
+        {
+            SchemaName = r.SchemaName,
+            Entity1LogicalName = r.Entity1LogicalName,
+            Entity1IntersectAttribute = r.Entity1IntersectAttribute,
+            Entity2LogicalName = r.Entity2LogicalName,
+            Entity2IntersectAttribute = r.Entity2IntersectAttribute,
+            IntersectEntityName = r.IntersectEntityName
+        };
+    }
+
+    private static MetadataKeyDto MapKeyToRpc(EntityKeyDto k)
+    {
+        return new MetadataKeyDto
+        {
+            SchemaName = k.SchemaName,
+            LogicalName = k.LogicalName,
+            DisplayName = k.DisplayName,
+            KeyAttributes = k.KeyAttributes,
+            EntityKeyIndexStatus = k.EntityKeyIndexStatus,
+            IsManaged = k.IsManaged
+        };
+    }
+
+    private static MetadataPrivilegeDto MapPrivilegeToRpc(PrivilegeDto p)
+    {
+        return new MetadataPrivilegeDto
+        {
+            PrivilegeId = p.PrivilegeId,
+            Name = p.Name,
+            PrivilegeType = p.PrivilegeType,
+            CanBeLocal = p.CanBeLocal,
+            CanBeDeep = p.CanBeDeep,
+            CanBeGlobal = p.CanBeGlobal,
+            CanBeBasic = p.CanBeBasic
+        };
+    }
+
+    private static MetadataOptionSetDto MapOptionSetToRpc(OptionSetMetadataDto os)
+    {
+        return new MetadataOptionSetDto
+        {
+            Name = os.Name,
+            DisplayName = os.DisplayName,
+            OptionSetType = os.OptionSetType,
+            IsGlobal = os.IsGlobal,
+            Options = os.Options.Select(MapOptionValueToRpc).ToList()
+        };
+    }
+
+    private static MetadataOptionValueDto MapOptionValueToRpc(OptionValueDto o)
+    {
+        return new MetadataOptionValueDto
+        {
+            Value = o.Value,
+            Label = o.Label,
+            Color = o.Color,
+            Description = o.Description
+        };
     }
 
     #endregion
@@ -3138,44 +3289,6 @@ public class SolutionComponentInfoDto
 }
 
 /// <summary>
-/// Response for schema/entities method.
-/// </summary>
-public class SchemaEntitiesResponse
-{
-    [JsonPropertyName("entities")] public List<EntitySummaryDto> Entities { get; set; } = [];
-}
-
-/// <summary>
-/// Entity summary for schema/entities response.
-/// </summary>
-public class EntitySummaryDto
-{
-    [JsonPropertyName("logicalName")] public string LogicalName { get; set; } = "";
-    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
-    [JsonPropertyName("isCustom")] public bool IsCustom { get; set; }
-}
-
-/// <summary>
-/// Response for schema/attributes method.
-/// </summary>
-public class SchemaAttributesResponse
-{
-    [JsonPropertyName("entityName")] public string EntityName { get; set; } = "";
-    [JsonPropertyName("attributes")] public List<AttributeSummaryDto> Attributes { get; set; } = [];
-}
-
-/// <summary>
-/// Attribute summary for schema/attributes response.
-/// </summary>
-public class AttributeSummaryDto
-{
-    [JsonPropertyName("logicalName")] public string LogicalName { get; set; } = "";
-    [JsonPropertyName("displayName")] public string? DisplayName { get; set; }
-    [JsonPropertyName("dataType")] public string DataType { get; set; } = "";
-    [JsonPropertyName("isCustom")] public bool IsCustom { get; set; }
-}
-
-/// <summary>
 /// Response for query/complete method.
 /// </summary>
 public class QueryCompleteResponse
@@ -3581,6 +3694,350 @@ public class TraceFilterDto
     [JsonPropertyName("endDate")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? EndDate { get; set; }
+}
+
+// ── Metadata DTOs ────────────────────────────────────────────────────────
+
+public class MetadataEntitiesResponse
+{
+    [JsonPropertyName("entities")]
+    public List<MetadataEntitySummaryDto> Entities { get; set; } = [];
+}
+
+public class MetadataEntitySummaryDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("ownershipType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OwnershipType { get; set; }
+
+    [JsonPropertyName("objectTypeCode")]
+    public int ObjectTypeCode { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}
+
+public class MetadataEntityResponse
+{
+    [JsonPropertyName("entity")]
+    public MetadataEntityDetailDto Entity { get; set; } = null!;
+}
+
+public class MetadataEntityDetailDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("ownershipType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OwnershipType { get; set; }
+
+    [JsonPropertyName("objectTypeCode")]
+    public int ObjectTypeCode { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("primaryIdAttribute")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryIdAttribute { get; set; }
+
+    [JsonPropertyName("primaryNameAttribute")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrimaryNameAttribute { get; set; }
+
+    [JsonPropertyName("entitySetName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EntitySetName { get; set; }
+
+    [JsonPropertyName("isActivity")]
+    public bool IsActivity { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public List<MetadataAttributeDto> Attributes { get; set; } = [];
+
+    [JsonPropertyName("oneToManyRelationships")]
+    public List<MetadataRelationshipDto> OneToManyRelationships { get; set; } = [];
+
+    [JsonPropertyName("manyToOneRelationships")]
+    public List<MetadataRelationshipDto> ManyToOneRelationships { get; set; } = [];
+
+    [JsonPropertyName("manyToManyRelationships")]
+    public List<MetadataManyToManyDto> ManyToManyRelationships { get; set; } = [];
+
+    [JsonPropertyName("keys")]
+    public List<MetadataKeyDto> Keys { get; set; } = [];
+
+    [JsonPropertyName("privileges")]
+    public List<MetadataPrivilegeDto> Privileges { get; set; } = [];
+
+    [JsonPropertyName("globalOptionSets")]
+    public List<MetadataOptionSetDto> GlobalOptionSets { get; set; } = [];
+}
+
+public class MetadataAttributeDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("attributeType")]
+    public string AttributeType { get; set; } = "";
+
+    [JsonPropertyName("attributeTypeName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AttributeTypeName { get; set; }
+
+    [JsonPropertyName("isPrimaryId")]
+    public bool IsPrimaryId { get; set; }
+
+    [JsonPropertyName("isPrimaryName")]
+    public bool IsPrimaryName { get; set; }
+
+    [JsonPropertyName("isCustomAttribute")]
+    public bool IsCustomAttribute { get; set; }
+
+    [JsonPropertyName("requiredLevel")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RequiredLevel { get; set; }
+
+    [JsonPropertyName("maxLength")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MaxLength { get; set; }
+
+    [JsonPropertyName("minValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? MinValue { get; set; }
+
+    [JsonPropertyName("maxValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? MaxValue { get; set; }
+
+    [JsonPropertyName("precision")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? Precision { get; set; }
+
+    [JsonPropertyName("targets")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? Targets { get; set; }
+
+    [JsonPropertyName("optionSetName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OptionSetName { get; set; }
+
+    [JsonPropertyName("isGlobalOptionSet")]
+    public bool IsGlobalOptionSet { get; set; }
+
+    [JsonPropertyName("options")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<MetadataOptionValueDto>? Options { get; set; }
+
+    [JsonPropertyName("format")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Format { get; set; }
+
+    [JsonPropertyName("dateTimeBehavior")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DateTimeBehavior { get; set; }
+
+    [JsonPropertyName("sourceType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SourceType { get; set; }
+
+    [JsonPropertyName("isSecured")]
+    public bool IsSecured { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("autoNumberFormat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AutoNumberFormat { get; set; }
+}
+
+public class MetadataRelationshipDto
+{
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("relationshipType")]
+    public string RelationshipType { get; set; } = "";
+
+    [JsonPropertyName("referencedEntity")]
+    public string ReferencedEntity { get; set; } = "";
+
+    [JsonPropertyName("referencedAttribute")]
+    public string ReferencedAttribute { get; set; } = "";
+
+    [JsonPropertyName("referencingEntity")]
+    public string ReferencingEntity { get; set; } = "";
+
+    [JsonPropertyName("referencingAttribute")]
+    public string ReferencingAttribute { get; set; } = "";
+
+    [JsonPropertyName("cascadeAssign")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeAssign { get; set; }
+
+    [JsonPropertyName("cascadeDelete")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeDelete { get; set; }
+
+    [JsonPropertyName("cascadeMerge")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeMerge { get; set; }
+
+    [JsonPropertyName("cascadeReparent")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeReparent { get; set; }
+
+    [JsonPropertyName("cascadeShare")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeShare { get; set; }
+
+    [JsonPropertyName("cascadeUnshare")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CascadeUnshare { get; set; }
+
+    [JsonPropertyName("isHierarchical")]
+    public bool IsHierarchical { get; set; }
+}
+
+public class MetadataManyToManyDto
+{
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("entity1LogicalName")]
+    public string Entity1LogicalName { get; set; } = "";
+
+    [JsonPropertyName("entity1IntersectAttribute")]
+    public string Entity1IntersectAttribute { get; set; } = "";
+
+    [JsonPropertyName("entity2LogicalName")]
+    public string Entity2LogicalName { get; set; } = "";
+
+    [JsonPropertyName("entity2IntersectAttribute")]
+    public string Entity2IntersectAttribute { get; set; } = "";
+
+    [JsonPropertyName("intersectEntityName")]
+    public string IntersectEntityName { get; set; } = "";
+}
+
+public class MetadataKeyDto
+{
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("keyAttributes")]
+    public List<string> KeyAttributes { get; set; } = [];
+
+    [JsonPropertyName("entityKeyIndexStatus")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EntityKeyIndexStatus { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+}
+
+public class MetadataPrivilegeDto
+{
+    [JsonPropertyName("privilegeId")]
+    public Guid PrivilegeId { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("privilegeType")]
+    public string PrivilegeType { get; set; } = "";
+
+    [JsonPropertyName("canBeLocal")]
+    public bool CanBeLocal { get; set; }
+
+    [JsonPropertyName("canBeDeep")]
+    public bool CanBeDeep { get; set; }
+
+    [JsonPropertyName("canBeGlobal")]
+    public bool CanBeGlobal { get; set; }
+
+    [JsonPropertyName("canBeBasic")]
+    public bool CanBeBasic { get; set; }
+}
+
+public class MetadataOptionSetDto
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    [JsonPropertyName("optionSetType")]
+    public string OptionSetType { get; set; } = "";
+
+    [JsonPropertyName("isGlobal")]
+    public bool IsGlobal { get; set; }
+
+    [JsonPropertyName("options")]
+    public List<MetadataOptionValueDto> Options { get; set; } = [];
+}
+
+public class MetadataOptionValueDto
+{
+    [JsonPropertyName("value")]
+    public int Value { get; set; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = "";
+
+    [JsonPropertyName("color")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Color { get; set; }
+
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
 }
 
 #endregion

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -789,8 +789,8 @@ public class RpcMethodHandler : IDisposable
     {
         return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
         {
-            var metadataService = sp.GetRequiredService<IMetadataService>();
-            var entities = await metadataService.GetEntitiesAsync(cancellationToken: ct);
+            var metadataProvider = sp.GetRequiredService<ICachedMetadataProvider>();
+            var entities = await metadataProvider.GetEntitiesAsync(ct);
 
             return new MetadataEntitiesResponse
             {

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -540,7 +540,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
             url += $"/main.aspx?pagetype=entitylist&etn={_selectedEntity.LogicalName}";
         }
 
-        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        using var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
         {
             Width = 70,
             Height = 7
@@ -548,7 +548,6 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
         dialog.Add(new Label { X = 1, Y = 2, Text = url });
         Application.Run(dialog);
-        dialog.Dispose();
     }
 
     #endregion

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -19,6 +19,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
     private readonly TableView _detailTable;
     private readonly Label _statusLabel;
     private readonly Button[] _tabButtons;
+    private readonly Action[] _tabClickHandlers;
 
     private List<EntitySummary> _allEntities = [];
     private List<EntitySummary> _filteredEntities = [];
@@ -77,6 +78,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
 
         // Create tab buttons
         _tabButtons = new Button[TabNames.Length];
+        _tabClickHandlers = new Action[TabNames.Length];
         var tabX = 0;
         for (int i = 0; i < TabNames.Length; i++)
         {
@@ -87,7 +89,8 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
                 Y = 0,
                 ColorScheme = i == 0 ? TuiColorPalette.TabActive : TuiColorPalette.TabInactive
             };
-            _tabButtons[i].Clicked += () => SwitchTab(idx);
+            _tabClickHandlers[i] = () => SwitchTab(idx);
+            _tabButtons[i].Clicked += _tabClickHandlers[i];
             // Estimate button width: text length + brackets/padding (Terminal.Gui adds "[ ]" around text)
             tabX += TabNames[i].Length + 6;
         }
@@ -153,8 +156,10 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
             return;
         }
 
-        _loadCts?.Cancel();
+        var oldCts = _loadCts;
         _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        oldCts?.Cancel();
+        oldCts?.Dispose();
         var ct = _loadCts.Token;
 
         try
@@ -192,8 +197,10 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
 
     private async Task LoadEntityDetailAsync(string logicalName)
     {
-        _loadCts?.Cancel();
+        var oldCts = _loadCts;
         _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        oldCts?.Cancel();
+        oldCts?.Dispose();
         var ct = _loadCts.Token;
 
         try
@@ -279,6 +286,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
             })
             .ToList();
 
+        _lastSelectedIndex = -1;
         _entityList.SetSource(displayNames);
         UpdateStatusLabel();
     }
@@ -325,6 +333,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
     {
         if (_selectedEntity == null)
         {
+            (_detailTable.Table as IDisposable)?.Dispose();
             _detailTable.Table = new System.Data.DataTable();
             return;
         }
@@ -339,6 +348,7 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
             _ => new System.Data.DataTable()
         };
 
+        (_detailTable.Table as IDisposable)?.Dispose();
         _detailTable.Table = dt;
     }
 
@@ -547,10 +557,9 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
     {
         _searchField.TextChanged -= OnSearchTextChanged;
         _entityList.SelectedItemChanged -= OnEntitySelectionChanged;
-        foreach (var btn in _tabButtons)
+        for (int i = 0; i < _tabButtons.Length; i++)
         {
-            // Button.Clicked is an event; we need to clear handlers.
-            // Since we used lambdas, the best we can do is dispose the button.
+            _tabButtons[i].Clicked -= _tabClickHandlers[i];
         }
         _loadCts?.Cancel();
         _loadCts?.Dispose();

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -79,20 +79,19 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
         // Create tab buttons
         _tabButtons = new Button[TabNames.Length];
         _tabClickHandlers = new Action[TabNames.Length];
-        var tabX = 0;
+        Button? previousButton = null;
         for (int i = 0; i < TabNames.Length; i++)
         {
             var idx = i;
             _tabButtons[i] = new Button(TabNames[i])
             {
-                X = tabX,
+                X = previousButton is null ? 0 : Pos.Right(previousButton) + 1,
                 Y = 0,
                 ColorScheme = i == 0 ? TuiColorPalette.TabActive : TuiColorPalette.TabInactive
             };
             _tabClickHandlers[i] = () => SwitchTab(idx);
             _tabButtons[i].Clicked += _tabClickHandlers[i];
-            // Estimate button width: text length + brackets/padding (Terminal.Gui adds "[ ]" around text)
-            tabX += TabNames[i].Length + 6;
+            previousButton = _tabButtons[i];
         }
 
         _detailTable = new TableView

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -1,0 +1,562 @@
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Metadata;
+using PPDS.Dataverse.Metadata.Models;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// TUI screen for browsing Dataverse entity metadata including attributes,
+/// relationships, keys, privileges, and choices.
+/// </summary>
+internal sealed class MetadataExplorerScreen : TuiScreenBase
+{
+    private readonly FrameView _entitiesFrame;
+    private readonly TextField _searchField;
+    private readonly ListView _entityList;
+    private readonly FrameView _detailsFrame;
+    private readonly TableView _detailTable;
+    private readonly Label _statusLabel;
+    private readonly Button[] _tabButtons;
+
+    private List<EntitySummary> _allEntities = [];
+    private List<EntitySummary> _filteredEntities = [];
+    private EntityMetadataDto? _selectedEntity;
+    private IReadOnlyList<OptionSetMetadataDto>? _globalOptionSets;
+    private int _activeTabIndex;
+    private object? _filterDebounceToken;
+    private CancellationTokenSource? _loadCts;
+    private int _lastSelectedIndex = -1;
+
+    private const int FilterDebounceMs = 300;
+
+    private static readonly string[] TabNames = ["Attributes", "Relationships", "Keys", "Privileges", "Choices"];
+
+    public override string Title => "Metadata";
+
+    public MetadataExplorerScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        // Left pane: entity list with search
+        _entitiesFrame = new FrameView("Entities")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Percent(35),
+            Height = Dim.Fill(1) // leave room for status label
+        };
+
+        _searchField = new TextField("")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            ColorScheme = TuiColorPalette.TextInput
+        };
+
+        _entityList = new ListView
+        {
+            X = 0,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        _entitiesFrame.Add(_searchField, _entityList);
+
+        // Right pane: details with tab buttons and table
+        _detailsFrame = new FrameView("Details")
+        {
+            X = Pos.Right(_entitiesFrame),
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1)
+        };
+
+        // Create tab buttons
+        _tabButtons = new Button[TabNames.Length];
+        var tabX = 0;
+        for (int i = 0; i < TabNames.Length; i++)
+        {
+            var idx = i;
+            _tabButtons[i] = new Button(TabNames[i])
+            {
+                X = tabX,
+                Y = 0,
+                ColorScheme = i == 0 ? TuiColorPalette.TabActive : TuiColorPalette.TabInactive
+            };
+            _tabButtons[i].Clicked += () => SwitchTab(idx);
+            // Estimate button width: text length + brackets/padding (Terminal.Gui adds "[ ]" around text)
+            tabX += TabNames[i].Length + 6;
+        }
+
+        _detailTable = new TableView
+        {
+            X = 0,
+            Y = 2,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(),
+            FullRowSelect = true,
+            Style = { ShowHorizontalHeaderOverline = false, ShowHorizontalHeaderUnderline = true }
+        };
+
+        foreach (var btn in _tabButtons) _detailsFrame.Add(btn);
+        _detailsFrame.Add(_detailTable);
+
+        // Status label at bottom
+        _statusLabel = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_entitiesFrame),
+            Width = Dim.Fill(),
+            Height = 1,
+            Text = "Loading...",
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        Content.Add(_entitiesFrame, _detailsFrame, _statusLabel);
+
+        // Wire up events
+        _searchField.TextChanged += OnSearchTextChanged;
+        _entityList.SelectedItemChanged += OnEntitySelectionChanged;
+
+        // Kick off initial load
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadEntitiesAsync(), "Metadata.InitialLoad");
+        }
+        else
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.R, "Refresh", () => ErrorService.FireAndForget(LoadEntitiesAsync(), "Metadata.Refresh"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.F, "Focus search", () => _searchField.SetFocus());
+        RegisterHotkey(registry, Key.CtrlMask | Key.O, "Open in Maker", OpenInMaker);
+    }
+
+    #region Data Loading
+
+    private async Task LoadEntitiesAsync()
+    {
+        if (string.IsNullOrEmpty(EnvironmentUrl))
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+            });
+            return;
+        }
+
+        _loadCts?.Cancel();
+        _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        var ct = _loadCts.Token;
+
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "Loading entities...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var metadataService = provider.GetRequiredService<IMetadataService>();
+            var entities = await metadataService.GetEntitiesAsync(cancellationToken: ct);
+
+            ct.ThrowIfCancellationRequested();
+
+            Application.MainLoop.Invoke(() =>
+            {
+                _allEntities = entities.OrderBy(e => e.LogicalName).ToList();
+                _selectedEntity = null;
+                _globalOptionSets = null;
+                _lastSelectedIndex = -1;
+                ApplyFilterOnUiThread();
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing or superseded */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load entities", ex, "Metadata.LoadEntities");
+                _statusLabel.Text = "Error loading entities";
+            });
+        }
+    }
+
+    private async Task LoadEntityDetailAsync(string logicalName)
+    {
+        _loadCts?.Cancel();
+        _loadCts = CancellationTokenSource.CreateLinkedTokenSource(ScreenCancellation);
+        var ct = _loadCts.Token;
+
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = $"Loading {logicalName}...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
+            var metadataService = provider.GetRequiredService<IMetadataService>();
+
+            var (entity, globalOptionSets) = await metadataService.GetEntityWithGlobalOptionSetsAsync(
+                logicalName, includeGlobalOptionSets: true, ct);
+
+            ct.ThrowIfCancellationRequested();
+
+            Application.MainLoop.Invoke(() =>
+            {
+                _selectedEntity = entity;
+                _globalOptionSets = globalOptionSets;
+                RefreshDetailTable();
+                UpdateStatusLabel();
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing or superseded */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError($"Failed to load entity: {logicalName}", ex, "Metadata.LoadEntity");
+                _statusLabel.Text = $"Error loading {logicalName}";
+            });
+        }
+    }
+
+    #endregion
+
+    #region Filtering
+
+    private void OnSearchTextChanged(NStack.ustring _)
+    {
+        if (_filterDebounceToken != null && Application.MainLoop != null)
+        {
+            Application.MainLoop.RemoveTimeout(_filterDebounceToken);
+            _filterDebounceToken = null;
+        }
+
+        if (Application.MainLoop != null)
+        {
+            _filterDebounceToken = Application.MainLoop.AddTimeout(
+                TimeSpan.FromMilliseconds(FilterDebounceMs),
+                _ =>
+                {
+                    _filterDebounceToken = null;
+                    ApplyFilterOnUiThread();
+                    return false;
+                });
+        }
+    }
+
+    private void ApplyFilterOnUiThread()
+    {
+        var filterText = _searchField.Text?.ToString() ?? "";
+
+        if (string.IsNullOrWhiteSpace(filterText))
+        {
+            _filteredEntities = new List<EntitySummary>(_allEntities);
+        }
+        else
+        {
+            _filteredEntities = _allEntities
+                .Where(e => e.LogicalName.Contains(filterText, StringComparison.OrdinalIgnoreCase)
+                    || e.DisplayName.Contains(filterText, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        var displayNames = _filteredEntities
+            .Select(e =>
+            {
+                var prefix = e.IsCustomEntity ? "\u25c6 " : "  ";
+                return $"{prefix}{e.LogicalName}";
+            })
+            .ToList();
+
+        _entityList.SetSource(displayNames);
+        UpdateStatusLabel();
+    }
+
+    #endregion
+
+    #region Entity Selection
+
+    private void OnEntitySelectionChanged(ListViewItemEventArgs args)
+    {
+        var index = args.Item;
+        if (index < 0 || index >= _filteredEntities.Count) return;
+        if (index == _lastSelectedIndex) return;
+        _lastSelectedIndex = index;
+
+        var entity = _filteredEntities[index];
+        ErrorService.FireAndForget(LoadEntityDetailAsync(entity.LogicalName), "Metadata.SelectEntity");
+    }
+
+    #endregion
+
+    #region Tab Switching
+
+    private void SwitchTab(int tabIndex)
+    {
+        if (tabIndex == _activeTabIndex) return;
+        _activeTabIndex = tabIndex;
+
+        for (int i = 0; i < _tabButtons.Length; i++)
+        {
+            _tabButtons[i].ColorScheme = i == _activeTabIndex
+                ? TuiColorPalette.TabActive
+                : TuiColorPalette.TabInactive;
+        }
+
+        RefreshDetailTable();
+    }
+
+    #endregion
+
+    #region Detail Table Population
+
+    private void RefreshDetailTable()
+    {
+        if (_selectedEntity == null)
+        {
+            _detailTable.Table = new System.Data.DataTable();
+            return;
+        }
+
+        var dt = _activeTabIndex switch
+        {
+            0 => BuildAttributesTable(),
+            1 => BuildRelationshipsTable(),
+            2 => BuildKeysTable(),
+            3 => BuildPrivilegesTable(),
+            4 => BuildChoicesTable(),
+            _ => new System.Data.DataTable()
+        };
+
+        _detailTable.Table = dt;
+    }
+
+    private System.Data.DataTable BuildAttributesTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("LogicalName", typeof(string));
+        dt.Columns.Add("DisplayName", typeof(string));
+        dt.Columns.Add("Type", typeof(string));
+        dt.Columns.Add("Required", typeof(string));
+        dt.Columns.Add("Custom", typeof(string));
+        dt.Columns.Add("MaxLength", typeof(string));
+
+        foreach (var attr in _selectedEntity!.Attributes.OrderBy(a => a.LogicalName))
+        {
+            dt.Rows.Add(
+                attr.LogicalName,
+                attr.DisplayName,
+                attr.AttributeType,
+                attr.RequiredLevel ?? "\u2014",
+                attr.IsCustomAttribute ? "\u2713" : "\u2014",
+                attr.MaxLength?.ToString() ?? "\u2014");
+        }
+
+        return dt;
+    }
+
+    private System.Data.DataTable BuildRelationshipsTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("SchemaName", typeof(string));
+        dt.Columns.Add("Type", typeof(string));
+        dt.Columns.Add("RelatedEntity", typeof(string));
+        dt.Columns.Add("LookupField", typeof(string));
+        dt.Columns.Add("CascadeDelete", typeof(string));
+
+        // One-to-Many
+        foreach (var rel in _selectedEntity!.OneToManyRelationships.OrderBy(r => r.SchemaName))
+        {
+            dt.Rows.Add(
+                rel.SchemaName,
+                "1:N",
+                rel.ReferencingEntity,
+                rel.ReferencingAttribute,
+                rel.CascadeDelete ?? "\u2014");
+        }
+
+        // Many-to-One
+        foreach (var rel in _selectedEntity.ManyToOneRelationships.OrderBy(r => r.SchemaName))
+        {
+            dt.Rows.Add(
+                rel.SchemaName,
+                "N:1",
+                rel.ReferencedEntity,
+                rel.ReferencingAttribute,
+                rel.CascadeDelete ?? "\u2014");
+        }
+
+        // Many-to-Many
+        foreach (var rel in _selectedEntity.ManyToManyRelationships.OrderBy(r => r.SchemaName))
+        {
+            var relatedEntity = rel.Entity1LogicalName == _selectedEntity.LogicalName
+                ? rel.Entity2LogicalName
+                : rel.Entity1LogicalName;
+
+            dt.Rows.Add(
+                rel.SchemaName,
+                "N:N",
+                relatedEntity,
+                rel.IntersectEntityName,
+                "\u2014");
+        }
+
+        return dt;
+    }
+
+    private System.Data.DataTable BuildKeysTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("DisplayName", typeof(string));
+        dt.Columns.Add("SchemaName", typeof(string));
+        dt.Columns.Add("KeyAttributes", typeof(string));
+        dt.Columns.Add("IndexStatus", typeof(string));
+
+        foreach (var key in _selectedEntity!.Keys.OrderBy(k => k.SchemaName))
+        {
+            dt.Rows.Add(
+                key.DisplayName,
+                key.SchemaName,
+                string.Join(", ", key.KeyAttributes),
+                key.EntityKeyIndexStatus ?? "\u2014");
+        }
+
+        return dt;
+    }
+
+    private System.Data.DataTable BuildPrivilegesTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("Name", typeof(string));
+        dt.Columns.Add("Type", typeof(string));
+        dt.Columns.Add("Basic", typeof(string));
+        dt.Columns.Add("Local", typeof(string));
+        dt.Columns.Add("Deep", typeof(string));
+        dt.Columns.Add("Global", typeof(string));
+
+        foreach (var priv in _selectedEntity!.Privileges.OrderBy(p => p.Name))
+        {
+            dt.Rows.Add(
+                priv.Name,
+                priv.PrivilegeType,
+                priv.CanBeBasic ? "\u2713" : "\u2014",
+                priv.CanBeLocal ? "\u2713" : "\u2014",
+                priv.CanBeDeep ? "\u2713" : "\u2014",
+                priv.CanBeGlobal ? "\u2713" : "\u2014");
+        }
+
+        return dt;
+    }
+
+    private System.Data.DataTable BuildChoicesTable()
+    {
+        var dt = new System.Data.DataTable();
+        dt.Columns.Add("AttributeName", typeof(string));
+        dt.Columns.Add("OptionSetName", typeof(string));
+        dt.Columns.Add("Global", typeof(string));
+        dt.Columns.Add("ValuesCount", typeof(int));
+
+        var choiceAttributes = _selectedEntity!.Attributes
+            .Where(a => a.OptionSetName != null)
+            .OrderBy(a => a.LogicalName)
+            .ToList();
+
+        foreach (var attr in choiceAttributes)
+        {
+            var valueCount = 0;
+            if (attr.Options != null)
+            {
+                valueCount = attr.Options.Count;
+            }
+            else if (attr.IsGlobalOptionSet && _globalOptionSets != null)
+            {
+                var globalOs = _globalOptionSets.FirstOrDefault(
+                    os => os.Name.Equals(attr.OptionSetName, StringComparison.OrdinalIgnoreCase));
+                if (globalOs != null)
+                {
+                    valueCount = globalOs.Options.Count;
+                }
+            }
+
+            dt.Rows.Add(
+                attr.LogicalName,
+                attr.OptionSetName ?? "\u2014",
+                attr.IsGlobalOptionSet ? "\u2713" : "\u2014",
+                valueCount);
+        }
+
+        return dt;
+    }
+
+    #endregion
+
+    #region Status and Navigation
+
+    private void UpdateStatusLabel()
+    {
+        var entityCount = _filteredEntities.Count;
+        var parts = new List<string> { $"{entityCount} entit{(entityCount != 1 ? "ies" : "y")}" };
+
+        if (_selectedEntity != null)
+        {
+            parts.Add($"Selected: {_selectedEntity.LogicalName} ({_selectedEntity.Attributes.Count} attributes)");
+        }
+
+        _statusLabel.Text = string.Join(" | ", parts);
+    }
+
+    private void OpenInMaker()
+    {
+        if (EnvironmentUrl == null)
+        {
+            ErrorService.ReportError("No environment URL available");
+            return;
+        }
+
+        var url = EnvironmentUrl;
+        if (_selectedEntity != null)
+        {
+            url += $"/main.aspx?pagetype=entitylist&etn={_selectedEntity.LogicalName}";
+        }
+
+        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        {
+            Width = 70,
+            Height = 7
+        };
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = url });
+        Application.Run(dialog);
+        dialog.Dispose();
+    }
+
+    #endregion
+
+    protected override void OnDispose()
+    {
+        _searchField.TextChanged -= OnSearchTextChanged;
+        _entityList.SelectedItemChanged -= OnEntitySelectionChanged;
+        foreach (var btn in _tabButtons)
+        {
+            // Button.Clicked is an event; we need to clear handlers.
+            // Since we used lambdas, the best we can do is dispose the button.
+        }
+        _loadCts?.Cancel();
+        _loadCts?.Dispose();
+        if (_filterDebounceToken != null)
+        {
+            Application.MainLoop?.RemoveTimeout(_filterDebounceToken);
+        }
+    }
+}

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -282,6 +282,7 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             new("Solutions", "Browse Dataverse solutions", () => NavigateToSolutions()),
             new("Import Jobs", "View solution import jobs", () => NavigateToImportJobs()),
             new("Plugin Traces", "Browse plugin trace logs", () => NavigateToPluginTraces()),
+            new("Metadata Browser", "Browse entity metadata", () => NavigateToMetadataBrowser()),
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Environment Details...", "View organization and connection info",
                 hasEnvironment ? () => ShowEnvironmentDetails() : (Action?)null),
@@ -505,6 +506,31 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             _contentArea.Remove(loadingLabel);
 
             var screen = new PluginTracesScreen(_session);
+            NavigateTo(screen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToMetadataBrowser()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Metadata Browser...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new MetadataExplorerScreen(_session);
             NavigateTo(screen);
 
             return false;

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -152,6 +152,44 @@ public class DataverseMetadataService : IMetadataService
     }
 
     /// <inheritdoc />
+    public async Task<(EntityMetadataDto Entity, IReadOnlyList<OptionSetMetadataDto> GlobalOptionSets)> GetEntityWithGlobalOptionSetsAsync(
+        string logicalName,
+        bool includeGlobalOptionSets = false,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await GetEntityAsync(
+            logicalName,
+            includeAttributes: true,
+            includeRelationships: true,
+            includeKeys: true,
+            includePrivileges: true,
+            cancellationToken: cancellationToken);
+
+        if (!includeGlobalOptionSets)
+        {
+            return (entity, Array.Empty<OptionSetMetadataDto>());
+        }
+
+        var globalOptionSetNames = entity.Attributes
+            .Where(a => a.IsGlobalOptionSet && !string.IsNullOrEmpty(a.OptionSetName))
+            .Select(a => a.OptionSetName!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (globalOptionSetNames.Count == 0)
+        {
+            return (entity, Array.Empty<OptionSetMetadataDto>());
+        }
+
+        var optionSetTasks = globalOptionSetNames
+            .Select(name => GetOptionSetAsync(name, cancellationToken));
+
+        var optionSets = await Task.WhenAll(optionSetTasks);
+
+        return (entity, optionSets);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<AttributeMetadataDto>> GetAttributesAsync(
         string entityLogicalName,
         string? attributeType = null,

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -184,9 +184,23 @@ public class DataverseMetadataService : IMetadataService
         }
 
         var optionSetTasks = globalOptionSetNames
-            .Select(name => GetOptionSetAsync(name, cancellationToken));
+            .Select(async name =>
+            {
+                try
+                {
+                    return await GetOptionSetAsync(name, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger?.LogWarning(ex, "Failed to retrieve global option set {OptionSetName} for entity {EntityLogicalName}", name, logicalName);
+                    return null;
+                }
+            });
 
-        var optionSets = await Task.WhenAll(optionSetTasks);
+        var optionSets = (await Task.WhenAll(optionSetTasks).ConfigureAwait(false))
+            .Where(os => os is not null)
+            .Select(os => os!)
+            .ToList();
 
         return (entity, optionSets);
     }

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataService.cs
@@ -157,6 +157,8 @@ public class DataverseMetadataService : IMetadataService
         bool includeGlobalOptionSets = false,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logicalName);
+
         var entity = await GetEntityAsync(
             logicalName,
             includeAttributes: true,

--- a/src/PPDS.Dataverse/Metadata/IMetadataService.cs
+++ b/src/PPDS.Dataverse/Metadata/IMetadataService.cs
@@ -41,6 +41,15 @@ public interface IMetadataService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets full metadata for a specific entity, optionally including
+    /// global option set values for picklist attributes.
+    /// </summary>
+    Task<(EntityMetadataDto Entity, IReadOnlyList<OptionSetMetadataDto> GlobalOptionSets)> GetEntityWithGlobalOptionSetsAsync(
+        string logicalName,
+        bool includeGlobalOptionSets = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets all attributes for an entity.
     /// </summary>
     /// <param name="entityLogicalName">The entity logical name.</param>

--- a/src/PPDS.Extension/esbuild.js
+++ b/src/PPDS.Extension/esbuild.js
@@ -90,6 +90,18 @@ const builds = [
         outfile: 'dist/plugin-traces-panel.js',
         logLevel: 'warning',
     },
+    // Metadata Browser panel webview (browser, IIFE)
+    {
+        entryPoints: ['src/panels/webview/metadata-browser-panel.ts'],
+        bundle: true,
+        format: 'iife',
+        minify: production,
+        sourcemap: !production,
+        sourcesContent: false,
+        platform: 'browser',
+        outfile: 'dist/metadata-browser-panel.js',
+        logLevel: 'warning',
+    },
     // ── Panel CSS bundles ────────────────────────────────────────────────────
     {
         entryPoints: ['src/panels/styles/query-panel.css'],
@@ -119,6 +131,14 @@ const builds = [
         bundle: true,
         minify: production,
         outfile: 'dist/plugin-traces-panel.css',
+        logLevel: 'warning',
+    },
+    // Metadata Browser panel CSS
+    {
+        entryPoints: ['src/panels/styles/metadata-browser-panel.css'],
+        bundle: true,
+        minify: production,
+        outfile: 'dist/metadata-browser-panel.css',
         logLevel: 'warning',
     },
 ];

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -248,6 +248,12 @@
         "icon": "$(debug-stackframe)"
       },
       {
+        "command": "ppds.openMetadataBrowser",
+        "title": "Open Metadata Browser",
+        "category": "PPDS",
+        "icon": "$(symbol-class)"
+      },
+      {
         "command": "ppds.copyEnvironmentUrl",
         "title": "Copy URL",
         "icon": "$(copy)"

--- a/src/PPDS.Extension/src/__tests__/daemonClient.test.ts
+++ b/src/PPDS.Extension/src/__tests__/daemonClient.test.ts
@@ -756,42 +756,58 @@ describe('DaemonClient', () => {
         });
     });
 
-    describe('schemaEntities', () => {
-        it('should call schema/entities and return result', async () => {
+    describe('metadataEntities', () => {
+        it('should call metadata/entities and return result', async () => {
             const mockResult = {
                 entities: [
-                    { logicalName: 'account', displayName: 'Account', isCustom: false },
-                    { logicalName: 'contact', displayName: 'Contact', isCustom: false },
+                    { logicalName: 'account', schemaName: 'Account', displayName: 'Account', isCustomEntity: false, isManaged: false, ownershipType: 'UserOwned', objectTypeCode: 1, description: null },
+                    { logicalName: 'contact', schemaName: 'Contact', displayName: 'Contact', isCustomEntity: false, isManaged: false, ownershipType: 'UserOwned', objectTypeCode: 2, description: null },
                 ],
             };
             mockConnection.sendRequest.mockResolvedValueOnce(mockResult);
 
-            const result = await client.schemaEntities();
+            const result = await client.metadataEntities();
 
-            expect(mockConnection.sendRequest).toHaveBeenCalledWith('schema/entities');
+            expect(mockConnection.sendRequest).toHaveBeenCalledWith('metadata/entities', {});
             expect(result.entities).toHaveLength(2);
             expect(result.entities[0].logicalName).toBe('account');
         });
     });
 
-    describe('schemaAttributes', () => {
-        it('should call schema/attributes with entity name', async () => {
+    describe('metadataEntity', () => {
+        it('should call metadata/entity with logicalName', async () => {
             const mockResult = {
-                entityName: 'account',
-                attributes: [
-                    { logicalName: 'name', displayName: 'Account Name', dataType: 'String', isCustom: false },
-                    { logicalName: 'accountid', displayName: 'Account', dataType: 'Uniqueidentifier', isCustom: false },
-                ],
+                entity: {
+                    logicalName: 'account',
+                    schemaName: 'Account',
+                    displayName: 'Account',
+                    isCustomEntity: false,
+                    isManaged: false,
+                    ownershipType: 'UserOwned',
+                    objectTypeCode: 1,
+                    description: null,
+                    primaryIdAttribute: 'accountid',
+                    primaryNameAttribute: 'name',
+                    entitySetName: 'accounts',
+                    isActivity: false,
+                    attributes: [],
+                    oneToManyRelationships: [],
+                    manyToOneRelationships: [],
+                    manyToManyRelationships: [],
+                    keys: [],
+                    privileges: [],
+                    globalOptionSets: [],
+                },
             };
             mockConnection.sendRequest.mockResolvedValueOnce(mockResult);
 
-            const result = await client.schemaAttributes('account');
+            const result = await client.metadataEntity('account', true);
 
-            expect(mockConnection.sendRequest).toHaveBeenCalledWith('schema/attributes', {
-                entity: 'account',
+            expect(mockConnection.sendRequest).toHaveBeenCalledWith('metadata/entity', {
+                logicalName: 'account',
+                includeGlobalOptionSets: true,
             });
-            expect(result.entityName).toBe('account');
-            expect(result.attributes).toHaveLength(2);
+            expect(result.entity.logicalName).toBe('account');
         });
     });
 

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -36,8 +36,8 @@ import type {
     ProfilesInvalidateResponse,
     SolutionsListResponse,
     SolutionComponentsResponse,
-    SchemaEntitiesResponse,
-    SchemaAttributesResponse,
+    MetadataEntitiesResponse,
+    MetadataEntityResponse,
     ImportJobsListResponse,
     ImportJobsGetResponse,
     PluginTracesListResponse,
@@ -825,35 +825,40 @@ export class DaemonClient implements vscode.Disposable {
         return result;
     }
 
-    // ── Schema ──────────────────────────────────────────────────────────────
+    // ── Metadata ────────────────────────────────────────────────────────────
 
-    /**
-     * Lists all entities in the active Dataverse environment.
-     * Used for IntelliSense entity completion.
-     */
-    async schemaEntities(): Promise<SchemaEntitiesResponse> {
+    async metadataEntities(environmentUrl?: string): Promise<MetadataEntitiesResponse> {
         await this.ensureConnected();
 
-        this.log.debug('Calling schema/entities...');
-        const result = await this.connection!.sendRequest<SchemaEntitiesResponse>('schema/entities');
+        const params: Record<string, unknown> = {};
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.debug('Calling metadata/entities...');
+        const result = await this.connection!.sendRequest<MetadataEntitiesResponse>(
+            'metadata/entities',
+            params
+        );
         this.log.debug(`Got ${result.entities.length} entities`);
 
         return result;
     }
 
-    /**
-     * Lists attributes for a specific entity in the active Dataverse environment.
-     * Used for IntelliSense attribute completion.
-     */
-    async schemaAttributes(entity: string): Promise<SchemaAttributesResponse> {
+    async metadataEntity(
+        logicalName: string,
+        includeGlobalOptionSets = false,
+        environmentUrl?: string,
+    ): Promise<MetadataEntityResponse> {
         await this.ensureConnected();
 
-        this.log.debug(`Calling schema/attributes for "${entity}"...`);
-        const result = await this.connection!.sendRequest<SchemaAttributesResponse>(
-            'schema/attributes',
-            { entity }
+        const params: Record<string, unknown> = { logicalName, includeGlobalOptionSets };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+
+        this.log.debug(`Calling metadata/entity for "${logicalName}"...`);
+        const result = await this.connection!.sendRequest<MetadataEntityResponse>(
+            'metadata/entity',
+            params
         );
-        this.log.debug(`Got ${result.attributes.length} attributes for ${result.entityName}`);
+        this.log.debug(`Got entity "${logicalName}" with ${result.entity.attributes.length} attributes`);
 
         return result;
     }

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -20,6 +20,7 @@ import { QueryPanel } from './panels/QueryPanel.js';
 import { SolutionsPanel } from './panels/SolutionsPanel.js';
 import { ImportJobsPanel } from './panels/ImportJobsPanel.js';
 import { PluginTracesPanel } from './panels/PluginTracesPanel.js';
+import { MetadataBrowserPanel } from './panels/MetadataBrowserPanel.js';
 import { migrateLegacyState } from './migration/legacyState.js';
 import { registerDebugCommands } from './commands/debugCommands.js';
 import { DaemonStatusBar } from './daemonStatusBar.js';
@@ -70,6 +71,9 @@ function registerPanelCommands(
         }),
         vscode.commands.registerCommand('ppds.openPluginTraces', () => {
             PluginTracesPanel.show(context.extensionUri, client);
+        }),
+        vscode.commands.registerCommand('ppds.openMetadataBrowser', () => {
+            MetadataBrowserPanel.show(context.extensionUri, client);
         }),
         vscode.commands.registerCommand('ppds.openQueryInNotebook', (sql?: string) => {
             void openQueryInNotebook(sql ?? '');
@@ -377,6 +381,7 @@ export function activate(context: vscode.ExtensionContext): void {
         solutionsPanels: () => SolutionsPanel.instanceCount,
         importJobsPanels: () => ImportJobsPanel.instanceCount,
         pluginTracesPanels: () => PluginTracesPanel.instanceCount,
+        metadataBrowserPanels: () => MetadataBrowserPanel.instanceCount,
     });
 
     // Register environment selection command for notebooks

--- a/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
+++ b/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
@@ -214,7 +214,7 @@ export class MetadataBrowserPanel extends WebviewPanelBase<MetadataBrowserPanelW
         }
     }
 
-    private async loadEntityDetail(logicalName: string): Promise<void> {
+    private async loadEntityDetail(logicalName: string, isRetry = false): Promise<void> {
         try {
             this.postMessage({ command: 'entityDetailLoading', logicalName });
             const result = await this.daemon.metadataEntity(logicalName, true, this.environmentUrl);
@@ -224,6 +224,11 @@ export class MetadataBrowserPanel extends WebviewPanelBase<MetadataBrowserPanelW
             });
         } catch (error) {
             const msg = error instanceof Error ? error.message : String(error);
+
+            if (await handleAuthError(this.daemon, error, isRetry, () => this.loadEntityDetail(logicalName, true))) {
+                return;
+            }
+
             this.postMessage({ command: 'error', message: `Failed to load entity detail: ${msg}` });
         }
     }

--- a/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
+++ b/src/PPDS.Extension/src/panels/MetadataBrowserPanel.ts
@@ -1,0 +1,302 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient } from '../daemonClient.js';
+import { handleAuthError } from '../utils/errorUtils.js';
+
+import { WebviewPanelBase } from './WebviewPanelBase.js';
+import { getNonce } from './webviewUtils.js';
+import { getEnvironmentPickerHtml, showEnvironmentPicker } from './environmentPicker.js';
+import type { MetadataBrowserPanelWebviewToHost, MetadataBrowserPanelHostToWebview } from './webview/shared/message-types.js';
+import { assertNever } from './webview/shared/assert-never.js';
+
+export class MetadataBrowserPanel extends WebviewPanelBase<MetadataBrowserPanelWebviewToHost, MetadataBrowserPanelHostToWebview> {
+    private static instances: MetadataBrowserPanel[] = [];
+    private static nextId = 1;
+    private readonly panelId: number;
+
+    private static readonly MAX_PANELS = 5;
+
+    private environmentUrl: string | undefined;
+    private environmentDisplayName: string | undefined;
+    private environmentType: string | null = null;
+    private environmentColor: string | null = null;
+    private environmentId: string | null = null;
+    private profileName: string | undefined;
+
+    /**
+     * Returns the number of open MetadataBrowserPanel instances.
+     * Used by diagnostic commands for panel state inspection.
+     */
+    static get instanceCount(): number {
+        return MetadataBrowserPanel.instances.length;
+    }
+
+    static show(extensionUri: vscode.Uri, daemon: DaemonClient, envUrl?: string, envDisplayName?: string): MetadataBrowserPanel {
+        if (MetadataBrowserPanel.instances.length >= MetadataBrowserPanel.MAX_PANELS) {
+            const oldest = MetadataBrowserPanel.instances[0];
+            oldest.panel?.reveal();
+            return oldest;
+        }
+        const panel = new MetadataBrowserPanel(extensionUri, daemon, envUrl, envDisplayName);
+        return panel;
+    }
+
+    private constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly daemon: DaemonClient,
+        initialEnvUrl?: string,
+        initialEnvDisplayName?: string,
+    ) {
+        super();
+
+        if (initialEnvUrl) {
+            this.environmentUrl = initialEnvUrl;
+            this.environmentDisplayName = initialEnvDisplayName ?? initialEnvUrl;
+        }
+
+        this.panelId = MetadataBrowserPanel.nextId++;
+        MetadataBrowserPanel.instances.push(this);
+
+        const panel = vscode.window.createWebviewPanel(
+            'ppds.metadataBrowser',
+            `Metadata Browser #${this.panelId}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: false,
+                localResourceRoots: [
+                    vscode.Uri.joinPath(extensionUri, 'node_modules'),
+                    vscode.Uri.joinPath(extensionUri, 'dist'),
+                ],
+            }
+        );
+
+        panel.webview.html = this.getHtmlContent(panel.webview);
+        this.initPanel(panel);
+        this.subscribeToDaemonReconnect(this.daemon);
+    }
+
+    protected async handleMessage(message: MetadataBrowserPanelWebviewToHost): Promise<void> {
+        switch (message.command) {
+            case 'ready':
+                await this.initialize();
+                break;
+            case 'requestEnvironmentList':
+                await this.handleEnvironmentPicker();
+                break;
+            case 'refresh':
+                await this.loadEntities();
+                break;
+            case 'selectEntity':
+                await this.loadEntityDetail(message.logicalName);
+                break;
+            case 'openInMaker':
+                await this.openInMaker(message.entityLogicalName);
+                break;
+            case 'copyToClipboard':
+                await vscode.env.clipboard.writeText(message.text);
+                break;
+            case 'webviewError':
+                this.logWebviewError(message.error, message.stack);
+                break;
+            default:
+                assertNever(message);
+        }
+    }
+
+    protected override onDaemonReconnected(): void {
+        void this.loadEntities();
+    }
+
+    override dispose(): void {
+        const idx = MetadataBrowserPanel.instances.indexOf(this);
+        if (idx >= 0) MetadataBrowserPanel.instances.splice(idx, 1);
+        super.dispose();
+    }
+
+    private async initialize(): Promise<void> {
+        try {
+            const who = await this.daemon.authWho();
+            this.profileName = who.name ?? `Profile ${who.index}`;
+            if (!this.environmentUrl && who.environment?.url) {
+                this.environmentUrl = who.environment.url;
+                this.environmentDisplayName = who.environment.displayName || who.environment.url;
+            }
+            this.environmentType = who.environment?.type ?? null;
+            if (who.environment?.environmentId) {
+                this.environmentId = who.environment.environmentId;
+            } else {
+                this.environmentId = await this.resolveEnvironmentId();
+            }
+            if (this.environmentUrl) {
+                try {
+                    const config = await this.daemon.envConfigGet(this.environmentUrl);
+                    this.environmentColor = config.resolvedColor ?? null;
+                } catch {
+                    this.environmentColor = null;
+                }
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: this.environmentDisplayName ?? 'No environment', envType: this.environmentType, envColor: this.environmentColor });
+            await this.loadEntities();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to initialize: ${msg}` });
+        }
+    }
+
+    private async handleEnvironmentPicker(): Promise<void> {
+        const result = await showEnvironmentPicker(this.daemon, this.environmentUrl);
+        if (result) {
+            this.environmentUrl = result.url;
+            this.environmentDisplayName = result.displayName;
+            this.environmentType = result.type;
+            this.environmentId = await this.resolveEnvironmentId();
+            try {
+                const config = await this.daemon.envConfigGet(result.url);
+                this.environmentColor = config.resolvedColor ?? null;
+            } catch {
+                this.environmentColor = null;
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: result.type, envColor: this.environmentColor });
+            await this.loadEntities();
+        }
+    }
+
+    private async resolveEnvironmentId(): Promise<string | null> {
+        if (!this.environmentUrl) return null;
+        try {
+            const normalise = (u: string): string => u.replace(/\/+$/, '').toLowerCase();
+            const targetUrl = normalise(this.environmentUrl);
+            const envResult = await this.daemon.envList();
+            const match = envResult.environments.find(
+                e => normalise(e.apiUrl) === targetUrl || (e.url && normalise(e.url) === targetUrl)
+            );
+            return match?.environmentId ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    private updatePanelTitle(): void {
+        if (!this.panel) return;
+        const context = [this.profileName, this.environmentDisplayName].filter(Boolean).join(' \u00B7 ');
+        const suffix = MetadataBrowserPanel.instances.length > 1 ? ` ${this.panelId}` : '';
+        this.panel.title = context ? `${context} \u2014 Metadata Browser${suffix}` : `Metadata Browser${suffix}`;
+    }
+
+    private async loadEntities(isRetry = false): Promise<void> {
+        try {
+            this.postMessage({ command: 'loading' });
+            const result = await this.daemon.metadataEntities(this.environmentUrl);
+
+            this.postMessage({
+                command: 'entitiesLoaded',
+                entities: result.entities.map(e => ({
+                    logicalName: e.logicalName,
+                    schemaName: e.schemaName,
+                    displayName: e.displayName,
+                    isCustomEntity: e.isCustomEntity,
+                    isManaged: e.isManaged,
+                    ownershipType: e.ownershipType,
+                    description: e.description,
+                })),
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+
+            if (await handleAuthError(this.daemon, error, isRetry, () => this.loadEntities(true))) {
+                return;
+            }
+
+            this.postMessage({ command: 'error', message: msg });
+        }
+    }
+
+    private async loadEntityDetail(logicalName: string): Promise<void> {
+        try {
+            this.postMessage({ command: 'entityDetailLoading', logicalName });
+            const result = await this.daemon.metadataEntity(logicalName, true, this.environmentUrl);
+            this.postMessage({
+                command: 'entityDetailLoaded',
+                entity: result.entity,
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load entity detail: ${msg}` });
+        }
+    }
+
+    private async openInMaker(entityLogicalName?: string): Promise<void> {
+        if (this.environmentId) {
+            let url: string;
+            if (entityLogicalName) {
+                url = `https://make.powerapps.com/environments/${this.environmentId}/entities/${entityLogicalName}`;
+            } else {
+                url = `https://make.powerapps.com/environments/${this.environmentId}/entities`;
+            }
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+        } else {
+            vscode.window.showInformationMessage('Environment ID not available \u2014 cannot open Maker Portal.');
+        }
+    }
+
+    getHtmlContent(webview: vscode.Webview): string {
+        const toolkitUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist', 'toolkit.min.js')
+        ).toString();
+        const panelJsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'metadata-browser-panel.js')
+        ).toString();
+        const panelCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'metadata-browser-panel.css')
+        ).toString();
+        const nonce = getNonce();
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- 'unsafe-inline' is required by @vscode/webview-ui-toolkit for dynamic styles -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="${panelCssUri}">
+    <script type="module" nonce="${nonce}" src="${toolkitUri}"></script>
+</head>
+<body>
+
+<div id="reconnect-banner" style="display:none; background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-foreground); padding: 6px 12px; text-align: center; font-size: 12px;">
+    Connection restored. Data may be stale. <a href="#" id="reconnect-refresh" style="color: var(--vscode-textLink-foreground);">Refresh</a>
+</div>
+
+<div class="toolbar">
+    <vscode-button id="refresh-btn" appearance="secondary" title="Refresh entity list">Refresh</vscode-button>
+    <vscode-button id="maker-btn" appearance="secondary" title="Open in Maker Portal">Maker Portal</vscode-button>
+    <span class="toolbar-spacer"></span>
+    ${getEnvironmentPickerHtml()}
+</div>
+
+<div class="split-pane">
+    <div class="entity-list-pane" id="entity-list-pane">
+        <div class="search-container">
+            <input type="text" id="entity-search" placeholder="Search entities..." />
+            <span id="filter-count"></span>
+        </div>
+        <div class="entity-list" id="entity-list"></div>
+    </div>
+    <div class="entity-detail-pane" id="entity-detail-pane">
+        <div class="tab-bar" id="tab-bar"></div>
+        <div class="tab-content" id="tab-content">
+            <div class="empty-state">Select an entity to view details</div>
+        </div>
+    </div>
+</div>
+
+<div class="status-bar"><span id="status-text">Loading...</span></div>
+
+<script nonce="${nonce}" src="${panelJsUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
@@ -1,0 +1,231 @@
+@import './shared.css';
+
+/* ── Metadata Browser Panel specific styles ────────────────────────────── */
+
+.split-pane {
+    display: flex;
+    height: calc(100vh - 70px);
+}
+
+.entity-list-pane {
+    width: 280px;
+    min-width: 200px;
+    border-right: 1px solid var(--vscode-panel-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.entity-detail-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.search-container {
+    padding: 6px;
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+#entity-search {
+    flex: 1;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border);
+    padding: 4px 8px;
+    font-size: 13px;
+}
+
+#entity-search:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+#filter-count {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+}
+
+.entity-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.entity-row {
+    padding: 4px 8px;
+    cursor: pointer;
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+    font-size: 13px;
+}
+
+.entity-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.entity-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+.entity-icon {
+    opacity: 0.7;
+    font-size: 11px;
+}
+
+.entity-display-name {
+    font-weight: 500;
+}
+
+.entity-logical-name {
+    opacity: 0.7;
+    font-size: 12px;
+    margin-left: auto;
+}
+
+/* ── Tab bar ───────────────────────────────────────────────────────────── */
+
+.tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    padding: 0 8px;
+}
+
+.tab-button {
+    padding: 6px 12px;
+    cursor: pointer;
+    border: none;
+    background: none;
+    color: var(--vscode-foreground);
+    opacity: 0.7;
+    border-bottom: 2px solid transparent;
+    font-size: 13px;
+}
+
+.tab-button:hover {
+    opacity: 1;
+}
+
+.tab-button.active {
+    opacity: 1;
+    border-bottom-color: var(--vscode-focusBorder);
+}
+
+/* ── Tab content ───────────────────────────────────────────────────────── */
+
+.tab-content {
+    flex: 1;
+    overflow: auto;
+    padding: 0;
+}
+
+/* ── DataTable (reused from shared) ────────────────────────────────────── */
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    table-layout: fixed;
+}
+
+.data-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--vscode-editor-background);
+}
+
+.data-table th {
+    text-align: left;
+    padding: 6px 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--vscode-descriptionForeground);
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.data-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.data-table th.sortable:hover {
+    color: var(--vscode-foreground);
+}
+
+.data-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.data-table-row {
+    cursor: pointer;
+}
+
+.data-table-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.data-table-row:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.data-table-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* ── Choices section ───────────────────────────────────────────────────── */
+
+.choices-section {
+    margin: 8px 0;
+}
+
+.choices-section-header {
+    padding: 6px 8px;
+    font-weight: 600;
+    font-size: 13px;
+    opacity: 0.8;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.option-values-row {
+    display: none;
+}
+
+.option-values-row.expanded {
+    display: table-row;
+}
+
+.option-values-row td {
+    padding: 4px 24px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.option-values-table {
+    table-layout: auto;
+}
+
+.option-values-table th,
+.option-values-table td {
+    white-space: nowrap;
+}
+
+.color-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 4px;
+}

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -518,7 +518,7 @@ function toggleOptionValues(
             row.appendChild(labelTd);
 
             const colorTd = document.createElement('td');
-            if (opt.color) {
+            if (opt.color && /^#[0-9a-fA-F]{3,8}$/.test(opt.color)) {
                 const swatch = document.createElement('span');
                 swatch.className = 'color-swatch';
                 swatch.style.backgroundColor = opt.color;

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -1,0 +1,618 @@
+// metadata-browser-panel.ts
+// External webview script for the Metadata Browser panel.
+// Built by esbuild as IIFE for browser, loaded via <script src="...">.
+
+import { escapeHtml } from './shared/dom-utils.js';
+import type {
+    MetadataBrowserPanelWebviewToHost,
+    MetadataBrowserPanelHostToWebview,
+    MetadataEntityViewDto,
+} from './shared/message-types.js';
+import type {
+    MetadataEntityDetailDto,
+    MetadataAttributeDto,
+} from '../../types.js';
+import { assertNever } from './shared/assert-never.js';
+import { getVsCodeApi } from './shared/vscode-api.js';
+import { installErrorHandler } from './shared/error-handler.js';
+import { DataTable } from './shared/data-table.js';
+
+const vscode = getVsCodeApi<MetadataBrowserPanelWebviewToHost>();
+installErrorHandler((msg) => vscode.postMessage(msg as MetadataBrowserPanelWebviewToHost));
+
+// ── DOM elements ──
+const entityListEl = document.getElementById('entity-list') as HTMLElement;
+const entitySearchEl = document.getElementById('entity-search') as HTMLInputElement;
+const tabBar = document.getElementById('tab-bar') as HTMLElement;
+const tabContent = document.getElementById('tab-content') as HTMLElement;
+const statusText = document.getElementById('status-text') as HTMLElement;
+const filterCount = document.getElementById('filter-count') as HTMLElement;
+const refreshBtn = document.getElementById('refresh-btn') as HTMLElement;
+const makerBtn = document.getElementById('maker-btn') as HTMLElement;
+
+// ── State ──
+let allEntities: MetadataEntityViewDto[] = [];
+let filteredEntities: MetadataEntityViewDto[] = [];
+let selectedEntityName: string | null = null;
+let currentEntity: MetadataEntityDetailDto | null = null;
+let activeTab = 'attributes';
+
+const TAB_DEFS = [
+    { id: 'attributes', label: 'Attributes' },
+    { id: 'relationships', label: 'Relationships' },
+    { id: 'keys', label: 'Keys' },
+    { id: 'privileges', label: 'Privileges' },
+    { id: 'choices', label: 'Choices' },
+];
+
+// ── Environment picker ──
+const envPickerBtn = document.getElementById('env-picker-btn') as HTMLElement;
+const envPickerName = document.getElementById('env-picker-name') as HTMLElement;
+envPickerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'requestEnvironmentList' });
+});
+function updateEnvironmentDisplay(name: string | null): void {
+    envPickerName.textContent = name || 'No environment';
+}
+
+// ── Button handlers ──
+refreshBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'refresh' });
+});
+
+makerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'openInMaker', entityLogicalName: selectedEntityName ?? undefined });
+});
+
+document.getElementById('reconnect-refresh')!.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.getElementById('reconnect-banner')!.style.display = 'none';
+    vscode.postMessage({ command: 'refresh' });
+});
+
+// ── Entity list rendering ──
+function renderEntityList(): void {
+    entityListEl.innerHTML = '';
+    for (const e of filteredEntities) {
+        const row = document.createElement('div');
+        row.className = 'entity-row';
+        if (e.logicalName === selectedEntityName) {
+            row.classList.add('selected');
+        }
+        row.setAttribute('data-name', e.logicalName);
+
+        const icon = document.createElement('span');
+        icon.className = 'entity-icon';
+        icon.textContent = e.isCustomEntity ? '\u25C6' : '\u25CB';
+        row.appendChild(icon);
+
+        const displayName = document.createElement('span');
+        displayName.className = 'entity-display-name';
+        displayName.textContent = e.displayName || e.logicalName;
+        row.appendChild(displayName);
+
+        const logicalName = document.createElement('span');
+        logicalName.className = 'entity-logical-name';
+        logicalName.textContent = e.logicalName;
+        row.appendChild(logicalName);
+
+        row.addEventListener('click', () => {
+            selectedEntityName = e.logicalName;
+            // Update selection visually
+            entityListEl.querySelectorAll<HTMLElement>('.entity-row.selected')
+                .forEach(r => r.classList.remove('selected'));
+            row.classList.add('selected');
+            vscode.postMessage({ command: 'selectEntity', logicalName: e.logicalName });
+        });
+
+        entityListEl.appendChild(row);
+    }
+}
+
+// ── Entity search / filter ──
+let filterTimer: ReturnType<typeof setTimeout> | null = null;
+
+entitySearchEl.addEventListener('input', () => {
+    if (filterTimer) clearTimeout(filterTimer);
+    filterTimer = setTimeout(() => {
+        applyFilter();
+    }, 150);
+});
+
+function applyFilter(): void {
+    const term = entitySearchEl.value.toLowerCase().trim();
+    if (!term) {
+        filteredEntities = allEntities;
+        filterCount.textContent = '';
+    } else {
+        filteredEntities = allEntities.filter(e =>
+            e.displayName.toLowerCase().includes(term) ||
+            e.logicalName.toLowerCase().includes(term) ||
+            e.schemaName.toLowerCase().includes(term)
+        );
+        filterCount.textContent = `${filteredEntities.length} of ${allEntities.length}`;
+    }
+    renderEntityList();
+    updateStatusText();
+}
+
+function updateStatusText(): void {
+    const total = allEntities.length;
+    const custom = allEntities.filter(e => e.isCustomEntity).length;
+    const system = total - custom;
+    if (filteredEntities.length !== total) {
+        statusText.textContent = `${filteredEntities.length} of ${total} entities (${custom} custom, ${system} system)`;
+    } else {
+        statusText.textContent = `${total} entities (${custom} custom, ${system} system)`;
+    }
+}
+
+// ── Tab bar rendering ──
+function renderTabBar(): void {
+    tabBar.innerHTML = '';
+    for (const tab of TAB_DEFS) {
+        const btn = document.createElement('button');
+        btn.className = 'tab-button';
+        if (tab.id === activeTab) btn.classList.add('active');
+        btn.textContent = tab.label;
+        btn.addEventListener('click', () => {
+            activeTab = tab.id;
+            tabBar.querySelectorAll<HTMLElement>('.tab-button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            renderTabContent();
+        });
+        tabBar.appendChild(btn);
+    }
+}
+
+// ── Tab content rendering ──
+function renderTabContent(): void {
+    if (!currentEntity) {
+        tabContent.innerHTML = '<div class="empty-state">Select an entity to view details</div>';
+        return;
+    }
+
+    switch (activeTab) {
+        case 'attributes':
+            renderAttributesTab();
+            break;
+        case 'relationships':
+            renderRelationshipsTab();
+            break;
+        case 'keys':
+            renderKeysTab();
+            break;
+        case 'privileges':
+            renderPrivilegesTab();
+            break;
+        case 'choices':
+            renderChoicesTab();
+            break;
+    }
+}
+
+// ── Attributes tab ──
+function renderAttributesTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    const table = new DataTable<MetadataAttributeDto>({
+        container: tabContent,
+        columns: [
+            { key: 'logicalName', label: 'Name', render: (a) => escapeHtml(a.logicalName) },
+            { key: 'displayName', label: 'Display Name', render: (a) => escapeHtml(a.displayName ?? '\u2014') },
+            { key: 'attributeType', label: 'Type', render: (a) => escapeHtml(a.attributeType) },
+            { key: 'requiredLevel', label: 'Required', render: (a) => escapeHtml(a.requiredLevel ?? '\u2014') },
+            { key: 'isCustomAttribute', label: 'Custom', render: (a) => a.isCustomAttribute ? '\u2713' : '\u2014' },
+            { key: 'maxLength', label: 'Max Length', render: (a) => a.maxLength !== null ? escapeHtml(String(a.maxLength)) : '\u2014' },
+            { key: 'description', label: 'Description', render: (a) => escapeHtml(a.description ?? '\u2014') },
+        ],
+        getRowId: (a) => a.logicalName,
+        defaultSortKey: 'logicalName',
+        defaultSortDirection: 'asc',
+        emptyMessage: 'No attributes',
+    });
+    table.setItems(currentEntity.attributes);
+}
+
+// ── Relationships tab ──
+interface RelationshipRow {
+    schemaName: string;
+    type: string;
+    relatedEntity: string;
+    lookupField: string;
+    cascadeDelete: string;
+}
+
+function buildRelationshipRows(): RelationshipRow[] {
+    if (!currentEntity) return [];
+    const rows: RelationshipRow[] = [];
+
+    for (const rel of currentEntity.oneToManyRelationships) {
+        rows.push({
+            schemaName: rel.schemaName,
+            type: '1:N',
+            relatedEntity: rel.referencingEntity ?? '\u2014',
+            lookupField: rel.referencingAttribute ?? '\u2014',
+            cascadeDelete: rel.cascadeDelete ?? '\u2014',
+        });
+    }
+
+    for (const rel of currentEntity.manyToOneRelationships) {
+        rows.push({
+            schemaName: rel.schemaName,
+            type: 'N:1',
+            relatedEntity: rel.referencedEntity ?? '\u2014',
+            lookupField: rel.referencingAttribute ?? '\u2014',
+            cascadeDelete: rel.cascadeDelete ?? '\u2014',
+        });
+    }
+
+    for (const rel of currentEntity.manyToManyRelationships) {
+        const related = rel.entity1LogicalName === currentEntity.logicalName
+            ? rel.entity2LogicalName
+            : rel.entity1LogicalName;
+        rows.push({
+            schemaName: rel.schemaName,
+            type: 'N:N',
+            relatedEntity: related ?? '\u2014',
+            lookupField: rel.intersectEntityName ?? '\u2014',
+            cascadeDelete: '\u2014',
+        });
+    }
+
+    return rows;
+}
+
+function renderRelationshipsTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    const rows = buildRelationshipRows();
+
+    const table = new DataTable<RelationshipRow>({
+        container: tabContent,
+        columns: [
+            { key: 'schemaName', label: 'Schema Name', render: (r) => escapeHtml(r.schemaName) },
+            { key: 'type', label: 'Type', render: (r) => escapeHtml(r.type) },
+            { key: 'relatedEntity', label: 'Related Entity', render: (r) => escapeHtml(r.relatedEntity) },
+            { key: 'lookupField', label: 'Lookup Field', render: (r) => escapeHtml(r.lookupField) },
+            { key: 'cascadeDelete', label: 'Cascade Delete', render: (r) => escapeHtml(r.cascadeDelete) },
+        ],
+        getRowId: (r) => r.schemaName + ':' + r.type,
+        defaultSortKey: 'schemaName',
+        defaultSortDirection: 'asc',
+        emptyMessage: 'No relationships',
+    });
+    table.setItems(rows);
+}
+
+// ── Keys tab ──
+interface KeyRow {
+    displayName: string;
+    schemaName: string;
+    keyAttributes: string;
+    indexStatus: string;
+}
+
+function renderKeysTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    const rows: KeyRow[] = currentEntity.keys.map(k => ({
+        displayName: k.displayName ?? '\u2014',
+        schemaName: k.schemaName,
+        keyAttributes: k.keyAttributes.join(', '),
+        indexStatus: k.entityKeyIndexStatus ?? '\u2014',
+    }));
+
+    const table = new DataTable<KeyRow>({
+        container: tabContent,
+        columns: [
+            { key: 'displayName', label: 'Display Name', render: (k) => escapeHtml(k.displayName) },
+            { key: 'schemaName', label: 'Schema Name', render: (k) => escapeHtml(k.schemaName) },
+            { key: 'keyAttributes', label: 'Key Attributes', render: (k) => escapeHtml(k.keyAttributes) },
+            { key: 'indexStatus', label: 'Index Status', render: (k) => escapeHtml(k.indexStatus) },
+        ],
+        getRowId: (k) => k.schemaName,
+        defaultSortKey: 'schemaName',
+        defaultSortDirection: 'asc',
+        emptyMessage: 'No alternate keys',
+    });
+    table.setItems(rows);
+}
+
+// ── Privileges tab ──
+interface PrivilegeRow {
+    name: string;
+    privilegeType: string;
+    canBeLocal: boolean;
+    canBeDeep: boolean;
+    canBeGlobal: boolean;
+    canBeBasic: boolean;
+}
+
+function renderPrivilegesTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    const rows: PrivilegeRow[] = currentEntity.privileges.map(p => ({
+        name: p.name,
+        privilegeType: p.privilegeType,
+        canBeLocal: p.canBeLocal,
+        canBeDeep: p.canBeDeep,
+        canBeGlobal: p.canBeGlobal,
+        canBeBasic: p.canBeBasic,
+    }));
+
+    const table = new DataTable<PrivilegeRow>({
+        container: tabContent,
+        columns: [
+            { key: 'name', label: 'Name', render: (p) => escapeHtml(p.name) },
+            { key: 'privilegeType', label: 'Type', render: (p) => escapeHtml(p.privilegeType) },
+            { key: 'canBeLocal', label: 'Local', render: (p) => p.canBeLocal ? '\u2713' : '\u2014' },
+            { key: 'canBeDeep', label: 'Deep', render: (p) => p.canBeDeep ? '\u2713' : '\u2014' },
+            { key: 'canBeGlobal', label: 'Global', render: (p) => p.canBeGlobal ? '\u2713' : '\u2014' },
+            { key: 'canBeBasic', label: 'Basic', render: (p) => p.canBeBasic ? '\u2713' : '\u2014' },
+        ],
+        getRowId: (p) => p.name,
+        defaultSortKey: 'name',
+        defaultSortDirection: 'asc',
+        emptyMessage: 'No privileges',
+    });
+    table.setItems(rows);
+}
+
+// ── Choices tab ──
+function renderChoicesTab(): void {
+    if (!currentEntity) return;
+    tabContent.innerHTML = '';
+
+    // Entity Choices: attributes with local option sets
+    const entityChoiceAttrs = currentEntity.attributes.filter(
+        a => a.options && a.options.length > 0 && !a.isGlobalOptionSet
+    );
+
+    // Global Option Sets
+    const globalOptionSets = currentEntity.globalOptionSets ?? [];
+
+    // -- Entity Choices section --
+    const entitySection = document.createElement('div');
+    entitySection.className = 'choices-section';
+
+    const entityHeader = document.createElement('div');
+    entityHeader.className = 'choices-section-header';
+    entityHeader.textContent = 'Entity Choices';
+    entitySection.appendChild(entityHeader);
+
+    if (entityChoiceAttrs.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No entity-level choice attributes';
+        entitySection.appendChild(empty);
+    } else {
+        const tableContainer = document.createElement('div');
+        entitySection.appendChild(tableContainer);
+
+        const table = new DataTable<MetadataAttributeDto>({
+            container: tableContainer,
+            columns: [
+                { key: 'logicalName', label: 'Attribute', render: (a) => escapeHtml(a.logicalName) },
+                { key: 'optionSetName', label: 'Option Set Name', render: (a) => escapeHtml(a.optionSetName ?? '\u2014') },
+                { key: 'optionsCount', label: 'Values Count', render: (a) => escapeHtml(String(a.options?.length ?? 0)) },
+            ],
+            getRowId: (a) => a.logicalName,
+            onRowClick: (a) => toggleOptionValues(a.logicalName, a.options ?? [], tableContainer),
+            defaultSortKey: 'logicalName',
+            defaultSortDirection: 'asc',
+            emptyMessage: 'No entity choices',
+        });
+        table.setItems(entityChoiceAttrs);
+    }
+
+    tabContent.appendChild(entitySection);
+
+    // -- Global Option Sets section --
+    const globalSection = document.createElement('div');
+    globalSection.className = 'choices-section';
+
+    const globalHeader = document.createElement('div');
+    globalHeader.className = 'choices-section-header';
+    globalHeader.textContent = 'Global Option Sets';
+    globalSection.appendChild(globalHeader);
+
+    if (globalOptionSets.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No global option sets';
+        globalSection.appendChild(empty);
+    } else {
+        interface GlobalOptionSetRow {
+            name: string;
+            displayName: string;
+            optionSetType: string;
+            valuesCount: number;
+            options: { value: number; label: string; color: string | null; description: string | null }[];
+        }
+
+        const globalRows: GlobalOptionSetRow[] = globalOptionSets.map(os => ({
+            name: os.name,
+            displayName: os.displayName ?? '\u2014',
+            optionSetType: os.optionSetType,
+            valuesCount: os.options.length,
+            options: os.options,
+        }));
+
+        const globalTableContainer = document.createElement('div');
+        globalSection.appendChild(globalTableContainer);
+
+        const globalTable = new DataTable<GlobalOptionSetRow>({
+            container: globalTableContainer,
+            columns: [
+                { key: 'name', label: 'Name', render: (o) => escapeHtml(o.name) },
+                { key: 'displayName', label: 'Display Name', render: (o) => escapeHtml(o.displayName) },
+                { key: 'optionSetType', label: 'Type', render: (o) => escapeHtml(o.optionSetType) },
+                { key: 'valuesCount', label: 'Values Count', render: (o) => escapeHtml(String(o.valuesCount)) },
+            ],
+            getRowId: (o) => o.name,
+            onRowClick: (o) => toggleOptionValues(o.name, o.options, globalTableContainer),
+            defaultSortKey: 'name',
+            defaultSortDirection: 'asc',
+            emptyMessage: 'No global option sets',
+        });
+        globalTable.setItems(globalRows);
+    }
+
+    tabContent.appendChild(globalSection);
+}
+
+/** Toggle visibility of option values sub-table for a choice row. */
+function toggleOptionValues(
+    key: string,
+    options: { value: number; label: string; color: string | null; description: string | null }[],
+    container: HTMLElement,
+): void {
+    const existingId = 'option-values-' + CSS.escape(key);
+    const existing = container.querySelector<HTMLElement>('#' + existingId);
+    if (existing) {
+        existing.classList.toggle('expanded');
+        return;
+    }
+
+    // Find the clicked row to insert the sub-table after it
+    const selectedRow = container.querySelector<HTMLElement>('.data-table-row.selected');
+    if (!selectedRow) return;
+
+    const tr = document.createElement('tr');
+    tr.id = 'option-values-' + key;
+    tr.className = 'option-values-row expanded';
+    const td = document.createElement('td');
+    td.colSpan = 99;
+
+    if (options.length === 0) {
+        td.textContent = 'No option values';
+    } else {
+        const subTable = document.createElement('table');
+        subTable.className = 'data-table option-values-table';
+
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        for (const label of ['Value', 'Label', 'Color', 'Description']) {
+            const th = document.createElement('th');
+            th.textContent = label;
+            headerRow.appendChild(th);
+        }
+        thead.appendChild(headerRow);
+        subTable.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+        for (const opt of options) {
+            const row = document.createElement('tr');
+
+            const valTd = document.createElement('td');
+            valTd.textContent = String(opt.value);
+            row.appendChild(valTd);
+
+            const labelTd = document.createElement('td');
+            labelTd.textContent = opt.label;
+            row.appendChild(labelTd);
+
+            const colorTd = document.createElement('td');
+            if (opt.color) {
+                const swatch = document.createElement('span');
+                swatch.className = 'color-swatch';
+                swatch.style.backgroundColor = opt.color;
+                colorTd.appendChild(swatch);
+                const colorText = document.createTextNode(opt.color);
+                colorTd.appendChild(colorText);
+            } else {
+                colorTd.textContent = '\u2014';
+            }
+            row.appendChild(colorTd);
+
+            const descTd = document.createElement('td');
+            descTd.textContent = opt.description ?? '\u2014';
+            row.appendChild(descTd);
+
+            tbody.appendChild(row);
+        }
+        subTable.appendChild(tbody);
+        td.appendChild(subTable);
+    }
+
+    tr.appendChild(td);
+    // Insert after the selected row in the table body
+    if (selectedRow.nextSibling) {
+        selectedRow.parentNode!.insertBefore(tr, selectedRow.nextSibling);
+    } else {
+        selectedRow.parentNode!.appendChild(tr);
+    }
+}
+
+// ── Message handling ──
+window.addEventListener('message', (event: MessageEvent<MetadataBrowserPanelHostToWebview>) => {
+    const msg = event.data;
+    // VS Code sends internal messages that lack 'command' -- ignore them
+    if (!msg || typeof msg !== 'object' || !('command' in msg)) return;
+    switch (msg.command) {
+        case 'updateEnvironment':
+            updateEnvironmentDisplay(msg.name);
+            {
+                const toolbar = document.querySelector('.toolbar');
+                if (toolbar) {
+                    if (msg.envType) {
+                        toolbar.setAttribute('data-env-type', msg.envType.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-type');
+                    }
+                    if (msg.envColor) {
+                        toolbar.setAttribute('data-env-color', msg.envColor.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-color');
+                    }
+                }
+            }
+            break;
+        case 'entitiesLoaded':
+            allEntities = msg.entities;
+            filteredEntities = msg.entities;
+            entitySearchEl.value = '';
+            filterCount.textContent = '';
+            renderEntityList();
+            renderTabBar();
+            if (!currentEntity) {
+                tabContent.innerHTML = '<div class="empty-state">Select an entity to view details</div>';
+            }
+            updateStatusText();
+            {
+                const reconnectBanner = document.getElementById('reconnect-banner');
+                if (reconnectBanner) reconnectBanner.style.display = 'none';
+            }
+            break;
+        case 'entityDetailLoading':
+            tabContent.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading ' + escapeHtml(msg.logicalName) + '...</div></div>';
+            break;
+        case 'entityDetailLoaded':
+            currentEntity = msg.entity;
+            renderTabBar();
+            renderTabContent();
+            break;
+        case 'loading':
+            entityListEl.innerHTML = '';
+            tabContent.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading entities...</div></div>';
+            statusText.textContent = 'Loading...';
+            break;
+        case 'error':
+            tabContent.innerHTML = '<div class="error-state">' + escapeHtml(msg.message) + '</div>';
+            statusText.textContent = 'Error';
+            break;
+        case 'daemonReconnected':
+            document.getElementById('reconnect-banner')!.style.display = '';
+            break;
+        default:
+            assertNever(msg);
+    }
+});
+
+// Signal ready
+vscode.postMessage({ command: 'ready' });

--- a/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
@@ -5,7 +5,7 @@
  */
 
 // Import daemon response types that appear in message payloads
-import type { QueryResultResponse, CompletionItemDto } from '../../../types.js';
+import type { QueryResultResponse, CompletionItemDto, MetadataEntityDetailDto } from '../../../types.js';
 
 // ── Query Panel ─────────────────────────────────────────────────────────────
 
@@ -209,6 +209,39 @@ export type PluginTracesPanelHostToWebview =
     | { command: 'timelineLoaded'; nodes: TimelineNodeViewDto[] }
     | { command: 'traceLevelLoaded'; level: string; levelValue: number }
     | { command: 'deleteComplete'; deletedCount: number }
+    | { command: 'loading' }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+
+// ── Metadata Browser Panel ─────────────────────────────────────────────
+
+/** Entity summary as sent to the webview for the entity list. */
+export interface MetadataEntityViewDto {
+    logicalName: string;
+    schemaName: string;
+    displayName: string;
+    isCustomEntity: boolean;
+    isManaged: boolean;
+    ownershipType: string | null;
+    description: string | null;
+}
+
+/** Messages the Metadata Browser Panel webview sends to the extension host. */
+export type MetadataBrowserPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectEntity'; logicalName: string }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker'; entityLogicalName?: string }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Metadata Browser Panel webview. */
+export type MetadataBrowserPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'entitiesLoaded'; entities: MetadataEntityViewDto[] }
+    | { command: 'entityDetailLoaded'; entity: MetadataEntityDetailDto }
+    | { command: 'entityDetailLoading'; logicalName: string }
     | { command: 'loading' }
     | { command: 'error'; message: string }
     | { command: 'daemonReconnected' };

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -268,28 +268,124 @@ export interface EnvWhoResponse {
     environmentType: string | null;
 }
 
-// ── Schema ──────────────────────────────────────────────────────────────────
+// ── Metadata ─────────────────────────────────────────────────────────────────
 
-export interface SchemaEntitiesResponse {
-    entities: EntitySummaryDto[];
+export interface MetadataEntitiesResponse {
+    entities: MetadataEntitySummaryDto[];
 }
 
-export interface EntitySummaryDto {
+export interface MetadataEntitySummaryDto {
+    logicalName: string;
+    schemaName: string;
+    displayName: string;
+    isCustomEntity: boolean;
+    isManaged: boolean;
+    ownershipType: string | null;
+    objectTypeCode: number;
+    description: string | null;
+}
+
+export interface MetadataEntityResponse {
+    entity: MetadataEntityDetailDto;
+}
+
+export interface MetadataEntityDetailDto extends MetadataEntitySummaryDto {
+    primaryIdAttribute: string | null;
+    primaryNameAttribute: string | null;
+    entitySetName: string | null;
+    isActivity: boolean;
+    attributes: MetadataAttributeDto[];
+    oneToManyRelationships: MetadataRelationshipDto[];
+    manyToOneRelationships: MetadataRelationshipDto[];
+    manyToManyRelationships: MetadataManyToManyDto[];
+    keys: MetadataKeyDto[];
+    privileges: MetadataPrivilegeDto[];
+    globalOptionSets: MetadataOptionSetDto[];
+}
+
+export interface MetadataAttributeDto {
     logicalName: string;
     displayName: string | null;
-    isCustom: boolean;
+    schemaName: string | null;
+    attributeType: string;
+    attributeTypeName: string | null;
+    isPrimaryId: boolean;
+    isPrimaryName: boolean;
+    isCustomAttribute: boolean;
+    requiredLevel: string | null;
+    maxLength: number | null;
+    minValue: number | null;
+    maxValue: number | null;
+    precision: number | null;
+    targets: string[] | null;
+    optionSetName: string | null;
+    isGlobalOptionSet: boolean;
+    options: MetadataOptionValueDto[] | null;
+    format: string | null;
+    dateTimeBehavior: string | null;
+    sourceType: number | null;
+    isSecured: boolean;
+    description: string | null;
+    autoNumberFormat: string | null;
 }
 
-export interface SchemaAttributesResponse {
-    entityName: string;
-    attributes: AttributeSummaryDto[];
+export interface MetadataRelationshipDto {
+    schemaName: string;
+    relationshipType: string;
+    referencedEntity: string | null;
+    referencedAttribute: string | null;
+    referencingEntity: string | null;
+    referencingAttribute: string | null;
+    cascadeAssign: string | null;
+    cascadeDelete: string | null;
+    cascadeMerge: string | null;
+    cascadeReparent: string | null;
+    cascadeShare: string | null;
+    cascadeUnshare: string | null;
+    isHierarchical: boolean;
 }
 
-export interface AttributeSummaryDto {
+export interface MetadataManyToManyDto {
+    schemaName: string;
+    entity1LogicalName: string | null;
+    entity1IntersectAttribute: string | null;
+    entity2LogicalName: string | null;
+    entity2IntersectAttribute: string | null;
+    intersectEntityName: string | null;
+}
+
+export interface MetadataKeyDto {
+    schemaName: string;
     logicalName: string;
     displayName: string | null;
-    dataType: string;
-    isCustom: boolean;
+    keyAttributes: string[];
+    entityKeyIndexStatus: string | null;
+    isManaged: boolean;
+}
+
+export interface MetadataPrivilegeDto {
+    privilegeId: string;
+    name: string;
+    privilegeType: string;
+    canBeLocal: boolean;
+    canBeDeep: boolean;
+    canBeGlobal: boolean;
+    canBeBasic: boolean;
+}
+
+export interface MetadataOptionSetDto {
+    name: string;
+    displayName: string | null;
+    optionSetType: string;
+    isGlobal: boolean;
+    options: MetadataOptionValueDto[];
+}
+
+export interface MetadataOptionValueDto {
+    value: number;
+    label: string;
+    color: string | null;
+    description: string | null;
 }
 
 // ── Import Jobs ──────────────────────────────────────────────────────────────

--- a/src/PPDS.Extension/src/views/toolsTreeView.ts
+++ b/src/PPDS.Extension/src/views/toolsTreeView.ts
@@ -39,6 +39,7 @@ export class ToolsTreeDataProvider
         { label: 'Solutions', commandId: 'ppds.openSolutions', icon: 'package' },
         { label: 'Import Jobs', commandId: 'ppds.openImportJobs', icon: 'history' },
         { label: 'Plugin Traces', commandId: 'ppds.openPluginTraces', icon: 'debug-stackframe' },
+        { label: 'Metadata Browser', commandId: 'ppds.openMetadataBrowser', icon: 'symbol-class' },
         { label: 'Show Logs', commandId: 'ppds.showLogs', icon: 'output', alwaysEnabled: true },
     ];
 

--- a/src/PPDS.Mcp/Tools/MetadataEntitiesListTool.cs
+++ b/src/PPDS.Mcp/Tools/MetadataEntitiesListTool.cs
@@ -1,0 +1,134 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Metadata;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that lists all entities (tables) in a Dataverse environment.
+/// </summary>
+[McpServerToolType]
+public sealed class MetadataEntitiesListTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetadataEntitiesListTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public MetadataEntitiesListTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Lists all entities (tables) in the connected Dataverse environment.
+    /// </summary>
+    /// <param name="customOnly">If true, only return custom entities.</param>
+    /// <param name="filter">Optional filter pattern for entity logical names.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of entity summaries.</returns>
+    [McpServerTool(Name = "ppds_metadata_entities")]
+    [Description("Lists all entities (tables) in the connected Dataverse environment. Returns entity logical names, display names, schema names, and ownership type. Use this to discover available entities before querying with ppds_metadata_entity for full details.")]
+    public async Task<MetadataEntitiesResult> ExecuteAsync(
+        [Description("If true, only return custom entities (not system entities).")] bool customOnly = false,
+        [Description("Optional filter pattern to match entity logical names. Supports * wildcard (e.g., 'account*', '*custom*').")] string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context
+            .CreateServiceProviderAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var metadataService = serviceProvider
+            .GetRequiredService<IMetadataService>();
+
+        var entities = await metadataService
+            .GetEntitiesAsync(customOnly, filter, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new MetadataEntitiesResult
+        {
+            Entities = entities.Select(e => new EntityListItem
+            {
+                LogicalName = e.LogicalName,
+                DisplayName = e.DisplayName,
+                SchemaName = e.SchemaName,
+                IsCustomEntity = e.IsCustomEntity,
+                IsManaged = e.IsManaged,
+                OwnershipType = e.OwnershipType,
+                Description = e.Description
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the metadata_entities tool.
+/// </summary>
+public sealed class MetadataEntitiesResult
+{
+    /// <summary>
+    /// Total number of entities returned.
+    /// </summary>
+    [JsonPropertyName("entityCount")]
+    public int EntityCount => Entities.Count;
+
+    /// <summary>
+    /// List of entity summaries.
+    /// </summary>
+    [JsonPropertyName("entities")]
+    public List<EntityListItem> Entities { get; set; } = [];
+}
+
+/// <summary>
+/// Summary information about an entity for list views.
+/// </summary>
+public sealed class EntityListItem
+{
+    /// <summary>
+    /// Entity logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    /// <summary>
+    /// Human-readable display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>
+    /// Schema name.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    /// <summary>
+    /// Whether this is a custom entity.
+    /// </summary>
+    [JsonPropertyName("isCustomEntity")]
+    public bool IsCustomEntity { get; set; }
+
+    /// <summary>
+    /// Whether this entity is part of a managed solution.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Ownership type (UserOwned, OrganizationOwned, None).
+    /// </summary>
+    [JsonPropertyName("ownershipType")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OwnershipType { get; set; }
+
+    /// <summary>
+    /// Entity description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}

--- a/tests/PPDS.Cli.Tests/Tui/CachedMetadataProviderTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/CachedMetadataProviderTests.cs
@@ -51,6 +51,10 @@ public class CachedMetadataProviderTests
             bool includeKeys = true, bool includePrivileges = true, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
+        public Task<(EntityMetadataDto Entity, IReadOnlyList<OptionSetMetadataDto> GlobalOptionSets)> GetEntityWithGlobalOptionSetsAsync(
+            string logicalName, bool includeGlobalOptionSets = false, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+
         public async Task<IReadOnlyList<AttributeMetadataDto>> GetAttributesAsync(
             string entityLogicalName, string? attributeType = null, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
## Summary
- **RPC:** Replace unused `schema/*` stubs with `metadata/entities` and `metadata/entity` endpoints returning rich entity summaries, attributes, relationships, keys, privileges, and global option sets
- **Extension:** Split-pane Metadata Browser panel with entity list (client-side search/filter), 5-tab detail view (Attributes, Relationships, Keys, Privileges, Choices), environment picker with per-panel scoping
- **TUI:** MetadataExplorerScreen with SplitterView, entity search, tabbed detail, hotkeys (Ctrl+R refresh, Ctrl+F search, Ctrl+O open in Maker)
- **MCP:** New `ppds_metadata_entities` tool for AI entity discovery with wildcard filter support
- **Service:** `GetEntityWithGlobalOptionSetsAsync` aggregates entity metadata + global option set values in one call

## Test Plan
- [x] .NET build: 0 errors, 0 warnings
- [x] .NET unit tests: all pass across net8.0/net9.0/net10.0
- [x] TypeScript typecheck (host + webview): clean
- [x] ESLint + Stylelint: clean
- [x] Extension unit tests: 231 pass
- [x] Extension E2E: panel opens, entity list loads (785 entities), search filters, entity detail loads with all tabs
- [x] TUI: screen loads, entity list renders with custom/system icons, menu entry works
- [x] MCP tool: builds and auto-discovers via [McpServerToolType]

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: extension, tui, mcp)
- [x] /qa completed (surfaces: extension)
- [x] /review completed (findings: 10 — 2 critical, 5 important fixed; 3 suggestions)

## Issues
Closes #338, #347, #354, #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)