### PR TITLE
feat(panels): add Connection References + Environment Variables panels

### DIFF
--- a/docs/plans/2026-03-17-panel-env-connref.md
+++ b/docs/plans/2026-03-17-panel-env-connref.md
@@ -1,0 +1,1537 @@
+# Phase 2a: Connection References + Environment Variables Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Connection References and Environment Variables panels across all 4 surfaces (Daemon RPC, VS Code extension, TUI, MCP), plus a shared solution filter component reusable by future panels.
+
+**Architecture:** Domain services (`IConnectionReferenceService`, `IConnectionService`, `IEnvironmentVariableService`) already exist. We add RPC endpoints in the daemon, VS Code webview panels with environment theming, TUI screens, and MCP tools. All surfaces call the same service methods (Constitution A1, A2).
+
+**Tech Stack:** C# (.NET 8), TypeScript (VS Code extension + webview), Terminal.Gui (TUI), StreamJsonRpc (RPC), ModelContextProtocol (MCP)
+
+**Spec:** `specs/panel-parity.md` — Panels 2 (Connection References) and 3 (Environment Variables), AC-CR-01 through AC-CR-10 and AC-EV-01 through AC-EV-10
+
+**GitHub Issues:** #339, #340, #349, #350, #357, #359, #587, #588
+
+---
+
+## Design Decisions
+
+### Shared solution filter component
+Both panels need solution filter dropdowns. Rather than building inline and extracting later, we build the shared `SolutionFilter` component in `webview/shared/solution-filter.ts` alongside the existing `DataTable`. This component handles solution list loading, dropdown rendering, persisted selection (via `vscode.getState`), and change events. Phase 2d (Web Resources) will import it directly.
+
+### SPN graceful degradation for Connections API
+`IConnectionService` uses the Power Platform Admin API (`service.powerapps.com`), which requires user-delegated authentication. Service principals cannot access it. The RPC handler catches failures from `IConnectionService` and sets all connection statuses to `"N/A"`. The panel remains fully functional — it just shows "N/A" in the status column instead of "Connected"/"Error". A warning is logged but never surfaced to the user as an error.
+
+### Environment Variables edit flow — modal dialog
+The `environmentVariables/set` write operation is surfaced in VS Code via an edit button that opens a modal dialog. The dialog shows the variable type, current value, default value, and a type-aware input field (text for String, number input for Number, toggle for Boolean, textarea for JSON). Validation runs before the RPC call. The TUI uses the same pattern with `EnvironmentVariableDetailDialog`.
+
+### Bottom detail pane for Connection References
+Row click shows connection info, dependent flows, and orphan status in a bottom detail pane below the table. This is consistent with the Import Jobs pattern (XML log viewer) and works with the existing DataTable component. No layout changes needed.
+
+### Sequential panel order within the phase
+Connection References first (read-only, establishes solution filter), then Environment Variables (adds write operation, reuses solution filter). This avoids building the edit flow before the shared infrastructure is solid.
+
+### No Application Service wrapper needed
+Both `IConnectionReferenceService` and `IEnvironmentVariableService` are already clean domain services with the right abstraction level. RPC handlers call them directly via DI, same as `IImportJobService`. The enrichment logic (merging connection status from `IConnectionService`) lives in the RPC handler since it's a cross-service join specific to the API layer.
+
+---
+
+## File Structure
+
+### Files to modify
+| File | Change |
+|------|--------|
+| `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs` | Add 6 RPC methods + DTOs for both panels |
+| `src/PPDS.Extension/src/types.ts` | Add ConnectionReference and EnvironmentVariable DTO interfaces |
+| `src/PPDS.Extension/src/daemonClient.ts` | Add 6 daemon client methods |
+| `src/PPDS.Extension/src/panels/webview/shared/message-types.ts` | Add message types for both panels |
+| `src/PPDS.Extension/esbuild.js` | Add 4 build entries (2 JS + 2 CSS) |
+| `src/PPDS.Extension/src/extension.ts` | Register 4 commands (open + openForEnv × 2 panels) |
+| `src/PPDS.Extension/package.json` | Add command contributions + menu items |
+| `src/PPDS.Cli/Tui/TuiShell.cs` | Add 2 menu items for new screens |
+
+### Files to create
+| File | Purpose |
+|------|---------|
+| **Shared** | |
+| `src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts` | Shared solution filter dropdown component |
+| **Connection References** | |
+| `src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts` | Host-side panel (extends WebviewPanelBase) |
+| `src/PPDS.Extension/src/panels/webview/connection-references-panel.ts` | Browser-side webview script |
+| `src/PPDS.Extension/src/panels/styles/connection-references-panel.css` | Panel-specific CSS |
+| `src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs` | TUI screen |
+| `src/PPDS.Mcp/Tools/ConnectionReferencesListTool.cs` | MCP list tool |
+| `src/PPDS.Mcp/Tools/ConnectionReferencesGetTool.cs` | MCP get tool (with flows) |
+| `src/PPDS.Mcp/Tools/ConnectionReferencesAnalyzeTool.cs` | MCP analyze tool (orphan detection) |
+| **Environment Variables** | |
+| `src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts` | Host-side panel (extends WebviewPanelBase) |
+| `src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts` | Browser-side webview script |
+| `src/PPDS.Extension/src/panels/styles/environment-variables-panel.css` | Panel-specific CSS |
+| `src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs` | TUI screen |
+| `src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs` | MCP list tool |
+| `src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs` | MCP get tool |
+| `src/PPDS.Mcp/Tools/EnvironmentVariablesSetTool.cs` | MCP set tool (write operation) |
+
+---
+
+## Chunk 1: Connection References — RPC Layer
+
+### Task 1: Add Connection References RPC endpoints and DTOs
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Add DTO classes at the end of the file (alongside existing DTOs)**
+
+```csharp
+// ── Connection References DTOs ──────────────────────────────────────────
+
+/// <summary>
+/// Response for connectionReferences/list method.
+/// </summary>
+public class ConnectionReferencesListResponse
+{
+    [JsonPropertyName("references")]
+    public List<ConnectionReferenceInfoDto> References { get; set; } = [];
+}
+
+/// <summary>
+/// Response for connectionReferences/get method.
+/// </summary>
+public class ConnectionReferencesGetResponse
+{
+    [JsonPropertyName("reference")]
+    public ConnectionReferenceDetailDto Reference { get; set; } = null!;
+}
+
+/// <summary>
+/// Response for connectionReferences/analyze method.
+/// </summary>
+public class ConnectionReferencesAnalyzeResponse
+{
+    [JsonPropertyName("orphanedReferences")]
+    public List<OrphanedReferenceDto> OrphanedReferences { get; set; } = [];
+
+    [JsonPropertyName("orphanedFlows")]
+    public List<OrphanedFlowDto> OrphanedFlows { get; set; } = [];
+
+    [JsonPropertyName("totalReferences")]
+    public int TotalReferences { get; set; }
+
+    [JsonPropertyName("totalFlows")]
+    public int TotalFlows { get; set; }
+}
+
+public class ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    public string? ConnectorId { get; set; }
+
+    [JsonPropertyName("connectionId")]
+    public string? ConnectionId { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    public string? ModifiedOn { get; set; }
+
+    [JsonPropertyName("connectionStatus")]
+    public string ConnectionStatus { get; set; } = "N/A";
+
+    [JsonPropertyName("connectorDisplayName")]
+    public string? ConnectorDisplayName { get; set; }
+}
+
+public class ConnectionReferenceDetailDto : ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("isBound")]
+    public bool IsBound { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    public string? CreatedOn { get; set; }
+
+    [JsonPropertyName("flows")]
+    public List<FlowReferenceDto> Flows { get; set; } = [];
+
+    [JsonPropertyName("connectionOwner")]
+    public string? ConnectionOwner { get; set; }
+
+    [JsonPropertyName("connectionIsShared")]
+    public bool? ConnectionIsShared { get; set; }
+}
+
+public class FlowReferenceDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+}
+
+public class OrphanedReferenceDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    public string? ConnectorId { get; set; }
+}
+
+public class OrphanedFlowDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("missingReference")]
+    public string? MissingReference { get; set; }
+}
+```
+
+- [ ] **Step 2: Add `connectionReferences/list` RPC method**
+
+Add after the existing `importJobs/get` method block:
+
+```csharp
+// ── Connection References ─────────────────────────────────────────────
+
+/// <summary>
+/// Lists connection references, optionally filtered by solution.
+/// Enriches with connection status from Power Platform API (graceful degradation for SPN).
+/// </summary>
+[JsonRpcMethod("connectionReferences/list")]
+public async Task<ConnectionReferencesListResponse> ConnectionReferencesListAsync(
+    string? solutionId = null,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var crService = sp.GetRequiredService<IConnectionReferenceService>();
+        var references = await crService.ListAsync(solutionName: solutionId, cancellationToken: ct);
+
+        // Try to enrich with connection status from Connections API (BAPI)
+        Dictionary<string, ConnectionInfo>? connectionMap = null;
+        try
+        {
+            var connService = sp.GetRequiredService<IConnectionService>();
+            var connections = await connService.ListAsync(cancellationToken: ct);
+            connectionMap = connections
+                .Where(c => c.ConnectionId != null)
+                .ToDictionary(c => c.ConnectionId!, c => c, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Connections API unavailable (likely SPN auth) — connection status will show N/A");
+        }
+
+        return new ConnectionReferencesListResponse
+        {
+            References = references.Select(r => MapConnectionReferenceToDto(r, connectionMap)).ToList()
+        };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 3: Add `connectionReferences/get` RPC method**
+
+```csharp
+/// <summary>
+/// Gets a single connection reference with dependent flows and connection details.
+/// </summary>
+[JsonRpcMethod("connectionReferences/get")]
+public async Task<ConnectionReferencesGetResponse> ConnectionReferencesGetAsync(
+    string logicalName,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(logicalName))
+        throw new RpcException(ErrorCodes.Validation.RequiredField, "logicalName is required");
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var crService = sp.GetRequiredService<IConnectionReferenceService>();
+        var reference = await crService.GetAsync(logicalName, ct);
+        if (reference == null)
+            throw new RpcException(ErrorCodes.Operation.NotFound, $"Connection reference '{logicalName}' not found");
+
+        var flows = await crService.GetFlowsUsingAsync(logicalName, ct);
+
+        // Try to get connection detail
+        ConnectionInfo? connectionInfo = null;
+        if (!string.IsNullOrEmpty(reference.ConnectionId))
+        {
+            try
+            {
+                var connService = sp.GetRequiredService<IConnectionService>();
+                connectionInfo = await connService.GetAsync(reference.ConnectionId, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Connections API unavailable — connection detail will be partial");
+            }
+        }
+
+        var dto = MapConnectionReferenceToDetailDto(reference, flows, connectionInfo);
+        return new ConnectionReferencesGetResponse { Reference = dto };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 4: Add `connectionReferences/analyze` RPC method**
+
+```csharp
+/// <summary>
+/// Analyzes connection references for orphaned references and flows.
+/// </summary>
+[JsonRpcMethod("connectionReferences/analyze")]
+public async Task<ConnectionReferencesAnalyzeResponse> ConnectionReferencesAnalyzeAsync(
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var crService = sp.GetRequiredService<IConnectionReferenceService>();
+        var analysis = await crService.AnalyzeAsync(cancellationToken: ct);
+
+        var response = new ConnectionReferencesAnalyzeResponse
+        {
+            TotalReferences = analysis.Relationships.Count(r =>
+                r.Type != RelationshipType.OrphanedFlow),
+            TotalFlows = analysis.Relationships.Count(r =>
+                r.Type != RelationshipType.OrphanedConnectionReference),
+        };
+
+        foreach (var rel in analysis.Relationships)
+        {
+            if (rel.Type == RelationshipType.OrphanedConnectionReference)
+            {
+                response.OrphanedReferences.Add(new OrphanedReferenceDto
+                {
+                    LogicalName = rel.ConnectionReferenceLogicalName ?? "",
+                    DisplayName = rel.ConnectionReferenceDisplayName,
+                    ConnectorId = rel.ConnectorId,
+                });
+            }
+            else if (rel.Type == RelationshipType.OrphanedFlow)
+            {
+                response.OrphanedFlows.Add(new OrphanedFlowDto
+                {
+                    UniqueName = rel.FlowUniqueName ?? "",
+                    DisplayName = rel.FlowDisplayName,
+                    MissingReference = rel.ConnectionReferenceLogicalName,
+                });
+            }
+        }
+
+        return response;
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 5: Add private mapper methods**
+
+```csharp
+private static ConnectionReferenceInfoDto MapConnectionReferenceToDto(
+    ConnectionReferenceInfo r,
+    Dictionary<string, ConnectionInfo>? connectionMap)
+{
+    var status = "N/A";
+    string? connectorDisplayName = null;
+
+    if (connectionMap != null && !string.IsNullOrEmpty(r.ConnectionId) &&
+        connectionMap.TryGetValue(r.ConnectionId, out var conn))
+    {
+        status = conn.Status.ToString();
+        connectorDisplayName = conn.ConnectorDisplayName;
+    }
+
+    return new ConnectionReferenceInfoDto
+    {
+        LogicalName = r.LogicalName,
+        DisplayName = r.DisplayName,
+        ConnectorId = r.ConnectorId,
+        ConnectionId = r.ConnectionId,
+        IsManaged = r.IsManaged,
+        ModifiedOn = r.ModifiedOn?.ToString("o"),
+        ConnectionStatus = status,
+        ConnectorDisplayName = connectorDisplayName,
+    };
+}
+
+private static ConnectionReferenceDetailDto MapConnectionReferenceToDetailDto(
+    ConnectionReferenceInfo r,
+    List<FlowInfo> flows,
+    ConnectionInfo? connectionInfo)
+{
+    var dto = new ConnectionReferenceDetailDto
+    {
+        LogicalName = r.LogicalName,
+        DisplayName = r.DisplayName,
+        Description = r.Description,
+        ConnectorId = r.ConnectorId,
+        ConnectionId = r.ConnectionId,
+        IsManaged = r.IsManaged,
+        IsBound = r.IsBound,
+        ModifiedOn = r.ModifiedOn?.ToString("o"),
+        CreatedOn = r.CreatedOn?.ToString("o"),
+        ConnectionStatus = connectionInfo?.Status.ToString() ?? "N/A",
+        ConnectorDisplayName = connectionInfo?.ConnectorDisplayName,
+        ConnectionOwner = connectionInfo?.CreatedBy,
+        ConnectionIsShared = connectionInfo?.IsShared,
+        Flows = flows.Select(f => new FlowReferenceDto
+        {
+            UniqueName = f.UniqueName,
+            DisplayName = f.DisplayName,
+            State = f.State.ToString(),
+        }).ToList(),
+    };
+    return dto;
+}
+```
+
+- [ ] **Step 6: Build to verify compilation**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -v q`
+Expected: Build succeeded. May need to add `using` directives for `IConnectionReferenceService`, `IConnectionService`, `ConnectionReferenceInfo`, `ConnectionInfo`, `FlowInfo`, `FlowConnectionAnalysis`, `RelationshipType`.
+
+---
+
+## Chunk 2: Connection References — MCP Tools
+
+### Task 2: Create MCP tools for Connection References
+
+**Files:**
+- Create: `src/PPDS.Mcp/Tools/ConnectionReferencesListTool.cs`
+- Create: `src/PPDS.Mcp/Tools/ConnectionReferencesGetTool.cs`
+- Create: `src/PPDS.Mcp/Tools/ConnectionReferencesAnalyzeTool.cs`
+
+- [ ] **Step 1: Create ConnectionReferencesListTool.cs**
+
+Follow the `ImportJobsListTool.cs` pattern exactly. Key differences:
+- Tool name: `ppds_connection_references_list`
+- Description: "List connection references in the current environment. Shows connector bindings and connection status. Optionally filter by solution name."
+- Parameters: `string? solutionId = null` (with description "Solution unique name to filter by")
+- Uses `McpToolContext` to create service provider
+- Gets `IConnectionReferenceService` and optionally `IConnectionService` (with try/catch for SPN graceful degradation — same pattern as RPC)
+- Returns `ConnectionReferencesListResult` with `List<ConnectionReferenceSummary>` items
+
+Result DTO fields: logicalName, displayName, connectorId, connectionId, isManaged, isBound, connectionStatus, connectorDisplayName
+
+- [ ] **Step 2: Create ConnectionReferencesGetTool.cs**
+
+- Tool name: `ppds_connection_references_get`
+- Description: "Get full details of a specific connection reference including dependent flows and connection info. Use the logicalName from ppds_connection_references_list."
+- Parameters: `string logicalName` (required)
+- Gets `IConnectionReferenceService.GetAsync` + `GetFlowsUsingAsync` + `IConnectionService.GetAsync` (with graceful degradation)
+- Returns `ConnectionReferencesGetResult` with full detail + flows list
+
+- [ ] **Step 3: Create ConnectionReferencesAnalyzeTool.cs**
+
+- Tool name: `ppds_connection_references_analyze`
+- Description: "Analyze connection references for orphaned references (not used by any flow) and orphaned flows (referencing missing connection references). Useful for deployment cleanup."
+- No required parameters
+- Gets `IConnectionReferenceService.AnalyzeAsync`
+- Returns `ConnectionReferencesAnalyzeResult` with orphanedReferences, orphanedFlows, summary counts
+
+- [ ] **Step 4: Build to verify**
+
+Run: `dotnet build src/PPDS.Mcp/PPDS.Mcp.csproj -v q`
+
+---
+
+## Chunk 3: Connection References — TUI Screen
+
+### Task 3: Create ConnectionReferencesScreen
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs`
+- Modify: `src/PPDS.Cli/Tui/TuiShell.cs` — add menu item
+
+- [ ] **Step 1: Create ConnectionReferencesScreen.cs**
+
+Follow `ImportJobsScreen.cs` pattern. Key structure:
+
+```csharp
+internal sealed class ConnectionReferencesScreen : TuiScreenBase
+{
+    private readonly TableView _table;
+    private readonly Label _statusLabel;
+    private List<ConnectionReferenceInfo> _references = [];
+    private string? _solutionFilter;
+
+    public override string Title => "Connection References";
+}
+```
+
+Table columns: Display Name, Logical Name, Connector, Status (N/A if BAPI unavailable), Managed, Modified On
+
+Hotkeys:
+- `Ctrl+R` → Refresh
+- `Enter` → Detail dialog (show connection info, flows list, orphan status)
+- `Ctrl+A` → Analyze dialog (orphan detection summary)
+- `Ctrl+F` → Solution filter dialog (list solutions, pick one or clear)
+- `Ctrl+O` → Open in Maker
+
+Data loading: call `IConnectionReferenceService.ListAsync(solutionName: _solutionFilter)`, then try `IConnectionService.ListAsync()` for status enrichment (catch and log on failure).
+
+Status format: "12 connection references — 10 bound — 2 unbound" or "12 connection references (filtered: MySolution)"
+
+- [ ] **Step 2: Create detail dialog**
+
+On `Enter` / cell activated:
+- Show `Dialog` with connection reference details
+- Sections: Connection Info (status, owner, shared/personal), Dependent Flows (list with state), Orphan indicator
+- Load flows via `IConnectionReferenceService.GetFlowsUsingAsync(logicalName)`
+
+- [ ] **Step 3: Create analyze dialog**
+
+On `Ctrl+A`:
+- Call `IConnectionReferenceService.AnalyzeAsync()`
+- Show `Dialog` with orphan summary: count of orphaned references, count of orphaned flows, list of each
+
+- [ ] **Step 4: Create solution filter dialog**
+
+On `Ctrl+F`:
+- Call `ISolutionService.ListAsync(includeManaged: false)`
+- Show `Dialog` with solution list for selection
+- "All" option to clear filter
+- Set `_solutionFilter` and reload data
+
+- [ ] **Step 5: Add menu item in TuiShell.cs**
+
+Add after the "Import Jobs" menu item (around line 283):
+
+```csharp
+new("Connection References", "View connection references", () => NavigateToConnectionReferences()),
+```
+
+Add `NavigateToConnectionReferences()` method following `NavigateToImportJobs()` pattern.
+
+- [ ] **Step 6: Build to verify**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -v q`
+
+---
+
+## Chunk 4: Connection References — VS Code Extension (TypeScript)
+
+### Task 4: Add TypeScript types and daemon client methods
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/types.ts`
+- Modify: `src/PPDS.Extension/src/daemonClient.ts`
+
+- [ ] **Step 1: Add DTO interfaces to types.ts**
+
+Add after the Import Jobs section:
+
+```typescript
+// ── Connection References ───────────────────────────────────────────────
+
+export interface ConnectionReferencesListResponse {
+    references: ConnectionReferenceInfoDto[];
+}
+
+export interface ConnectionReferencesGetResponse {
+    reference: ConnectionReferenceDetailDto;
+}
+
+export interface ConnectionReferencesAnalyzeResponse {
+    orphanedReferences: OrphanedReferenceDto[];
+    orphanedFlows: OrphanedFlowDto[];
+    totalReferences: number;
+    totalFlows: number;
+}
+
+export interface ConnectionReferenceInfoDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+    connectionId: string | null;
+    isManaged: boolean;
+    modifiedOn: string | null;
+    connectionStatus: string;
+    connectorDisplayName: string | null;
+}
+
+export interface ConnectionReferenceDetailDto extends ConnectionReferenceInfoDto {
+    description: string | null;
+    isBound: boolean;
+    createdOn: string | null;
+    flows: FlowReferenceDto[];
+    connectionOwner: string | null;
+    connectionIsShared: boolean | null;
+}
+
+export interface FlowReferenceDto {
+    uniqueName: string;
+    displayName: string | null;
+    state: string | null;
+}
+
+export interface OrphanedReferenceDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+}
+
+export interface OrphanedFlowDto {
+    uniqueName: string;
+    displayName: string | null;
+    missingReference: string | null;
+}
+```
+
+- [ ] **Step 2: Add daemon client methods to daemonClient.ts**
+
+Add after the `importJobsGet` method, following the same pattern:
+
+```typescript
+// ── Connection References ───────────────────────────────────────────────
+
+async connectionReferencesList(solutionId?: string, environmentUrl?: string): Promise<ConnectionReferencesListResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (solutionId !== undefined) params.solutionId = solutionId;
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling connectionReferences/list...');
+    const result = await this.connection!.sendRequest<ConnectionReferencesListResponse>('connectionReferences/list', params);
+    this.log.debug(`Got ${result.references.length} connection references`);
+    return result;
+}
+
+async connectionReferencesGet(logicalName: string, environmentUrl?: string): Promise<ConnectionReferencesGetResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { logicalName };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling connectionReferences/get for ${logicalName}...`);
+    return await this.connection!.sendRequest<ConnectionReferencesGetResponse>('connectionReferences/get', params);
+}
+
+async connectionReferencesAnalyze(environmentUrl?: string): Promise<ConnectionReferencesAnalyzeResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling connectionReferences/analyze...');
+    return await this.connection!.sendRequest<ConnectionReferencesAnalyzeResponse>('connectionReferences/analyze', params);
+}
+```
+
+- [ ] **Step 3: Add import for new response types in daemonClient.ts**
+
+Ensure the import statement at the top of `daemonClient.ts` includes the new types.
+
+- [ ] **Step 4: Typecheck to verify**
+
+Run: `npm run typecheck` from `src/PPDS.Extension/`
+
+### Task 5: Create shared solution filter component
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts`
+
+- [ ] **Step 1: Create the SolutionFilter class**
+
+```typescript
+import { escapeHtml, escapeAttr } from './utils.js';
+
+export interface SolutionOption {
+    id: string;
+    uniqueName: string;
+    friendlyName: string;
+}
+
+export interface SolutionFilterOptions {
+    /** Called when the user selects a solution or clears the filter */
+    onChange: (solutionId: string | null) => void;
+    /** VS Code API for state persistence */
+    getState: () => Record<string, unknown> | undefined;
+    setState: (state: Record<string, unknown>) => void;
+    /** Storage key for persisted selection (default: 'solutionFilter') */
+    storageKey?: string;
+}
+
+export class SolutionFilter {
+    private container: HTMLElement;
+    private options: SolutionFilterOptions;
+    private solutions: SolutionOption[] = [];
+    private selectedId: string | null = null;
+    private storageKey: string;
+
+    constructor(container: HTMLElement, options: SolutionFilterOptions) {
+        this.container = container;
+        this.options = options;
+        this.storageKey = options.storageKey ?? 'solutionFilter';
+        // Restore persisted selection
+        const state = options.getState();
+        if (state && typeof state[this.storageKey] === 'string') {
+            this.selectedId = state[this.storageKey] as string;
+        }
+        this.render();
+    }
+
+    /** Load solutions from the host and render the dropdown */
+    setSolutions(solutions: SolutionOption[]): void {
+        this.solutions = solutions;
+        this.render();
+    }
+
+    /** Get the currently selected solution ID (null = all) */
+    getSelectedId(): string | null {
+        return this.selectedId;
+    }
+
+    private render(): void {
+        // Renders a <select> dropdown with "All Solutions" + solution list
+        // Uses escapeHtml/escapeAttr for safety (Constitution S1)
+        // Persists selection to vscode state on change
+    }
+
+    private persist(): void {
+        const state = this.options.getState() ?? {};
+        if (this.selectedId) {
+            state[this.storageKey] = this.selectedId;
+        } else {
+            delete state[this.storageKey];
+        }
+        this.options.setState(state);
+    }
+}
+```
+
+The render method creates a `<select>` element with an "All Solutions" option and one `<option>` per solution. On change, it updates `selectedId`, persists, and calls `onChange`.
+
+- [ ] **Step 2: Verify build** — this is a shared module, no standalone build needed; it will be imported by panel scripts.
+
+### Task 6: Create Connection References webview panel
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/webview/connection-references-panel.ts`
+- Create: `src/PPDS.Extension/src/panels/styles/connection-references-panel.css`
+- Modify: `src/PPDS.Extension/src/panels/webview/shared/message-types.ts` — add message types
+
+- [ ] **Step 1: Add message types to message-types.ts**
+
+```typescript
+// ── Connection References ───────────────────────────────────────────────
+
+export interface ConnectionReferenceViewDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+    connectionId: string | null;
+    isManaged: boolean;
+    modifiedOn: string | null;
+    connectionStatus: string;
+    connectorDisplayName: string | null;
+}
+
+export interface ConnectionReferenceDetailViewDto extends ConnectionReferenceViewDto {
+    description: string | null;
+    isBound: boolean;
+    createdOn: string | null;
+    flows: { uniqueName: string; displayName: string | null; state: string | null }[];
+    connectionOwner: string | null;
+    connectionIsShared: boolean | null;
+}
+
+export interface ConnectionReferencesAnalyzeViewDto {
+    orphanedReferences: { logicalName: string; displayName: string | null; connectorId: string | null }[];
+    orphanedFlows: { uniqueName: string; displayName: string | null; missingReference: string | null }[];
+    totalReferences: number;
+    totalFlows: number;
+}
+
+export type ConnectionReferencesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectReference'; logicalName: string }
+    | { command: 'analyze' }
+    | { command: 'filterBySolution'; solutionId: string | null }
+    | { command: 'requestSolutionList' }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+export type ConnectionReferencesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string; envColor: string }
+    | { command: 'loading' }
+    | { command: 'connectionReferencesLoaded'; references: ConnectionReferenceViewDto[] }
+    | { command: 'connectionReferenceDetailLoaded'; reference: ConnectionReferenceDetailViewDto }
+    | { command: 'analyzeResult'; result: ConnectionReferencesAnalyzeViewDto }
+    | { command: 'solutionListLoaded'; solutions: { id: string; uniqueName: string; friendlyName: string }[] }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+```
+
+- [ ] **Step 2: Create connection-references-panel.ts webview script**
+
+Follow `import-jobs-panel.ts` pattern:
+- Initialize `DataTable<ConnectionReferenceViewDto>` with columns: Display Name, Logical Name, Connector, Status (color-coded badge), Managed, Modified On
+- Default sort: logicalName ascending
+- Initialize `SolutionFilter` in the toolbar area
+- On `ready`: post `requestSolutionList`, then data loads
+- On row click: post `selectReference` with logicalName
+- On `connectionReferenceDetailLoaded`: render bottom detail pane with connection info, flows list, orphan indicator
+- On `analyzeResult`: render analyze modal/overlay with orphan counts and lists
+- Status bar format: "12 connection references — 10 bound — 2 unbound"
+- Connection status badges: "Connected" (green), "Error" (red), "N/A" (gray)
+
+- [ ] **Step 3: Create connection-references-panel.css**
+
+Import shared.css. Add:
+- Connection status badge styles (reuse status-badge pattern from import-jobs)
+- Detail pane styles (reuse import-jobs detail pane pattern)
+- Solution filter dropdown styling
+- Analyze result overlay/modal styling
+
+- [ ] **Step 4: Add esbuild entries**
+
+Add to `esbuild.js` after the import-jobs-panel entries:
+
+```javascript
+// Connection References panel webview (browser, IIFE)
+{
+    entryPoints: ['src/panels/webview/connection-references-panel.ts'],
+    bundle: true,
+    format: 'iife',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'browser',
+    outfile: 'dist/connection-references-panel.js',
+    logLevel: 'warning',
+},
+```
+
+And CSS entry:
+
+```javascript
+// Connection References panel CSS
+{
+    entryPoints: ['src/panels/styles/connection-references-panel.css'],
+    bundle: true,
+    minify: production,
+    outfile: 'dist/connection-references-panel.css',
+    logLevel: 'warning',
+},
+```
+
+### Task 7: Create ConnectionReferencesPanel host-side panel
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts`
+
+- [ ] **Step 1: Create ConnectionReferencesPanel.ts**
+
+Follow `ImportJobsPanel.ts` pattern exactly:
+- `ConnectionReferencesPanel extends WebviewPanelBase<ConnectionReferencesPanelWebviewToHost, ConnectionReferencesPanelHostToWebview>`
+- Static `show(extensionUri, daemon, envUrl?, envDisplayName?)` factory
+- Static instance tracking with `MAX_PANELS = 5`
+- `viewType = 'ppds.connectionReferences'`
+- `handleMessage()` dispatches on command:
+  - `ready` → `initialize()` → load auth context → resolve environment → `loadConnectionReferences()`
+  - `refresh` → `loadConnectionReferences()`
+  - `selectReference` → `loadConnectionReferenceDetail(logicalName)`
+  - `analyze` → `runAnalysis()`
+  - `filterBySolution` → store solutionId → `loadConnectionReferences()`
+  - `requestSolutionList` → `loadSolutionList()`
+  - `requestEnvironmentList` → show QuickPick
+  - `openInMaker` → open URL
+  - `copyToClipboard` → clipboard
+  - `webviewError` → log
+- `loadConnectionReferences()`: calls `daemon.connectionReferencesList(solutionId, environmentUrl)`, posts `connectionReferencesLoaded`
+- `loadConnectionReferenceDetail(logicalName)`: calls `daemon.connectionReferencesGet(logicalName, environmentUrl)`, posts `connectionReferenceDetailLoaded`
+- `runAnalysis()`: calls `daemon.connectionReferencesAnalyze(environmentUrl)`, posts `analyzeResult`
+- `loadSolutionList()`: calls `daemon.solutionsList(undefined, false, environmentUrl)`, posts `solutionListLoaded`
+- HTML template loads `connection-references-panel.js` and `connection-references-panel.css`
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck` from `src/PPDS.Extension/`
+
+### Task 8: Register Connection References panel in extension
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/extension.ts`
+- Modify: `src/PPDS.Extension/package.json`
+
+- [ ] **Step 1: Add commands to package.json**
+
+In the `commands` array:
+```json
+{
+    "command": "ppds.openConnectionReferences",
+    "title": "Open Connection References",
+    "category": "PPDS",
+    "icon": "$(plug)"
+},
+{
+    "command": "ppds.openConnectionReferencesForEnv",
+    "title": "Open Connection References",
+    "icon": "$(plug)"
+}
+```
+
+In the `view/item/context` menus array, add after the importJobs entry:
+```json
+{
+    "command": "ppds.openConnectionReferencesForEnv",
+    "when": "view == ppds.profiles && viewItem == environment",
+    "group": "env-tools@4"
+}
+```
+
+- [ ] **Step 2: Register commands in extension.ts**
+
+Import `ConnectionReferencesPanel` and register both commands following the Import Jobs pattern:
+```typescript
+vscode.commands.registerCommand('ppds.openConnectionReferences', () => {
+    ConnectionReferencesPanel.show(context.extensionUri, client);
+});
+
+vscode.commands.registerCommand('ppds.openConnectionReferencesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
+    ConnectionReferencesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+}));
+```
+
+- [ ] **Step 3: Build and typecheck**
+
+Run: `npm run build && npm run typecheck` from `src/PPDS.Extension/`
+
+- [ ] **Step 4: Verify .NET build is still clean**
+
+Run: `dotnet build PPDS.sln -v q`
+
+---
+
+## Chunk 5: Environment Variables — RPC Layer
+
+### Task 9: Add Environment Variables RPC endpoints and DTOs
+
+**Files:**
+- Modify: `src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs`
+
+- [ ] **Step 1: Add DTO classes**
+
+```csharp
+// ── Environment Variables DTOs ──────────────────────────────────────────
+
+public class EnvironmentVariablesListResponse
+{
+    [JsonPropertyName("variables")]
+    public List<EnvironmentVariableInfoDto> Variables { get; set; } = [];
+}
+
+public class EnvironmentVariablesGetResponse
+{
+    [JsonPropertyName("variable")]
+    public EnvironmentVariableDetailDto Variable { get; set; } = null!;
+}
+
+public class EnvironmentVariablesSetResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
+public class EnvironmentVariableInfoDto
+{
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    [JsonPropertyName("defaultValue")]
+    public string? DefaultValue { get; set; }
+
+    [JsonPropertyName("currentValue")]
+    public string? CurrentValue { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("isRequired")]
+    public bool IsRequired { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    public string? ModifiedOn { get; set; }
+
+    [JsonPropertyName("hasOverride")]
+    public bool HasOverride { get; set; }
+
+    [JsonPropertyName("isMissing")]
+    public bool IsMissing { get; set; }
+}
+
+public class EnvironmentVariableDetailDto : EnvironmentVariableInfoDto
+{
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    public string? CreatedOn { get; set; }
+}
+```
+
+- [ ] **Step 2: Add `environmentVariables/list` RPC method**
+
+```csharp
+// ── Environment Variables ─────────────────────────────────────────────
+
+[JsonRpcMethod("environmentVariables/list")]
+public async Task<EnvironmentVariablesListResponse> EnvironmentVariablesListAsync(
+    string? solutionId = null,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var evService = sp.GetRequiredService<IEnvironmentVariableService>();
+        var variables = await evService.ListAsync(solutionName: solutionId, cancellationToken: ct);
+
+        return new EnvironmentVariablesListResponse
+        {
+            Variables = variables.Select(MapEnvironmentVariableToDto).ToList()
+        };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 3: Add `environmentVariables/get` RPC method**
+
+```csharp
+[JsonRpcMethod("environmentVariables/get")]
+public async Task<EnvironmentVariablesGetResponse> EnvironmentVariablesGetAsync(
+    string schemaName,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(schemaName))
+        throw new RpcException(ErrorCodes.Validation.RequiredField, "schemaName is required");
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var evService = sp.GetRequiredService<IEnvironmentVariableService>();
+        var variable = await evService.GetAsync(schemaName, ct);
+        if (variable == null)
+            throw new RpcException(ErrorCodes.Operation.NotFound, $"Environment variable '{schemaName}' not found");
+
+        return new EnvironmentVariablesGetResponse
+        {
+            Variable = MapEnvironmentVariableToDetailDto(variable)
+        };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 4: Add `environmentVariables/set` RPC method**
+
+```csharp
+[JsonRpcMethod("environmentVariables/set")]
+public async Task<EnvironmentVariablesSetResponse> EnvironmentVariablesSetAsync(
+    string schemaName,
+    string value,
+    string? environmentUrl = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(schemaName))
+        throw new RpcException(ErrorCodes.Validation.RequiredField, "schemaName is required");
+    if (value == null)
+        throw new RpcException(ErrorCodes.Validation.RequiredField, "value is required");
+
+    return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+    {
+        var evService = sp.GetRequiredService<IEnvironmentVariableService>();
+        var success = await evService.SetValueAsync(schemaName, value, ct);
+        return new EnvironmentVariablesSetResponse { Success = success };
+    }, cancellationToken);
+}
+```
+
+- [ ] **Step 5: Add private mapper methods**
+
+```csharp
+private static EnvironmentVariableInfoDto MapEnvironmentVariableToDto(EnvironmentVariableInfo v)
+{
+    return new EnvironmentVariableInfoDto
+    {
+        SchemaName = v.SchemaName,
+        DisplayName = v.DisplayName,
+        Type = v.Type,
+        DefaultValue = v.DefaultValue,
+        CurrentValue = v.CurrentValue,
+        IsManaged = v.IsManaged,
+        IsRequired = v.IsRequired,
+        ModifiedOn = v.ModifiedOn?.ToString("o"),
+        HasOverride = v.CurrentValue != null && v.CurrentValue != v.DefaultValue,
+        IsMissing = v.IsRequired && v.CurrentValue == null && v.DefaultValue == null,
+    };
+}
+
+private static EnvironmentVariableDetailDto MapEnvironmentVariableToDetailDto(EnvironmentVariableInfo v)
+{
+    return new EnvironmentVariableDetailDto
+    {
+        SchemaName = v.SchemaName,
+        DisplayName = v.DisplayName,
+        Description = v.Description,
+        Type = v.Type,
+        DefaultValue = v.DefaultValue,
+        CurrentValue = v.CurrentValue,
+        IsManaged = v.IsManaged,
+        IsRequired = v.IsRequired,
+        ModifiedOn = v.ModifiedOn?.ToString("o"),
+        CreatedOn = v.CreatedOn?.ToString("o"),
+        HasOverride = v.CurrentValue != null && v.CurrentValue != v.DefaultValue,
+        IsMissing = v.IsRequired && v.CurrentValue == null && v.DefaultValue == null,
+    };
+}
+```
+
+- [ ] **Step 6: Build to verify**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -v q`
+
+---
+
+## Chunk 6: Environment Variables — MCP Tools
+
+### Task 10: Create MCP tools for Environment Variables
+
+**Files:**
+- Create: `src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs`
+- Create: `src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs`
+- Create: `src/PPDS.Mcp/Tools/EnvironmentVariablesSetTool.cs`
+
+- [ ] **Step 1: Create EnvironmentVariablesListTool.cs**
+
+- Tool name: `ppds_environment_variables_list`
+- Description: "List environment variable definitions and their current values. Shows default vs current values, type, and override status. Optionally filter by solution name."
+- Parameters: `string? solutionId = null`
+- Result DTO fields: schemaName, displayName, type, defaultValue, currentValue, isManaged, isRequired, hasOverride, isMissing
+
+- [ ] **Step 2: Create EnvironmentVariablesGetTool.cs**
+
+- Tool name: `ppds_environment_variables_get`
+- Description: "Get full details of a specific environment variable including description, type, and values. Use the schemaName from ppds_environment_variables_list."
+- Parameters: `string schemaName` (required)
+
+- [ ] **Step 3: Create EnvironmentVariablesSetTool.cs**
+
+- Tool name: `ppds_environment_variables_set`
+- Description: "Set the current value of an environment variable. Creates the value record if none exists. AI agents can use this to fix misconfigurations during deployment troubleshooting."
+- Parameters: `string schemaName` (required), `string value` (required)
+- Returns success boolean
+
+- [ ] **Step 4: Build to verify**
+
+Run: `dotnet build src/PPDS.Mcp/PPDS.Mcp.csproj -v q`
+
+---
+
+## Chunk 7: Environment Variables — TUI Screen
+
+### Task 11: Create EnvironmentVariablesScreen
+
+**Files:**
+- Create: `src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs`
+- Modify: `src/PPDS.Cli/Tui/TuiShell.cs` — add menu item
+
+- [ ] **Step 1: Create EnvironmentVariablesScreen.cs**
+
+Follow `ImportJobsScreen.cs` + `ConnectionReferencesScreen.cs` patterns.
+
+Table columns: Schema Name, Display Name, Type, Default Value, Current Value, Managed, Modified On
+
+Hotkeys:
+- `Ctrl+R` → Refresh
+- `Enter` → Detail/edit dialog
+- `Ctrl+E` → Export deployment settings
+- `Ctrl+F` → Solution filter dialog (reuse pattern from ConnectionReferencesScreen)
+- `Ctrl+O` → Open in Maker
+
+Status format: "15 environment variables — 3 overridden — 1 missing value"
+
+Visual indicators in table:
+- Override: current value differs from default (could use color/marker)
+- Missing: required variable with no value and no default (warning color)
+
+- [ ] **Step 2: Create detail/edit dialog**
+
+On `Enter` / cell activated:
+- Show `Dialog` with variable details: schema name, display name, description, type, default value
+- Editable field for current value with type-aware validation:
+  - String: `TextField`
+  - Number: `TextField` with numeric validation
+  - Boolean: `CheckBox` or RadioGroup (true/false)
+  - JSON: `TextView` (multi-line) with JSON parse validation
+  - DataSource / Secret: read-only display
+- "Save" button calls `IEnvironmentVariableService.SetValueAsync()`
+- "Cancel" dismisses without changes
+- On save success: refresh the table row
+
+- [ ] **Step 3: Create export dialog**
+
+On `Ctrl+E`:
+- Call `IEnvironmentVariableService.ExportAsync(solutionName: _solutionFilter)`
+- Serialize to `.deploymentsettings.json` format
+- Prompt for file path (use `SaveDialog` or write to current directory)
+- Write file and show success message
+
+- [ ] **Step 4: Add menu item in TuiShell.cs**
+
+Add after the "Connection References" menu item:
+
+```csharp
+new("Environment Variables", "View and edit environment variables", () => NavigateToEnvironmentVariables()),
+```
+
+Add `NavigateToEnvironmentVariables()` method.
+
+- [ ] **Step 5: Build to verify**
+
+Run: `dotnet build src/PPDS.Cli/PPDS.Cli.csproj -v q`
+
+---
+
+## Chunk 8: Environment Variables — VS Code Extension (TypeScript)
+
+### Task 12: Add TypeScript types and daemon client methods
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/types.ts`
+- Modify: `src/PPDS.Extension/src/daemonClient.ts`
+
+- [ ] **Step 1: Add DTO interfaces to types.ts**
+
+```typescript
+// ── Environment Variables ───────────────────────────────────────────────
+
+export interface EnvironmentVariablesListResponse {
+    variables: EnvironmentVariableInfoDto[];
+}
+
+export interface EnvironmentVariablesGetResponse {
+    variable: EnvironmentVariableDetailDto;
+}
+
+export interface EnvironmentVariablesSetResponse {
+    success: boolean;
+}
+
+export interface EnvironmentVariableInfoDto {
+    schemaName: string;
+    displayName: string | null;
+    type: string;
+    defaultValue: string | null;
+    currentValue: string | null;
+    isManaged: boolean;
+    isRequired: boolean;
+    modifiedOn: string | null;
+    hasOverride: boolean;
+    isMissing: boolean;
+}
+
+export interface EnvironmentVariableDetailDto extends EnvironmentVariableInfoDto {
+    description: string | null;
+    createdOn: string | null;
+}
+```
+
+- [ ] **Step 2: Add daemon client methods**
+
+```typescript
+// ── Environment Variables ───────────────────────────────────────────────
+
+async environmentVariablesList(solutionId?: string, environmentUrl?: string): Promise<EnvironmentVariablesListResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = {};
+    if (solutionId !== undefined) params.solutionId = solutionId;
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info('Calling environmentVariables/list...');
+    const result = await this.connection!.sendRequest<EnvironmentVariablesListResponse>('environmentVariables/list', params);
+    this.log.debug(`Got ${result.variables.length} environment variables`);
+    return result;
+}
+
+async environmentVariablesGet(schemaName: string, environmentUrl?: string): Promise<EnvironmentVariablesGetResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { schemaName };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling environmentVariables/get for ${schemaName}...`);
+    return await this.connection!.sendRequest<EnvironmentVariablesGetResponse>('environmentVariables/get', params);
+}
+
+async environmentVariablesSet(schemaName: string, value: string, environmentUrl?: string): Promise<EnvironmentVariablesSetResponse> {
+    await this.ensureConnected();
+    const params: Record<string, unknown> = { schemaName, value };
+    if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+    this.log.info(`Calling environmentVariables/set for ${schemaName}...`);
+    return await this.connection!.sendRequest<EnvironmentVariablesSetResponse>('environmentVariables/set', params);
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck` from `src/PPDS.Extension/`
+
+### Task 13: Create Environment Variables webview panel
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts`
+- Create: `src/PPDS.Extension/src/panels/styles/environment-variables-panel.css`
+- Modify: `src/PPDS.Extension/src/panels/webview/shared/message-types.ts`
+
+- [ ] **Step 1: Add message types to message-types.ts**
+
+```typescript
+// ── Environment Variables ────────────────────────────────────────────────
+
+export interface EnvironmentVariableViewDto {
+    schemaName: string;
+    displayName: string | null;
+    type: string;
+    defaultValue: string | null;
+    currentValue: string | null;
+    isManaged: boolean;
+    isRequired: boolean;
+    modifiedOn: string | null;
+    hasOverride: boolean;
+    isMissing: boolean;
+}
+
+export interface EnvironmentVariableDetailViewDto extends EnvironmentVariableViewDto {
+    description: string | null;
+    createdOn: string | null;
+}
+
+export type EnvironmentVariablesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectVariable'; schemaName: string }
+    | { command: 'editVariable'; schemaName: string }
+    | { command: 'saveVariable'; schemaName: string; value: string }
+    | { command: 'filterBySolution'; solutionId: string | null }
+    | { command: 'requestSolutionList' }
+    | { command: 'exportDeploymentSettings' }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+export type EnvironmentVariablesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string; envColor: string }
+    | { command: 'loading' }
+    | { command: 'environmentVariablesLoaded'; variables: EnvironmentVariableViewDto[] }
+    | { command: 'environmentVariableDetailLoaded'; variable: EnvironmentVariableDetailViewDto }
+    | { command: 'editVariableDialog'; variable: EnvironmentVariableDetailViewDto }
+    | { command: 'variableSaved'; schemaName: string; success: boolean }
+    | { command: 'solutionListLoaded'; solutions: { id: string; uniqueName: string; friendlyName: string }[] }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+```
+
+- [ ] **Step 2: Create environment-variables-panel.ts webview script**
+
+Follow the connection-references-panel.ts pattern:
+- Initialize `DataTable<EnvironmentVariableViewDto>` with columns: Schema Name, Display Name, Type, Default Value, Current Value (with override/missing indicators), Managed, Modified On
+- Default sort: schemaName ascending
+- Initialize `SolutionFilter` in toolbar
+- Current Value column render: highlight if `hasOverride` (different color), warning icon if `isMissing`
+- Edit button in row or action column → posts `editVariable`
+- On `editVariableDialog`: render modal dialog with type-aware input:
+  - String: `<input type="text">`
+  - Number: `<input type="number">`
+  - Boolean: `<select>` with true/false options
+  - JSON: `<textarea>` with syntax validation on blur
+  - DataSource / Secret: display-only with message
+- Save button in dialog: validate, then post `saveVariable`
+- On `variableSaved`: close dialog, refresh affected row
+- Export button in toolbar → posts `exportDeploymentSettings`
+- Status bar: "15 environment variables — 3 overridden — 1 missing"
+
+- [ ] **Step 3: Create environment-variables-panel.css**
+
+Import shared.css. Add:
+- Override value highlight (e.g., subtle background tint)
+- Missing value warning indicator (yellow/orange icon or border)
+- Edit dialog modal styles
+- Type-specific input field styling
+- Export button styling
+
+- [ ] **Step 4: Add esbuild entries**
+
+```javascript
+// Environment Variables panel webview (browser, IIFE)
+{
+    entryPoints: ['src/panels/webview/environment-variables-panel.ts'],
+    bundle: true,
+    format: 'iife',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'browser',
+    outfile: 'dist/environment-variables-panel.js',
+    logLevel: 'warning',
+},
+```
+
+```javascript
+// Environment Variables panel CSS
+{
+    entryPoints: ['src/panels/styles/environment-variables-panel.css'],
+    bundle: true,
+    minify: production,
+    outfile: 'dist/environment-variables-panel.css',
+    logLevel: 'warning',
+},
+```
+
+### Task 14: Create EnvironmentVariablesPanel host-side panel
+
+**Files:**
+- Create: `src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts`
+
+- [ ] **Step 1: Create EnvironmentVariablesPanel.ts**
+
+Follow `ConnectionReferencesPanel.ts` pattern:
+- `EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVariablesPanelWebviewToHost, EnvironmentVariablesPanelHostToWebview>`
+- `viewType = 'ppds.environmentVariables'`
+- `handleMessage()` dispatches on command:
+  - `ready` → `initialize()` → load auth context → resolve environment → `loadEnvironmentVariables()`
+  - `refresh` → `loadEnvironmentVariables()`
+  - `selectVariable` → `loadEnvironmentVariableDetail(schemaName)`
+  - `editVariable` → `loadEnvironmentVariableForEdit(schemaName)` (fetches detail, posts `editVariableDialog`)
+  - `saveVariable` → `saveEnvironmentVariable(schemaName, value)` (calls `daemon.environmentVariablesSet()`, posts `variableSaved`, refreshes list)
+  - `filterBySolution` → store solutionId → `loadEnvironmentVariables()`
+  - `requestSolutionList` → `loadSolutionList()`
+  - `exportDeploymentSettings` → prompt save location, call daemon, write file
+  - `requestEnvironmentList` → show QuickPick
+  - `openInMaker` → open URL
+- `exportDeploymentSettings()`: For export, the host can call `daemon.environmentVariablesList()`, format as deployment settings JSON, and use `vscode.workspace.fs.writeFile()` with a save dialog
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck` from `src/PPDS.Extension/`
+
+### Task 15: Register Environment Variables panel in extension
+
+**Files:**
+- Modify: `src/PPDS.Extension/src/extension.ts`
+- Modify: `src/PPDS.Extension/package.json`
+
+- [ ] **Step 1: Add commands to package.json**
+
+```json
+{
+    "command": "ppds.openEnvironmentVariables",
+    "title": "Open Environment Variables",
+    "category": "PPDS",
+    "icon": "$(symbol-variable)"
+},
+{
+    "command": "ppds.openEnvironmentVariablesForEnv",
+    "title": "Open Environment Variables",
+    "icon": "$(symbol-variable)"
+}
+```
+
+Context menu:
+```json
+{
+    "command": "ppds.openEnvironmentVariablesForEnv",
+    "when": "view == ppds.profiles && viewItem == environment",
+    "group": "env-tools@5"
+}
+```
+
+- [ ] **Step 2: Register commands in extension.ts**
+
+Import `EnvironmentVariablesPanel` and register both commands.
+
+- [ ] **Step 3: Full build verification**
+
+Run: `npm run build && npm run typecheck` from `src/PPDS.Extension/`
+Run: `dotnet build PPDS.sln -v q`
+Run: `dotnet test PPDS.sln --filter "Category!=Integration" -v q`
+
+---
+
+## Chunk 9: Integration Testing and Polish
+
+### Task 16: End-to-end verification
+
+- [ ] **Step 1: Run full quality gates**
+
+```
+dotnet build PPDS.sln -v q
+dotnet test PPDS.sln --filter "Category!=Integration" -v q
+npm run typecheck (from src/PPDS.Extension/)
+npm run lint (from src/PPDS.Extension/)
+npm run ext:test (from src/PPDS.Extension/)
+```
+
+- [ ] **Step 2: Verify extension builds and runs**
+
+- Build extension: `npm run build`
+- Launch extension in development mode
+- Verify both panels appear in command palette
+- Verify panels appear in environment context menu
+
+- [ ] **Step 3: TUI verification**
+
+- Launch TUI: `ppds tui`
+- Verify "Connection References" and "Environment Variables" appear in menu
+- Navigate to each screen, verify layout and hotkeys
+
+- [ ] **Step 4: MCP verification**
+
+- Verify tools are registered: check MCP tool discovery
+- Test `ppds_connection_references_list`, `ppds_environment_variables_list`
+- Test `ppds_environment_variables_set` with a test variable
+
+---
+
+## Summary
+
+| Chunk | Focus | Tasks | Key Risk |
+|-------|-------|-------|----------|
+| 1 | CR RPC | T1 (3 endpoints + DTOs + mappers) | SPN graceful degradation logic |
+| 2 | CR MCP | T2 (3 tools) | Duplicating SPN degradation from RPC |
+| 3 | CR TUI | T3 (screen + 3 dialogs + menu) | Solution filter dialog pattern |
+| 4 | CR VS Code | T4-T8 (types, client, shared filter, webview, host, registration) | Shared solution filter component design |
+| 5 | EV RPC | T9 (3 endpoints + DTOs + mappers) | Write operation validation |
+| 6 | EV MCP | T10 (3 tools including write) | Set tool requires clear description for AI safety |
+| 7 | EV TUI | T11 (screen + edit dialog + export + menu) | Type-aware edit validation in TUI |
+| 8 | EV VS Code | T12-T15 (types, client, webview, host, registration) | Edit dialog modal UX |
+| 9 | Integration | T16 (gates, verify all surfaces) | Cross-surface consistency |
+
+**Total new files:** ~18
+**Total modified files:** ~8
+**Estimated acceptance criteria coverage:** AC-CR-01 through AC-CR-10, AC-EV-01 through AC-EV-10

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -2228,16 +2228,6 @@ public class RpcMethodHandler : IDisposable
     public async Task<PluginTracesListResponse> PluginTracesListAsync(
         TraceFilterDto? filter = null,
         int top = 100,
-    #region Connection References
-
-    /// <summary>
-    /// Lists connection references, optionally filtered by solution.
-    /// Enriches with connection status from Power Platform API (graceful degradation for SPN).
-    /// Maps to: ppds connref list --json
-    /// </summary>
-    [JsonRpcMethod("connectionReferences/list")]
-    public async Task<ConnectionReferencesListResponse> ConnectionReferencesListAsync(
-        string? solutionId = null,
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
@@ -2250,25 +2240,6 @@ public class RpcMethodHandler : IDisposable
             return new PluginTracesListResponse
             {
                 Traces = traces.Select(MapTraceInfoToDto).ToList()
-            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
-            var references = await connRefService.ListAsync(solutionName: solutionId, cancellationToken: ct);
-
-            // Try to enrich with connection status from Power Platform API
-            Dictionary<string, ConnectionInfo>? connectionMap = null;
-            try
-            {
-                var connectionService = sp.GetRequiredService<IConnectionService>();
-                var connections = await connectionService.ListAsync(cancellationToken: ct);
-                connectionMap = connections.ToDictionary(c => c.ConnectionId, c => c);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Unable to retrieve connection status (SPN may not have access to Connections API). Continuing without connection enrichment.");
-            }
-
-            return new ConnectionReferencesListResponse
-            {
-                References = references.Select(r => MapConnectionReferenceToDto(r, connectionMap)).ToList()
             };
         }, cancellationToken);
     }
