### PR TITLE
feat(migration): polish import output quality (#277-280)

### DIFF
--- a/src/PPDS.Migration/Import/ImportResult.cs
+++ b/src/PPDS.Migration/Import/ImportResult.cs
@@ -21,6 +21,11 @@ namespace PPDS.Migration.Import
         public int TiersProcessed { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of records in the source data file.
+        /// </summary>
+        public int SourceRecordCount { get; set; }
+
+        /// <summary>
         /// Gets or sets the number of records imported.
         /// </summary>
         public int RecordsImported { get; set; }

--- a/src/PPDS.Migration/Import/ImportResult.cs
+++ b/src/PPDS.Migration/Import/ImportResult.cs
@@ -36,6 +36,11 @@ namespace PPDS.Migration.Import
         public int RelationshipsProcessed { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of relationship failures.
+        /// </summary>
+        public int RelationshipsFailed { get; set; }
+
+        /// <summary>
         /// Gets or sets the import duration.
         /// </summary>
         public TimeSpan Duration { get; set; }

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -478,6 +478,7 @@ namespace PPDS.Migration.Import
                 RecordsImported = totalImported,
                 RecordsUpdated = deferredResult.SuccessCount,
                 RelationshipsProcessed = relationshipResult.SuccessCount,
+                RelationshipsFailed = relationshipResult.FailureCount,
                 Duration = duration,
                 Phase1Duration = phase1Duration,
                 Phase2Duration = phase2Duration,

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -688,7 +688,8 @@ namespace PPDS.Migration.Import
                 RecordIndex = e.Index,
                 RecordId = e.RecordId,
                 ErrorCode = e.ErrorCode,
-                Message = e.Message
+                Message = e.Message,
+                Diagnostics = e.Diagnostics
             }).ToList();
 
             entityStopwatch.Stop();

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -527,6 +527,7 @@ namespace PPDS.Migration.Import
                 CreatedCount = totalCreated,
                 UpdatedCount = totalUpdated,
                 M2MCount = relationshipResult.SuccessCount > 0 ? relationshipResult.SuccessCount : null,
+                RelationshipsFailed = relationshipResult.FailureCount > 0 ? relationshipResult.FailureCount : null,
                 PoolStatistics = _connectionPool.Statistics,
                 Duration = result.Duration,
                 Errors = errors.ToArray()

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -179,7 +179,7 @@ namespace PPDS.Migration.Import
 
                 return BuildImportResult(
                     plan, entityResults, errors, warnings,
-                    totalImported, deferredResult, relationshipResult,
+                    totalImported, data.TotalRecordCount, deferredResult, relationshipResult,
                     stopwatch.Elapsed, phase1Duration, phase2Duration, phase3Duration,
                     options, progress);
             }
