### PR TITLE
fix(workflow): stop hook blocks on incomplete workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -106,6 +106,14 @@ For EACH phase in the plan, repeat this cycle:
 - Review each agent's summary (do NOT read full transcripts - save context)
 - Mark tasks as completed
 
+**B2. Cross-Agent Consistency Check**
+When parallel agents implement the same semantic concept across surfaces (e.g., RPC + MCP + TUI + Extension), check for consistency BEFORE proceeding:
+- Same field names and types across surfaces (e.g., `HasOverride` uses the same logic in MCP and RPC)
+- Nullable/non-nullable agreement between C# DTOs and TypeScript interfaces
+- Error codes defined in one layer are actually used in other layers
+- Default values match across surfaces (e.g., "N/A" fallback in both mapper and TS type)
+This prevents the most common parallel-agent defect: each agent delivers its slice correctly but cross-slice contracts are inconsistent.
+
 **C. Verify Phase Gate**
 - Run full solution build: `dotnet build PPDS.sln -v q` (or appropriate build command)
 - Run full test suite: `dotnet test PPDS.sln --filter "Category!=Integration" -v q --no-build`

--- a/.claude/hooks/session-start-workflow.py
+++ b/.claude/hooks/session-start-workflow.py
@@ -207,7 +207,10 @@ def _behavioral_rules():
         "  • You MUST visually verify affected surfaces before declaring done.\n"
         "    A passing test suite is NOT verification. Use the product yourself.\n"
         "  • Do NOT declare work complete without running /gates → /verify → /qa → /review.\n"
-        "  • PR creation WILL BE BLOCKED if these steps are incomplete."
+        "  • PR creation WILL BE BLOCKED if these steps are incomplete.\n"
+        "  • The stop hook WILL BLOCK session end if workflow steps are incomplete.\n"
+        "  • After each workflow step, proceed to the next WITHOUT asking permission.\n"
+        "    gates → verify → qa → review → pr is a pipeline. Execute end-to-end."
     )
 
 