@@ -2288,20 +2259,6 @@ public class RpcMethodHandler : IDisposable
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,
                 "The 'id' parameter must be a valid GUID");
-    /// Gets a single connection reference with dependent flows and connection details.
-    /// Maps to: ppds connref get --json
-    /// </summary>
-    [JsonRpcMethod("connectionReferences/get")]
-    public async Task<ConnectionReferencesGetResponse> ConnectionReferencesGetAsync(
-        string logicalName,
-        string? environmentUrl = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(logicalName))
-        {
-            throw new RpcException(
-                ErrorCodes.Validation.RequiredField,
-                "The 'logicalName' parameter is required");
         }
 
         return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
@@ -2403,33 +2360,6 @@ public class RpcMethodHandler : IDisposable
             return new PluginTracesDeleteResponse
             {
                 DeletedCount = deletedCount
-            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
-
-            var reference = await connRefService.GetAsync(logicalName, ct)
-                ?? throw new RpcException(
-                    ErrorCodes.Operation.NotFound,
-                    $"Connection reference '{logicalName}' not found");
-
-            var flows = await connRefService.GetFlowsUsingAsync(logicalName, ct);
-
-            // Try to get connection details (graceful degradation for SPN)
-            ConnectionInfo? connectionInfo = null;
-            if (!string.IsNullOrEmpty(reference.ConnectionId))
-            {
-                try
-                {
-                    var connectionService = sp.GetRequiredService<IConnectionService>();
-                    connectionInfo = await connectionService.GetAsync(reference.ConnectionId, ct);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Unable to retrieve connection details for '{ConnectionId}' (SPN may not have access). Continuing without connection enrichment.", reference.ConnectionId);
-                }
-            }
-
-            return new ConnectionReferencesGetResponse
-            {
-                Reference = MapConnectionReferenceToDetailDto(reference, flows, connectionInfo)
             };
         }, cancellationToken);
     }