@@ -190,7 +190,7 @@ namespace PPDS.Migration.Import
 
                 return BuildFailureResult(
                     plan, entityResults, errors, warnings,
-                    totalImported, stopwatch.Elapsed, ex, options, progress);
+                    totalImported, data.TotalRecordCount, stopwatch.Elapsed, ex, options, progress);
             }
             finally
             {
@@ -462,6 +462,7 @@ namespace PPDS.Migration.Import
             ConcurrentBag<MigrationError> errors,
             IWarningCollector warnings,
             int totalImported,
+            int sourceRecordCount,
             PhaseResult deferredResult,
             PhaseResult relationshipResult,
             TimeSpan duration,
@@ -475,6 +476,7 @@ namespace PPDS.Migration.Import
             {
                 Success = errors.IsEmpty,
                 TiersProcessed = plan.TierCount,
+                SourceRecordCount = sourceRecordCount,
                 RecordsImported = totalImported,
                 RecordsUpdated = deferredResult.SuccessCount,
                 RelationshipsProcessed = relationshipResult.SuccessCount,
@@ -518,6 +520,7 @@ namespace PPDS.Migration.Import
             progress?.Complete(new MigrationResult
             {
                 Success = result.Success,
+                SourceRecordCount = sourceRecordCount,
                 RecordsProcessed = result.RecordsImported + result.RecordsUpdated + totalFailureCount + relationshipResult.SuccessCount,
                 SuccessCount = result.RecordsImported + result.RecordsUpdated + relationshipResult.SuccessCount,
                 FailureCount = totalFailureCount,
@@ -540,6 +543,7 @@ namespace PPDS.Migration.Import
             ConcurrentBag<MigrationError> errors,
             IWarningCollector warnings,
             int totalImported,
+            int sourceRecordCount,
             TimeSpan duration,
             Exception ex,
             ImportOptions options,
@@ -560,6 +564,7 @@ namespace PPDS.Migration.Import
             {
                 Success = false,
                 TiersProcessed = plan.TierCount,
+                SourceRecordCount = sourceRecordCount,
                 RecordsImported = totalImported,
                 Duration = duration,
                 EntityResults = entityResults.ToArray(),

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -527,6 +527,7 @@ namespace PPDS.Migration.Import
                 CreatedCount = totalCreated,
                 UpdatedCount = totalUpdated,
                 M2MCount = relationshipResult.SuccessCount > 0 ? relationshipResult.SuccessCount : null,
+                PoolStatistics = _connectionPool.Statistics,
                 Duration = result.Duration,
                 Errors = errors.ToArray()
             });

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -188,13 +188,12 @@ namespace PPDS.Migration.Progress
                 : "";
             Console.Error.WriteLine($"    {result.SuccessCount:N0} record(s) in {result.Duration:hh\\:mm\\:ss} ({result.RecordsPerSecond:F1} rec/s){m2mBreakdown}");
 
-            // Source vs imported comparison when there's a difference
-            if (result.SourceRecordCount.HasValue && result.SourceRecordCount.Value != result.SuccessCount)
+            // Source vs imported comparison when there are failures
+            // Only show when failures exist to avoid confusion from deferred field/M2M counts inflating SuccessCount
+            if (result.SourceRecordCount.HasValue && result.FailureCount > 0)
             {
-                var entitySuccessCount = result.M2MCount.HasValue
-                    ? result.SuccessCount - result.M2MCount.Value
-                    : result.SuccessCount;
-                Console.Error.WriteLine($"        Source: {result.SourceRecordCount.Value:N0} | Imported: {entitySuccessCount:N0} | Failed: {result.FailureCount:N0}");
+                var importedCount = result.SourceRecordCount.Value - result.FailureCount;
+                Console.Error.WriteLine($"        Source: {result.SourceRecordCount.Value:N0} | Imported: {importedCount:N0} | Failed: {result.FailureCount:N0}");
             }
 
             // Show created/updated breakdown for upsert operations

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -387,6 +387,12 @@ namespace PPDS.Migration.Progress
                 return "MISSING_REFERENCE";
             }
 
+            // Self-referential parent doesn't exist
+            if (Regex.IsMatch(message, @"\w+ With Ids? = .+ Do(es)? Not Exist", RegexOptions.IgnoreCase))
+            {
+                return "MISSING_PARENT";
+            }
+
             // Duplicate record
             if (message.Contains("duplicate", StringComparison.OrdinalIgnoreCase) ||
                 message.Contains("already exists", StringComparison.OrdinalIgnoreCase))

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -192,8 +192,10 @@ namespace PPDS.Migration.Progress
             // Only show when failures exist to avoid confusion from deferred field/M2M counts inflating SuccessCount
             if (result.SourceRecordCount.HasValue && result.FailureCount > 0)
             {
-                var importedCount = result.SourceRecordCount.Value - result.FailureCount;
-                Console.Error.WriteLine($"        Source: {result.SourceRecordCount.Value:N0} | Imported: {importedCount:N0} | Failed: {result.FailureCount:N0}");
+                // Exclude M2M relationship failures — SourceRecordCount only covers entity records
+                var entityFailureCount = result.FailureCount - result.RelationshipsFailed.GetValueOrDefault();
+                var importedCount = result.SourceRecordCount.Value - entityFailureCount;
+                Console.Error.WriteLine($"        Source: {result.SourceRecordCount.Value:N0} | Imported: {importedCount:N0} | Failed: {entityFailureCount:N0}");
             }
 
             // Show created/updated breakdown for upsert operations

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -320,6 +320,20 @@ namespace PPDS.Migration.Progress
                 }
             }
 