--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
-Stop hook: emits workflow completion summary when session ends.
-Cannot block session end — always exits 0.
+Stop hook: blocks session end when critical workflow steps are incomplete.
+Returns exit code 2 with decision:block to prevent premature stopping.
+Returns exit code 0 when workflow is complete or on main branch.
 """
 import json
 import os
@@ -17,9 +18,29 @@ def main():
         pass
 
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+
+    # Get current branch
+    branch = "unknown"
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    # On main: always allow stop (no workflow enforcement)
+    if branch in ("main", "master", "unknown"):
+        sys.exit(0)
+
     state_path = os.path.join(project_dir, ".claude", "workflow-state.json")
 
-    # No state file — nothing to report
+    # No state file — no workflow tracked, allow stop
     if not os.path.exists(state_path):
         sys.exit(0)
 
@@ -29,10 +50,7 @@ def main():
     except (json.JSONDecodeError, OSError):
         sys.exit(0)
 
-    # Get branch
-    branch = state.get("branch", "unknown")
-
-    # Get current HEAD
+    # Get current HEAD for staleness check
     head_sha = None
     try:
         result = subprocess.run(
@@ -58,59 +76,101 @@ def main():
             timeout=10,
         )
         if result.returncode == 0:
-            uncommitted = len([line for line in result.stdout.strip().split("\n") if line.strip()])
+            uncommitted = len(
+                [line for line in result.stdout.strip().split("\n") if line.strip()]
+            )
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
-    lines = [f"SESSION END — Workflow status for {branch}:"]
+    # --- Determine what's missing ---
+    missing = []
 
     # Gates
     gates = state.get("gates", {})
     gates_ref = gates.get("commit_ref")
     gates_passed = gates.get("passed")
-    if gates_passed and gates_ref and head_sha and gates_ref == head_sha:
-        lines.append("  ✓ Gates passed")
-    elif gates_passed:
-        lines.append("  ⚠ Gates stale (code changed since last run)")
-    else:
-        lines.append("  ✗ Gates not run")
+    gates_current = gates_passed and gates_ref and head_sha and gates_ref == head_sha
+    if not gates_current:
+        if gates_passed:
+            missing.append("/gates (stale — code changed since last run)")
+        else:
+            missing.append("/gates")
 
-    # Verify
+    # Verify (at least one surface)
     verify = state.get("verify", {})
     verified = [k for k, v in verify.items() if v]
-    if verified:
-        lines.append(f"  ✓ Verified: {', '.join(verified)}")
-    else:
-        lines.append("  ✗ No surfaces verified")
+    if not verified:
+        missing.append("/verify (no surfaces verified)")
 
-    # QA
+    # QA (at least one surface)
     qa = state.get("qa", {})
     qa_done = [k for k, v in qa.items() if v]
-    if qa_done:
-        lines.append(f"  ✓ QA completed: {', '.join(qa_done)}")
-    else:
-        lines.append("  ✗ QA not completed — /qa was never run")
+    if not qa_done:
+        missing.append("/qa")
 
     # Review
     review = state.get("review", {})
-    if review.get("passed"):
-        lines.append(f"  ✓ Review passed ({review.get('findings', 0)} findings)")
-    else:
-        lines.append("  ✗ Review not completed — /review was never run")
+    if not review.get("passed"):
+        missing.append("/review")
 
-    # PR
+    # PR Gemini triage — if PR exists but gemini_triaged is false
     pr = state.get("pr", {})
-    if pr and pr.get("url"):
-        lines.append(f"  ✓ PR: {pr['url']}")
-    else:
-        lines.append("  ⚠ PR not created")
+    pr_created = pr and pr.get("url")
+    if pr_created and not pr.get("gemini_triaged"):
+        missing.append("Gemini review triage (PR created but comments not triaged)")
 
     # Uncommitted changes
     if uncommitted > 0:
+        missing.append(f"uncommitted changes ({uncommitted} files)")
+
+    # --- Build status summary (always emitted) ---
+    lines = [f"Workflow status for {branch}:"]
+    lines.append(f"  {'✓' if gates_current else '✗'} Gates")
+    lines.append(
+        f"  {'✓' if verified else '✗'} Verified"
+        + (f": {', '.join(verified)}" if verified else "")
+    )
+    lines.append(
+        f"  {'✓' if qa_done else '✗'} QA"
+        + (f": {', '.join(qa_done)}" if qa_done else "")
+    )
+    lines.append(
+        f"  {'✓' if review.get('passed') else '✗'} Review"
+        + (f" ({review.get('findings', 0)} findings)" if review.get("passed") else "")
+    )
+    if pr_created:
+        triaged = "✓" if pr.get("gemini_triaged") else "✗"
+        lines.append(f"  ✓ PR: {pr['url']}")
+        lines.append(f"  {triaged} Gemini review triaged")
+    else:
+        lines.append("  ⚠ PR not created")
+
+    if uncommitted > 0:
         lines.append(f"  ⚠ Uncommitted changes in {uncommitted} files")
 
-    print("\n".join(lines), file=sys.stderr)
-    sys.exit(0)
+    # --- Decision: block or allow ---
+    if missing:
+        lines.insert(0, "BLOCKED — incomplete workflow steps:")
+        lines.append("")
+        lines.append("Remaining steps:")
+        for step in missing:
+            lines.append(f"  → {step}")
+        lines.append("")
+        lines.append(
+            "Complete these steps before stopping. "
+            "Run them in order: /gates → /verify → /qa → /review → /pr"
+        )
+
+        output = {
+            "decision": "block",
+            "reason": "\n".join(lines),
+        }
+        print(json.dumps(output))
+        sys.exit(2)
+    else:
+        lines.insert(0, "SESSION END — all workflow steps complete:")
+        print("\n".join(lines), file=sys.stderr)
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -98,6 +98,12 @@ Reply text:
 
 **Do NOT use `gh pr comment`** — that creates a top-level comment, not a threaded reply.
 
+**Common mistakes:**
+- WRONG: `gh pr comment 123 --body "Addressed all feedback"` → this is a single top-level comment, not per-comment replies
+- WRONG: Posting a summary issue comment that groups all findings → reviewers can't see which comment was addressed
+- RIGHT: Loop over each `comment_id` from the API response and POST a reply to each one individually
+- RIGHT: Each reply references the specific commit SHA or explains why the finding was dismissed
+
 **Push fixes as a new commit:**
 ```bash
 git add <files>
@@ -132,6 +138,19 @@ After PR is created:
   }
 }
 ```
+
+After Gemini comments are triaged (step 4 complete), update workflow state:
+```json
+{
+  "pr": {
+    "url": "https://github.com/...",
+    "created": "2026-03-16T17:00:00Z",
+    "gemini_triaged": true
+  }
+}
+```
+
+The stop hook will BLOCK the session from ending if `gemini_triaged` is not set after PR creation. Do not skip step 4.
 
 ## Timeout Behavior
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,9 @@ Steps 5-8 enforced by hooks. PR gate blocks `gh pr create` if incomplete. Run /s
 "Don't ask, just do it" applies to: committing, gates, verification, QA, review, triaging review comments (fix valid, dismiss invalid w/ rationale). Does NOT apply to: skipping workflow steps, filing/closing issues, PRs without passing gates.
 After external review: respond to EACH PR comment individually with action taken. Include summary in status report.
 
+### Pipeline chaining
+After completing each workflow step, proceed to the next step without asking for permission. The sequence gates → verify → qa → review → pr is a pipeline — execute it end-to-end unless a step fails. Do NOT stop between steps to present a summary and wait. The stop hook will block the session from ending if steps are incomplete.
+
 ## Git Hooks
 
 Pre-commit hook (`scripts/hooks/`) runs `typecheck:all` + `eslint --quiet` on extension TS changes. Auto-configured by `npm install`. Manual: `git config core.hooksPath scripts/hooks`.


### PR DESCRIPTION
## Summary

- **Stop hook upgraded to block sessions** from ending when workflow steps (gates, verify, qa, review, Gemini triage) are incomplete — returns exit code 2 with `decision: block`
- **Pipeline chaining** added to CLAUDE.md and session-start hook — sessions now proceed autonomously through gates → verify → qa → review → pr without stopping to ask permission
- **Per-comment reply enforcement** — added common-mistake examples to `/pr` skill and `gemini_triaged` workflow state tracking

## Context

Retrospective analysis of PRs 615-618 (panel parity Phase 2) identified three systemic problems:
1. Sessions stopped and waited for user to say "proceed" between workflow steps
2. Sessions created PRs but didn't wait for Gemini review comments
3. Sessions responded with bulk summary comments instead of individual threaded replies

Root cause: the stop hook couldn't prevent premature session end (it always exited 0). With exit code 2 blocking, the workflow is now mechanically enforced end-to-end.

Also filed 8 GitHub issues (#619-#626) for extension feature gaps identified during the audit.

## Test Plan
- [x] Stop hook tested: blocks on feature branch with incomplete state, allows on main
- [x] Stop hook tested: emits all missing steps in one message
- [x] Stop hook tested: allows stop when all steps complete
- [x] Gemini triage tracking: `pr.gemini_triaged` in workflow state

## Verification
- [x] /gates — N/A (process-only: hooks, skills, markdown)
- [x] /verify — N/A (no UI surfaces)
- [x] /qa — N/A (no product behavior)
- [x] /review — changes reviewed during retro discussion with user

🤖 Generated with [Claude Code](https://claude.com/claude-code)