@@ -2440,11 +2370,6 @@ public class RpcMethodHandler : IDisposable
     /// </summary>
     [JsonRpcMethod("pluginTraces/traceLevel")]
     public async Task<PluginTracesTraceLevelResponse> PluginTracesTraceLevelAsync(
-    /// Analyzes connection references for orphaned references and flows.
-    /// Maps to: ppds connref analyze --json
-    /// </summary>
-    [JsonRpcMethod("connectionReferences/analyze")]
-    public async Task<ConnectionReferencesAnalyzeResponse> ConnectionReferencesAnalyzeAsync(
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
@@ -2457,45 +2382,6 @@ public class RpcMethodHandler : IDisposable
             {
                 Level = settings.SettingName,
                 LevelValue = (int)settings.Setting
-            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
-            var analysis = await connRefService.AnalyzeAsync(cancellationToken: ct);
-
-            var orphanedReferences = analysis.Relationships
-                .Where(r => r.Type == ConnRefRelationshipType.OrphanedConnectionReference)
-                .Select(r => new OrphanedReferenceDto
-                {
-                    LogicalName = r.ConnectionReferenceLogicalName ?? "",
-                    DisplayName = r.ConnectionReferenceDisplayName,
-                    ConnectorId = r.ConnectorId
-                })
-                .ToList();
-
-            var orphanedFlows = analysis.Relationships
-                .Where(r => r.Type == ConnRefRelationshipType.OrphanedFlow)
-                .Select(r => new OrphanedFlowDto
-                {
-                    UniqueName = r.FlowUniqueName ?? "",
-                    DisplayName = r.FlowDisplayName,
-                    MissingReference = r.ConnectionReferenceLogicalName
-                })
-                .ToList();
-
-            return new ConnectionReferencesAnalyzeResponse
-            {
-                OrphanedReferences = orphanedReferences,
-                OrphanedFlows = orphanedFlows,
-                TotalReferences = analysis.Relationships
-                    .Where(r => r.Type is ConnRefRelationshipType.OrphanedConnectionReference
-                             or ConnRefRelationshipType.FlowToConnectionReference)
-                    .Select(r => r.ConnectionReferenceLogicalName)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .Count(),
-                TotalFlows = analysis.Relationships
-                    .Where(r => r.Type is ConnRefRelationshipType.OrphanedFlow
-                             or ConnRefRelationshipType.FlowToConnectionReference)
-                    .Select(r => r.FlowUniqueName)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .Count()
             };
         }, cancellationToken);
     }
@@ -2619,6 +2505,147 @@ public class RpcMethodHandler : IDisposable
             WidthPercent = node.WidthPercent,
             HierarchyDepth = node.HierarchyDepth,
             Children = node.Children.Select(MapTimelineNodeToDto).ToList()
+        };
+    }
+
+    #endregion
+
+    #region Connection References
+
+    /// <summary>
+    /// Lists connection references, optionally filtered by solution.
+    /// Enriches with connection status from Power Platform API (graceful degradation for SPN).
+    /// Maps to: ppds connref list --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/list")]
+    public async Task<ConnectionReferencesListResponse> ConnectionReferencesListAsync(
+        string? solutionId = null,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+            var references = await connRefService.ListAsync(solutionName: solutionId, cancellationToken: ct);
+
+            // Try to enrich with connection status from Power Platform API
+            Dictionary<string, ConnectionInfo>? connectionMap = null;
+            try
+            {
+                var connectionService = sp.GetRequiredService<IConnectionService>();
+                var connections = await connectionService.ListAsync(cancellationToken: ct);
+                connectionMap = connections.ToDictionary(c => c.ConnectionId, c => c);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Unable to retrieve connection status (SPN may not have access to Connections API). Continuing without connection enrichment.");
+            }
+
+            return new ConnectionReferencesListResponse
+            {
+                References = references.Select(r => MapConnectionReferenceToDto(r, connectionMap)).ToList()
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a single connection reference with dependent flows and connection details.
+    /// Maps to: ppds connref get --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/get")]
+    public async Task<ConnectionReferencesGetResponse> ConnectionReferencesGetAsync(
+        string logicalName,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(logicalName))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'logicalName' parameter is required");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+
+            var reference = await connRefService.GetAsync(logicalName, ct)
+                ?? throw new RpcException(
+                    ErrorCodes.Operation.NotFound,
+                    $"Connection reference '{logicalName}' not found");
+
+            var flows = await connRefService.GetFlowsUsingAsync(logicalName, ct);
+
+            // Try to get connection details (graceful degradation for SPN)
+            ConnectionInfo? connectionInfo = null;
+            if (!string.IsNullOrEmpty(reference.ConnectionId))
+            {
+                try
+                {
+                    var connectionService = sp.GetRequiredService<IConnectionService>();
+                    connectionInfo = await connectionService.GetAsync(reference.ConnectionId, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Unable to retrieve connection details for '{ConnectionId}' (SPN may not have access). Continuing without connection enrichment.", reference.ConnectionId);
+                }
+            }
+
+            return new ConnectionReferencesGetResponse
+            {
+                Reference = MapConnectionReferenceToDetailDto(reference, flows, connectionInfo)
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Analyzes connection references for orphaned references and flows.
+    /// Maps to: ppds connref analyze --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/analyze")]
+    public async Task<ConnectionReferencesAnalyzeResponse> ConnectionReferencesAnalyzeAsync(
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+            var analysis = await connRefService.AnalyzeAsync(cancellationToken: ct);
+
+            var orphanedReferences = analysis.Relationships
+                .Where(r => r.Type == ConnRefRelationshipType.OrphanedConnectionReference)
+                .Select(r => new OrphanedReferenceDto
+                {
+                    LogicalName = r.ConnectionReferenceLogicalName ?? "",
+                    DisplayName = r.ConnectionReferenceDisplayName,
+                    ConnectorId = r.ConnectorId
+                })
+                .ToList();
+
+            var orphanedFlows = analysis.Relationships
+                .Where(r => r.Type == ConnRefRelationshipType.OrphanedFlow)
+                .Select(r => new OrphanedFlowDto
+                {
+                    UniqueName = r.FlowUniqueName ?? "",
+                    DisplayName = r.FlowDisplayName,
+                    MissingReference = r.ConnectionReferenceLogicalName
+                })
+                .ToList();
+
+            return new ConnectionReferencesAnalyzeResponse
+            {
+                OrphanedReferences = orphanedReferences,
+                OrphanedFlows = orphanedFlows,
+                TotalReferences = analysis.Relationships.Count(r =>
+                    r.Type == ConnRefRelationshipType.OrphanedConnectionReference ||
+                    r.Type == ConnRefRelationshipType.FlowToConnectionReference),
+                TotalFlows = analysis.Relationships.Count(r =>
+                    r.Type == ConnRefRelationshipType.OrphanedFlow ||
+                    r.Type == ConnRefRelationshipType.FlowToConnectionReference)
+            };
+        }, cancellationToken);
+    }
+
     private static ConnectionReferenceInfoDto MapConnectionReferenceToDto(
         ConnectionReferenceInfo r,
         Dictionary<string, ConnectionInfo>? connectionMap)
@@ -2748,7 +2775,7 @@ public class RpcMethodHandler : IDisposable
                 "The 'schemaName' parameter is required");
         }
 
-        if (value == null)
+        if (string.IsNullOrWhiteSpace(value))
         {
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,
@@ -3842,149 +3869,6 @@ public class PluginTracesTraceLevelResponse
 }
 
 public class PluginTracesSetTraceLevelResponse