+            // Show API call statistics if available
+            if (result.PoolStatistics != null && result.PoolStatistics.RequestsServed > 0)
+            {
+                Console.Error.WriteLine();
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                var apiLine = $"    API calls: {result.PoolStatistics.RequestsServed:N0}";
+                if (result.PoolStatistics.ThrottleEvents > 0)
+                {
+                    apiLine += $" ({result.PoolStatistics.ThrottleEvents:N0} throttled, {result.PoolStatistics.TotalBackoffTime.TotalSeconds:F1}s backoff)";
+                }
+                Console.Error.WriteLine(apiLine);
+                Console.ResetColor();
+            }
+
             Console.Error.WriteLine();
         }
 

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -181,12 +181,21 @@ namespace PPDS.Migration.Progress
             }
             Console.ResetColor();
 
-            // Summary line: "    42,366 records in 00:00:08 (4,774.5 rec/s)"
+            // Summary line: "    42,366 record(s) in 00:00:08 (4,774.5 rec/s)"
             // Include M2M breakdown if present: "... [42,000 entities + 366 M2M]"
             var m2mBreakdown = result.M2MCount.HasValue && result.M2MCount.Value > 0
                 ? $" [{result.SuccessCount - result.M2MCount.Value:N0} entities + {result.M2MCount.Value:N0} M2M]"
                 : "";
             Console.Error.WriteLine($"    {result.SuccessCount:N0} record(s) in {result.Duration:hh\\:mm\\:ss} ({result.RecordsPerSecond:F1} rec/s){m2mBreakdown}");