-// ── Connection References DTOs ─────────────────────────────────────────────────
-
-public class ConnectionReferencesListResponse
-{
-    [JsonPropertyName("references")]
-    public List<ConnectionReferenceInfoDto> References { get; set; } = [];
-}
-
-public class ConnectionReferencesGetResponse
-{
-    [JsonPropertyName("reference")]
-    public ConnectionReferenceDetailDto Reference { get; set; } = null!;
-}
-
-public class ConnectionReferencesAnalyzeResponse
-{
-    [JsonPropertyName("orphanedReferences")]
-    public List<OrphanedReferenceDto> OrphanedReferences { get; set; } = [];
-
-    [JsonPropertyName("orphanedFlows")]
-    public List<OrphanedFlowDto> OrphanedFlows { get; set; } = [];
-
-    [JsonPropertyName("totalReferences")]
-    public int TotalReferences { get; set; }
-
-    [JsonPropertyName("totalFlows")]
-    public int TotalFlows { get; set; }
-}
-
-public class ConnectionReferenceInfoDto
-{
-    [JsonPropertyName("logicalName")]
-    public string LogicalName { get; set; } = "";
-
-    [JsonPropertyName("displayName")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? DisplayName { get; set; }
-
-    [JsonPropertyName("connectorId")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectorId { get; set; }
-
-    [JsonPropertyName("connectionId")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectionId { get; set; }
-
-    [JsonPropertyName("isManaged")]
-    public bool IsManaged { get; set; }
-
-    [JsonPropertyName("modifiedOn")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ModifiedOn { get; set; }
-
-    [JsonPropertyName("connectionStatus")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectionStatus { get; set; }
-
-    [JsonPropertyName("connectorDisplayName")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectorDisplayName { get; set; }
-}
-
-public class ConnectionReferenceDetailDto : ConnectionReferenceInfoDto
-{
-    [JsonPropertyName("description")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Description { get; set; }
-
-    [JsonPropertyName("isBound")]
-    public bool IsBound { get; set; }
-
-    [JsonPropertyName("createdOn")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? CreatedOn { get; set; }
-
-    [JsonPropertyName("flows")]
-    public List<FlowReferenceDto> Flows { get; set; } = [];
-
-    [JsonPropertyName("connectionOwner")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectionOwner { get; set; }
-
-    [JsonPropertyName("connectionIsShared")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? ConnectionIsShared { get; set; }
-}
-
-public class FlowReferenceDto
-{
-    [JsonPropertyName("uniqueName")]
-    public string UniqueName { get; set; } = "";
-
-    [JsonPropertyName("displayName")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? DisplayName { get; set; }
-
-    [JsonPropertyName("state")]
-    public string State { get; set; } = "";
-}
-
-public class OrphanedReferenceDto
-{
-    [JsonPropertyName("logicalName")]
-    public string LogicalName { get; set; } = "";
-
-    [JsonPropertyName("displayName")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? DisplayName { get; set; }
-
-    [JsonPropertyName("connectorId")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ConnectorId { get; set; }
-}
-
-public class OrphanedFlowDto
-{
-    [JsonPropertyName("uniqueName")]
-    public string UniqueName { get; set; } = "";
-
-    [JsonPropertyName("displayName")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? DisplayName { get; set; }
-
-    [JsonPropertyName("missingReference")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? MissingReference { get; set; }
-}
-
-// ── Environment Variables DTOs ─────────────────────────────────────────────────
-
-public class EnvironmentVariablesListResponse
-{
-    [JsonPropertyName("variables")]
-    public List<EnvironmentVariableInfoDto> Variables { get; set; } = [];
-}
-
-public class EnvironmentVariablesGetResponse
-{
-    [JsonPropertyName("variable")]
-    public EnvironmentVariableDetailDto Variable { get; set; } = null!;
-}
-
-public class EnvironmentVariablesSetResponse
 {
     [JsonPropertyName("success")]
     public bool Success { get; set; }
@@ -4477,6 +4361,156 @@ public class MetadataOptionValueDto
     [JsonPropertyName("description")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
+}
+
+// ── Connection References DTOs ─────────────────────────────────────────────────
+
+public class ConnectionReferencesListResponse
+{
+    [JsonPropertyName("references")]
+    public List<ConnectionReferenceInfoDto> References { get; set; } = [];
+}
+
+public class ConnectionReferencesGetResponse
+{
+    [JsonPropertyName("reference")]
+    public ConnectionReferenceDetailDto Reference { get; set; } = null!;
+}
+
+public class ConnectionReferencesAnalyzeResponse
+{
+    [JsonPropertyName("orphanedReferences")]
+    public List<OrphanedReferenceDto> OrphanedReferences { get; set; } = [];
+
+    [JsonPropertyName("orphanedFlows")]
+    public List<OrphanedFlowDto> OrphanedFlows { get; set; } = [];
+
+    [JsonPropertyName("totalReferences")]
+    public int TotalReferences { get; set; }
+
+    [JsonPropertyName("totalFlows")]
+    public int TotalFlows { get; set; }
+}
+
+public class ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+
+    [JsonPropertyName("connectionId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionId { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+
+    [JsonPropertyName("connectionStatus")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionStatus { get; set; }
+
+    [JsonPropertyName("connectorDisplayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorDisplayName { get; set; }
+}
+
+public class ConnectionReferenceDetailDto : ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("isBound")]
+    public bool IsBound { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CreatedOn { get; set; }
+
+    [JsonPropertyName("flows")]
+    public List<FlowReferenceDto> Flows { get; set; } = [];
+
+    [JsonPropertyName("connectionOwner")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionOwner { get; set; }
+
+    [JsonPropertyName("connectionIsShared")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ConnectionIsShared { get; set; }
+}
+
+public class FlowReferenceDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = "";
+}
+
+public class OrphanedReferenceDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+}
+
+public class OrphanedFlowDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("missingReference")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MissingReference { get; set; }
+}
+
+// ── Environment Variables DTOs ─────────────────────────────────────────────────
+
+public class EnvironmentVariablesListResponse
+{
+    [JsonPropertyName("variables")]
+    public List<EnvironmentVariableInfoDto> Variables { get; set; } = [];
+}
+
+public class EnvironmentVariablesGetResponse
+{
+    [JsonPropertyName("variable")]
+    public EnvironmentVariableDetailDto Variable { get; set; } = null!;
+}
+
+public class EnvironmentVariablesSetResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+}
+
 public class EnvironmentVariableInfoDto
 {
     [JsonPropertyName("schemaName")]

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -29,6 +29,7 @@ using StreamJsonRpc;
 // Aliases to disambiguate from local DTOs
 using PluginTypeInfoModel = PPDS.Cli.Plugins.Registration.PluginTypeInfo;
 using PluginImageInfoModel = PPDS.Cli.Plugins.Registration.PluginImageInfo;
+using ConnRefRelationshipType = PPDS.Dataverse.Services.RelationshipType;
 
 namespace PPDS.Cli.Commands.Serve.Handlers;
 
@@ -2227,6 +2228,16 @@ public class RpcMethodHandler : IDisposable
     public async Task<PluginTracesListResponse> PluginTracesListAsync(
         TraceFilterDto? filter = null,
         int top = 100,
+    #region Connection References
+
+    /// <summary>
+    /// Lists connection references, optionally filtered by solution.
+    /// Enriches with connection status from Power Platform API (graceful degradation for SPN).
+    /// Maps to: ppds connref list --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/list")]
+    public async Task<ConnectionReferencesListResponse> ConnectionReferencesListAsync(
+        string? solutionId = null,
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
@@ -2239,6 +2250,25 @@ public class RpcMethodHandler : IDisposable
             return new PluginTracesListResponse
             {
                 Traces = traces.Select(MapTraceInfoToDto).ToList()
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+            var references = await connRefService.ListAsync(solutionName: solutionId, cancellationToken: ct);
+
+            // Try to enrich with connection status from Power Platform API
+            Dictionary<string, ConnectionInfo>? connectionMap = null;
+            try
+            {
+                var connectionService = sp.GetRequiredService<IConnectionService>();
+                var connections = await connectionService.ListAsync(cancellationToken: ct);
+                connectionMap = connections.ToDictionary(c => c.ConnectionId, c => c);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Unable to retrieve connection status (SPN may not have access to Connections API). Continuing without connection enrichment.");
+            }
+
+            return new ConnectionReferencesListResponse
+            {
+                References = references.Select(r => MapConnectionReferenceToDto(r, connectionMap)).ToList()
             };
         }, cancellationToken);
     }
@@ -2258,6 +2288,20 @@ public class RpcMethodHandler : IDisposable
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,
                 "The 'id' parameter must be a valid GUID");
+    /// Gets a single connection reference with dependent flows and connection details.
+    /// Maps to: ppds connref get --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/get")]
+    public async Task<ConnectionReferencesGetResponse> ConnectionReferencesGetAsync(
+        string logicalName,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(logicalName))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'logicalName' parameter is required");
         }
 
         return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
@@ -2359,6 +2403,33 @@ public class RpcMethodHandler : IDisposable
             return new PluginTracesDeleteResponse
             {
                 DeletedCount = deletedCount
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+
+            var reference = await connRefService.GetAsync(logicalName, ct)
+                ?? throw new RpcException(
+                    ErrorCodes.Operation.NotFound,
+                    $"Connection reference '{logicalName}' not found");
+
+            var flows = await connRefService.GetFlowsUsingAsync(logicalName, ct);
+
+            // Try to get connection details (graceful degradation for SPN)
+            ConnectionInfo? connectionInfo = null;
+            if (!string.IsNullOrEmpty(reference.ConnectionId))
+            {
+                try
+                {
+                    var connectionService = sp.GetRequiredService<IConnectionService>();
+                    connectionInfo = await connectionService.GetAsync(reference.ConnectionId, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Unable to retrieve connection details for '{ConnectionId}' (SPN may not have access). Continuing without connection enrichment.", reference.ConnectionId);
+                }
+            }
+
+            return new ConnectionReferencesGetResponse
+            {
+                Reference = MapConnectionReferenceToDetailDto(reference, flows, connectionInfo)
             };
         }, cancellationToken);
     }
@@ -2369,6 +2440,11 @@ public class RpcMethodHandler : IDisposable
     /// </summary>
     [JsonRpcMethod("pluginTraces/traceLevel")]
     public async Task<PluginTracesTraceLevelResponse> PluginTracesTraceLevelAsync(
+    /// Analyzes connection references for orphaned references and flows.
+    /// Maps to: ppds connref analyze --json
+    /// </summary>
+    [JsonRpcMethod("connectionReferences/analyze")]
+    public async Task<ConnectionReferencesAnalyzeResponse> ConnectionReferencesAnalyzeAsync(
         string? environmentUrl = null,
         CancellationToken cancellationToken = default)
     {
@@ -2381,6 +2457,39 @@ public class RpcMethodHandler : IDisposable
             {
                 Level = settings.SettingName,
                 LevelValue = (int)settings.Setting
+            var connRefService = sp.GetRequiredService<IConnectionReferenceService>();
+            var analysis = await connRefService.AnalyzeAsync(cancellationToken: ct);
+
+            var orphanedReferences = analysis.Relationships
+                .Where(r => r.Type == ConnRefRelationshipType.OrphanedConnectionReference)
+                .Select(r => new OrphanedReferenceDto
+                {
+                    LogicalName = r.ConnectionReferenceLogicalName ?? "",
+                    DisplayName = r.ConnectionReferenceDisplayName,
+                    ConnectorId = r.ConnectorId
+                })
+                .ToList();
+
+            var orphanedFlows = analysis.Relationships
+                .Where(r => r.Type == ConnRefRelationshipType.OrphanedFlow)
+                .Select(r => new OrphanedFlowDto
+                {
+                    UniqueName = r.FlowUniqueName ?? "",
+                    DisplayName = r.FlowDisplayName,
+                    MissingReference = r.ConnectionReferenceLogicalName
+                })
+                .ToList();
+
+            return new ConnectionReferencesAnalyzeResponse
+            {
+                OrphanedReferences = orphanedReferences,
+                OrphanedFlows = orphanedFlows,
+                TotalReferences = analysis.Relationships.Count(r =>
+                    r.Type == ConnRefRelationshipType.OrphanedConnectionReference ||
+                    r.Type == ConnRefRelationshipType.FlowToConnectionReference),
+                TotalFlows = analysis.Relationships.Count(r =>
+                    r.Type == ConnRefRelationshipType.OrphanedFlow ||
+                    r.Type == ConnRefRelationshipType.FlowToConnectionReference)
             };
         }, cancellationToken);
     }
@@ -2504,6 +2613,187 @@ public class RpcMethodHandler : IDisposable
             WidthPercent = node.WidthPercent,
             HierarchyDepth = node.HierarchyDepth,
             Children = node.Children.Select(MapTimelineNodeToDto).ToList()
+    private static ConnectionReferenceInfoDto MapConnectionReferenceToDto(
+        ConnectionReferenceInfo r,
+        Dictionary<string, ConnectionInfo>? connectionMap)
+    {
+        ConnectionInfo? connInfo = null;
+        if (!string.IsNullOrEmpty(r.ConnectionId) && connectionMap != null)
+        {
+            connectionMap.TryGetValue(r.ConnectionId, out connInfo);
+        }
+
+        return new ConnectionReferenceInfoDto
+        {
+            LogicalName = r.LogicalName,
+            DisplayName = r.DisplayName,
+            ConnectorId = r.ConnectorId,
+            ConnectionId = r.ConnectionId,
+            IsManaged = r.IsManaged,
+            ModifiedOn = r.ModifiedOn?.ToString("o"),
+            ConnectionStatus = connInfo?.Status.ToString(),
+            ConnectorDisplayName = connInfo?.ConnectorDisplayName
+        };
+    }
+
+    private static ConnectionReferenceDetailDto MapConnectionReferenceToDetailDto(
+        ConnectionReferenceInfo r,
+        List<FlowInfo> flows,
+        ConnectionInfo? connectionInfo)
+    {
+        return new ConnectionReferenceDetailDto
+        {
+            LogicalName = r.LogicalName,
+            DisplayName = r.DisplayName,
+            ConnectorId = r.ConnectorId,
+            ConnectionId = r.ConnectionId,
+            IsManaged = r.IsManaged,
+            ModifiedOn = r.ModifiedOn?.ToString("o"),
+            ConnectionStatus = connectionInfo?.Status.ToString(),
+            ConnectorDisplayName = connectionInfo?.ConnectorDisplayName,
+            Description = r.Description,
+            IsBound = r.IsBound,
+            CreatedOn = r.CreatedOn?.ToString("o"),
+            Flows = flows.Select(f => new FlowReferenceDto
+            {
+                UniqueName = f.UniqueName,
+                DisplayName = f.DisplayName,
+                State = f.State.ToString()
+            }).ToList(),
+            ConnectionOwner = connectionInfo?.CreatedBy,
+            ConnectionIsShared = connectionInfo?.IsShared
+        };
+    }
+
+    #endregion
+
+    #region Environment Variables
+
+    /// <summary>
+    /// Lists environment variable definitions with current values.
+    /// Maps to: ppds envvar list --json
+    /// </summary>
+    [JsonRpcMethod("environmentVariables/list")]
+    public async Task<EnvironmentVariablesListResponse> EnvironmentVariablesListAsync(
+        string? solutionId = null,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var envVarService = sp.GetRequiredService<IEnvironmentVariableService>();
+            var variables = await envVarService.ListAsync(solutionName: solutionId, cancellationToken: ct);
+
+            return new EnvironmentVariablesListResponse
+            {
+                Variables = variables.Select(MapEnvironmentVariableToDto).ToList()
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a single environment variable detail.
+    /// Maps to: ppds envvar get --json
+    /// </summary>
+    [JsonRpcMethod("environmentVariables/get")]
+    public async Task<EnvironmentVariablesGetResponse> EnvironmentVariablesGetAsync(
+        string schemaName,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'schemaName' parameter is required");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var envVarService = sp.GetRequiredService<IEnvironmentVariableService>();
+
+            var variable = await envVarService.GetAsync(schemaName, ct)
+                ?? throw new RpcException(
+                    ErrorCodes.Operation.NotFound,
+                    $"Environment variable '{schemaName}' not found");
+
+            return new EnvironmentVariablesGetResponse
+            {
+                Variable = MapEnvironmentVariableToDetailDto(variable)
+            };
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sets an environment variable value.
+    /// Maps to: ppds envvar set --json
+    /// </summary>
+    [JsonRpcMethod("environmentVariables/set")]
+    public async Task<EnvironmentVariablesSetResponse> EnvironmentVariablesSetAsync(
+        string schemaName,
+        string value,
+        string? environmentUrl = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'schemaName' parameter is required");
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new RpcException(
+                ErrorCodes.Validation.RequiredField,
+                "The 'value' parameter is required");
+        }
+
+        return await WithProfileAndEnvironmentAsync(environmentUrl, async (sp, ct) =>
+        {
+            var envVarService = sp.GetRequiredService<IEnvironmentVariableService>();
+            var success = await envVarService.SetValueAsync(schemaName, value, ct);
+
+            return new EnvironmentVariablesSetResponse
+            {
+                Success = success
+            };
+        }, cancellationToken);
+    }
+
+    private static EnvironmentVariableInfoDto MapEnvironmentVariableToDto(EnvironmentVariableInfo v)
+    {
+        return new EnvironmentVariableInfoDto
+        {
+            SchemaName = v.SchemaName,
+            DisplayName = v.DisplayName,
+            Type = v.Type,
+            DefaultValue = v.DefaultValue,
+            CurrentValue = v.CurrentValue,
+            IsManaged = v.IsManaged,
+            IsRequired = v.IsRequired,
+            ModifiedOn = v.ModifiedOn?.ToString("o"),
+            HasOverride = v.CurrentValueId.HasValue,
+            IsMissing = v.IsRequired && string.IsNullOrEmpty(v.CurrentValue) && string.IsNullOrEmpty(v.DefaultValue)
+        };
+    }
+
+    private static EnvironmentVariableDetailDto MapEnvironmentVariableToDetailDto(EnvironmentVariableInfo v)
+    {
+        return new EnvironmentVariableDetailDto
+        {
+            SchemaName = v.SchemaName,
+            DisplayName = v.DisplayName,
+            Type = v.Type,
+            DefaultValue = v.DefaultValue,
+            CurrentValue = v.CurrentValue,
+            IsManaged = v.IsManaged,
+            IsRequired = v.IsRequired,
+            ModifiedOn = v.ModifiedOn?.ToString("o"),
+            HasOverride = v.CurrentValueId.HasValue,
+            IsMissing = v.IsRequired && string.IsNullOrEmpty(v.CurrentValue) && string.IsNullOrEmpty(v.DefaultValue),
+            Description = v.Description,
+            CreatedOn = v.CreatedOn?.ToString("o")
         };
     }
 
@@ -3546,6 +3836,149 @@ public class PluginTracesTraceLevelResponse
 }
 
 public class PluginTracesSetTraceLevelResponse
+// ── Connection References DTOs ─────────────────────────────────────────────────
+
+public class ConnectionReferencesListResponse
+{
+    [JsonPropertyName("references")]
+    public List<ConnectionReferenceInfoDto> References { get; set; } = [];
+}
+
+public class ConnectionReferencesGetResponse
+{
+    [JsonPropertyName("reference")]
+    public ConnectionReferenceDetailDto Reference { get; set; } = null!;
+}
+
+public class ConnectionReferencesAnalyzeResponse
+{
+    [JsonPropertyName("orphanedReferences")]
+    public List<OrphanedReferenceDto> OrphanedReferences { get; set; } = [];
+
+    [JsonPropertyName("orphanedFlows")]
+    public List<OrphanedFlowDto> OrphanedFlows { get; set; } = [];
+
+    [JsonPropertyName("totalReferences")]
+    public int TotalReferences { get; set; }
+
+    [JsonPropertyName("totalFlows")]
+    public int TotalFlows { get; set; }
+}
+
+public class ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+
+    [JsonPropertyName("connectionId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionId { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+
+    [JsonPropertyName("connectionStatus")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionStatus { get; set; }
+
+    [JsonPropertyName("connectorDisplayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorDisplayName { get; set; }
+}
+
+public class ConnectionReferenceDetailDto : ConnectionReferenceInfoDto
+{
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("isBound")]
+    public bool IsBound { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CreatedOn { get; set; }
+
+    [JsonPropertyName("flows")]
+    public List<FlowReferenceDto> Flows { get; set; } = [];
+
+    [JsonPropertyName("connectionOwner")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionOwner { get; set; }
+
+    [JsonPropertyName("connectionIsShared")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? ConnectionIsShared { get; set; }
+}
+
+public class FlowReferenceDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("state")]
+    public string State { get; set; } = "";
+}
+
+public class OrphanedReferenceDto
+{
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+}
+
+public class OrphanedFlowDto
+{
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("missingReference")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MissingReference { get; set; }
+}
+
+// ── Environment Variables DTOs ─────────────────────────────────────────────────
+
+public class EnvironmentVariablesListResponse
+{
+    [JsonPropertyName("variables")]
+    public List<EnvironmentVariableInfoDto> Variables { get; set; } = [];
+}
+
+public class EnvironmentVariablesGetResponse
+{
+    [JsonPropertyName("variable")]
+    public EnvironmentVariableDetailDto Variable { get; set; } = null!;
+}
+
+public class EnvironmentVariablesSetResponse
 {
     [JsonPropertyName("success")]
     public bool Success { get; set; }
@@ -4038,6 +4471,52 @@ public class MetadataOptionValueDto
     [JsonPropertyName("description")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
+public class EnvironmentVariableInfoDto
+{
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    [JsonPropertyName("defaultValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DefaultValue { get; set; }
+
+    [JsonPropertyName("currentValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CurrentValue { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("isRequired")]
+    public bool IsRequired { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+
+    [JsonPropertyName("hasOverride")]
+    public bool HasOverride { get; set; }
+
+    [JsonPropertyName("isMissing")]
+    public bool IsMissing { get; set; }
+}
+
+public class EnvironmentVariableDetailDto : EnvironmentVariableInfoDto
+{
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CreatedOn { get; set; }
 }
 
 #endregion

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -2484,12 +2484,18 @@ public class RpcMethodHandler : IDisposable
             {
                 OrphanedReferences = orphanedReferences,
                 OrphanedFlows = orphanedFlows,
-                TotalReferences = analysis.Relationships.Count(r =>
-                    r.Type == ConnRefRelationshipType.OrphanedConnectionReference ||
-                    r.Type == ConnRefRelationshipType.FlowToConnectionReference),
-                TotalFlows = analysis.Relationships.Count(r =>
-                    r.Type == ConnRefRelationshipType.OrphanedFlow ||
-                    r.Type == ConnRefRelationshipType.FlowToConnectionReference)
+                TotalReferences = analysis.Relationships
+                    .Where(r => r.Type is ConnRefRelationshipType.OrphanedConnectionReference
+                             or ConnRefRelationshipType.FlowToConnectionReference)
+                    .Select(r => r.ConnectionReferenceLogicalName)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count(),
+                TotalFlows = analysis.Relationships
+                    .Where(r => r.Type is ConnRefRelationshipType.OrphanedFlow
+                             or ConnRefRelationshipType.FlowToConnectionReference)
+                    .Select(r => r.FlowUniqueName)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count()
             };
         }, cancellationToken);
     }
@@ -2631,7 +2637,7 @@ public class RpcMethodHandler : IDisposable
             ConnectionId = r.ConnectionId,
             IsManaged = r.IsManaged,
             ModifiedOn = r.ModifiedOn?.ToString("o"),
-            ConnectionStatus = connInfo?.Status.ToString(),
+            ConnectionStatus = connInfo?.Status.ToString() ?? "N/A",
             ConnectorDisplayName = connInfo?.ConnectorDisplayName
         };
     }
@@ -2649,7 +2655,7 @@ public class RpcMethodHandler : IDisposable
             ConnectionId = r.ConnectionId,
             IsManaged = r.IsManaged,
             ModifiedOn = r.ModifiedOn?.ToString("o"),
-            ConnectionStatus = connectionInfo?.Status.ToString(),
+            ConnectionStatus = connectionInfo?.Status.ToString() ?? "N/A",
             ConnectorDisplayName = connectionInfo?.ConnectorDisplayName,
             Description = r.Description,
             IsBound = r.IsBound,
@@ -2742,7 +2748,7 @@ public class RpcMethodHandler : IDisposable
                 "The 'schemaName' parameter is required");
         }
 
-        if (string.IsNullOrWhiteSpace(value))
+        if (value == null)
         {
             throw new RpcException(
                 ErrorCodes.Validation.RequiredField,

--- a/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
@@ -1,0 +1,496 @@
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Services;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// TUI screen for viewing connection references and their relationship with flows.
+/// </summary>
+internal sealed class ConnectionReferencesScreen : TuiScreenBase
+{
+    private readonly TableView _table;
+    private readonly Label _statusLabel;
+    private List<ConnectionReferenceInfo> _references = [];
+    private List<ConnectionInfo> _connections = [];
+    private string? _solutionFilter;
+    private Dialog? _detailDialog;
+    private bool _isShowingDetail;
+
+    public override string Title => "Connection References";
+
+    public ConnectionReferencesScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        _table = new TableView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            FullRowSelect = true,
+            Style = { ShowHorizontalHeaderOverline = false, ShowHorizontalHeaderUnderline = true }
+        };
+
+        _statusLabel = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_table),
+            Width = Dim.Fill(),
+            Height = 1,
+            Text = "Loading...",
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        _table.CellActivated += OnCellActivated;
+
+        Content.Add(_table, _statusLabel);
+
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadDataAsync(), "ConnectionReferences.InitialLoad");
+        }
+        else
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.R, "Refresh", () => ErrorService.FireAndForget(LoadDataAsync(), "ConnectionReferences.Refresh"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.A, "Analyze", () => ErrorService.FireAndForget(ShowAnalyzeDialogAsync(), "ConnectionReferences.Analyze"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.F, "Solution Filter", () => ErrorService.FireAndForget(ShowSolutionFilterDialogAsync(), "ConnectionReferences.Filter"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.O, "Open in Maker", OpenInMaker);
+    }
+
+    private async Task LoadDataAsync()
+    {
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "Loading connection references...";
+            });
+            Application.Refresh();
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var crService = provider.GetRequiredService<IConnectionReferenceService>();
+
+            _references = await crService.ListAsync(
+                solutionName: _solutionFilter,
+                cancellationToken: ScreenCancellation);
+
+            // Try to load connections for status enrichment (SPN graceful degradation)
+            try
+            {
+                var connService = provider.GetService<IConnectionService>();
+                if (connService != null)
+                {
+                    _connections = await connService.ListAsync(cancellationToken: ScreenCancellation);
+                }
+            }
+            catch (Exception ex)
+            {
+                TuiDebugLog.Log($"ConnectionReferences: Failed to load connections for status enrichment: {ex.Message}");
+                _connections = [];
+            }
+
+            var dt = new System.Data.DataTable();
+            dt.Columns.Add("Display Name", typeof(string));
+            dt.Columns.Add("Logical Name", typeof(string));
+            dt.Columns.Add("Connector", typeof(string));
+            dt.Columns.Add("Status", typeof(string));
+            dt.Columns.Add("Managed", typeof(string));
+            dt.Columns.Add("Modified On", typeof(string));
+
+            foreach (var cr in _references)
+            {
+                var status = GetConnectionStatus(cr);
+
+                dt.Rows.Add(
+                    cr.DisplayName ?? "\u2014",
+                    cr.LogicalName,
+                    FormatConnectorId(cr.ConnectorId),
+                    status,
+                    cr.IsManaged ? "Yes" : "No",
+                    cr.ModifiedOn?.ToString("g") ?? "\u2014");
+            }
+
+            Application.MainLoop.Invoke(() =>
+            {
+                _table.Table = dt;
+                var bound = _references.Count(r => r.IsBound);
+                var unbound = _references.Count(r => !r.IsBound);
+                var statusParts = new List<string>
+                {
+                    $"{_references.Count} connection reference{(_references.Count != 1 ? "s" : "")}"
+                };
+                if (bound > 0) statusParts.Add($"{bound} bound");
+                if (unbound > 0) statusParts.Add($"{unbound} unbound");
+                if (_solutionFilter != null) statusParts.Add($"filtered: {_solutionFilter}");
+                _statusLabel.Text = string.Join(" \u2014 ", statusParts);
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load connection references", ex, "ConnectionReferences.Load");
+                _statusLabel.Text = "Error loading connection references";
+            });
+        }
+    }
+
+    private string GetConnectionStatus(ConnectionReferenceInfo cr)
+    {
+        if (!cr.IsBound) return "Unbound";
+
+        // Try to find matching connection for richer status
+        var conn = _connections.FirstOrDefault(c =>
+            string.Equals(c.ConnectionId, cr.ConnectionId, StringComparison.OrdinalIgnoreCase));
+
+        if (conn == null) return "Bound";
+
+        return conn.Status switch
+        {
+            ConnectionStatus.Connected => "Connected",
+            ConnectionStatus.Error => "Error",
+            _ => "Bound"
+        };
+    }
+
+    private static string FormatConnectorId(string? connectorId)
+    {
+        if (string.IsNullOrEmpty(connectorId)) return "\u2014";
+
+        // Extract the connector name from the full path
+        // e.g., "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps" -> "shared_commondataserviceforapps"
+        var lastSlash = connectorId.LastIndexOf('/');
+        return lastSlash >= 0 ? connectorId[(lastSlash + 1)..] : connectorId;
+    }
+
+    private void OnCellActivated(TableView.CellActivatedEventArgs args)
+    {
+        if (_isShowingDetail) return;
+        if (args.Row < 0 || args.Row >= _references.Count) return;
+        var cr = _references[args.Row];
+        ErrorService.FireAndForget(ShowDetailDialogAsync(cr), "ConnectionReferences.ShowDetail");
+    }
+
+    private async Task ShowDetailDialogAsync(ConnectionReferenceInfo cr)
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IConnectionReferenceService>();
+
+            var flows = await service.GetFlowsUsingAsync(cr.LogicalName, ScreenCancellation);
+
+            // Find matching connection for additional details
+            ConnectionInfo? conn = null;
+            if (cr.IsBound)
+            {
+                conn = _connections.FirstOrDefault(c =>
+                    string.Equals(c.ConnectionId, cr.ConnectionId, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var lines = new List<string>
+            {
+                $"Display Name: {cr.DisplayName ?? "\u2014"}",
+                $"Logical Name: {cr.LogicalName}",
+                $"Description: {cr.Description ?? "\u2014"}",
+                $"Connector: {FormatConnectorId(cr.ConnectorId)}",
+                $"Connection ID: {cr.ConnectionId ?? "(none)"}",
+                $"Status: {GetConnectionStatus(cr)}",
+                $"Managed: {(cr.IsManaged ? "Yes" : "No")}",
+                $"Created: {cr.CreatedOn?.ToString("g") ?? "\u2014"}",
+                $"Modified: {cr.ModifiedOn?.ToString("g") ?? "\u2014"}",
+            };
+
+            if (conn != null)
+            {
+                lines.Add("");
+                lines.Add("--- Connection Details ---");
+                lines.Add($"Connection Name: {conn.DisplayName ?? "\u2014"}");
+                lines.Add($"Connector Name: {conn.ConnectorDisplayName ?? "\u2014"}");
+                lines.Add($"Connection Status: {conn.Status}");
+                lines.Add($"Shared: {(conn.IsShared ? "Yes" : "No")}");
+                lines.Add($"Created By: {conn.CreatedBy ?? "\u2014"}");
+            }
+
+            lines.Add("");
+            lines.Add($"--- Dependent Flows ({flows.Count}) ---");
+            if (flows.Count == 0)
+            {
+                lines.Add("  (no flows use this connection reference)");
+            }
+            else
+            {
+                foreach (var flow in flows)
+                {
+                    lines.Add($"  {flow.DisplayName ?? flow.UniqueName} [{flow.State}]");
+                }
+            }
+
+            var text = string.Join(Environment.NewLine, lines);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                if (_isShowingDetail) return;
+                _isShowingDetail = true;
+
+                _detailDialog?.Dispose();
+
+                var textView = new TextView
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill(),
+                    ReadOnly = true,
+                    Text = text
+                };
+
+                _detailDialog = new Dialog(
+                    $"Connection Reference: {cr.DisplayName ?? cr.LogicalName}",
+                    new Button("Close", is_default: true))
+                {
+                    Width = Dim.Percent(80),
+                    Height = Dim.Percent(80)
+                };
+                _detailDialog.Add(textView);
+                Application.Run(_detailDialog);
+                _detailDialog.Dispose();
+                _detailDialog = null;
+                _isShowingDetail = false;
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _isShowingDetail = false;
+                ErrorService.ReportError("Failed to load connection reference details", ex, "ConnectionReferences.Detail");
+            });
+        }
+    }
+
+    private async Task ShowAnalyzeDialogAsync()
+    {
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "Analyzing connection references...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IConnectionReferenceService>();
+
+            var analysis = await service.AnalyzeAsync(
+                solutionName: _solutionFilter,
+                cancellationToken: ScreenCancellation);
+
+            var lines = new List<string>
+            {
+                "Connection Reference Analysis",
+                new string('=', 40),
+                "",
+                $"Valid Relationships: {analysis.ValidCount}",
+                $"Orphaned Flows: {analysis.OrphanedFlowCount}",
+                $"Orphaned Connection References: {analysis.OrphanedConnectionReferenceCount}",
+                ""
+            };
+
+            if (analysis.HasOrphans)
+            {
+                var orphanedFlows = analysis.Relationships
+                    .Where(r => r.Type == RelationshipType.OrphanedFlow)
+                    .ToList();
+
+                if (orphanedFlows.Count > 0)
+                {
+                    lines.Add("--- Orphaned Flows (reference missing CRs) ---");
+                    foreach (var r in orphanedFlows)
+                    {
+                        lines.Add($"  Flow: {r.FlowDisplayName ?? r.FlowUniqueName ?? "\u2014"}");
+                        lines.Add($"    Missing CR: {r.ConnectionReferenceLogicalName ?? "\u2014"}");
+                    }
+                    lines.Add("");
+                }
+
+                var orphanedCRs = analysis.Relationships
+                    .Where(r => r.Type == RelationshipType.OrphanedConnectionReference)
+                    .ToList();
+
+                if (orphanedCRs.Count > 0)
+                {
+                    lines.Add("--- Orphaned Connection References (unused) ---");
+                    foreach (var r in orphanedCRs)
+                    {
+                        lines.Add($"  {r.ConnectionReferenceDisplayName ?? r.ConnectionReferenceLogicalName ?? "\u2014"}");
+                        lines.Add($"    Connector: {FormatConnectorId(r.ConnectorId)}");
+                        lines.Add($"    Bound: {(r.IsBound == true ? "Yes" : "No")}");
+                    }
+                    lines.Add("");
+                }
+            }
+            else
+            {
+                lines.Add("No orphans detected. All connection references and flows are properly linked.");
+            }
+
+            var text = string.Join(Environment.NewLine, lines);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                // Restore status label
+                var bound = _references.Count(r => r.IsBound);
+                var unbound = _references.Count(r => !r.IsBound);
+                var statusParts = new List<string>
+                {
+                    $"{_references.Count} connection reference{(_references.Count != 1 ? "s" : "")}"
+                };
+                if (bound > 0) statusParts.Add($"{bound} bound");
+                if (unbound > 0) statusParts.Add($"{unbound} unbound");
+                if (_solutionFilter != null) statusParts.Add($"filtered: {_solutionFilter}");
+                _statusLabel.Text = string.Join(" \u2014 ", statusParts);
+
+                var textView = new TextView
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill(),
+                    ReadOnly = true,
+                    Text = text
+                };
+
+                var dialog = new Dialog(
+                    "Connection Reference Analysis",
+                    new Button("Close", is_default: true))
+                {
+                    Width = Dim.Percent(80),
+                    Height = Dim.Percent(80)
+                };
+                dialog.Add(textView);
+                Application.Run(dialog);
+                dialog.Dispose();
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to analyze connection references", ex, "ConnectionReferences.Analyze");
+                // Restore status
+                _statusLabel.Text = "Analysis failed";
+            });
+        }
+    }
+
+    private async Task ShowSolutionFilterDialogAsync()
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var solutionService = provider.GetRequiredService<ISolutionService>();
+
+            var solutions = await solutionService.ListAsync(
+                includeManaged: false,
+                cancellationToken: ScreenCancellation);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                var names = new List<string> { "(All - no filter)" };
+                names.AddRange(solutions.Select(s => s.UniqueName));
+
+                var listView = new ListView(names)
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill()
+                };
+
+                // Pre-select current filter
+                if (_solutionFilter != null)
+                {
+                    var idx = names.IndexOf(_solutionFilter);
+                    if (idx >= 0) listView.SelectedItem = idx;
+                }
+
+                var selectButton = new Button("Select", is_default: true);
+                var cancelButton = new Button("Cancel");
+
+                var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
+                {
+                    Width = Dim.Percent(60),
+                    Height = Dim.Percent(70)
+                };
+                dialog.Add(listView);
+
+                var confirmed = false;
+                selectButton.Clicked += () =>
+                {
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+                cancelButton.Clicked += () => Application.RequestStop();
+                listView.OpenSelectedItem += _ =>
+                {
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+
+                Application.Run(dialog);
+                dialog.Dispose();
+
+                if (confirmed)
+                {
+                    var idx = listView.SelectedItem;
+                    _solutionFilter = idx == 0 ? null : names[idx];
+                    ErrorService.FireAndForget(LoadDataAsync(), "ConnectionReferences.FilterApply");
+                }
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load solutions for filter", ex, "ConnectionReferences.FilterLoad");
+            });
+        }
+    }
+
+    private void OpenInMaker()
+    {
+        if (EnvironmentUrl == null)
+        {
+            ErrorService.ReportError("No environment URL available");
+            return;
+        }
+        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        {
+            Width = 60,
+            Height = 7
+        };
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/connectors" });
+        Application.Run(dialog);
+        dialog.Dispose();
+    }
+
+    protected override void OnDispose()
+    {
+        _table.CellActivated -= OnCellActivated;
+        _detailDialog?.Dispose();
+    }
+}

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -1,0 +1,553 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Dataverse.Services;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// TUI screen for viewing and editing environment variables.
+/// </summary>
+internal sealed class EnvironmentVariablesScreen : TuiScreenBase
+{
+    private readonly TableView _table;
+    private readonly Label _statusLabel;
+    private List<EnvironmentVariableInfo> _variables = [];
+    private string? _solutionFilter;
+    private Dialog? _detailDialog;
+    private bool _isShowingDetail;
+
+    public override string Title => "Environment Variables";
+
+    public EnvironmentVariablesScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        _table = new TableView
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(1),
+            FullRowSelect = true,
+            Style = { ShowHorizontalHeaderOverline = false, ShowHorizontalHeaderUnderline = true }
+        };
+
+        _statusLabel = new Label
+        {
+            X = 0,
+            Y = Pos.Bottom(_table),
+            Width = Dim.Fill(),
+            Height = 1,
+            Text = "Loading...",
+            ColorScheme = TuiColorPalette.Default
+        };
+
+        _table.CellActivated += OnCellActivated;
+
+        Content.Add(_table, _statusLabel);
+
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.InitialLoad");
+        }
+        else
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.R, "Refresh", () => ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.Refresh"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.E, "Export", () => ErrorService.FireAndForget(ExportAsync(), "EnvironmentVariables.Export"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.F, "Solution Filter", () => ErrorService.FireAndForget(ShowSolutionFilterDialogAsync(), "EnvironmentVariables.Filter"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.O, "Open in Maker", OpenInMaker);
+    }
+
+    private async Task LoadDataAsync()
+    {
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "Loading environment variables...";
+            });
+            Application.Refresh();
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IEnvironmentVariableService>();
+
+            _variables = await service.ListAsync(
+                solutionName: _solutionFilter,
+                cancellationToken: ScreenCancellation);
+
+            var dt = new System.Data.DataTable();
+            dt.Columns.Add("Schema Name", typeof(string));
+            dt.Columns.Add("Display Name", typeof(string));
+            dt.Columns.Add("Type", typeof(string));
+            dt.Columns.Add("Default Value", typeof(string));
+            dt.Columns.Add("Current Value", typeof(string));
+            dt.Columns.Add("Managed", typeof(string));
+
+            foreach (var v in _variables)
+            {
+                dt.Rows.Add(
+                    v.SchemaName,
+                    v.DisplayName ?? "\u2014",
+                    v.Type,
+                    TruncateValue(v.DefaultValue),
+                    TruncateValue(v.CurrentValue),
+                    v.IsManaged ? "Yes" : "No");
+            }
+
+            Application.MainLoop.Invoke(() =>
+            {
+                _table.Table = dt;
+                var overridden = _variables.Count(v => v.CurrentValue != null);
+                var missing = _variables.Count(v => v.IsRequired && v.DefaultValue == null && v.CurrentValue == null);
+                var statusParts = new List<string>
+                {
+                    $"{_variables.Count} environment variable{(_variables.Count != 1 ? "s" : "")}"
+                };
+                if (overridden > 0) statusParts.Add($"{overridden} overridden");
+                if (missing > 0) statusParts.Add($"{missing} missing");
+                if (_solutionFilter != null) statusParts.Add($"filtered: {_solutionFilter}");
+                _statusLabel.Text = string.Join(" \u2014 ", statusParts);
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load environment variables", ex, "EnvironmentVariables.Load");
+                _statusLabel.Text = "Error loading environment variables";
+            });
+        }
+    }
+
+    private static string TruncateValue(string? value)
+    {
+        if (value == null) return "\u2014";
+        return value.Length > 50 ? value[..47] + "..." : value;
+    }
+
+    private void OnCellActivated(TableView.CellActivatedEventArgs args)
+    {
+        if (_isShowingDetail) return;
+        if (args.Row < 0 || args.Row >= _variables.Count) return;
+        var variable = _variables[args.Row];
+        ErrorService.FireAndForget(ShowEditDialogAsync(variable), "EnvironmentVariables.ShowEdit");
+    }
+
+    private async Task ShowEditDialogAsync(EnvironmentVariableInfo variable)
+    {
+        try
+        {
+            await Task.CompletedTask; // Ensure async context for consistency
+
+            Application.MainLoop.Invoke(() =>
+            {
+                if (_isShowingDetail) return;
+                _isShowingDetail = true;
+
+                _detailDialog?.Dispose();
+
+                var isReadOnly = variable.Type is "DataSource" or "Secret";
+
+                // Build detail content area
+                var y = 0;
+                var detailViews = new List<View>();
+
+                var schemaLabel = new Label($"Schema Name: {variable.SchemaName}") { X = 1, Y = y++ };
+                detailViews.Add(schemaLabel);
+                var displayLabel = new Label($"Display Name: {variable.DisplayName ?? "\u2014"}") { X = 1, Y = y++ };
+                detailViews.Add(displayLabel);
+                var typeLabel = new Label($"Type: {variable.Type}") { X = 1, Y = y++ };
+                detailViews.Add(typeLabel);
+                var managedLabel = new Label($"Managed: {(variable.IsManaged ? "Yes" : "No")}") { X = 1, Y = y++ };
+                detailViews.Add(managedLabel);
+                var requiredLabel = new Label($"Required: {(variable.IsRequired ? "Yes" : "No")}") { X = 1, Y = y++ };
+                detailViews.Add(requiredLabel);
+                var descLabel = new Label($"Description: {variable.Description ?? "\u2014"}") { X = 1, Y = y++ };
+                detailViews.Add(descLabel);
+
+                y++;
+                var defaultLabel = new Label($"Default Value: {variable.DefaultValue ?? "(none)"}") { X = 1, Y = y++ };
+                detailViews.Add(defaultLabel);
+
+                y++;
+                var currentLabel = new Label("Current Value:") { X = 1, Y = y++ };
+                detailViews.Add(currentLabel);
+
+                View? valueEditor = null;
+                RadioGroup? boolGroup = null;
+
+                if (isReadOnly)
+                {
+                    var readOnlyLabel = new Label(variable.CurrentValue ?? "(not set - read only)")
+                    {
+                        X = 1, Y = y++
+                    };
+                    detailViews.Add(readOnlyLabel);
+                }
+                else if (variable.Type == "Boolean")
+                {
+                    boolGroup = new RadioGroup(new NStack.ustring[] { "true", "false" })
+                    {
+                        X = 1,
+                        Y = y
+                    };
+                    // Set initial selection
+                    if (string.Equals(variable.CurrentValue, "true", StringComparison.OrdinalIgnoreCase)
+                        || (variable.CurrentValue == null && string.Equals(variable.DefaultValue, "true", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        boolGroup.SelectedItem = 0;
+                    }
+                    else
+                    {
+                        boolGroup.SelectedItem = 1;
+                    }
+                    y += 2;
+                    detailViews.Add(boolGroup);
+                }
+                else if (variable.Type == "JSON")
+                {
+                    var textView = new TextView
+                    {
+                        X = 1,
+                        Y = y,
+                        Width = Dim.Fill(2),
+                        Height = 6,
+                        Text = variable.CurrentValue ?? variable.DefaultValue ?? "",
+                        ReadOnly = false
+                    };
+                    valueEditor = textView;
+                    y += 6;
+                    detailViews.Add(textView);
+                }
+                else
+                {
+                    // String or Number
+                    var textField = new TextField(variable.CurrentValue ?? "")
+                    {
+                        X = 1,
+                        Y = y++,
+                        Width = Dim.Fill(2)
+                    };
+                    valueEditor = textField;
+                    detailViews.Add(textField);
+                }
+
+                var buttons = new List<Button>();
+                Button? saveButton = null;
+
+                if (!isReadOnly)
+                {
+                    saveButton = new Button("Save");
+                    buttons.Add(saveButton);
+                }
+
+                var closeButton = new Button("Close", is_default: isReadOnly);
+                buttons.Add(closeButton);
+
+                _detailDialog = new Dialog(
+                    $"Environment Variable: {variable.DisplayName ?? variable.SchemaName}",
+                    buttons.ToArray())
+                {
+                    Width = Dim.Percent(70),
+                    Height = Dim.Percent(70)
+                };
+
+                foreach (var view in detailViews)
+                {
+                    _detailDialog.Add(view);
+                }
+
+                closeButton.Clicked += () => Application.RequestStop();
+
+                if (saveButton != null)
+                {
+                    saveButton.Clicked += () =>
+                    {
+                        string? newValue = null;
+
+                        if (variable.Type == "Boolean" && boolGroup != null)
+                        {
+                            newValue = boolGroup.SelectedItem == 0 ? "true" : "false";
+                        }
+                        else if (variable.Type == "JSON" && valueEditor is TextView tv)
+                        {
+                            newValue = tv.Text?.ToString();
+                        }
+                        else if (valueEditor is TextField tf)
+                        {
+                            newValue = tf.Text?.ToString();
+
+                            // Validate numeric input
+                            if (variable.Type == "Number" && !string.IsNullOrEmpty(newValue))
+                            {
+                                if (!decimal.TryParse(newValue, out _))
+                                {
+                                    MessageBox.ErrorQuery("Validation Error", "Value must be a valid number.", "OK");
+                                    return;
+                                }
+                            }
+                        }
+
+                        if (newValue != null)
+                        {
+                            Application.RequestStop();
+                            ErrorService.FireAndForget(
+                                SaveValueAsync(variable.SchemaName, newValue),
+                                "EnvironmentVariables.Save");
+                        }
+                    };
+                }
+
+                Application.Run(_detailDialog);
+                _detailDialog.Dispose();
+                _detailDialog = null;
+                _isShowingDetail = false;
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _isShowingDetail = false;
+                ErrorService.ReportError("Failed to show environment variable details", ex, "EnvironmentVariables.Detail");
+            });
+        }
+    }
+
+    private async Task SaveValueAsync(string schemaName, string value)
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IEnvironmentVariableService>();
+
+            var result = await service.SetValueAsync(schemaName, value, ScreenCancellation);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                if (result)
+                {
+                    _statusLabel.Text = $"Saved value for {schemaName}";
+                }
+                else
+                {
+                    _statusLabel.Text = $"Failed to save value for {schemaName} (variable not found)";
+                }
+            });
+
+            // Reload data to reflect the change
+            await LoadDataAsync();
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to save environment variable value", ex, "EnvironmentVariables.Save");
+            });
+        }
+    }
+
+    private async Task ExportAsync()
+    {
+        try
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                _statusLabel.Text = "Exporting environment variables...";
+            });
+
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var service = provider.GetRequiredService<IEnvironmentVariableService>();
+
+            var export = await service.ExportAsync(
+                solutionName: _solutionFilter,
+                cancellationToken: ScreenCancellation);
+
+            var json = JsonSerializer.Serialize(export, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            var fileName = _solutionFilter != null
+                ? $"{_solutionFilter}-env-variables.json"
+                : "env-variables.json";
+
+            Application.MainLoop.Invoke(() =>
+            {
+                var textView = new TextView
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill(),
+                    ReadOnly = true,
+                    Text = json
+                };
+
+                var copyButton = new Button("Copy Path");
+                var closeButton = new Button("Close", is_default: true);
+
+                var dialog = new Dialog(
+                    $"Export: {fileName}",
+                    copyButton, closeButton)
+                {
+                    Width = Dim.Percent(80),
+                    Height = Dim.Percent(80)
+                };
+                dialog.Add(textView);
+
+                var filePath = System.IO.Path.Combine(Environment.CurrentDirectory, fileName);
+
+                copyButton.Clicked += () =>
+                {
+                    try
+                    {
+                        System.IO.File.WriteAllText(filePath, json);
+                        _statusLabel.Text = $"Exported to {filePath}";
+                    }
+                    catch (Exception ex)
+                    {
+                        ErrorService.ReportError("Failed to write export file", ex, "EnvironmentVariables.ExportWrite");
+                    }
+                    Application.RequestStop();
+                };
+
+                closeButton.Clicked += () => Application.RequestStop();
+
+                Application.Run(dialog);
+                dialog.Dispose();
+
+                // Restore status
+                var overridden = _variables.Count(v => v.CurrentValue != null);
+                var missing = _variables.Count(v => v.IsRequired && v.DefaultValue == null && v.CurrentValue == null);
+                var statusParts = new List<string>
+                {
+                    $"{_variables.Count} environment variable{(_variables.Count != 1 ? "s" : "")}"
+                };
+                if (overridden > 0) statusParts.Add($"{overridden} overridden");
+                if (missing > 0) statusParts.Add($"{missing} missing");
+                if (_solutionFilter != null) statusParts.Add($"filtered: {_solutionFilter}");
+                _statusLabel.Text = string.Join(" \u2014 ", statusParts);
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to export environment variables", ex, "EnvironmentVariables.Export");
+                _statusLabel.Text = "Export failed";
+            });
+        }
+    }
+
+    private async Task ShowSolutionFilterDialogAsync()
+    {
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var solutionService = provider.GetRequiredService<ISolutionService>();
+
+            var solutions = await solutionService.ListAsync(
+                includeManaged: false,
+                cancellationToken: ScreenCancellation);
+
+            Application.MainLoop.Invoke(() =>
+            {
+                var names = new List<string> { "(All - no filter)" };
+                names.AddRange(solutions.Select(s => s.UniqueName));
+
+                var listView = new ListView(names)
+                {
+                    X = 0,
+                    Y = 0,
+                    Width = Dim.Fill(),
+                    Height = Dim.Fill()
+                };
+
+                // Pre-select current filter
+                if (_solutionFilter != null)
+                {
+                    var idx = names.IndexOf(_solutionFilter);
+                    if (idx >= 0) listView.SelectedItem = idx;
+                }
+
+                var selectButton = new Button("Select", is_default: true);
+                var cancelButton = new Button("Cancel");
+
+                var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
+                {
+                    Width = Dim.Percent(60),
+                    Height = Dim.Percent(70)
+                };
+                dialog.Add(listView);
+
+                var confirmed = false;
+                selectButton.Clicked += () =>
+                {
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+                cancelButton.Clicked += () => Application.RequestStop();
+                listView.OpenSelectedItem += _ =>
+                {
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+
+                Application.Run(dialog);
+                dialog.Dispose();
+
+                if (confirmed)
+                {
+                    var idx = listView.SelectedItem;
+                    _solutionFilter = idx == 0 ? null : names[idx];
+                    ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
+                }
+            });
+        }
+        catch (OperationCanceledException) { /* screen closing */ }
+        catch (Exception ex)
+        {
+            Application.MainLoop.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to load solutions for filter", ex, "EnvironmentVariables.FilterLoad");
+            });
+        }
+    }
+
+    private void OpenInMaker()
+    {
+        if (EnvironmentUrl == null)
+        {
+            ErrorService.ReportError("No environment URL available");
+            return;
+        }
+        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        {
+            Width = 60,
+            Height = 7
+        };
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/environmentvariables" });
+        Application.Run(dialog);
+        dialog.Dispose();
+    }
+
+    protected override void OnDispose()
+    {
+        _table.CellActivated -= OnCellActivated;
+        _detailDialog?.Dispose();
+    }
+}

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -188,7 +188,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 {
                     var readOnlyLabel = new Label(variable.CurrentValue ?? "(not set - read only)")
                     {
-                        X = 1, Y = y++
+                        X = 1, Y = y
                     };
                     detailViews.Add(readOnlyLabel);
                 }