+
+            // Source vs imported comparison when there's a difference
+            if (result.SourceRecordCount.HasValue && result.SourceRecordCount.Value != result.SuccessCount)
+            {
+                var entitySuccessCount = result.M2MCount.HasValue
+                    ? result.SuccessCount - result.M2MCount.Value
+                    : result.SuccessCount;
+                Console.Error.WriteLine($"        Source: {result.SourceRecordCount.Value:N0} | Imported: {entitySuccessCount:N0} | Failed: {result.FailureCount:N0}");
+            }
 
             // Show created/updated breakdown for upsert operations
             if (result.CreatedCount.HasValue && result.UpdatedCount.HasValue)

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -253,6 +253,16 @@ namespace PPDS.Migration.Progress
                     {
                         Console.Error.WriteLine($"Error Pattern: {topPattern.Value:N0} of {result.Errors.Count:N0} errors share the same cause:");
                         Console.Error.WriteLine($"  {GetPatternDescription(topPattern.Key)}");
+
+                        // For MISSING_PARENT, show which lookup fields are involved
+                        if (topPattern.Key == "MISSING_PARENT")
+                        {
+                            var fieldNames = ExtractDiagnosticFieldNames(result.Errors);
+                            if (fieldNames.Count > 0)
+                            {
+                                Console.Error.WriteLine($"  Lookup fields: {string.Join(", ", fieldNames)}");
+                            }
+                        }
                     }
                     else
                     {
@@ -387,6 +397,7 @@ namespace PPDS.Migration.Progress
             "MISSING_USER" => "Referenced systemuser (owner/createdby/modifiedby) does not exist in target environment",
             "MISSING_TEAM" => "Referenced team does not exist in target environment",
             "MISSING_REFERENCE" => "Referenced record does not exist in target environment",
+            "MISSING_PARENT" => "Referenced parent record does not exist in target environment",
             "DUPLICATE_RECORD" => "Record already exists (duplicate detected)",
             "PERMISSION_DENIED" => "Insufficient permissions to create/update records",
             "REQUIRED_FIELD" => "Required field is missing or null",
@@ -415,6 +426,11 @@ namespace PPDS.Migration.Progress
                         suggestions.Add("Check that the data file includes all required parent records");
                         break;
 
+                    case "MISSING_PARENT":
+                        suggestions.Add("Parent records must exist before child records can reference them");
+                        suggestions.Add("Check self-referential lookups (e.g., parentaccountid) — the referenced record may not have been imported yet");
+                        break;
+
                     case "DUPLICATE_RECORD":
                         suggestions.Add("Use --mode Update to update existing records instead of creating duplicates");
                         suggestions.Add("Or use --mode Upsert to create-or-update based on record ID");
@@ -434,6 +450,21 @@ namespace PPDS.Migration.Progress
 
             // Deduplicate suggestions
             return suggestions.Distinct().ToList();
+        }
+
+        /// <summary>
+        /// Extracts unique field names from error diagnostics.
+        /// </summary>
+        private static List<string> ExtractDiagnosticFieldNames(IReadOnlyList<MigrationError> errors)
+        {
+            return errors
+                .Where(e => e.Diagnostics != null)
+                .SelectMany(e => e.Diagnostics!)
+                .Where(d => !string.IsNullOrEmpty(d.FieldName))
+                .Select(d => d.FieldName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         /// <inheritdoc />

--- a/src/PPDS.Migration/Progress/ImportOutputManager.cs
+++ b/src/PPDS.Migration/Progress/ImportOutputManager.cs
@@ -253,6 +253,8 @@ namespace PPDS.Migration.Progress
                 RecordsImported = result.RecordsImported,
                 RecordsUpdated = result.RecordsUpdated,
                 RecordsFailed = _errorCount,
+                RelationshipsProcessed = result.RelationshipsProcessed > 0 ? result.RelationshipsProcessed : null,
+                RelationshipsFailed = result.RelationshipsFailed > 0 ? result.RelationshipsFailed : null,
                 RecordsPerSecond = result.RecordsPerSecond,
                 ErrorPatterns = DetectErrorPatterns(result),
                 Entities = result.EntityResults.Count > 0
@@ -420,6 +422,12 @@ namespace PPDS.Migration.Progress
 
             [JsonPropertyName("recordsFailed")]
             public int RecordsFailed { get; set; }
+
+            [JsonPropertyName("relationshipsProcessed")]
+            public int? RelationshipsProcessed { get; set; }
+
+            [JsonPropertyName("relationshipsFailed")]
+            public int? RelationshipsFailed { get; set; }
 
             [JsonPropertyName("recordsPerSecond")]
             public double RecordsPerSecond { get; set; }

--- a/src/PPDS.Migration/Progress/ImportOutputManager.cs
+++ b/src/PPDS.Migration/Progress/ImportOutputManager.cs
@@ -250,6 +250,7 @@ namespace PPDS.Migration.Progress
                 Success = result.Success,
                 Duration = result.Duration,
                 TiersProcessed = result.TiersProcessed,
+                SourceRecordCount = result.SourceRecordCount,
                 RecordsImported = result.RecordsImported,
                 RecordsUpdated = result.RecordsUpdated,
                 RecordsFailed = _errorCount,
@@ -413,6 +414,9 @@ namespace PPDS.Migration.Progress
 
             [JsonPropertyName("tiersProcessed")]
             public int TiersProcessed { get; set; }
+
+            [JsonPropertyName("sourceRecordCount")]
+            public int SourceRecordCount { get; set; }
 
             [JsonPropertyName("recordsImported")]
             public int RecordsImported { get; set; }

--- a/src/PPDS.Migration/Progress/MigrationResult.cs
+++ b/src/PPDS.Migration/Progress/MigrationResult.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
 
 namespace PPDS.Migration.Progress
 {
@@ -61,6 +62,11 @@ namespace PPDS.Migration.Progress
         /// Only populated for import operations; null otherwise.
         /// </summary>
         public int? M2MCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection pool statistics at the end of the operation.
+        /// </summary>
+        public PoolStatistics? PoolStatistics { get; set; }
 
         /// <summary>
         /// Gets the average records per second.

--- a/src/PPDS.Migration/Progress/MigrationResult.cs
+++ b/src/PPDS.Migration/Progress/MigrationResult.cs
@@ -64,6 +64,12 @@ namespace PPDS.Migration.Progress
         public int? M2MCount { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of M2M relationship failures.
+        /// Only populated for import operations; null otherwise.
+        /// </summary>
+        public int? RelationshipsFailed { get; set; }
+
+        /// <summary>
         /// Gets or sets the connection pool statistics at the end of the operation.
         /// </summary>
         public PoolStatistics? PoolStatistics { get; set; }

--- a/src/PPDS.Migration/Progress/MigrationResult.cs
+++ b/src/PPDS.Migration/Progress/MigrationResult.cs
@@ -15,6 +15,11 @@ namespace PPDS.Migration.Progress
         public bool Success { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of records in the source data file.
+        /// </summary>
+        public int? SourceRecordCount { get; set; }
+
+        /// <summary>
         /// Gets or sets the total records processed.
         /// </summary>
         public int RecordsProcessed { get; set; }

--- a/tests/PPDS.Migration.Tests/Import/ImportResultTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/ImportResultTests.cs
@@ -14,9 +14,11 @@ public class ImportResultTests
 
         result.Success.Should().BeFalse();
         result.TiersProcessed.Should().Be(0);
+        result.SourceRecordCount.Should().Be(0);
         result.RecordsImported.Should().Be(0);
         result.RecordsUpdated.Should().Be(0);
         result.RelationshipsProcessed.Should().Be(0);
+        result.RelationshipsFailed.Should().Be(0);
         result.Duration.Should().Be(TimeSpan.Zero);
         result.Errors.Should().NotBeNull().And.BeEmpty();
         result.EntityResults.Should().NotBeNull().And.BeEmpty();
@@ -33,9 +35,11 @@ public class ImportResultTests
         {
             Success = true,
             TiersProcessed = 3,
+            SourceRecordCount = 1100,
             RecordsImported = 1000,
             RecordsUpdated = 50,
             RelationshipsProcessed = 10,
+            RelationshipsFailed = 2,
             Duration = duration,
             Errors = errors,
             EntityResults = entityResults
@@ -43,9 +47,11 @@ public class ImportResultTests
 
         result.Success.Should().BeTrue();
         result.TiersProcessed.Should().Be(3);
+        result.SourceRecordCount.Should().Be(1100);
         result.RecordsImported.Should().Be(1000);
         result.RecordsUpdated.Should().Be(50);
         result.RelationshipsProcessed.Should().Be(10);
+        result.RelationshipsFailed.Should().Be(2);
         result.Duration.Should().Be(duration);
         result.Errors.Should().HaveCount(1);
         result.EntityResults.Should().HaveCount(1);

--- a/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
@@ -51,6 +51,30 @@ public class ConsoleProgressReporterTests : IDisposable
     }
 
     [Fact]
+    public void Complete_ShowsSourceVsImported_ExcludingM2MFailures()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = false,
+            SourceRecordCount = 1000,
+            SuccessCount = 970,
+            FailureCount = 70, // 50 entity failures + 20 M2M failures
+            RelationshipsFailed = 20,
+            RecordsProcessed = 1040,
+            Duration = TimeSpan.FromSeconds(10)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        // Should show entity-only stats: 1000 source - 50 entity failures = 950 imported
+        output.Should().Contain("Source: 1,000");
+        output.Should().Contain("Imported: 950");
+        output.Should().Contain("Failed: 50");
+    }
+
+    [Fact]
     public void Complete_OmitsSourceComparison_WhenNoFailures()
     {
         var reporter = new ConsoleProgressReporter { OperationName = "Import" };

--- a/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
@@ -29,7 +29,7 @@ public class ConsoleProgressReporterTests : IDisposable
     #region Complete() — Source vs Imported Comparison (#280)
 
     [Fact]
-    public void Complete_ShowsSourceVsImported_WhenCountsDiffer()
+    public void Complete_ShowsSourceVsImported_WhenFailuresExist()
     {
         var reporter = new ConsoleProgressReporter { OperationName = "Import" };
         var result = new MigrationResult
@@ -51,7 +51,7 @@ public class ConsoleProgressReporterTests : IDisposable
     }
 
     [Fact]
-    public void Complete_OmitsSourceComparison_WhenCountsMatch()
+    public void Complete_OmitsSourceComparison_WhenNoFailures()
     {
         var reporter = new ConsoleProgressReporter { OperationName = "Import" };
         var result = new MigrationResult

--- a/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
@@ -1,0 +1,343 @@
+using FluentAssertions;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Progress;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Progress;
+
+public class ConsoleProgressReporterTests : IDisposable
+{
+    private readonly TextWriter _originalStdErr;
+    private readonly StringWriter _capturedStdErr;
+
+    public ConsoleProgressReporterTests()
+    {
+        _originalStdErr = Console.Error;
+        _capturedStdErr = new StringWriter();
+        Console.SetError(_capturedStdErr);
+    }
+
+    public void Dispose()
+    {
+        Console.SetError(_originalStdErr);
+        _capturedStdErr.Dispose();
+    }
+
+    private string GetOutput() => _capturedStdErr.ToString();
+
+    #region Complete() — Source vs Imported Comparison (#280)
+
+    [Fact]
+    public void Complete_ShowsSourceVsImported_WhenCountsDiffer()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SourceRecordCount = 1000,
+            SuccessCount = 950,
+            FailureCount = 50,
+            RecordsProcessed = 1000,
+            Duration = TimeSpan.FromSeconds(10)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("Source: 1,000");
+        output.Should().Contain("Imported: 950");
+        output.Should().Contain("Failed: 50");
+    }
+
+    [Fact]
+    public void Complete_OmitsSourceComparison_WhenCountsMatch()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SourceRecordCount = 100,
+            SuccessCount = 100,
+            FailureCount = 0,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(5)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().NotContain("Source:");
+    }
+
+    [Fact]
+    public void Complete_OmitsSourceComparison_WhenSourceCountIsNull()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SourceRecordCount = null,
+            SuccessCount = 100,
+            FailureCount = 0,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(5)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().NotContain("Source:");
+    }
+
+    #endregion
+
+    #region Complete() — API Call Count (#279)
+
+    [Fact]
+    public void Complete_ShowsApiCallCount_WhenPoolStatisticsPresent()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SuccessCount = 100,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(10),
+            PoolStatistics = new PoolStatistics
+            {
+                RequestsServed = 1234,
+                ThrottleEvents = 0,
+                TotalBackoffTime = TimeSpan.Zero
+            }
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("API calls: 1,234");
+        output.Should().NotContain("throttled");
+    }
+
+    [Fact]
+    public void Complete_ShowsThrottleInfo_WhenThrottleEventsPresent()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SuccessCount = 100,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(10),
+            PoolStatistics = new PoolStatistics
+            {
+                RequestsServed = 500,
+                ThrottleEvents = 3,
+                TotalBackoffTime = TimeSpan.FromSeconds(2.5)
+            }
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("API calls: 500");
+        output.Should().Contain("3 throttled");
+        output.Should().Contain("2.5s backoff");
+    }
+
+    [Fact]
+    public void Complete_OmitsApiCallCount_WhenPoolStatisticsNull()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SuccessCount = 100,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(5),
+            PoolStatistics = null
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().NotContain("API calls");
+    }
+
+    #endregion
+
+    #region Complete() — MISSING_PARENT Pattern (#278)
+
+    [Fact]
+    public void Complete_ShowsFieldNames_ForMissingParentPattern()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var diagnostics = new List<BatchFailureDiagnostic>
+        {
+            new()
+            {
+                RecordId = Guid.NewGuid(),
+                RecordIndex = 0,
+                FieldName = "parentaccountid",
+                ReferencedId = Guid.NewGuid(),
+                Pattern = "MISSING_PARENT"
+            }
+        };
+
+        // Create enough errors with MISSING_PARENT pattern to trigger the 80% threshold
+        var errors = Enumerable.Range(0, 10).Select(i => new MigrationError
+        {
+            EntityLogicalName = "account",
+            Message = $"account With Id = {Guid.NewGuid()} Does Not Exist",
+            Diagnostics = diagnostics
+        }).ToList();
+
+        var result = new MigrationResult
+        {
+            Success = false,
+            SuccessCount = 90,
+            FailureCount = 10,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(5),
+            Errors = errors
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("Referenced parent record does not exist");
+        output.Should().Contain("Lookup fields: parentaccountid");
+    }
+
+    [Fact]
+    public void Complete_ShowsMultipleFieldNames_ForMissingParentPattern()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+
+        var errors = new List<MigrationError>();
+        for (var i = 0; i < 10; i++)
+        {
+            errors.Add(new MigrationError
+            {
+                EntityLogicalName = "account",
+                Message = $"account With Id = {Guid.NewGuid()} Does Not Exist",
+                Diagnostics = new List<BatchFailureDiagnostic>
+                {
+                    new()
+                    {
+                        FieldName = i % 2 == 0 ? "parentaccountid" : "primarycontactid",
+                        ReferencedId = Guid.NewGuid(),
+                        Pattern = "MISSING_PARENT"
+                    }
+                }
+            });
+        }
+
+        var result = new MigrationResult
+        {
+            Success = false,
+            SuccessCount = 90,
+            FailureCount = 10,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(5),
+            Errors = errors
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("parentaccountid");
+        output.Should().Contain("primarycontactid");
+    }
+
+    [Fact]
+    public void Complete_ShowsMissingParentSuggestion()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+
+        var errors = Enumerable.Range(0, 10).Select(_ => new MigrationError
+        {
+            EntityLogicalName = "account",
+            Message = $"account With Id = {Guid.NewGuid()} Does Not Exist"
+        }).ToList();
+
+        var result = new MigrationResult
+        {
+            Success = false,
+            SuccessCount = 0,
+            FailureCount = 10,
+            RecordsProcessed = 10,
+            Duration = TimeSpan.FromSeconds(5),
+            Errors = errors
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("self-referential lookups");
+    }
+
+    #endregion
+
+    #region Complete() — Basic Output
+
+    [Fact]
+    public void Complete_ShowsSuccessMessage_WhenSuccessful()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SuccessCount = 100,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(10)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("Import succeeded.");
+        output.Should().Contain("100 record(s)");
+    }
+
+    [Fact]
+    public void Complete_ShowsErrorMessage_WhenFailed()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = false,
+            SuccessCount = 90,
+            FailureCount = 10,
+            RecordsProcessed = 100,
+            Duration = TimeSpan.FromSeconds(10)
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("Import completed with errors.");
+        output.Should().Contain("10 Error(s)");
+    }
+
+    [Fact]
+    public void Complete_ShowsM2MBreakdown_WhenPresent()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Import" };
+        var result = new MigrationResult
+        {
+            Success = true,
+            SuccessCount = 1100,
+            RecordsProcessed = 1100,
+            Duration = TimeSpan.FromSeconds(10),
+            M2MCount = 100
+        };
+
+        reporter.Complete(result);
+
+        var output = GetOutput();
+        output.Should().Contain("1,000 entities + 100 M2M");
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Migration.Tests/Progress/ErrorReportWriterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ErrorReportWriterTests.cs
@@ -241,6 +241,29 @@ public class ErrorReportWriterTests : IDisposable
 
     #endregion
 