@@ -209,7 +209,6 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                     {
                         boolGroup.SelectedItem = 1;
                     }
-                    y += 2;
                     detailViews.Add(boolGroup);
                 }
                 else if (variable.Type == "JSON")
@@ -224,7 +223,6 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                         ReadOnly = false
                     };
                     valueEditor = textView;
-                    y += 6;
                     detailViews.Add(textView);
                 }
                 else
@@ -233,7 +231,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                     var textField = new TextField(variable.CurrentValue ?? "")
                     {
                         X = 1,
-                        Y = y++,
+                        Y = y,
                         Width = Dim.Fill(2)
                     };
                     valueEditor = textField;

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -280,6 +280,20 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                         else if (variable.Type == "JSON" && valueEditor is TextView tv)
                         {
                             newValue = tv.Text?.ToString();
+
+                            // Validate JSON syntax
+                            if (!string.IsNullOrEmpty(newValue))
+                            {
+                                try
+                                {
+                                    System.Text.Json.JsonDocument.Parse(newValue);
+                                }
+                                catch (System.Text.Json.JsonException)
+                                {
+                                    MessageBox.ErrorQuery("Validation Error", "Value must be valid JSON.", "OK");
+                                    return;
+                                }
+                            }
                         }
                         else if (valueEditor is TextField tf)
                         {

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -281,6 +281,8 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             new("SQL Query", "Run SQL queries against Dataverse", () => NavigateToSqlQuery()),
             new("Solutions", "Browse Dataverse solutions", () => NavigateToSolutions()),
             new("Import Jobs", "View solution import jobs", () => NavigateToImportJobs()),
+            new("Connection References", "View connection references", () => NavigateToConnectionReferences()),
+            new("Environment Variables", "View and edit environment variables", () => NavigateToEnvironmentVariables()),
             new("Plugin Traces", "Browse plugin trace logs", () => NavigateToPluginTraces()),
             new("Metadata Browser", "Browse entity metadata", () => NavigateToMetadataBrowser()),
             new("", "", () => {}, null, null, Key.Null), // Separator
@@ -481,6 +483,56 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             _contentArea.Remove(loadingLabel);
 
             var screen = new ImportJobsScreen(_session);
+            NavigateTo(screen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToConnectionReferences()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Connection References...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new ConnectionReferencesScreen(_session);
+            NavigateTo(screen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToEnvironmentVariables()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Environment Variables...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new EnvironmentVariablesScreen(_session);
             NavigateTo(screen);
 
             return false;

--- a/src/PPDS.Extension/esbuild.js
+++ b/src/PPDS.Extension/esbuild.js
@@ -139,6 +139,8 @@ const builds = [
         bundle: true,
         minify: production,
         outfile: 'dist/metadata-browser-panel.css',
+        logLevel: 'warning',
+    },
     // Connection References panel webview (browser, IIFE)
     {
         entryPoints: ['src/panels/webview/connection-references-panel.ts'],

--- a/src/PPDS.Extension/esbuild.js
+++ b/src/PPDS.Extension/esbuild.js
@@ -139,6 +139,44 @@ const builds = [
         bundle: true,
         minify: production,
         outfile: 'dist/metadata-browser-panel.css',
+    // Connection References panel webview (browser, IIFE)
+    {
+        entryPoints: ['src/panels/webview/connection-references-panel.ts'],
+        bundle: true,
+        format: 'iife',
+        minify: production,
+        sourcemap: !production,
+        sourcesContent: false,
+        platform: 'browser',
+        outfile: 'dist/connection-references-panel.js',
+        logLevel: 'warning',
+    },
+    // Connection References panel CSS
+    {
+        entryPoints: ['src/panels/styles/connection-references-panel.css'],
+        bundle: true,
+        minify: production,
+        outfile: 'dist/connection-references-panel.css',
+        logLevel: 'warning',
+    },
+    // Environment Variables panel webview (browser, IIFE)
+    {
+        entryPoints: ['src/panels/webview/environment-variables-panel.ts'],
+        bundle: true,
+        format: 'iife',
+        minify: production,
+        sourcemap: !production,
+        sourcesContent: false,
+        platform: 'browser',
+        outfile: 'dist/environment-variables-panel.js',
+        logLevel: 'warning',
+    },
+    // Environment Variables panel CSS
+    {
+        entryPoints: ['src/panels/styles/environment-variables-panel.css'],
+        bundle: true,
+        minify: production,
+        outfile: 'dist/environment-variables-panel.css',
         logLevel: 'warning',
     },
 ];

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -252,6 +252,26 @@
         "title": "Open Metadata Browser",
         "category": "PPDS",
         "icon": "$(symbol-class)"
+        "command": "ppds.openConnectionReferences",
+        "title": "Open Connection References",
+        "category": "PPDS",
+        "icon": "$(plug)"
+      },
+      {
+        "command": "ppds.openConnectionReferencesForEnv",
+        "title": "Open Connection References",
+        "icon": "$(plug)"
+      },
+      {
+        "command": "ppds.openEnvironmentVariables",
+        "title": "Open Environment Variables",
+        "category": "PPDS",
+        "icon": "$(symbol-variable)"
+      },
+      {
+        "command": "ppds.openEnvironmentVariablesForEnv",
+        "title": "Open Environment Variables",
+        "icon": "$(symbol-variable)"
       },
       {
         "command": "ppds.copyEnvironmentUrl",
@@ -385,8 +405,14 @@
         },
         {
           "command": "ppds.openPluginTracesForEnv",
+          "command": "ppds.openConnectionReferencesForEnv",
           "when": "view == ppds.profiles && viewItem == environment",
           "group": "env-tools@4"
+        },
+        {
+          "command": "ppds.openEnvironmentVariablesForEnv",
+          "when": "view == ppds.profiles && viewItem == environment",
+          "group": "env-tools@5"
         },
         {
           "command": "ppds.openInMaker",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -407,14 +407,18 @@
         },
         {
           "command": "ppds.openPluginTracesForEnv",
-          "command": "ppds.openConnectionReferencesForEnv",
           "when": "view == ppds.profiles && viewItem == environment",
           "group": "env-tools@4"
         },
         {
-          "command": "ppds.openEnvironmentVariablesForEnv",
+          "command": "ppds.openConnectionReferencesForEnv",
           "when": "view == ppds.profiles && viewItem == environment",
           "group": "env-tools@5"
+        },
+        {
+          "command": "ppds.openEnvironmentVariablesForEnv",
+          "when": "view == ppds.profiles && viewItem == environment",
+          "group": "env-tools@6"
         },
         {
           "command": "ppds.openInMaker",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -252,6 +252,8 @@
         "title": "Open Metadata Browser",
         "category": "PPDS",
         "icon": "$(symbol-class)"
+      },
+      {
         "command": "ppds.openConnectionReferences",
         "title": "Open Connection References",
         "category": "PPDS",

--- a/src/PPDS.Extension/src/daemonClient.ts
+++ b/src/PPDS.Extension/src/daemonClient.ts
@@ -47,6 +47,12 @@ import type {
     PluginTracesTraceLevelResponse,
     PluginTracesSetTraceLevelResponse,
     TraceFilterDto,
+    ConnectionReferencesListResponse,
+    ConnectionReferencesGetResponse,
+    ConnectionReferencesAnalyzeResponse,
+    EnvironmentVariablesListResponse,
+    EnvironmentVariablesGetResponse,
+    EnvironmentVariablesSetResponse,
 } from './types.js';
 
 // Re-export AuthWhoResponse for profileCommands.ts convenience
@@ -742,6 +748,65 @@ export class DaemonClient implements vscode.Disposable {
     }
 
     // ── Plugin Traces ─────────────────────────────────────────────────────────
+    // ── Connection References ───────────────────────────────────────────────
+
+    async connectionReferencesList(solutionId?: string, environmentUrl?: string): Promise<ConnectionReferencesListResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = {};
+        if (solutionId !== undefined) params.solutionId = solutionId;
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info('Calling connectionReferences/list...');
+        const result = await this.connection!.sendRequest<ConnectionReferencesListResponse>('connectionReferences/list', params);
+        this.log.debug(`Got ${result.references.length} connection references`);
+        return result;
+    }
+
+    async connectionReferencesGet(logicalName: string, environmentUrl?: string): Promise<ConnectionReferencesGetResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = { logicalName };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info(`Calling connectionReferences/get for ${logicalName}...`);
+        return await this.connection!.sendRequest<ConnectionReferencesGetResponse>('connectionReferences/get', params);
+    }
+
+    async connectionReferencesAnalyze(environmentUrl?: string): Promise<ConnectionReferencesAnalyzeResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = {};
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info('Calling connectionReferences/analyze...');
+        return await this.connection!.sendRequest<ConnectionReferencesAnalyzeResponse>('connectionReferences/analyze', params);
+    }
+
+    // ── Environment Variables ───────────────────────────────────────────────
+
+    async environmentVariablesList(solutionId?: string, environmentUrl?: string): Promise<EnvironmentVariablesListResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = {};
+        if (solutionId !== undefined) params.solutionId = solutionId;
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info('Calling environmentVariables/list...');
+        const result = await this.connection!.sendRequest<EnvironmentVariablesListResponse>('environmentVariables/list', params);
+        this.log.debug(`Got ${result.variables.length} environment variables`);
+        return result;
+    }
+
+    async environmentVariablesGet(schemaName: string, environmentUrl?: string): Promise<EnvironmentVariablesGetResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = { schemaName };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info(`Calling environmentVariables/get for ${schemaName}...`);
+        return await this.connection!.sendRequest<EnvironmentVariablesGetResponse>('environmentVariables/get', params);
+    }
+
+    async environmentVariablesSet(schemaName: string, value: string, environmentUrl?: string): Promise<EnvironmentVariablesSetResponse> {
+        await this.ensureConnected();
+        const params: Record<string, unknown> = { schemaName, value };
+        if (environmentUrl !== undefined) params.environmentUrl = environmentUrl;
+        this.log.info(`Calling environmentVariables/set for ${schemaName}...`);
+        return await this.connection!.sendRequest<EnvironmentVariablesSetResponse>('environmentVariables/set', params);
+    }
+
+    // ── Schema ──────────────────────────────────────────────────────────────
 
     async pluginTracesList(filter?: TraceFilterDto, top?: number, environmentUrl?: string): Promise<PluginTracesListResponse> {
         await this.ensureConnected();

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -21,6 +21,8 @@ import { SolutionsPanel } from './panels/SolutionsPanel.js';
 import { ImportJobsPanel } from './panels/ImportJobsPanel.js';
 import { PluginTracesPanel } from './panels/PluginTracesPanel.js';
 import { MetadataBrowserPanel } from './panels/MetadataBrowserPanel.js';
+import { ConnectionReferencesPanel } from './panels/ConnectionReferencesPanel.js';
+import { EnvironmentVariablesPanel } from './panels/EnvironmentVariablesPanel.js';
 import { migrateLegacyState } from './migration/legacyState.js';
 import { registerDebugCommands } from './commands/debugCommands.js';
 import { DaemonStatusBar } from './daemonStatusBar.js';
@@ -74,6 +76,11 @@ function registerPanelCommands(
         }),
         vscode.commands.registerCommand('ppds.openMetadataBrowser', () => {
             MetadataBrowserPanel.show(context.extensionUri, client);
+        vscode.commands.registerCommand('ppds.openConnectionReferences', () => {
+            ConnectionReferencesPanel.show(context.extensionUri, client);
+        }),
+        vscode.commands.registerCommand('ppds.openEnvironmentVariables', () => {
+            EnvironmentVariablesPanel.show(context.extensionUri, client);
         }),
         vscode.commands.registerCommand('ppds.openQueryInNotebook', (sql?: string) => {
             void openQueryInNotebook(sql ?? '');
@@ -274,6 +281,16 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('ppds.openPluginTracesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
             if (!item?.envUrl) return;
             PluginTracesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+        // Open Connection References targeting this environment
+        vscode.commands.registerCommand('ppds.openConnectionReferencesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
+            if (!item?.envUrl) return;
+            ConnectionReferencesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+        })),
+
+        // Open Environment Variables targeting this environment
+        vscode.commands.registerCommand('ppds.openEnvironmentVariablesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
+            if (!item?.envUrl) return;
+            EnvironmentVariablesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
         })),
 
         // Copy environment URL to clipboard
@@ -382,6 +399,8 @@ export function activate(context: vscode.ExtensionContext): void {
         importJobsPanels: () => ImportJobsPanel.instanceCount,
         pluginTracesPanels: () => PluginTracesPanel.instanceCount,
         metadataBrowserPanels: () => MetadataBrowserPanel.instanceCount,
+        connectionReferencesPanels: () => ConnectionReferencesPanel.instanceCount,
+        environmentVariablesPanels: () => EnvironmentVariablesPanel.instanceCount,
     });
 
     // Register environment selection command for notebooks

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -76,6 +76,7 @@ function registerPanelCommands(
         }),
         vscode.commands.registerCommand('ppds.openMetadataBrowser', () => {
             MetadataBrowserPanel.show(context.extensionUri, client);
+        }),
         vscode.commands.registerCommand('ppds.openConnectionReferences', () => {
             ConnectionReferencesPanel.show(context.extensionUri, client);
         }),
@@ -281,6 +282,8 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('ppds.openPluginTracesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
             if (!item?.envUrl) return;
             PluginTracesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+        })),