+    [Fact]
+    public async Task WriteAsync_WithMissingParentError_ClassifiesPattern()
+    {
+        var filePath = Path.Combine(_tempDir, "report.json");
+        var result = new ImportResult
+        {
+            RecordsImported = 95,
+            Errors = new List<MigrationError>
+            {
+                new()
+                {
+                    EntityLogicalName = "account",
+                    Message = "account With Id = abc-123 Does Not Exist"
+                }
+            }
+        };
+
+        await ErrorReportWriter.WriteAsync(filePath, result, null, null);
+
+        var json = await File.ReadAllTextAsync(filePath);
+        json.Should().Contain("MISSING_PARENT");
+    }
+
     #region Helper Methods
 
     private static ImportResult CreateBasicImportResult()

--- a/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using PPDS.Dataverse.Pooling;
 using PPDS.Migration.Progress;
 using Xunit;
 
@@ -12,6 +13,7 @@ public class MigrationResultTests
         var result = new MigrationResult();
 
         result.Success.Should().BeFalse();
+        result.SourceRecordCount.Should().BeNull();
         result.RecordsProcessed.Should().Be(0);
         result.SuccessCount.Should().Be(0);
         result.FailureCount.Should().Be(0);
@@ -20,6 +22,7 @@ public class MigrationResultTests
         result.CreatedCount.Should().BeNull();
         result.UpdatedCount.Should().BeNull();
         result.M2MCount.Should().BeNull();