+
         // Open Connection References targeting this environment
         vscode.commands.registerCommand('ppds.openConnectionReferencesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
             if (!item?.envUrl) return;

--- a/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
+++ b/src/PPDS.Extension/src/panels/ConnectionReferencesPanel.ts
@@ -1,0 +1,375 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient } from '../daemonClient.js';
+import { handleAuthError } from '../utils/errorUtils.js';
+
+import { WebviewPanelBase } from './WebviewPanelBase.js';
+import { getNonce } from './webviewUtils.js';
+import { getEnvironmentPickerHtml, showEnvironmentPicker } from './environmentPicker.js';
+import type { ConnectionReferencesPanelWebviewToHost, ConnectionReferencesPanelHostToWebview } from './webview/shared/message-types.js';
+import { assertNever } from './webview/shared/assert-never.js';
+
+export class ConnectionReferencesPanel extends WebviewPanelBase<ConnectionReferencesPanelWebviewToHost, ConnectionReferencesPanelHostToWebview> {
+    private static instances: ConnectionReferencesPanel[] = [];
+    private static nextId = 1;
+    private readonly panelId: number;
+
+    private static readonly MAX_PANELS = 5;
+
+    private environmentUrl: string | undefined;
+    private environmentDisplayName: string | undefined;
+    private environmentType: string | null = null;
+    private environmentColor: string | null = null;
+    private environmentId: string | null = null;
+    private profileName: string | undefined;
+    private solutionFilter: string | null = null;
+
+    /**
+     * Returns the number of open ConnectionReferencesPanel instances.
+     * Used by diagnostic commands for panel state inspection.
+     */
+    static get instanceCount(): number {
+        return ConnectionReferencesPanel.instances.length;
+    }
+
+    static show(extensionUri: vscode.Uri, daemon: DaemonClient, envUrl?: string, envDisplayName?: string): ConnectionReferencesPanel {
+        if (ConnectionReferencesPanel.instances.length >= ConnectionReferencesPanel.MAX_PANELS) {
+            const oldest = ConnectionReferencesPanel.instances[0];
+            oldest.panel?.reveal();
+            return oldest;
+        }
+        const panel = new ConnectionReferencesPanel(extensionUri, daemon, envUrl, envDisplayName);
+        return panel;
+    }
+
+    private constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly daemon: DaemonClient,
+        initialEnvUrl?: string,
+        initialEnvDisplayName?: string,
+    ) {
+        super();
+
+        if (initialEnvUrl) {
+            this.environmentUrl = initialEnvUrl;
+            this.environmentDisplayName = initialEnvDisplayName ?? initialEnvUrl;
+        }
+
+        this.panelId = ConnectionReferencesPanel.nextId++;
+        ConnectionReferencesPanel.instances.push(this);
+
+        const panel = vscode.window.createWebviewPanel(
+            'ppds.connectionReferences',
+            `Connection References #${this.panelId}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: false,
+                localResourceRoots: [
+                    vscode.Uri.joinPath(extensionUri, 'node_modules'),
+                    vscode.Uri.joinPath(extensionUri, 'dist'),
+                ],
+            }
+        );
+
+        panel.webview.html = this.getHtmlContent(panel.webview);
+        this.initPanel(panel);
+        this.subscribeToDaemonReconnect(this.daemon);
+    }
+
+    protected async handleMessage(message: ConnectionReferencesPanelWebviewToHost): Promise<void> {
+        switch (message.command) {
+            case 'ready':
+                await this.initialize();
+                break;
+            case 'refresh':
+                await this.loadConnectionReferences();
+                break;
+            case 'selectReference':
+                await this.loadConnectionReferenceDetail(message.logicalName);
+                break;
+            case 'analyze':
+                await this.runAnalysis();
+                break;
+            case 'filterBySolution':
+                this.solutionFilter = message.solutionId;
+                await this.loadConnectionReferences();
+                break;
+            case 'requestSolutionList':
+                await this.loadSolutionList();
+                break;
+            case 'requestEnvironmentList':
+                await this.handleEnvironmentPicker();
+                break;
+            case 'openInMaker':
+                await this.openInMaker();
+                break;
+            case 'copyToClipboard':
+                await vscode.env.clipboard.writeText(message.text);
+                break;
+            case 'webviewError':
+                this.logWebviewError(message.error, message.stack);
+                break;
+            default:
+                assertNever(message);
+        }
+    }
+
+    protected override onDaemonReconnected(): void {
+        void this.loadConnectionReferences();
+    }
+
+    override dispose(): void {
+        const idx = ConnectionReferencesPanel.instances.indexOf(this);
+        if (idx >= 0) ConnectionReferencesPanel.instances.splice(idx, 1);
+        super.dispose();
+    }
+
+    private async initialize(): Promise<void> {
+        try {
+            const who = await this.daemon.authWho();
+            this.profileName = who.name ?? `Profile ${who.index}`;
+            if (!this.environmentUrl && who.environment?.url) {
+                this.environmentUrl = who.environment.url;
+                this.environmentDisplayName = who.environment.displayName || who.environment.url;
+            }
+            this.environmentType = who.environment?.type ?? null;
+            if (who.environment?.environmentId) {
+                this.environmentId = who.environment.environmentId;
+            } else {
+                this.environmentId = await this.resolveEnvironmentId();
+            }
+            if (this.environmentUrl) {
+                try {
+                    const config = await this.daemon.envConfigGet(this.environmentUrl);
+                    this.environmentColor = config.resolvedColor ?? null;
+                } catch {
+                    this.environmentColor = null;
+                }
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: this.environmentDisplayName ?? 'No environment', envType: this.environmentType, envColor: this.environmentColor });
+            await this.loadConnectionReferences();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to initialize: ${msg}` });
+        }
+    }
+
+    private async handleEnvironmentPicker(): Promise<void> {
+        const result = await showEnvironmentPicker(this.daemon, this.environmentUrl);
+        if (result) {
+            this.environmentUrl = result.url;
+            this.environmentDisplayName = result.displayName;
+            this.environmentType = result.type;
+            this.environmentId = await this.resolveEnvironmentId();
+            try {
+                const config = await this.daemon.envConfigGet(result.url);
+                this.environmentColor = config.resolvedColor ?? null;
+            } catch {
+                this.environmentColor = null;
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: result.type, envColor: this.environmentColor });
+            await this.loadConnectionReferences();
+        }
+    }
+
+    private async resolveEnvironmentId(): Promise<string | null> {
+        if (!this.environmentUrl) return null;
+        try {
+            const normalise = (u: string): string => u.replace(/\/+$/, '').toLowerCase();
+            const targetUrl = normalise(this.environmentUrl);
+            const envResult = await this.daemon.envList();
+            const match = envResult.environments.find(
+                e => normalise(e.apiUrl) === targetUrl || (e.url && normalise(e.url) === targetUrl)
+            );
+            return match?.environmentId ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    private updatePanelTitle(): void {
+        if (!this.panel) return;
+        const context = [this.profileName, this.environmentDisplayName].filter(Boolean).join(' \u00B7 ');
+        const suffix = ConnectionReferencesPanel.instances.length > 1 ? ` ${this.panelId}` : '';
+        this.panel.title = context ? `${context} \u2014 Connection References${suffix}` : `Connection References${suffix}`;
+    }
+
+    private async loadConnectionReferences(isRetry = false): Promise<void> {
+        try {
+            this.postMessage({ command: 'loading' });
+            const result = await this.daemon.connectionReferencesList(
+                this.solutionFilter ?? undefined,
+                this.environmentUrl,
+            );
+
+            this.postMessage({
+                command: 'connectionReferencesLoaded',
+                references: result.references.map(r => ({
+                    logicalName: r.logicalName,
+                    displayName: r.displayName,
+                    connectorId: r.connectorId,
+                    connectionId: r.connectionId,
+                    isManaged: r.isManaged,
+                    modifiedOn: r.modifiedOn,
+                    connectionStatus: r.connectionStatus,
+                    connectorDisplayName: r.connectorDisplayName,
+                })),
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+
+            if (await handleAuthError(this.daemon, error, isRetry, () => this.loadConnectionReferences(true))) {
+                return;
+            }
+
+            this.postMessage({ command: 'error', message: msg });
+        }
+    }
+
+    private async loadConnectionReferenceDetail(logicalName: string): Promise<void> {
+        try {
+            const result = await this.daemon.connectionReferencesGet(logicalName, this.environmentUrl);
+            const ref = result.reference;
+            this.postMessage({
+                command: 'connectionReferenceDetailLoaded',
+                detail: {
+                    logicalName: ref.logicalName,
+                    displayName: ref.displayName,
+                    connectorId: ref.connectorId,
+                    connectionId: ref.connectionId,
+                    isManaged: ref.isManaged,
+                    modifiedOn: ref.modifiedOn,
+                    connectionStatus: ref.connectionStatus,
+                    connectorDisplayName: ref.connectorDisplayName,
+                    description: ref.description,
+                    isBound: ref.isBound,
+                    createdOn: ref.createdOn,
+                    flows: ref.flows.map(f => ({
+                        uniqueName: f.uniqueName,
+                        displayName: f.displayName,
+                        state: f.state,
+                    })),
+                    connectionOwner: ref.connectionOwner,
+                    connectionIsShared: ref.connectionIsShared,
+                },
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load detail: ${msg}` });
+        }
+    }
+
+    private async runAnalysis(): Promise<void> {
+        try {
+            this.postMessage({ command: 'loading' });
+            const result = await this.daemon.connectionReferencesAnalyze(this.environmentUrl);
+            this.postMessage({
+                command: 'analyzeResult',
+                result: {
+                    orphanedReferences: result.orphanedReferences.map(r => ({
+                        logicalName: r.logicalName,
+                        displayName: r.displayName,
+                        connectorId: r.connectorId,
+                    })),
+                    orphanedFlows: result.orphanedFlows.map(f => ({
+                        uniqueName: f.uniqueName,
+                        displayName: f.displayName,
+                        missingReference: f.missingReference,
+                    })),
+                    totalReferences: result.totalReferences,
+                    totalFlows: result.totalFlows,
+                },
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Analysis failed: ${msg}` });
+        }
+    }
+
+    private async loadSolutionList(): Promise<void> {
+        try {
+            const result = await this.daemon.solutionsList(undefined, false, this.environmentUrl);
+            this.postMessage({
+                command: 'solutionListLoaded',
+                solutions: result.solutions.map(s => ({
+                    id: s.id,
+                    uniqueName: s.uniqueName,
+                    friendlyName: s.friendlyName,
+                })),
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load solutions: ${msg}` });
+        }
+    }
+
+    private async openInMaker(): Promise<void> {
+        if (this.environmentId) {
+            const url = `https://make.powerapps.com/environments/${this.environmentId}/connections`;
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+        } else {
+            vscode.window.showInformationMessage('Environment ID not available \u2014 cannot open Maker Portal.');
+        }
+    }
+
+    getHtmlContent(webview: vscode.Webview): string {
+        const toolkitUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist', 'toolkit.min.js')
+        ).toString();
+        const panelJsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'connection-references-panel.js')
+        ).toString();
+        const panelCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'connection-references-panel.css')
+        ).toString();
+        const nonce = getNonce();
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- 'unsafe-inline' is required by @vscode/webview-ui-toolkit for dynamic styles -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="${panelCssUri}">
+    <script type="module" nonce="${nonce}" src="${toolkitUri}"></script>
+</head>
+<body>
+
+<div id="reconnect-banner" style="display:none; background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-foreground); padding: 6px 12px; text-align: center; font-size: 12px;">
+    Connection restored. Data may be stale. <a href="#" id="reconnect-refresh" style="color: var(--vscode-textLink-foreground);">Refresh</a>
+</div>
+
+<div class="toolbar">
+    <vscode-button id="refresh-btn" appearance="secondary" title="Refresh connection references">Refresh</vscode-button>
+    <vscode-button id="analyze-btn" appearance="secondary" title="Analyze orphaned references">Analyze</vscode-button>
+    <vscode-button id="maker-btn" appearance="secondary" title="Open Connections in Maker Portal">Maker Portal</vscode-button>
+    <div id="solution-filter-container" class="solution-filter-container"></div>
+    <span class="toolbar-spacer"></span>
+    ${getEnvironmentPickerHtml()}
+</div>
+
+<div class="content" id="content">
+    <div class="empty-state" id="empty-state">Loading connection references...</div>
+</div>
+
+<div class="detail-pane" id="detail-pane" style="display: none;">
+    <div class="detail-header">
+        <span id="detail-title">Connection Reference Detail</span>
+        <button class="detail-close-btn" id="detail-close" title="Close detail">\u00D7</button>
+    </div>
+    <div class="detail-content" id="detail-content"></div>
+</div>
+
+<div class="status-bar">
+    <span id="status-text">Loading...</span>
+</div>
+
+<script nonce="${nonce}" src="${panelJsUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -1,0 +1,426 @@
+import * as vscode from 'vscode';
+
+import type { DaemonClient } from '../daemonClient.js';
+import { handleAuthError } from '../utils/errorUtils.js';
+
+import { WebviewPanelBase } from './WebviewPanelBase.js';
+import { getNonce } from './webviewUtils.js';
+import { getEnvironmentPickerHtml, showEnvironmentPicker } from './environmentPicker.js';
+import type { EnvironmentVariablesPanelWebviewToHost, EnvironmentVariablesPanelHostToWebview } from './webview/shared/message-types.js';
+import { assertNever } from './webview/shared/assert-never.js';
+
+export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVariablesPanelWebviewToHost, EnvironmentVariablesPanelHostToWebview> {
+    private static instances: EnvironmentVariablesPanel[] = [];
+    private static nextId = 1;
+    private readonly panelId: number;
+
+    private static readonly MAX_PANELS = 5;
+
+    private environmentUrl: string | undefined;
+    private environmentDisplayName: string | undefined;
+    private environmentType: string | null = null;
+    private environmentColor: string | null = null;
+    private environmentId: string | null = null;
+    private profileName: string | undefined;
+    private solutionFilter: string | null = null;
+
+    /**
+     * Returns the number of open EnvironmentVariablesPanel instances.
+     * Used by diagnostic commands for panel state inspection.
+     */
+    static get instanceCount(): number {
+        return EnvironmentVariablesPanel.instances.length;
+    }
+
+    static show(extensionUri: vscode.Uri, daemon: DaemonClient, envUrl?: string, envDisplayName?: string): EnvironmentVariablesPanel {
+        if (EnvironmentVariablesPanel.instances.length >= EnvironmentVariablesPanel.MAX_PANELS) {
+            const oldest = EnvironmentVariablesPanel.instances[0];
+            oldest.panel?.reveal();
+            return oldest;
+        }
+        const panel = new EnvironmentVariablesPanel(extensionUri, daemon, envUrl, envDisplayName);
+        return panel;
+    }
+
+    private constructor(
+        private readonly extensionUri: vscode.Uri,
+        private readonly daemon: DaemonClient,
+        initialEnvUrl?: string,
+        initialEnvDisplayName?: string,
+    ) {
+        super();
+
+        if (initialEnvUrl) {
+            this.environmentUrl = initialEnvUrl;
+            this.environmentDisplayName = initialEnvDisplayName ?? initialEnvUrl;
+        }
+
+        this.panelId = EnvironmentVariablesPanel.nextId++;
+        EnvironmentVariablesPanel.instances.push(this);
+
+        const panel = vscode.window.createWebviewPanel(
+            'ppds.environmentVariables',
+            `Environment Variables #${this.panelId}`,
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: false,
+                localResourceRoots: [
+                    vscode.Uri.joinPath(extensionUri, 'node_modules'),
+                    vscode.Uri.joinPath(extensionUri, 'dist'),
+                ],
+            }
+        );
+
+        panel.webview.html = this.getHtmlContent(panel.webview);
+        this.initPanel(panel);
+        this.subscribeToDaemonReconnect(this.daemon);
+    }
+
+    protected async handleMessage(message: EnvironmentVariablesPanelWebviewToHost): Promise<void> {
+        switch (message.command) {
+            case 'ready':
+                await this.initialize();
+                break;
+            case 'refresh':
+                await this.loadEnvironmentVariables();
+                break;
+            case 'selectVariable':
+                await this.loadEnvironmentVariableDetail(message.schemaName);
+                break;
+            case 'editVariable':
+                await this.startEditVariable(message.schemaName);
+                break;
+            case 'saveVariable':
+                await this.saveEnvironmentVariable(message.schemaName, message.value);
+                break;
+            case 'filterBySolution':
+                this.solutionFilter = message.solutionId;
+                await this.loadEnvironmentVariables();
+                break;
+            case 'requestSolutionList':
+                await this.loadSolutionList();
+                break;
+            case 'exportDeploymentSettings':
+                await this.exportDeploymentSettings();
+                break;
+            case 'requestEnvironmentList':
+                await this.handleEnvironmentPicker();
+                break;
+            case 'openInMaker':
+                await this.openInMaker();
+                break;
+            case 'copyToClipboard':
+                await vscode.env.clipboard.writeText(message.text);
+                break;
+            case 'webviewError':
+                this.logWebviewError(message.error, message.stack);
+                break;
+            default:
+                assertNever(message);
+        }
+    }
+
+    protected override onDaemonReconnected(): void {
+        void this.loadEnvironmentVariables();
+    }
+
+    override dispose(): void {
+        const idx = EnvironmentVariablesPanel.instances.indexOf(this);
+        if (idx >= 0) EnvironmentVariablesPanel.instances.splice(idx, 1);
+        super.dispose();
+    }
+
+    private async initialize(): Promise<void> {
+        try {
+            const who = await this.daemon.authWho();
+            this.profileName = who.name ?? `Profile ${who.index}`;
+            if (!this.environmentUrl && who.environment?.url) {
+                this.environmentUrl = who.environment.url;
+                this.environmentDisplayName = who.environment.displayName || who.environment.url;
+            }
+            this.environmentType = who.environment?.type ?? null;
+            if (who.environment?.environmentId) {
+                this.environmentId = who.environment.environmentId;
+            } else {
+                this.environmentId = await this.resolveEnvironmentId();
+            }
+            if (this.environmentUrl) {
+                try {
+                    const config = await this.daemon.envConfigGet(this.environmentUrl);
+                    this.environmentColor = config.resolvedColor ?? null;
+                } catch {
+                    this.environmentColor = null;
+                }
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: this.environmentDisplayName ?? 'No environment', envType: this.environmentType, envColor: this.environmentColor });
+            await this.loadEnvironmentVariables();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to initialize: ${msg}` });
+        }
+    }
+
+    private async handleEnvironmentPicker(): Promise<void> {
+        const result = await showEnvironmentPicker(this.daemon, this.environmentUrl);
+        if (result) {
+            this.environmentUrl = result.url;
+            this.environmentDisplayName = result.displayName;
+            this.environmentType = result.type;
+            this.environmentId = await this.resolveEnvironmentId();
+            try {
+                const config = await this.daemon.envConfigGet(result.url);
+                this.environmentColor = config.resolvedColor ?? null;
+            } catch {
+                this.environmentColor = null;
+            }
+            this.updatePanelTitle();
+            this.postMessage({ command: 'updateEnvironment', name: result.displayName, envType: result.type, envColor: this.environmentColor });
+            await this.loadEnvironmentVariables();
+        }
+    }
+
+    private async resolveEnvironmentId(): Promise<string | null> {
+        if (!this.environmentUrl) return null;
+        try {
+            const normalise = (u: string): string => u.replace(/\/+$/, '').toLowerCase();
+            const targetUrl = normalise(this.environmentUrl);
+            const envResult = await this.daemon.envList();
+            const match = envResult.environments.find(
+                e => normalise(e.apiUrl) === targetUrl || (e.url && normalise(e.url) === targetUrl)
+            );
+            return match?.environmentId ?? null;
+        } catch {
+            return null;
+        }
+    }
+
+    private updatePanelTitle(): void {
+        if (!this.panel) return;
+        const context = [this.profileName, this.environmentDisplayName].filter(Boolean).join(' \u00B7 ');
+        const suffix = EnvironmentVariablesPanel.instances.length > 1 ? ` ${this.panelId}` : '';
+        this.panel.title = context ? `${context} \u2014 Environment Variables${suffix}` : `Environment Variables${suffix}`;
+    }
+
+    private async loadEnvironmentVariables(isRetry = false): Promise<void> {
+        try {
+            this.postMessage({ command: 'loading' });
+            const result = await this.daemon.environmentVariablesList(
+                this.solutionFilter ?? undefined,
+                this.environmentUrl,
+            );
+
+            this.postMessage({
+                command: 'environmentVariablesLoaded',
+                variables: result.variables.map(v => ({
+                    schemaName: v.schemaName,
+                    displayName: v.displayName,
+                    type: v.type,
+                    defaultValue: v.defaultValue,
+                    currentValue: v.currentValue,
+                    isManaged: v.isManaged,
+                    isRequired: v.isRequired,
+                    modifiedOn: v.modifiedOn,
+                    hasOverride: v.hasOverride,
+                    isMissing: v.isMissing,
+                })),
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+
+            if (await handleAuthError(this.daemon, error, isRetry, () => this.loadEnvironmentVariables(true))) {
+                return;
+            }
+
+            this.postMessage({ command: 'error', message: msg });
+        }
+    }
+
+    private async loadEnvironmentVariableDetail(schemaName: string): Promise<void> {
+        try {
+            const result = await this.daemon.environmentVariablesGet(schemaName, this.environmentUrl);
+            const v = result.variable;
+            this.postMessage({
+                command: 'environmentVariableDetailLoaded',
+                detail: {
+                    schemaName: v.schemaName,
+                    displayName: v.displayName,
+                    type: v.type,
+                    defaultValue: v.defaultValue,
+                    currentValue: v.currentValue,
+                    isManaged: v.isManaged,
+                    isRequired: v.isRequired,
+                    modifiedOn: v.modifiedOn,
+                    hasOverride: v.hasOverride,
+                    isMissing: v.isMissing,
+                    description: v.description,
+                    createdOn: v.createdOn,
+                },
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load detail: ${msg}` });
+        }
+    }
+
+    private async startEditVariable(schemaName: string): Promise<void> {
+        try {
+            const result = await this.daemon.environmentVariablesGet(schemaName, this.environmentUrl);
+            const v = result.variable;
+            this.postMessage({
+                command: 'editVariableDialog',
+                schemaName: v.schemaName,
+                displayName: v.displayName,
+                type: v.type,
+                currentValue: v.currentValue,
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load variable for editing: ${msg}` });
+        }
+    }
+
+    private async saveEnvironmentVariable(schemaName: string, value: string): Promise<void> {
+        try {
+            const result = await this.daemon.environmentVariablesSet(schemaName, value, this.environmentUrl);
+            this.postMessage({ command: 'variableSaved', schemaName, success: result.success });
+            await this.loadEnvironmentVariables();
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to save variable: ${msg}` });
+        }
+    }
+
+    private async exportDeploymentSettings(): Promise<void> {
+        try {
+            const result = await this.daemon.environmentVariablesList(
+                this.solutionFilter ?? undefined,
+                this.environmentUrl,
+            );
+
+            const settings = {
+                EnvironmentVariables: result.variables.map(v => ({
+                    SchemaName: v.schemaName,
+                    Value: v.currentValue ?? v.defaultValue ?? '',
+                })),
+            };
+
+            const content = JSON.stringify(settings, null, 2);
+            const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+            const uri = await vscode.window.showSaveDialog({
+                defaultUri: defaultUri ? vscode.Uri.joinPath(defaultUri, 'deployment-settings.json') : undefined,
+                filters: { 'JSON Files': ['json'] },
+                title: 'Export Deployment Settings',
+            });
+
+            if (uri) {
+                await vscode.workspace.fs.writeFile(uri, Buffer.from(content, 'utf-8'));
+                this.postMessage({ command: 'deploymentSettingsExported', filePath: uri.fsPath });
+            }
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Export failed: ${msg}` });
+        }
+    }
+
+    private async loadSolutionList(): Promise<void> {
+        try {
+            const result = await this.daemon.solutionsList(undefined, false, this.environmentUrl);
+            this.postMessage({
+                command: 'solutionListLoaded',
+                solutions: result.solutions.map(s => ({
+                    id: s.id,
+                    uniqueName: s.uniqueName,
+                    friendlyName: s.friendlyName,
+                })),
+            });
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            this.postMessage({ command: 'error', message: `Failed to load solutions: ${msg}` });
+        }
+    }
+
+    private async openInMaker(): Promise<void> {
+        if (this.environmentId) {
+            const url = `https://make.powerapps.com/environments/${this.environmentId}/solutions/environmentvariables`;
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+        } else {
+            vscode.window.showInformationMessage('Environment ID not available \u2014 cannot open Maker Portal.');
+        }
+    }
+
+    getHtmlContent(webview: vscode.Webview): string {
+        const toolkitUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode', 'webview-ui-toolkit', 'dist', 'toolkit.min.js')
+        ).toString();
+        const panelJsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'environment-variables-panel.js')
+        ).toString();
+        const panelCssUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.extensionUri, 'dist', 'environment-variables-panel.css')
+        ).toString();
+        const nonce = getNonce();
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <!-- 'unsafe-inline' is required by @vscode/webview-ui-toolkit for dynamic styles -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="${panelCssUri}">
+    <script type="module" nonce="${nonce}" src="${toolkitUri}"></script>
+</head>
+<body>
+
+<div id="reconnect-banner" style="display:none; background: var(--vscode-inputValidation-infoBackground, #063b49); color: var(--vscode-foreground); padding: 6px 12px; text-align: center; font-size: 12px;">
+    Connection restored. Data may be stale. <a href="#" id="reconnect-refresh" style="color: var(--vscode-textLink-foreground);">Refresh</a>
+</div>
+
+<div class="toolbar">
+    <vscode-button id="refresh-btn" appearance="secondary" title="Refresh environment variables">Refresh</vscode-button>
+    <vscode-button id="export-btn" appearance="secondary" title="Export deployment settings">Export</vscode-button>
+    <vscode-button id="maker-btn" appearance="secondary" title="Open Environment Variables in Maker Portal">Maker Portal</vscode-button>
+    <div id="solution-filter-container" class="solution-filter-container"></div>
+    <span class="toolbar-spacer"></span>
+    ${getEnvironmentPickerHtml()}
+</div>
+
+<div class="content" id="content">
+    <div class="empty-state" id="empty-state">Loading environment variables...</div>
+</div>
+
+<div class="detail-pane" id="detail-pane" style="display: none;">
+    <div class="detail-header">
+        <span id="detail-title">Environment Variable Detail</span>
+        <button class="detail-close-btn" id="detail-close" title="Close detail">\u00D7</button>
+    </div>
+    <div class="detail-content" id="detail-content"></div>
+</div>
+
+<div id="edit-dialog" class="edit-dialog-overlay" style="display: none;">
+    <div class="edit-dialog">
+        <div class="edit-dialog-header">
+            <span id="edit-dialog-title">Edit Variable</span>
+            <button class="detail-close-btn" id="edit-dialog-close" title="Close">\u00D7</button>
+        </div>
+        <div class="edit-dialog-body">
+            <div id="edit-dialog-input-container"></div>
+        </div>
+        <div class="edit-dialog-footer">
+            <vscode-button id="edit-dialog-save" appearance="primary">Save</vscode-button>
+            <vscode-button id="edit-dialog-cancel" appearance="secondary">Cancel</vscode-button>
+        </div>
+    </div>
+</div>
+
+<div class="status-bar">
+    <span id="status-text">Loading...</span>
+</div>
+
+<script nonce="${nonce}" src="${panelJsUri}"></script>
+</body>
+</html>`;
+    }
+}

--- a/src/PPDS.Extension/src/panels/styles/connection-references-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/connection-references-panel.css
@@ -1,0 +1,242 @@
+@import './shared.css';
+
+/* ── Connection References Panel specific styles ─────────────────────── */
+
+.content {
+    flex: 1;
+    overflow: auto;
+}
+
+/* ── Solution filter ─────────────────────────────────────────────────── */
+
+.solution-filter-container {
+    display: flex;
+    align-items: center;
+}
+
+.solution-filter-select {
+    background: var(--vscode-dropdown-background, var(--vscode-input-background));
+    color: var(--vscode-dropdown-foreground, var(--vscode-input-foreground));
+    border: 1px solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent));
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-size: 12px;
+    max-width: 200px;
+    cursor: pointer;
+}
+
+.solution-filter-select:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+}
+
+/* ── DataTable ──────────────────────────────────────────────────────── */
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    table-layout: fixed;
+}
+
+.data-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--vscode-editor-background);
+}
+
+.data-table th {
+    text-align: left;
+    padding: 6px 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--vscode-descriptionForeground);
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.data-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.data-table th.sortable:hover {
+    color: var(--vscode-foreground);
+}
+
+.data-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.data-table-row {
+    cursor: pointer;
+}
+
+.data-table-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.data-table-row:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.data-table-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* ── Status badges ──────────────────────────────────────────────────── */
+
+.status-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-size: 11px;
+}
+
+.status-connected {
+    background: color-mix(in srgb, var(--vscode-testing-iconPassed, #73c991) 20%, transparent);
+    color: var(--vscode-testing-iconPassed, #73c991);
+}
+
+.status-error {
+    background: color-mix(in srgb, var(--vscode-testing-iconFailed, #f14c4c) 20%, transparent);
+    color: var(--vscode-testing-iconFailed, #f14c4c);
+}
+
+.status-na {
+    background: color-mix(in srgb, var(--vscode-descriptionForeground) 15%, transparent);
+    color: var(--vscode-descriptionForeground);
+}
+
+/* ── Detail pane ────────────────────────────────────────────────────── */
+
+.detail-pane {
+    border-top: 1px solid var(--vscode-panel-border);
+    max-height: 40vh;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editor-background);
+}
+
+.detail-close-btn {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: var(--vscode-foreground);
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.detail-close-btn:hover {
+    color: var(--vscode-textLink-foreground);
+}
+
+.detail-content {
+    flex: 1;
+    overflow: auto;
+    padding: 8px 12px;
+    margin: 0;
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+}
+
+.detail-section {
+    margin-bottom: 12px;
+}
+
+.detail-section-title {
+    font-weight: 600;
+    font-size: 12px;
+    margin-bottom: 6px;
+    color: var(--vscode-foreground);
+}
+
+.detail-row {
+    font-size: 12px;
+    padding: 2px 0;
+}
+
+.detail-label {
+    color: var(--vscode-descriptionForeground);
+    font-weight: 500;
+}
+
+.detail-value {
+    color: var(--vscode-foreground);
+}
+
+.detail-flow-item {
+    font-size: 12px;
+    padding: 2px 0 2px 12px;
+}
+
+.detail-flow-name {
+    color: var(--vscode-foreground);
+}
+
+.detail-flow-state {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+
+/* ── Analysis results ───────────────────────────────────────────────── */
+
+.analysis-results {
+    padding: 12px;
+}
+
+.analysis-summary {
+    font-size: 13px;
+    margin-bottom: 16px;
+    padding: 8px 12px;
+    background: var(--vscode-editor-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+}
+
+.analysis-section {
+    margin-bottom: 12px;
+}
+
+.analysis-section-title {
+    font-weight: 600;
+    font-size: 12px;
+    margin-bottom: 6px;
+}
+
+.analysis-item {
+    font-size: 12px;
+    padding: 3px 0 3px 12px;
+}
+
+.analysis-item.orphaned {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.analysis-item-detail {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.analysis-clean {
+    font-style: italic;
+    color: var(--vscode-testing-iconPassed, #73c991);
+    padding: 8px 0;
+}

--- a/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
@@ -1,0 +1,264 @@
+@import './shared.css';
+
+/* ── Environment Variables Panel specific styles ─────────────────────── */
+
+.content {
+    flex: 1;
+    overflow: auto;
+}
+
+/* ── Solution filter ─────────────────────────────────────────────────── */
+
+.solution-filter-container {
+    display: flex;
+    align-items: center;
+}
+
+.solution-filter-select {
+    background: var(--vscode-dropdown-background, var(--vscode-input-background));
+    color: var(--vscode-dropdown-foreground, var(--vscode-input-foreground));
+    border: 1px solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent));
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-size: 12px;
+    max-width: 200px;
+    cursor: pointer;
+}
+
+.solution-filter-select:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+}
+
+/* ── DataTable ──────────────────────────────────────────────────────── */
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    table-layout: fixed;
+}
+
+.data-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--vscode-editor-background);
+}
+
+.data-table th {
+    text-align: left;
+    padding: 6px 8px;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--vscode-descriptionForeground);
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.data-table th.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.data-table th.sortable:hover {
+    color: var(--vscode-foreground);
+}
+
+.data-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.data-table-row {
+    cursor: pointer;
+}
+
+.data-table-row:hover {
+    background: var(--vscode-list-hoverBackground);
+}
+
+.data-table-row:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.data-table-row.selected {
+    background: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* ── Value indicators ───────────────────────────────────────────────── */
+
+.value-override {
+    color: var(--vscode-textLink-foreground, #3794ff);
+    font-weight: 500;
+}
+
+.value-missing {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-size: 11px;
+    background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 20%, transparent);
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+/* ── Detail pane ────────────────────────────────────────────────────── */
+
+.detail-pane {
+    border-top: 1px solid var(--vscode-panel-border);
+    max-height: 40vh;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+}
+
+.detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editor-background);
+}
+
+.detail-close-btn {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: var(--vscode-foreground);
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.detail-close-btn:hover {
+    color: var(--vscode-textLink-foreground);
+}
+
+.detail-content {
+    flex: 1;
+    overflow: auto;
+    padding: 8px 12px;
+    margin: 0;
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+}
+
+.detail-section {
+    margin-bottom: 12px;
+}
+
+.detail-row {
+    font-size: 12px;
+    padding: 2px 0;
+}
+
+.detail-label {
+    color: var(--vscode-descriptionForeground);
+    font-weight: 500;
+}
+
+.detail-value {
+    color: var(--vscode-foreground);
+}
+
+.detail-actions {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--vscode-panel-border);
+}
+
+.detail-edit-btn {
+    background: var(--vscode-button-secondaryBackground, #3a3d41);
+    color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+    border: none;
+    padding: 4px 12px;
+    border-radius: 2px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.detail-edit-btn:hover {
+    background: var(--vscode-button-secondaryHoverBackground, #45494e);
+}
+
+/* ── Edit dialog modal ──────────────────────────────────────────────── */
+
+.edit-dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.edit-dialog {
+    background: var(--vscode-editor-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    min-width: 400px;
+    max-width: 600px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.edit-dialog-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+
+.edit-dialog-body {
+    padding: 12px;
+}
+
+.edit-dialog-footer {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 8px 12px;
+    border-top: 1px solid var(--vscode-panel-border);
+}
+
+.edit-input {
+    width: 100%;
+    box-sizing: border-box;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+    padding: 4px 8px;
+    border-radius: 2px;
+    font-size: 13px;
+    font-family: var(--vscode-font-family);
+}
+
+.edit-input:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+}
+
+.edit-textarea {
+    min-height: 120px;
+    resize: vertical;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: var(--vscode-editor-font-size, 13px);
+}
+
+.edit-readonly {
+    font-size: 12px;
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+    padding: 8px 0;
+}

--- a/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/environment-variables-panel.css
@@ -262,3 +262,13 @@
     font-style: italic;
     padding: 8px 0;
 }
+
+.edit-validation-error {
+    color: var(--vscode-inputValidation-errorForeground, #f14c4c);
+    background: var(--vscode-inputValidation-errorBackground, rgba(241, 76, 76, 0.1));
+    border: 1px solid var(--vscode-inputValidation-errorBorder, #f14c4c);
+    font-size: 12px;
+    padding: 4px 8px;
+    margin-top: 4px;
+    border-radius: 2px;
+}

--- a/src/PPDS.Extension/src/panels/webview/connection-references-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/connection-references-panel.ts
@@ -1,0 +1,290 @@
+// connection-references-panel.ts
+// External webview script for the Connection References panel.
+// Built by esbuild as IIFE for browser, loaded via <script src="...">.
+
+import { escapeHtml } from './shared/dom-utils.js';
+import type {
+    ConnectionReferencesPanelWebviewToHost,
+    ConnectionReferencesPanelHostToWebview,
+    ConnectionReferenceViewDto,
+    ConnectionReferenceDetailViewDto,
+    ConnectionReferencesAnalyzeViewDto,
+} from './shared/message-types.js';
+import { assertNever } from './shared/assert-never.js';
+import { getVsCodeApi } from './shared/vscode-api.js';
+import { installErrorHandler } from './shared/error-handler.js';
+import { DataTable } from './shared/data-table.js';
+import { SolutionFilter } from './shared/solution-filter.js';
+
+const vscode = getVsCodeApi<ConnectionReferencesPanelWebviewToHost>();
+installErrorHandler((msg) => vscode.postMessage(msg as ConnectionReferencesPanelWebviewToHost));
+const content = document.getElementById('content') as HTMLElement;
+const statusText = document.getElementById('status-text') as HTMLElement;
+const refreshBtn = document.getElementById('refresh-btn') as HTMLElement;
+const analyzeBtn = document.getElementById('analyze-btn') as HTMLElement;
+const makerBtn = document.getElementById('maker-btn') as HTMLElement;
+const detailPane = document.getElementById('detail-pane') as HTMLElement;
+const detailContent = document.getElementById('detail-content') as HTMLElement;
+const detailClose = document.getElementById('detail-close') as HTMLElement;
+
+// ── Environment picker ──
+const envPickerBtn = document.getElementById('env-picker-btn') as HTMLElement;
+const envPickerName = document.getElementById('env-picker-name') as HTMLElement;
+envPickerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'requestEnvironmentList' });
+});
+function updateEnvironmentDisplay(name: string | null): void {
+    envPickerName.textContent = name || 'No environment';
+}
+
+// ── Solution filter ──
+const solutionFilterContainer = document.getElementById('solution-filter-container') as HTMLElement;
+const solutionFilter = new SolutionFilter(solutionFilterContainer, {
+    onChange: (solutionId) => {
+        vscode.postMessage({ command: 'filterBySolution', solutionId });
+    },
+    getState: () => vscode.getState() as Record<string, unknown> | undefined,
+    setState: (state) => vscode.setState(state),
+});
+
+// Request solution list on load
+vscode.postMessage({ command: 'requestSolutionList' });
+
+// ── Status badge helper ──
+function statusBadgeHtml(status: string): string {
+    const lower = status.toLowerCase();
+    let cls = 'status-badge';
+    if (lower === 'connected') cls += ' status-connected';
+    else if (lower === 'error') cls += ' status-error';
+    else cls += ' status-na';
+    return '<span class="' + cls + '">' + escapeHtml(status) + '</span>';
+}
+
+// ── DataTable setup ──
+const table = new DataTable<ConnectionReferenceViewDto>({
+    container: content,
+    columns: [
+        {
+            key: 'displayName',
+            label: 'Display Name',
+            render: (r) => escapeHtml(r.displayName ?? '\u2014'),
+        },
+        {
+            key: 'logicalName',
+            label: 'Logical Name',
+            render: (r) => escapeHtml(r.logicalName),
+        },
+        {
+            key: 'connectorDisplayName',
+            label: 'Connector',
+            render: (r) => escapeHtml(r.connectorDisplayName ?? r.connectorId ?? '\u2014'),
+        },
+        {
+            key: 'connectionStatus',
+            label: 'Status',
+            render: (r) => statusBadgeHtml(r.connectionStatus),
+        },
+        {
+            key: 'isManaged',
+            label: 'Managed',
+            render: (r) => escapeHtml(r.isManaged ? 'Yes' : 'No'),
+            className: '80px',
+        },
+        {
+            key: 'modifiedOn',
+            label: 'Modified On',
+            render: (r) => escapeHtml(r.modifiedOn ?? '\u2014'),
+        },
+    ],
+    getRowId: (r) => r.logicalName,
+    onRowClick: (r) => {
+        vscode.postMessage({ command: 'selectReference', logicalName: r.logicalName });
+    },
+    defaultSortKey: 'logicalName',
+    defaultSortDirection: 'asc',
+    statusEl: statusText,
+    formatStatus: (items) => {
+        const bound = items.filter(r => r.connectionStatus.toLowerCase() === 'connected').length;
+        const unbound = items.length - bound;
+        const parts = [items.length + ' connection reference' + (items.length !== 1 ? 's' : '')];
+        if (bound > 0) parts.push(bound + ' bound');
+        if (unbound > 0) parts.push(unbound + ' unbound');
+        return parts.join(' \u2014 ');
+    },
+    emptyMessage: 'No connection references found',
+});
+
+// ── Button handlers ──
+refreshBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'refresh' });
+});
+
+analyzeBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'analyze' });
+});
+
+makerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'openInMaker' });
+});
+
+detailClose.addEventListener('click', () => {
+    detailPane.style.display = 'none';
+});
+
+document.getElementById('reconnect-refresh')!.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.getElementById('reconnect-banner')!.style.display = 'none';
+    vscode.postMessage({ command: 'refresh' });
+});
+
+// ── Keyboard shortcuts ──
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && detailPane.style.display !== 'none') {
+        detailPane.style.display = 'none';
+    }
+});
+
+// ── Detail rendering ──
+function renderDetail(detail: ConnectionReferenceDetailViewDto): void {
+    let html = '<div class="detail-section">';
+    html += '<div class="detail-row"><span class="detail-label">Logical Name:</span> <span class="detail-value">' + escapeHtml(detail.logicalName) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Display Name:</span> <span class="detail-value">' + escapeHtml(detail.displayName ?? '\u2014') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Connector:</span> <span class="detail-value">' + escapeHtml(detail.connectorDisplayName ?? detail.connectorId ?? '\u2014') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Status:</span> <span class="detail-value">' + statusBadgeHtml(detail.connectionStatus) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Bound:</span> <span class="detail-value">' + escapeHtml(detail.isBound ? 'Yes' : 'No') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Managed:</span> <span class="detail-value">' + escapeHtml(detail.isManaged ? 'Yes' : 'No') + '</span></div>';
+    if (detail.connectionOwner) {
+        html += '<div class="detail-row"><span class="detail-label">Owner:</span> <span class="detail-value">' + escapeHtml(detail.connectionOwner) + '</span></div>';
+    }
+    if (detail.connectionIsShared !== null) {
+        html += '<div class="detail-row"><span class="detail-label">Shared:</span> <span class="detail-value">' + escapeHtml(detail.connectionIsShared ? 'Yes' : 'No') + '</span></div>';
+    }
+    if (detail.description) {
+        html += '<div class="detail-row"><span class="detail-label">Description:</span> <span class="detail-value">' + escapeHtml(detail.description) + '</span></div>';
+    }
+    if (detail.createdOn) {
+        html += '<div class="detail-row"><span class="detail-label">Created On:</span> <span class="detail-value">' + escapeHtml(detail.createdOn) + '</span></div>';
+    }
+    if (detail.modifiedOn) {
+        html += '<div class="detail-row"><span class="detail-label">Modified On:</span> <span class="detail-value">' + escapeHtml(detail.modifiedOn) + '</span></div>';
+    }
+    html += '</div>';
+
+    if (detail.flows.length > 0) {
+        html += '<div class="detail-section">';
+        html += '<div class="detail-section-title">Flows (' + detail.flows.length + ')</div>';
+        for (const flow of detail.flows) {
+            html += '<div class="detail-flow-item">';
+            html += '<span class="detail-flow-name">' + escapeHtml(flow.displayName ?? flow.uniqueName) + '</span>';
+            if (flow.state) {
+                html += ' <span class="detail-flow-state">' + escapeHtml(flow.state) + '</span>';
+            }
+            html += '</div>';
+        }
+        html += '</div>';
+    }
+
+    detailContent.innerHTML = html;
+    detailPane.style.display = '';
+}
+
+// ── Analysis rendering ──
+function renderAnalysis(result: ConnectionReferencesAnalyzeViewDto): void {
+    let html = '<div class="analysis-results">';
+    html += '<div class="analysis-summary">';
+    html += '<strong>Analysis Complete:</strong> ' + escapeHtml(String(result.totalReferences)) + ' references, '
+        + escapeHtml(String(result.totalFlows)) + ' flows examined';
+    html += '</div>';
+
+    if (result.orphanedReferences.length > 0) {
+        html += '<div class="analysis-section">';
+        html += '<div class="analysis-section-title">Orphaned References (' + result.orphanedReferences.length + ')</div>';
+        for (const r of result.orphanedReferences) {
+            html += '<div class="analysis-item orphaned">';
+            html += escapeHtml(r.displayName ?? r.logicalName);
+            if (r.connectorId) html += ' <span class="analysis-item-detail">' + escapeHtml(r.connectorId) + '</span>';
+            html += '</div>';
+        }
+        html += '</div>';
+    }
+
+    if (result.orphanedFlows.length > 0) {
+        html += '<div class="analysis-section">';
+        html += '<div class="analysis-section-title">Orphaned Flows (' + result.orphanedFlows.length + ')</div>';
+        for (const f of result.orphanedFlows) {
+            html += '<div class="analysis-item orphaned">';
+            html += escapeHtml(f.displayName ?? f.uniqueName);
+            if (f.missingReference) html += ' <span class="analysis-item-detail">missing: ' + escapeHtml(f.missingReference) + '</span>';
+            html += '</div>';
+        }
+        html += '</div>';
+    }
+
+    if (result.orphanedReferences.length === 0 && result.orphanedFlows.length === 0) {
+        html += '<div class="analysis-section"><div class="analysis-clean">No orphaned references or flows found.</div></div>';
+    }
+
+    html += '</div>';
+    content.innerHTML = html;
+    statusText.textContent = 'Analysis complete';
+}
+
+// ── Message handling ──
+window.addEventListener('message', (event: MessageEvent<ConnectionReferencesPanelHostToWebview>) => {
+    const msg = event.data;
+    // VS Code sends internal messages that lack 'command' -- ignore them
+    if (!msg || typeof msg !== 'object' || !('command' in msg)) return;
+    switch (msg.command) {
+        case 'updateEnvironment':
+            updateEnvironmentDisplay(msg.name);
+            {
+                const toolbar = document.querySelector('.toolbar');
+                if (toolbar) {
+                    if (msg.envType) {
+                        toolbar.setAttribute('data-env-type', msg.envType.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-type');
+                    }
+                    if (msg.envColor) {
+                        toolbar.setAttribute('data-env-color', msg.envColor.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-color');
+                    }
+                }
+            }
+            break;
+        case 'connectionReferencesLoaded':
+            table.setItems(msg.references);
+            detailPane.style.display = 'none';
+            {
+                const reconnectBanner = document.getElementById('reconnect-banner');
+                if (reconnectBanner) reconnectBanner.style.display = 'none';
+            }
+            break;
+        case 'connectionReferenceDetailLoaded':
+            renderDetail(msg.detail);
+            break;
+        case 'analyzeResult':
+            renderAnalysis(msg.result);
+            break;
+        case 'solutionListLoaded':
+            solutionFilter.setSolutions(msg.solutions);
+            break;
+        case 'loading':
+            content.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading connection references...</div></div>';
+            statusText.textContent = 'Loading...';
+            break;
+        case 'error':
+            content.innerHTML = '<div class="error-state">' + escapeHtml(msg.message) + '</div>';
+            statusText.textContent = 'Error';
+            break;
+        case 'daemonReconnected':
+            document.getElementById('reconnect-banner')!.style.display = '';
+            break;
+        default:
+            assertNever(msg);
+    }
+});
+
+// Signal ready
+vscode.postMessage({ command: 'ready' });

--- a/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
@@ -1,0 +1,322 @@
+// environment-variables-panel.ts
+// External webview script for the Environment Variables panel.
+// Built by esbuild as IIFE for browser, loaded via <script src="...">.
+
+import { escapeHtml } from './shared/dom-utils.js';
+import type {
+    EnvironmentVariablesPanelWebviewToHost,
+    EnvironmentVariablesPanelHostToWebview,
+    EnvironmentVariableViewDto,
+    EnvironmentVariableDetailViewDto,
+} from './shared/message-types.js';
+import { assertNever } from './shared/assert-never.js';
+import { getVsCodeApi } from './shared/vscode-api.js';
+import { installErrorHandler } from './shared/error-handler.js';
+import { DataTable } from './shared/data-table.js';
+import { SolutionFilter } from './shared/solution-filter.js';
+
+const vscode = getVsCodeApi<EnvironmentVariablesPanelWebviewToHost>();
+installErrorHandler((msg) => vscode.postMessage(msg as EnvironmentVariablesPanelWebviewToHost));
+const content = document.getElementById('content') as HTMLElement;
+const statusText = document.getElementById('status-text') as HTMLElement;
+const refreshBtn = document.getElementById('refresh-btn') as HTMLElement;
+const exportBtn = document.getElementById('export-btn') as HTMLElement;
+const makerBtn = document.getElementById('maker-btn') as HTMLElement;
+const detailPane = document.getElementById('detail-pane') as HTMLElement;
+const detailContent = document.getElementById('detail-content') as HTMLElement;
+const detailClose = document.getElementById('detail-close') as HTMLElement;
+
+// ── Edit dialog elements ──
+const editDialog = document.getElementById('edit-dialog') as HTMLElement;
+const editDialogTitle = document.getElementById('edit-dialog-title') as HTMLElement;
+const editDialogInputContainer = document.getElementById('edit-dialog-input-container') as HTMLElement;
+const editDialogSave = document.getElementById('edit-dialog-save') as HTMLElement;
+const editDialogCancel = document.getElementById('edit-dialog-cancel') as HTMLElement;
+const editDialogClose = document.getElementById('edit-dialog-close') as HTMLElement;
+
+let editingSchemaName: string | null = null;
+
+// ── Environment picker ──
+const envPickerBtn = document.getElementById('env-picker-btn') as HTMLElement;
+const envPickerName = document.getElementById('env-picker-name') as HTMLElement;
+envPickerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'requestEnvironmentList' });
+});
+function updateEnvironmentDisplay(name: string | null): void {
+    envPickerName.textContent = name || 'No environment';
+}
+
+// ── Solution filter ──
+const solutionFilterContainer = document.getElementById('solution-filter-container') as HTMLElement;
+const solutionFilter = new SolutionFilter(solutionFilterContainer, {
+    onChange: (solutionId) => {
+        vscode.postMessage({ command: 'filterBySolution', solutionId });
+    },
+    getState: () => vscode.getState() as Record<string, unknown> | undefined,
+    setState: (state) => vscode.setState(state),
+});
+
+// Request solution list on load
+vscode.postMessage({ command: 'requestSolutionList' });
+
+// ── Value rendering helpers ──
+function renderCurrentValue(v: EnvironmentVariableViewDto): string {
+    if (v.isMissing) {
+        return '<span class="value-missing" title="Required value is missing">Missing</span>';
+    }
+    if (v.hasOverride) {
+        return '<span class="value-override" title="Value has been overridden">' + escapeHtml(v.currentValue ?? '\u2014') + '</span>';
+    }
+    return escapeHtml(v.currentValue ?? '\u2014');
+}
+
+// ── DataTable setup ──
+const table = new DataTable<EnvironmentVariableViewDto>({
+    container: content,
+    columns: [
+        {
+            key: 'schemaName',
+            label: 'Schema Name',
+            render: (v) => escapeHtml(v.schemaName),
+        },
+        {
+            key: 'displayName',
+            label: 'Display Name',
+            render: (v) => escapeHtml(v.displayName ?? '\u2014'),
+        },
+        {
+            key: 'type',
+            label: 'Type',
+            render: (v) => escapeHtml(v.type),
+            className: '100px',
+        },
+        {
+            key: 'defaultValue',
+            label: 'Default Value',
+            render: (v) => escapeHtml(v.defaultValue ?? '\u2014'),
+        },
+        {
+            key: 'currentValue',
+            label: 'Current Value',
+            render: renderCurrentValue,
+        },
+        {
+            key: 'isManaged',
+            label: 'Managed',
+            render: (v) => escapeHtml(v.isManaged ? 'Yes' : 'No'),
+            className: '80px',
+        },
+    ],
+    getRowId: (v) => v.schemaName,
+    onRowClick: (v) => {
+        vscode.postMessage({ command: 'selectVariable', schemaName: v.schemaName });
+    },
+    defaultSortKey: 'schemaName',
+    defaultSortDirection: 'asc',
+    statusEl: statusText,
+    formatStatus: (items) => {
+        const overridden = items.filter(v => v.hasOverride).length;
+        const missing = items.filter(v => v.isMissing).length;
+        const parts = [items.length + ' environment variable' + (items.length !== 1 ? 's' : '')];
+        if (overridden > 0) parts.push(overridden + ' overridden');
+        if (missing > 0) parts.push(missing + ' missing');
+        return parts.join(' \u2014 ');
+    },
+    emptyMessage: 'No environment variables found',
+});
+
+// ── Button handlers ──
+refreshBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'refresh' });
+});
+
+exportBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'exportDeploymentSettings' });
+});
+
+makerBtn.addEventListener('click', () => {
+    vscode.postMessage({ command: 'openInMaker' });
+});
+
+detailClose.addEventListener('click', () => {
+    detailPane.style.display = 'none';
+});
+
+document.getElementById('reconnect-refresh')!.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.getElementById('reconnect-banner')!.style.display = 'none';
+    vscode.postMessage({ command: 'refresh' });
+});
+
+// ── Edit dialog handlers ──
+editDialogCancel.addEventListener('click', () => {
+    editDialog.style.display = 'none';
+    editingSchemaName = null;
+});
+
+editDialogClose.addEventListener('click', () => {
+    editDialog.style.display = 'none';
+    editingSchemaName = null;
+});
+
+editDialogSave.addEventListener('click', () => {
+    if (!editingSchemaName) return;
+    const input = editDialogInputContainer.querySelector<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('input, select, textarea');
+    if (!input) return;
+    vscode.postMessage({ command: 'saveVariable', schemaName: editingSchemaName, value: input.value });
+});
+
+// ── Keyboard shortcuts ──
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+        if (editDialog.style.display !== 'none') {
+            editDialog.style.display = 'none';
+            editingSchemaName = null;
+        } else if (detailPane.style.display !== 'none') {
+            detailPane.style.display = 'none';
+        }
+    }
+});
+
+// ── Detail rendering ──
+function renderDetail(detail: EnvironmentVariableDetailViewDto): void {
+    let html = '<div class="detail-section">';
+    html += '<div class="detail-row"><span class="detail-label">Schema Name:</span> <span class="detail-value">' + escapeHtml(detail.schemaName) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Display Name:</span> <span class="detail-value">' + escapeHtml(detail.displayName ?? '\u2014') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Type:</span> <span class="detail-value">' + escapeHtml(detail.type) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Default Value:</span> <span class="detail-value">' + escapeHtml(detail.defaultValue ?? '\u2014') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Current Value:</span> <span class="detail-value">' + renderCurrentValue(detail) + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Managed:</span> <span class="detail-value">' + escapeHtml(detail.isManaged ? 'Yes' : 'No') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Required:</span> <span class="detail-value">' + escapeHtml(detail.isRequired ? 'Yes' : 'No') + '</span></div>';
+    html += '<div class="detail-row"><span class="detail-label">Has Override:</span> <span class="detail-value">' + escapeHtml(detail.hasOverride ? 'Yes' : 'No') + '</span></div>';
+    if (detail.description) {
+        html += '<div class="detail-row"><span class="detail-label">Description:</span> <span class="detail-value">' + escapeHtml(detail.description) + '</span></div>';
+    }
+    if (detail.createdOn) {
+        html += '<div class="detail-row"><span class="detail-label">Created On:</span> <span class="detail-value">' + escapeHtml(detail.createdOn) + '</span></div>';
+    }
+    if (detail.modifiedOn) {
+        html += '<div class="detail-row"><span class="detail-label">Modified On:</span> <span class="detail-value">' + escapeHtml(detail.modifiedOn) + '</span></div>';
+    }
+    html += '</div>';
+
+    // Edit button for editable types
+    const editableTypes = ['String', 'Number', 'Boolean', 'JSON'];
+    const lower = detail.type.toLowerCase();
+    if (editableTypes.some(t => t.toLowerCase() === lower)) {
+        html += '<div class="detail-actions">';
+        html += '<button class="detail-edit-btn" id="detail-edit-btn">Edit Value</button>';
+        html += '</div>';
+    }
+
+    detailContent.innerHTML = html;
+    detailPane.style.display = '';
+
+    // Wire edit button
+    const editBtn = document.getElementById('detail-edit-btn');
+    if (editBtn) {
+        editBtn.addEventListener('click', () => {
+            vscode.postMessage({ command: 'editVariable', schemaName: detail.schemaName });
+        });
+    }
+}
+
+// ── Edit dialog rendering ──
+function showEditDialog(schemaName: string, displayName: string | null, type: string, currentValue: string | null): void {
+    editingSchemaName = schemaName;
+    editDialogTitle.textContent = 'Edit: ' + (displayName ?? schemaName);
+    const lower = type.toLowerCase();
+    let inputHtml: string;
+
+    if (lower === 'boolean') {
+        const isTrue = currentValue?.toLowerCase() === 'true';
+        inputHtml = '<select class="edit-input">'
+            + '<option value="true"' + (isTrue ? ' selected' : '') + '>true</option>'
+            + '<option value="false"' + (!isTrue ? ' selected' : '') + '>false</option>'
+            + '</select>';
+    } else if (lower === 'number') {
+        inputHtml = '<input type="number" class="edit-input" value="' + escapeHtml(currentValue ?? '') + '" />';
+    } else if (lower === 'json') {
+        inputHtml = '<textarea class="edit-input edit-textarea">' + escapeHtml(currentValue ?? '') + '</textarea>';
+    } else if (lower === 'datasource' || lower === 'secret') {
+        inputHtml = '<div class="edit-readonly">This variable type cannot be edited here.</div>';
+        editDialogSave.style.display = 'none';
+    } else {
+        // String or unknown
+        inputHtml = '<input type="text" class="edit-input" value="' + escapeHtml(currentValue ?? '') + '" />';
+    }
+
+    editDialogInputContainer.innerHTML = inputHtml;
+    editDialogSave.style.display = '';
+    if (lower === 'datasource' || lower === 'secret') {
+        editDialogSave.style.display = 'none';
+    }
+    editDialog.style.display = '';
+}
+
+// ── Message handling ──
+window.addEventListener('message', (event: MessageEvent<EnvironmentVariablesPanelHostToWebview>) => {
+    const msg = event.data;
+    // VS Code sends internal messages that lack 'command' -- ignore them
+    if (!msg || typeof msg !== 'object' || !('command' in msg)) return;
+    switch (msg.command) {
+        case 'updateEnvironment':
+            updateEnvironmentDisplay(msg.name);
+            {
+                const toolbar = document.querySelector('.toolbar');
+                if (toolbar) {
+                    if (msg.envType) {
+                        toolbar.setAttribute('data-env-type', msg.envType.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-type');
+                    }
+                    if (msg.envColor) {
+                        toolbar.setAttribute('data-env-color', msg.envColor.toLowerCase());
+                    } else {
+                        toolbar.removeAttribute('data-env-color');
+                    }
+                }
+            }
+            break;
+        case 'environmentVariablesLoaded':
+            table.setItems(msg.variables);
+            detailPane.style.display = 'none';
+            {
+                const reconnectBanner = document.getElementById('reconnect-banner');
+                if (reconnectBanner) reconnectBanner.style.display = 'none';
+            }
+            break;
+        case 'environmentVariableDetailLoaded':
+            renderDetail(msg.detail);
+            break;
+        case 'editVariableDialog':
+            showEditDialog(msg.schemaName, msg.displayName, msg.type, msg.currentValue);
+            break;
+        case 'variableSaved':
+            editDialog.style.display = 'none';
+            editingSchemaName = null;
+            break;
+        case 'solutionListLoaded':
+            solutionFilter.setSolutions(msg.solutions);
+            break;
+        case 'deploymentSettingsExported':
+            // No special webview handling needed -- user saw the save dialog
+            break;
+        case 'loading':
+            content.innerHTML = '<div class="loading-state"><div class="spinner"></div><div>Loading environment variables...</div></div>';
+            statusText.textContent = 'Loading...';
+            break;
+        case 'error':
+            content.innerHTML = '<div class="error-state">' + escapeHtml(msg.message) + '</div>';
+            statusText.textContent = 'Error';
+            break;
+        case 'daemonReconnected':
+            document.getElementById('reconnect-banner')!.style.display = '';
+            break;
+        default:
+            assertNever(msg);
+    }
+});
+
+// Signal ready
+vscode.postMessage({ command: 'ready' });

--- a/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/environment-variables-panel.ts
@@ -35,6 +35,7 @@ const editDialogCancel = document.getElementById('edit-dialog-cancel') as HTMLEl
 const editDialogClose = document.getElementById('edit-dialog-close') as HTMLElement;
 
 let editingSchemaName: string | null = null;
+let editingType: string | null = null;
 
 // ── Environment picker ──
 const envPickerBtn = document.getElementById('env-picker-btn') as HTMLElement;
@@ -163,7 +164,35 @@ editDialogSave.addEventListener('click', () => {
     if (!editingSchemaName) return;
     const input = editDialogInputContainer.querySelector<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('input, select, textarea');
     if (!input) return;
-    vscode.postMessage({ command: 'saveVariable', schemaName: editingSchemaName, value: input.value });
+    const val = input.value;
+
+    // Type-aware validation (AC-EV-05)
+    if (editingType === 'json' && val.trim()) {
+        try { JSON.parse(val); } catch {
+            const existing = editDialogInputContainer.querySelector('.edit-validation-error');
+            if (existing) existing.remove();
+            const err = document.createElement('div');
+            err.className = 'edit-validation-error';
+            err.textContent = 'Invalid JSON syntax';
+            editDialogInputContainer.appendChild(err);
+            return;
+        }
+    }
+    if (editingType === 'number' && val.trim() && isNaN(Number(val))) {
+        const existing = editDialogInputContainer.querySelector('.edit-validation-error');
+        if (existing) existing.remove();
+        const err = document.createElement('div');
+        err.className = 'edit-validation-error';
+        err.textContent = 'Invalid number';
+        editDialogInputContainer.appendChild(err);
+        return;
+    }
+
+    // Clear any previous validation error
+    const existing = editDialogInputContainer.querySelector('.edit-validation-error');
+    if (existing) existing.remove();
+
+    vscode.postMessage({ command: 'saveVariable', schemaName: editingSchemaName, value: val });
 });
 
 // ── Keyboard shortcuts ──
@@ -224,8 +253,9 @@ function renderDetail(detail: EnvironmentVariableDetailViewDto): void {
 // ── Edit dialog rendering ──
 function showEditDialog(schemaName: string, displayName: string | null, type: string, currentValue: string | null): void {
     editingSchemaName = schemaName;
+    editingType = type.toLowerCase();
     editDialogTitle.textContent = 'Edit: ' + (displayName ?? schemaName);
-    const lower = type.toLowerCase();
+    const lower = editingType;
     let inputHtml: string;
 
     if (lower === 'boolean') {

--- a/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
@@ -243,6 +243,9 @@ export type MetadataBrowserPanelHostToWebview =
     | { command: 'entityDetailLoaded'; entity: MetadataEntityDetailDto }
     | { command: 'entityDetailLoading'; logicalName: string }
     | { command: 'loading' }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+
 // ── Connection References Panel ──────────────────────────────────────────
 
 /** Connection reference info as sent to the webview for table display. */

--- a/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/message-types.ts
@@ -243,5 +243,115 @@ export type MetadataBrowserPanelHostToWebview =
     | { command: 'entityDetailLoaded'; entity: MetadataEntityDetailDto }
     | { command: 'entityDetailLoading'; logicalName: string }
     | { command: 'loading' }
+// ── Connection References Panel ──────────────────────────────────────────
+
+/** Connection reference info as sent to the webview for table display. */
+export interface ConnectionReferenceViewDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+    connectionId: string | null;
+    isManaged: boolean;
+    modifiedOn: string | null;
+    connectionStatus: string;
+    connectorDisplayName: string | null;
+}
+
+/** Connection reference detail sent when a row is selected. */
+export interface ConnectionReferenceDetailViewDto extends ConnectionReferenceViewDto {
+    description: string | null;
+    isBound: boolean;
+    createdOn: string | null;
+    flows: { uniqueName: string; displayName: string | null; state: string | null }[];
+    connectionOwner: string | null;
+    connectionIsShared: boolean | null;
+}
+
+/** Analysis result sent after running orphan analysis. */
+export interface ConnectionReferencesAnalyzeViewDto {
+    orphanedReferences: { logicalName: string; displayName: string | null; connectorId: string | null }[];
+    orphanedFlows: { uniqueName: string; displayName: string | null; missingReference: string | null }[];
+    totalReferences: number;
+    totalFlows: number;
+}
+
+/** Solution option used by the solution filter dropdown. */
+export interface SolutionOptionDto {
+    id: string;
+    uniqueName: string;
+    friendlyName: string;
+}
+
+/** Messages the Connection References Panel webview sends to the extension host. */
+export type ConnectionReferencesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectReference'; logicalName: string }
+    | { command: 'analyze' }
+    | { command: 'filterBySolution'; solutionId: string | null }
+    | { command: 'requestSolutionList' }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Connection References Panel webview. */
+export type ConnectionReferencesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'loading' }
+    | { command: 'connectionReferencesLoaded'; references: ConnectionReferenceViewDto[] }
+    | { command: 'connectionReferenceDetailLoaded'; detail: ConnectionReferenceDetailViewDto }
+    | { command: 'analyzeResult'; result: ConnectionReferencesAnalyzeViewDto }
+    | { command: 'solutionListLoaded'; solutions: SolutionOptionDto[] }
+    | { command: 'error'; message: string }
+    | { command: 'daemonReconnected' };
+
+// ── Environment Variables Panel ──────────────────────────────────────────
+
+/** Environment variable info as sent to the webview for table display. */
+export interface EnvironmentVariableViewDto {
+    schemaName: string;
+    displayName: string | null;
+    type: string;
+    defaultValue: string | null;
+    currentValue: string | null;
+    isManaged: boolean;
+    isRequired: boolean;
+    modifiedOn: string | null;
+    hasOverride: boolean;
+    isMissing: boolean;
+}
+
+/** Environment variable detail sent when a row is selected. */
+export interface EnvironmentVariableDetailViewDto extends EnvironmentVariableViewDto {
+    description: string | null;
+    createdOn: string | null;
+}
+
+/** Messages the Environment Variables Panel webview sends to the extension host. */
+export type EnvironmentVariablesPanelWebviewToHost =
+    | { command: 'ready' }
+    | { command: 'refresh' }
+    | { command: 'selectVariable'; schemaName: string }
+    | { command: 'editVariable'; schemaName: string }
+    | { command: 'saveVariable'; schemaName: string; value: string }
+    | { command: 'filterBySolution'; solutionId: string | null }
+    | { command: 'requestSolutionList' }
+    | { command: 'exportDeploymentSettings' }
+    | { command: 'requestEnvironmentList' }
+    | { command: 'openInMaker' }
+    | { command: 'copyToClipboard'; text: string }
+    | { command: 'webviewError'; error: string; stack?: string };
+
+/** Messages the extension host sends to the Environment Variables Panel webview. */
+export type EnvironmentVariablesPanelHostToWebview =
+    | { command: 'updateEnvironment'; name: string; envType: string | null; envColor: string | null }
+    | { command: 'loading' }
+    | { command: 'environmentVariablesLoaded'; variables: EnvironmentVariableViewDto[] }
+    | { command: 'environmentVariableDetailLoaded'; detail: EnvironmentVariableDetailViewDto }
+    | { command: 'editVariableDialog'; schemaName: string; displayName: string | null; type: string; currentValue: string | null }
+    | { command: 'variableSaved'; schemaName: string; success: boolean }
+    | { command: 'solutionListLoaded'; solutions: SolutionOptionDto[] }
+    | { command: 'deploymentSettingsExported'; filePath: string }
     | { command: 'error'; message: string }
     | { command: 'daemonReconnected' };

--- a/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/solution-filter.ts
@@ -1,0 +1,77 @@
+import { escapeHtml, escapeAttr } from './dom-utils.js';
+
+export interface SolutionOption {
+    id: string;
+    uniqueName: string;
+    friendlyName: string;
+}
+
+export interface SolutionFilterOptions {
+    onChange: (solutionId: string | null) => void;
+    getState: () => Record<string, unknown> | undefined;
+    setState: (state: Record<string, unknown>) => void;
+    storageKey?: string;
+}
+
+export class SolutionFilter {
+    private container: HTMLElement;
+    private options: SolutionFilterOptions;
+    private solutions: SolutionOption[] = [];
+    private selectedId: string | null = null;
+    private readonly storageKey: string;
+
+    constructor(container: HTMLElement, options: SolutionFilterOptions) {
+        this.container = container;
+        this.options = options;
+        this.storageKey = options.storageKey ?? 'solutionFilter';
+
+        // Restore persisted selection
+        const state = options.getState();
+        if (state && typeof state[this.storageKey] === 'string') {
+            this.selectedId = state[this.storageKey] as string;
+        }
+
+        this.render();
+    }
+
+    setSolutions(solutions: SolutionOption[]): void {
+        this.solutions = solutions;
+        // Validate persisted selection still exists
+        if (this.selectedId && !solutions.find(s => s.uniqueName === this.selectedId)) {
+            this.selectedId = null;
+            this.persist();
+        }
+        this.render();
+    }
+
+    getSelectedId(): string | null {
+        return this.selectedId;
+    }
+
+    private render(): void {
+        let html = '<select class="solution-filter-select" title="Filter by solution">';
+        html += '<option value="">' + escapeHtml('All Solutions') + '</option>';
+        for (const s of this.solutions) {
+            const selected = s.uniqueName === this.selectedId ? ' selected' : '';
+            html += '<option value="' + escapeAttr(s.uniqueName) + '"' + selected + '>'
+                + escapeHtml(s.friendlyName) + '</option>';
+        }
+        html += '</select>';
+        this.container.innerHTML = html;
+
+        const select = this.container.querySelector('select');
+        if (select) {
+            select.addEventListener('change', () => {
+                this.selectedId = select.value || null;
+                this.persist();
+                this.options.onChange(this.selectedId);
+            });
+        }
+    }
+
+    private persist(): void {
+        const state = this.options.getState() ?? {};
+        state[this.storageKey] = this.selectedId ?? '';
+        this.options.setState(state);
+    }
+}

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -488,6 +488,8 @@ export interface TraceFilterDto {
     minDurationMs?: number;
     startDate?: string;
     endDate?: string;
+}
+
 // ── Connection References ───────────────────────────────────────────────
 
 export interface ConnectionReferencesListResponse {

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -488,4 +488,89 @@ export interface TraceFilterDto {
     minDurationMs?: number;
     startDate?: string;
     endDate?: string;
+// ── Connection References ───────────────────────────────────────────────
+
+export interface ConnectionReferencesListResponse {
+    references: ConnectionReferenceInfoDto[];
+}
+
+export interface ConnectionReferencesGetResponse {
+    reference: ConnectionReferenceDetailDto;
+}
+
+export interface ConnectionReferencesAnalyzeResponse {
+    orphanedReferences: OrphanedReferenceDto[];
+    orphanedFlows: OrphanedFlowDto[];
+    totalReferences: number;
+    totalFlows: number;
+}
+
+export interface ConnectionReferenceInfoDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+    connectionId: string | null;
+    isManaged: boolean;
+    modifiedOn: string | null;
+    connectionStatus: string;
+    connectorDisplayName: string | null;
+}
+
+export interface ConnectionReferenceDetailDto extends ConnectionReferenceInfoDto {
+    description: string | null;
+    isBound: boolean;
+    createdOn: string | null;
+    flows: FlowReferenceDto[];
+    connectionOwner: string | null;
+    connectionIsShared: boolean | null;
+}
+
+export interface FlowReferenceDto {
+    uniqueName: string;
+    displayName: string | null;
+    state: string | null;
+}
+
+export interface OrphanedReferenceDto {
+    logicalName: string;
+    displayName: string | null;
+    connectorId: string | null;
+}
+
+export interface OrphanedFlowDto {
+    uniqueName: string;
+    displayName: string | null;
+    missingReference: string | null;
+}
+
+// ── Environment Variables ───────────────────────────────────────────────
+
+export interface EnvironmentVariablesListResponse {
+    variables: EnvironmentVariableInfoDto[];
+}
+
+export interface EnvironmentVariablesGetResponse {
+    variable: EnvironmentVariableDetailDto;
+}
+
+export interface EnvironmentVariablesSetResponse {
+    success: boolean;
+}
+
+export interface EnvironmentVariableInfoDto {
+    schemaName: string;
+    displayName: string | null;
+    type: string;
+    defaultValue: string | null;
+    currentValue: string | null;
+    isManaged: boolean;
+    isRequired: boolean;
+    modifiedOn: string | null;
+    hasOverride: boolean;
+    isMissing: boolean;
+}
+
+export interface EnvironmentVariableDetailDto extends EnvironmentVariableInfoDto {
+    description: string | null;
+    createdOn: string | null;
 }

--- a/src/PPDS.Mcp/Tools/ConnectionReferencesAnalyzeTool.cs
+++ b/src/PPDS.Mcp/Tools/ConnectionReferencesAnalyzeTool.cs
@@ -1,0 +1,180 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that analyzes connection references for orphaned references and flows.
+/// </summary>
+[McpServerToolType]
+public sealed class ConnectionReferencesAnalyzeTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionReferencesAnalyzeTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public ConnectionReferencesAnalyzeTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Analyzes connection references for orphaned references and orphaned flows.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Analysis results with orphan detection.</returns>
+    [McpServerTool(Name = "ppds_connection_references_analyze")]
+    [Description("Analyze connection references for orphaned references (not used by any flow) and orphaned flows (referencing missing connection references). Useful for deployment cleanup.")]
+    public async Task<ConnectionReferencesAnalyzeResult> ExecuteAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IConnectionReferenceService>();
+
+        var analysis = await service.AnalyzeAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var orphanedReferences = analysis.Relationships
+            .Where(r => r.Type == RelationshipType.OrphanedConnectionReference)
+            .Select(r => new OrphanedConnectionReferenceSummary
+            {
+                LogicalName = r.ConnectionReferenceLogicalName ?? "",
+                DisplayName = r.ConnectionReferenceDisplayName,
+                ConnectorId = r.ConnectorId,
+                IsBound = r.IsBound
+            })
+            .ToList();
+
+        var orphanedFlows = analysis.Relationships
+            .Where(r => r.Type == RelationshipType.OrphanedFlow)
+            .Select(r => new OrphanedFlowSummary
+            {
+                UniqueName = r.FlowUniqueName ?? "",
+                DisplayName = r.FlowDisplayName,
+                MissingConnectionReferenceLogicalName = r.ConnectionReferenceLogicalName
+            })
+            .ToList();
+
+        return new ConnectionReferencesAnalyzeResult
+        {
+            OrphanedReferences = orphanedReferences,
+            OrphanedFlows = orphanedFlows,
+            TotalRelationships = analysis.Relationships.Count,
+            ValidRelationships = analysis.ValidCount,
+            OrphanedReferenceCount = analysis.OrphanedConnectionReferenceCount,
+            OrphanedFlowCount = analysis.OrphanedFlowCount,
+            HasOrphans = analysis.HasOrphans
+        };
+    }
+}
+
+/// <summary>
+/// Result of the connection_references_analyze tool.
+/// </summary>
+public sealed class ConnectionReferencesAnalyzeResult
+{
+    /// <summary>
+    /// Orphaned connection references (not used by any flow).
+    /// </summary>
+    [JsonPropertyName("orphanedReferences")]
+    public List<OrphanedConnectionReferenceSummary> OrphanedReferences { get; set; } = [];
+
+    /// <summary>
+    /// Orphaned flows (referencing missing connection references).
+    /// </summary>
+    [JsonPropertyName("orphanedFlows")]
+    public List<OrphanedFlowSummary> OrphanedFlows { get; set; } = [];
+
+    /// <summary>
+    /// Total number of relationships analyzed.
+    /// </summary>
+    [JsonPropertyName("totalRelationships")]
+    public int TotalRelationships { get; set; }
+
+    /// <summary>
+    /// Number of valid flow-to-connection-reference relationships.
+    /// </summary>
+    [JsonPropertyName("validRelationships")]
+    public int ValidRelationships { get; set; }
+
+    /// <summary>
+    /// Number of orphaned connection references.
+    /// </summary>
+    [JsonPropertyName("orphanedReferenceCount")]
+    public int OrphanedReferenceCount { get; set; }
+
+    /// <summary>
+    /// Number of orphaned flows.
+    /// </summary>
+    [JsonPropertyName("orphanedFlowCount")]
+    public int OrphanedFlowCount { get; set; }
+
+    /// <summary>
+    /// Whether any orphans were detected.
+    /// </summary>
+    [JsonPropertyName("hasOrphans")]
+    public bool HasOrphans { get; set; }
+}
+
+/// <summary>
+/// An orphaned connection reference (not used by any flow).
+/// </summary>
+public sealed class OrphanedConnectionReferenceSummary
+{
+    /// <summary>
+    /// The connection reference logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    /// <summary>
+    /// The display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The connector ID.
+    /// </summary>
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+
+    /// <summary>
+    /// Whether the connection reference is bound to a connection.
+    /// </summary>
+    [JsonPropertyName("isBound")]
+    public bool? IsBound { get; set; }
+}
+
+/// <summary>
+/// An orphaned flow (referencing a missing connection reference).
+/// </summary>
+public sealed class OrphanedFlowSummary
+{
+    /// <summary>
+    /// The flow unique name.
+    /// </summary>
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    /// <summary>
+    /// The flow display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The logical name of the missing connection reference.
+    /// </summary>
+    [JsonPropertyName("missingConnectionReferenceLogicalName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MissingConnectionReferenceLogicalName { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/ConnectionReferencesGetTool.cs
+++ b/src/PPDS.Mcp/Tools/ConnectionReferencesGetTool.cs
@@ -1,0 +1,191 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that gets full details of a specific connection reference.
+/// </summary>
+[McpServerToolType]
+public sealed class ConnectionReferencesGetTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionReferencesGetTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public ConnectionReferencesGetTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Gets full details of a specific connection reference including dependent flows.
+    /// </summary>
+    /// <param name="logicalName">The logical name of the connection reference.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Connection reference details with dependent flows.</returns>
+    [McpServerTool(Name = "ppds_connection_references_get")]
+    [Description("Get full details of a specific connection reference including dependent flows and connection info. Use the logicalName from ppds_connection_references_list.")]
+    public async Task<ConnectionReferencesGetResult> ExecuteAsync(
+        [Description("Logical name of the connection reference")]
+        string logicalName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(logicalName))
+        {
+            throw new ArgumentException("logicalName is required.", nameof(logicalName));
+        }
+
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IConnectionReferenceService>();
+
+        var reference = await service.GetAsync(logicalName, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Connection reference '{logicalName}' not found.");
+
+        var flows = await service.GetFlowsUsingAsync(logicalName, cancellationToken).ConfigureAwait(false);
+
+        return new ConnectionReferencesGetResult
+        {
+            LogicalName = reference.LogicalName,
+            DisplayName = reference.DisplayName,
+            Description = reference.Description,
+            ConnectorId = reference.ConnectorId,
+            ConnectionId = reference.ConnectionId,
+            IsManaged = reference.IsManaged,
+            IsBound = reference.IsBound,
+            ConnectionStatus = "N/A",
+            ConnectorDisplayName = null,
+            CreatedOn = reference.CreatedOn?.ToString("o"),
+            ModifiedOn = reference.ModifiedOn?.ToString("o"),
+            Flows = flows.Select(f => new ConnectionReferenceFlowSummary
+            {
+                UniqueName = f.UniqueName,
+                DisplayName = f.DisplayName,
+                State = f.State.ToString(),
+                Category = f.Category.ToString()
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the connection_references_get tool.
+/// </summary>
+public sealed class ConnectionReferencesGetResult
+{
+    /// <summary>
+    /// The connection reference logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    /// <summary>
+    /// The display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The connector ID.
+    /// </summary>
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+
+    /// <summary>
+    /// The bound connection ID, or null if unbound.
+    /// </summary>
+    [JsonPropertyName("connectionId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionId { get; set; }
+
+    /// <summary>
+    /// Whether this is a managed component.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Whether a connection is bound.
+    /// </summary>
+    [JsonPropertyName("isBound")]
+    public bool IsBound { get; set; }
+
+    /// <summary>
+    /// Connection status (Connected, Error, Unknown, or N/A if unavailable).
+    /// </summary>
+    [JsonPropertyName("connectionStatus")]
+    public string ConnectionStatus { get; set; } = "N/A";
+
+    /// <summary>
+    /// The connector display name, or null if unavailable.
+    /// </summary>
+    [JsonPropertyName("connectorDisplayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorDisplayName { get; set; }
+
+    /// <summary>
+    /// When the connection reference was created (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CreatedOn { get; set; }
+
+    /// <summary>
+    /// When the connection reference was last modified (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+
+    /// <summary>
+    /// Flows that depend on this connection reference.
+    /// </summary>
+    [JsonPropertyName("flows")]
+    public List<ConnectionReferenceFlowSummary> Flows { get; set; } = [];
+}
+
+/// <summary>
+/// Summary of a flow that uses a connection reference.
+/// </summary>
+public sealed class ConnectionReferenceFlowSummary
+{
+    /// <summary>
+    /// The flow unique name.
+    /// </summary>
+    [JsonPropertyName("uniqueName")]
+    public string UniqueName { get; set; } = "";
+
+    /// <summary>
+    /// The flow display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The flow state (Draft, Activated, Suspended).
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string State { get; set; } = "";
+
+    /// <summary>
+    /// The flow category (ModernFlow, DesktopFlow).
+    /// </summary>
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = "";
+}

--- a/src/PPDS.Mcp/Tools/ConnectionReferencesListTool.cs
+++ b/src/PPDS.Mcp/Tools/ConnectionReferencesListTool.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that lists connection references in the current environment.
+/// </summary>
+[McpServerToolType]
+public sealed class ConnectionReferencesListTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionReferencesListTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public ConnectionReferencesListTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Lists connection references in the current environment.
+    /// </summary>
+    /// <param name="solutionId">Optional solution unique name to filter by.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of connection reference summaries.</returns>
+    [McpServerTool(Name = "ppds_connection_references_list")]
+    [Description("List connection references in the current environment. Shows connector bindings and whether connections are bound. Optionally filter by solution name.")]
+    public async Task<ConnectionReferencesListResult> ExecuteAsync(
+        [Description("Solution unique name to filter by")]
+        string? solutionId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IConnectionReferenceService>();
+
+        var references = await service.ListAsync(solutionName: solutionId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new ConnectionReferencesListResult
+        {
+            ConnectionReferences = references.Select(r => new ConnectionReferenceSummary
+            {
+                LogicalName = r.LogicalName,
+                DisplayName = r.DisplayName,
+                ConnectorId = r.ConnectorId,
+                ConnectionId = r.ConnectionId,
+                IsManaged = r.IsManaged,
+                IsBound = r.IsBound,
+                ConnectionStatus = "N/A",
+                ConnectorDisplayName = null
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the connection_references_list tool.
+/// </summary>
+public sealed class ConnectionReferencesListResult
+{
+    /// <summary>
+    /// List of connection reference summaries.
+    /// </summary>
+    [JsonPropertyName("connectionReferences")]
+    public List<ConnectionReferenceSummary> ConnectionReferences { get; set; } = [];
+}
+
+/// <summary>
+/// Summary information about a connection reference.
+/// </summary>
+public sealed class ConnectionReferenceSummary
+{
+    /// <summary>
+    /// The connection reference logical name.
+    /// </summary>
+    [JsonPropertyName("logicalName")]
+    public string LogicalName { get; set; } = "";
+
+    /// <summary>
+    /// The display name of the connection reference.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The connector ID (e.g., "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps").
+    /// </summary>
+    [JsonPropertyName("connectorId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorId { get; set; }
+
+    /// <summary>
+    /// The bound connection ID, or null if unbound.
+    /// </summary>
+    [JsonPropertyName("connectionId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectionId { get; set; }
+
+    /// <summary>
+    /// Whether this is a managed component.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Whether a connection is bound.
+    /// </summary>
+    [JsonPropertyName("isBound")]
+    public bool IsBound { get; set; }
+
+    /// <summary>
+    /// Connection status (Connected, Error, Unknown, or N/A if unavailable).
+    /// </summary>
+    [JsonPropertyName("connectionStatus")]
+    public string ConnectionStatus { get; set; } = "N/A";
+
+    /// <summary>
+    /// The connector display name, or null if unavailable.
+    /// </summary>
+    [JsonPropertyName("connectorDisplayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ConnectorDisplayName { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs
@@ -59,7 +59,7 @@ public sealed class EnvironmentVariablesGetTool
             IsManaged = variable.IsManaged,
             IsRequired = variable.IsRequired,
             SecretStore = variable.SecretStore,
-            HasOverride = variable.CurrentValue != null && variable.CurrentValue != variable.DefaultValue,
+            HasOverride = variable.CurrentValueId.HasValue,
             IsMissing = variable.IsRequired && variable.CurrentValue == null && variable.DefaultValue == null,
             CreatedOn = variable.CreatedOn?.ToString("o"),
             ModifiedOn = variable.ModifiedOn?.ToString("o")

--- a/src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvironmentVariablesGetTool.cs
@@ -1,0 +1,159 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that gets full details of a specific environment variable.
+/// </summary>
+[McpServerToolType]
+public sealed class EnvironmentVariablesGetTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentVariablesGetTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public EnvironmentVariablesGetTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Gets full details of a specific environment variable including description, type, and values.
+    /// </summary>
+    /// <param name="schemaName">The schema name of the environment variable.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Environment variable details.</returns>
+    [McpServerTool(Name = "ppds_environment_variables_get")]
+    [Description("Get full details of a specific environment variable including description, type, and values. Use the schemaName from ppds_environment_variables_list.")]
+    public async Task<EnvironmentVariablesGetResult> ExecuteAsync(
+        [Description("Schema name of the environment variable")]
+        string schemaName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            throw new ArgumentException("schemaName is required.", nameof(schemaName));
+        }
+
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IEnvironmentVariableService>();
+
+        var variable = await service.GetAsync(schemaName, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Environment variable '{schemaName}' not found.");
+
+        return new EnvironmentVariablesGetResult
+        {
+            SchemaName = variable.SchemaName,
+            DisplayName = variable.DisplayName,
+            Description = variable.Description,
+            Type = variable.Type,
+            DefaultValue = variable.DefaultValue,
+            CurrentValue = variable.CurrentValue,
+            IsManaged = variable.IsManaged,
+            IsRequired = variable.IsRequired,
+            SecretStore = variable.SecretStore,
+            HasOverride = variable.CurrentValue != null && variable.CurrentValue != variable.DefaultValue,
+            IsMissing = variable.IsRequired && variable.CurrentValue == null && variable.DefaultValue == null,
+            CreatedOn = variable.CreatedOn?.ToString("o"),
+            ModifiedOn = variable.ModifiedOn?.ToString("o")
+        };
+    }
+}
+
+/// <summary>
+/// Result of the environment_variables_get tool.
+/// </summary>
+public sealed class EnvironmentVariablesGetResult
+{
+    /// <summary>
+    /// The schema name.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    /// <summary>
+    /// The display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The variable type (String, Number, Boolean, JSON, DataSource, Secret).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    /// <summary>
+    /// The default value.
+    /// </summary>
+    [JsonPropertyName("defaultValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DefaultValue { get; set; }
+
+    /// <summary>
+    /// The current value (from EnvironmentVariableValue record).
+    /// </summary>
+    [JsonPropertyName("currentValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CurrentValue { get; set; }
+
+    /// <summary>
+    /// Whether this is a managed variable.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Whether the variable is required.
+    /// </summary>
+    [JsonPropertyName("isRequired")]
+    public bool IsRequired { get; set; }
+
+    /// <summary>
+    /// The secret store for secret-type variables.
+    /// </summary>
+    [JsonPropertyName("secretStore")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SecretStore { get; set; }
+
+    /// <summary>
+    /// Whether the current value overrides the default.
+    /// </summary>
+    [JsonPropertyName("hasOverride")]
+    public bool HasOverride { get; set; }
+
+    /// <summary>
+    /// Whether the variable is required but has no value.
+    /// </summary>
+    [JsonPropertyName("isMissing")]
+    public bool IsMissing { get; set; }
+
+    /// <summary>
+    /// When the variable was created (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CreatedOn { get; set; }
+
+    /// <summary>
+    /// When the variable was last modified (ISO 8601).
+    /// </summary>
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ModifiedOn { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs
@@ -53,7 +53,7 @@ public sealed class EnvironmentVariablesListTool
                 CurrentValue = v.CurrentValue,
                 IsManaged = v.IsManaged,
                 IsRequired = v.IsRequired,
-                HasOverride = v.CurrentValue != null && v.CurrentValue != v.DefaultValue,
+                HasOverride = v.CurrentValueId.HasValue,
                 IsMissing = v.IsRequired && v.CurrentValue == null && v.DefaultValue == null
             }).ToList()
         };

--- a/src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvironmentVariablesListTool.cs
@@ -1,0 +1,136 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that lists environment variable definitions and their current values.
+/// </summary>
+[McpServerToolType]
+public sealed class EnvironmentVariablesListTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentVariablesListTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public EnvironmentVariablesListTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Lists environment variable definitions and their current values.
+    /// </summary>
+    /// <param name="solutionId">Optional solution unique name to filter by.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of environment variable summaries.</returns>
+    [McpServerTool(Name = "ppds_environment_variables_list")]
+    [Description("List environment variable definitions and their current values. Shows default vs current values, type, and override status. Optionally filter by solution name.")]
+    public async Task<EnvironmentVariablesListResult> ExecuteAsync(
+        [Description("Solution unique name to filter by")]
+        string? solutionId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IEnvironmentVariableService>();
+
+        var variables = await service.ListAsync(solutionName: solutionId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new EnvironmentVariablesListResult
+        {
+            EnvironmentVariables = variables.Select(v => new EnvironmentVariableSummary
+            {
+                SchemaName = v.SchemaName,
+                DisplayName = v.DisplayName,
+                Type = v.Type,
+                DefaultValue = v.DefaultValue,
+                CurrentValue = v.CurrentValue,
+                IsManaged = v.IsManaged,
+                IsRequired = v.IsRequired,
+                HasOverride = v.CurrentValue != null && v.CurrentValue != v.DefaultValue,
+                IsMissing = v.IsRequired && v.CurrentValue == null && v.DefaultValue == null
+            }).ToList()
+        };
+    }
+}
+
+/// <summary>
+/// Result of the environment_variables_list tool.
+/// </summary>
+public sealed class EnvironmentVariablesListResult
+{
+    /// <summary>
+    /// List of environment variable summaries.
+    /// </summary>
+    [JsonPropertyName("environmentVariables")]
+    public List<EnvironmentVariableSummary> EnvironmentVariables { get; set; } = [];
+}
+
+/// <summary>
+/// Summary information about an environment variable.
+/// </summary>
+public sealed class EnvironmentVariableSummary
+{
+    /// <summary>
+    /// The schema name of the environment variable.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    /// <summary>
+    /// The display name.
+    /// </summary>
+    [JsonPropertyName("displayName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// The variable type (String, Number, Boolean, JSON, DataSource, Secret).
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    /// <summary>
+    /// The default value defined on the variable.
+    /// </summary>
+    [JsonPropertyName("defaultValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DefaultValue { get; set; }
+
+    /// <summary>
+    /// The current value (from EnvironmentVariableValue record).
+    /// </summary>
+    [JsonPropertyName("currentValue")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CurrentValue { get; set; }
+
+    /// <summary>
+    /// Whether this is a managed variable.
+    /// </summary>
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    /// <summary>
+    /// Whether the variable is required.
+    /// </summary>
+    [JsonPropertyName("isRequired")]
+    public bool IsRequired { get; set; }
+
+    /// <summary>
+    /// Whether the current value overrides the default (currentValue != null and differs from defaultValue).
+    /// </summary>
+    [JsonPropertyName("hasOverride")]
+    public bool HasOverride { get; set; }
+
+    /// <summary>
+    /// Whether the variable is required but has no value (neither current nor default).
+    /// </summary>
+    [JsonPropertyName("isMissing")]
+    public bool IsMissing { get; set; }
+}

--- a/src/PPDS.Mcp/Tools/EnvironmentVariablesSetTool.cs
+++ b/src/PPDS.Mcp/Tools/EnvironmentVariablesSetTool.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using PPDS.Dataverse.Services;
+using PPDS.Mcp.Infrastructure;
+
+namespace PPDS.Mcp.Tools;
+
+/// <summary>
+/// MCP tool that sets the current value of an environment variable.
+/// </summary>
+[McpServerToolType]
+public sealed class EnvironmentVariablesSetTool
+{
+    private readonly McpToolContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentVariablesSetTool"/> class.
+    /// </summary>
+    /// <param name="context">The MCP tool context.</param>
+    public EnvironmentVariablesSetTool(McpToolContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <summary>
+    /// Sets the current value of an environment variable.
+    /// </summary>
+    /// <param name="schemaName">The schema name of the environment variable.</param>
+    /// <param name="value">The new value to set.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    [McpServerTool(Name = "ppds_environment_variables_set")]
+    [Description("Set the current value of an environment variable. Creates the value record if none exists. AI agents can use this to fix misconfigurations during deployment troubleshooting.")]
+    public async Task<EnvironmentVariablesSetResult> ExecuteAsync(
+        [Description("Schema name of the environment variable")]
+        string schemaName,
+        [Description("New value to set")]
+        string value,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            throw new ArgumentException("schemaName is required.", nameof(schemaName));
+        }
+
+        if (_context.IsReadOnly)
+        {
+            throw new InvalidOperationException(
+                "Cannot set environment variable value: this MCP session is read-only.");
+        }
+
+        await using var serviceProvider = await _context.CreateServiceProviderAsync(cancellationToken).ConfigureAwait(false);
+        var service = serviceProvider.GetRequiredService<IEnvironmentVariableService>();
+
+        var success = await service.SetValueAsync(schemaName, value, cancellationToken).ConfigureAwait(false);
+
+        return new EnvironmentVariablesSetResult
+        {
+            Success = success,
+            SchemaName = schemaName,
+            Message = success
+                ? $"Environment variable '{schemaName}' value updated successfully."
+                : $"Environment variable '{schemaName}' not found."
+        };
+    }
+}
+
+/// <summary>
+/// Result of the environment_variables_set tool.
+/// </summary>
+public sealed class EnvironmentVariablesSetResult
+{
+    /// <summary>
+    /// Whether the operation succeeded.
+    /// </summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// The schema name of the variable that was set.
+    /// </summary>
+    [JsonPropertyName("schemaName")]
+    public string SchemaName { get; set; } = "";
+
+    /// <summary>
+    /// Human-readable result message.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = "";
+}

--- a/tests/PPDS.Tui.E2eTests/tests/__snapshots__/sql-query.spec.ts.snap
+++ b/tests/PPDS.Tui.E2eTests/tests/__snapshots__/sql-query.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`SQL Query Keyboard Navigation › Tab cycles through controls | 1`] = S
 ││└────────────────────────────────────────────────────────────────────────────┘││
 ││                                                                              ││
 ││                                                                              ││
-││ Profile: [2] (3b039cb2-3e2f-4cfd-83a…    Environment: PPDS Demo - Dev [DEV] ▼││
+││ Profile: PPDS (josh@powerplatformdev…    Environment: PPDS Demo - Dev [DEV] ▼││
 │└──────────────────────────────────────────────────────────────────────────────┘│
 ╰────────────────────────────────────────────────────────────────────────────────╯
 `;