+        result.PoolStatistics.Should().BeNull();
     }
 
     [Fact]
@@ -27,10 +30,17 @@ public class MigrationResultTests
     {
         var duration = TimeSpan.FromMinutes(10);
         var errors = new List<MigrationError> { new() { Message = "Test error" } };
+        var poolStats = new PoolStatistics
+        {
+            RequestsServed = 1234,
+            ThrottleEvents = 5,
+            TotalBackoffTime = TimeSpan.FromSeconds(3)
+        };
 
         var result = new MigrationResult
         {
             Success = true,
+            SourceRecordCount = 5500,
             RecordsProcessed = 5000,
             SuccessCount = 4950,
             FailureCount = 50,
@@ -38,10 +48,12 @@ public class MigrationResultTests
             Errors = errors,
             CreatedCount = 3000,
             UpdatedCount = 1950,
-            M2MCount = 500
+            M2MCount = 500,
+            PoolStatistics = poolStats
         };
 
         result.Success.Should().BeTrue();
+        result.SourceRecordCount.Should().Be(5500);
         result.RecordsProcessed.Should().Be(5000);
         result.SuccessCount.Should().Be(4950);
         result.FailureCount.Should().Be(50);
@@ -50,6 +62,9 @@ public class MigrationResultTests
         result.CreatedCount.Should().Be(3000);
         result.UpdatedCount.Should().Be(1950);
         result.M2MCount.Should().Be(500);
+        result.PoolStatistics.Should().BeSameAs(poolStats);
+        result.PoolStatistics!.RequestsServed.Should().Be(1234);
+        result.PoolStatistics.ThrottleEvents.Should().Be(5);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/MigrationResultTests.cs
@@ -22,6 +22,7 @@ public class MigrationResultTests
         result.CreatedCount.Should().BeNull();
         result.UpdatedCount.Should().BeNull();
         result.M2MCount.Should().BeNull();
+        result.RelationshipsFailed.Should().BeNull();
         result.PoolStatistics.Should().BeNull();
     }
 


### PR DESCRIPTION
## Summary
- **#278** — MISSING_PARENT errors now show lookup field names from diagnostics, with pattern description and actionable suggestions
- **#277** — summary.json includes `relationshipsProcessed` and `relationshipsFailed` fields for M2M tracking
- **#280** — Source vs imported record comparison shown in console output and summary.json when failures exist
- **#279** — API call count (requests, throttles, backoff time) displayed in console completion summary

## Test Plan
- [x] 263 migration tests pass across net8.0/net9.0/net10.0 (13 new tests added)
- [x] ConsoleProgressReporter output verified for all 4 features via unit tests
- [x] MISSING_PARENT classification verified in both ErrorReportWriter and ConsoleProgressReporter
- [x] ImportResult/MigrationResult property defaults and setters verified
- [x] Full solution build (0 errors, 0 warnings)

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: cli)
- [x] /qa completed (surfaces: cli)
- [x] /review completed (findings: 3 — 1 important fixed, 2 pre-existing suggestions noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)