@@ -65,7 +65,7 @@ exports[`SQL Query Screen › Ctrl+E without results shows error message | 1`] =
 ││└────────────────────────────────────────────────────────────────────────────┘││
 ││                                                                              ││
 ││                                                                              ││
-││ Profile: [2] (3b039cb2-3e2f-4cfd-83a…    Environment: PPDS Demo - Dev [DEV] ▼││
+││ Profile: PPDS (josh@powerplatformdev…    Environment: PPDS Demo - Dev [DEV] ▼││
 │└──────────────────────────────────────────────────────────────────────────────┘│
 ╰────────────────────────────────────────────────────────────────────────────────╯
 `;
@@ -100,7 +100,7 @@ exports[`SQL Query Screen › SQL Query screen snapshot for visual regression | 
 ││└────────────────────────────────────────────────────────────────────────────┘││
 ││                                                                              ││
 ││                                                                              ││
-││ Profile: [2] (3b039cb2-3e2f-4cfd-83a…    Environment: PPDS Demo - Dev [DEV] ▼││
+││ Profile: PPDS (josh@powerplatformdev…    Environment: PPDS Demo - Dev [DEV] ▼││
 │└──────────────────────────────────────────────────────────────────────────────┘│
 ╰────────────────────────────────────────────────────────────────────────────────╯
 `;
@@ -135,7 +135,7 @@ exports[`SQL Query Screen › Tools menu opens SQL Query screen | 1`] = String.r
 ││└────────────────────────────────────────────────────────────────────────────┘││
 ││                                                                              ││
 ││                                                                              ││
-││ Profile: [2] (3b039cb2-3e2f-4cfd-83a…    Environment: PPDS Demo - Dev [DEV] ▼││
+││ Profile: PPDS (josh@powerplatformdev…    Environment: PPDS Demo - Dev [DEV] ▼││
 │└──────────────────────────────────────────────────────────────────────────────┘│
 ╰────────────────────────────────────────────────────────────────────────────────╯
 `;


### PR DESCRIPTION
## Summary

- **Connection References panel** across RPC (3 endpoints), MCP (3 tools), TUI (screen + dialogs), and VS Code (webview panel with DataTable, detail pane, analyze) — includes SPN graceful degradation for Connections API
- **Environment Variables panel** across RPC (3 endpoints incl. write), MCP (3 tools incl. set), TUI (screen + type-aware edit dialog + export), and VS Code (webview panel with edit modal, override/missing indicators)
- **Shared solution filter** component (`solution-filter.ts`) reusable by future panels (Web Resources in Phase 2d)

Closes #339, #340, #349, #350, #357, #359, #587, #588

## Test Plan

- [x] .NET build: 0 errors, 0 warnings
- [x] .NET tests: all passing across net8.0/9.0/10.0
- [x] TypeScript typecheck: 0 errors (host + webview)
- [x] ESLint: 0 errors
- [x] CSS lint: 0 errors
- [x] Extension unit tests: 231 passing
- [x] MCP tests: 58 passing across all TFMs
- [x] Extension visual verification: both panels render with real Dataverse data
- [x] SPN graceful degradation confirmed via logs

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: extension, mcp)
- [x] /review completed (findings: 10 — 2 critical + 4 important fixed, 4 suggestions noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)