### PR TITLE
fix: 9 V1 bug fixes — TUI crashes, extension regex, migration silent failures

### DIFF
--- a/src/PPDS.Cli/Services/ProfileResolutionService.cs
+++ b/src/PPDS.Cli/Services/ProfileResolutionService.cs
@@ -20,13 +20,15 @@ public sealed class ProfileResolutionService
             if (!string.IsNullOrEmpty(config.Label))
             {
                 if (string.Equals(config.Label, "dbo", StringComparison.OrdinalIgnoreCase))
-                    throw new ArgumentException(
-                        $"'{config.Label}' cannot be used as an environment label (reserved for SQL schema convention).",
-                        nameof(configs));
+                {
+                    TuiDebugLog.Log($"Warning: Environment label '{config.Label}' is reserved (SQL schema convention) — skipping");
+                    continue;
+                }
 
                 if (_labelIndex.ContainsKey(config.Label))
                 {
-                    TuiDebugLog.Log($"Warning: Duplicate environment label '{config.Label}' — using last occurrence");
+                    TuiDebugLog.Log($"Warning: Duplicate environment label '{config.Label}' — keeping first occurrence");
+                    continue;
                 }
 
                 _labelIndex[config.Label] = config;

--- a/src/PPDS.Cli/Tui/PpdsApplication.cs
+++ b/src/PPDS.Cli/Tui/PpdsApplication.cs
@@ -98,8 +98,11 @@ internal sealed class PpdsApplication : IDisposable
 
         // Start warming the connection pool in the background
         // This runs while Terminal.Gui initializes, so connection is ready faster
+        // Note: don't wrap in FireAndForget here — WireInitializationToSplash in TuiShell
+        // already observes this task with proper error handling on the splash screen.
+        // Double-observation via FireAndForget causes a raw "Background operation failed"
+        // message when initialization fails (e.g., no active profile).
         var initTask = _session.InitializeAsync(cancellationToken);
-        _session.GetErrorService().FireAndForget(initTask, "SessionInit");
 
         // Register cancellation to request stop
         using var registration = cancellationToken.Register(() => Application.RequestStop());

--- a/src/PPDS.Extension/src/utils/fetchXmlToSql.ts
+++ b/src/PPDS.Extension/src/utils/fetchXmlToSql.ts
@@ -428,9 +428,14 @@ export class FetchXmlToSqlTranspiler {
 	 * Note: Nested filters are flattened - all conditions are extracted
 	 * and joined with the parent filter's type (AND/OR).
 	 * Captures end position for comment association.
+	 * Limitation: Lazy match stops at the first </filter>, so conditions
+	 * after a nested </filter> within the same parent are not captured.
+	 * This is a trade-off — greedy match incorrectly spans across separate
+	 * entity filters in multi-entity FetchXML, which is worse.
 	 */
 	private parseFilter(xml: string): ParsedFilter | null {
-		// Find the first filter element in the main entity
+		// Find the first filter element — lazy match to avoid spanning across
+		// separate entity filters in multi-entity FetchXML
 		const filterMatch = xml.match(
 			/<filter([^>]*)>([\s\S]*?)<\/filter>/i
 		);

--- a/src/PPDS.Extension/src/utils/fetchXmlToSql.ts
+++ b/src/PPDS.Extension/src/utils/fetchXmlToSql.ts
@@ -432,7 +432,7 @@ export class FetchXmlToSqlTranspiler {
 	private parseFilter(xml: string): ParsedFilter | null {
 		// Find the first filter element in the main entity
 		const filterMatch = xml.match(
-			/<filter([^>]*)>([\s\S]*)<\/filter>/i
+			/<filter([^>]*)>([\s\S]*?)<\/filter>/i
 		);
 
 		if (!filterMatch) {

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -150,7 +150,7 @@ namespace PPDS.Migration.Export
                 });
 
                 var relationshipData = await ExportM2MRelationshipsAsync(
-                    schema, entityData, options, progress, cancellationToken).ConfigureAwait(false);
+                    schema, entityData, options, progress, errors, cancellationToken).ConfigureAwait(false);
 
                 // Write to output file
                 progress?.Report(new ProgressEventArgs
@@ -319,6 +319,7 @@ namespace PPDS.Migration.Export
             ConcurrentDictionary<string, IReadOnlyList<Entity>> entityData,
             ExportOptions options,
             IProgressReporter? progress,
+            ConcurrentBag<MigrationError> errors,
             CancellationToken cancellationToken)
         {
             var result = new Dictionary<string, IReadOnlyList<ManyToManyRelationshipData>>(StringComparer.OrdinalIgnoreCase);
@@ -362,6 +363,12 @@ namespace PPDS.Migration.Export
                     {
                         _logger?.LogWarning(ex, "Failed to export M2M relationship {Relationship} for entity {Entity}",
                             rel.Name, entitySchema.LogicalName);
+                        errors.Add(new MigrationError
+                        {
+                            Phase = MigrationPhase.Exporting,
+                            EntityLogicalName = entitySchema.LogicalName,
+                            Message = $"M2M relationship '{rel.Name}' export failed: {ex.Message}"
+                        });
                     }
                 }
 

--- a/src/PPDS.Migration/Formats/CmtSchemaReader.cs
+++ b/src/PPDS.Migration/Formats/CmtSchemaReader.cs
@@ -138,9 +138,16 @@ namespace PPDS.Migration.Formats
                 }
             }
 
-            // Check for filter element
+            // Check for filter element — use inner XML to preserve nested <filter>/<condition> elements
+            // (.Value only returns concatenated text content, losing element structure)
             var filterElement = element.Element("filter");
-            var fetchXmlFilter = filterElement?.Value;
+            string? fetchXmlFilter = null;
+            if (filterElement != null)
+            {
+                fetchXmlFilter = filterElement.HasElements
+                    ? string.Concat(filterElement.Nodes())
+                    : filterElement.Value;
+            }
 
             return new EntitySchema
             {

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -349,8 +349,7 @@ namespace PPDS.Migration.Import
             }
             catch (Exception ex)
             {
-                // Role lookup failed - this is expected when source role ID doesn't exist in target
-                _logger?.LogDebug(ex, "Role lookup by ID {RoleId} failed (expected for cross-environment migrations)", sourceRoleId);
+                _logger?.LogWarning(ex, "Role lookup by ID {RoleId} failed — role may not exist in target environment", sourceRoleId);
             }
 
             // Role doesn't exist with source ID - this is the common case

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -101,8 +101,8 @@ namespace PPDS.Migration.Import
             _logger?.LogDebug("Processing {Count} M2M operations with parallelism {DOP}",
                 allOperations.Count, parallelism);
 
-            // Track first exception for non-ContinueOnError mode
-            Exception? firstException = null;
+            // Track all exceptions for non-ContinueOnError mode
+            var exceptions = new ConcurrentBag<Exception>();
             var shouldStop = false;
 
             await Parallel.ForEachAsync(
@@ -245,16 +245,19 @@ namespace PPDS.Migration.Import
                             if (!context.Options.ContinueOnError)
                             {
                                 shouldStop = true;
-                                firstException ??= ex;
+                                exceptions.Add(ex);
                             }
                         }
                     }
                 }).ConfigureAwait(false);
 
-            // If we stopped due to an error in non-ContinueOnError mode, rethrow
-            if (firstException != null)
+            // If we stopped due to errors in non-ContinueOnError mode, rethrow all
+            if (!exceptions.IsEmpty)
             {
-                throw firstException;
+                var allExceptions = exceptions.ToArray();
+                throw allExceptions.Length == 1
+                    ? allExceptions[0]
+                    : new AggregateException("Multiple M2M association failures", allExceptions);
             }
 
             // Report final completion (parallel counting may not hit exact total)

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -30,6 +30,11 @@ namespace PPDS.Migration.Import
         private ConcurrentDictionary<string, string>? _relationshipNameCache;
 
         /// <summary>
+        /// Tracks whether the metadata cache load failed, for surfacing to callers.
+        /// </summary>
+        private bool _metadataCacheLoadFailed;
+
+        /// <summary>
         /// Tracks the last reported progress count for throttling.
         /// Thread-safe via Interlocked operations.
         /// </summary>
@@ -281,9 +286,14 @@ namespace PPDS.Migration.Import
                     successCount, stopwatch.ElapsedMilliseconds, parallelism);
             }
 
+            if (_metadataCacheLoadFailed)
+            {
+                _logger?.LogError("M2M relationship metadata cache failed to load — relationship name resolution may have used unresolved names");
+            }
+
             return new PhaseResult
             {
-                Success = failureCount == 0,
+                Success = failureCount == 0 && !_metadataCacheLoadFailed,
                 RecordsProcessed = successCount + failureCount,
                 SuccessCount = successCount,
                 FailureCount = failureCount,
@@ -430,8 +440,8 @@ namespace PPDS.Migration.Import
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Failed to load M2M relationship metadata - relationship name resolution may fail");
-                // Don't throw - we'll try with the original names
+                _logger?.LogError(ex, "Failed to load M2M relationship metadata - relationship name resolution may fail");
+                _metadataCacheLoadFailed = true;
             }
         }
 

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -194,7 +194,7 @@ namespace PPDS.Migration.Import
             }
             finally
             {
-                await EnablePluginsAfterImportAsync(disabledPluginSteps, progress).ConfigureAwait(false);
+                await EnablePluginsAfterImportAsync(disabledPluginSteps, progress, warnings).ConfigureAwait(false);
             }
         }
 
@@ -310,7 +310,8 @@ namespace PPDS.Migration.Import
         /// </summary>
         private async Task EnablePluginsAfterImportAsync(
             IReadOnlyList<Guid> disabledPluginSteps,
-            IProgressReporter? progress)
+            IProgressReporter? progress,
+            IWarningCollector warnings)
         {
             if (disabledPluginSteps.Count == 0 || _pluginStepManager == null)
             {
@@ -333,6 +334,12 @@ namespace PPDS.Migration.Import
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "Failed to re-enable some plugin steps");
+                warnings.AddWarning(new ImportWarning
+                {
+                    Code = ImportWarningCodes.PluginReenableFailed,
+                    Message = $"Failed to re-enable {disabledPluginSteps.Count} plugin steps: {ex.Message}",
+                    Impact = $"{disabledPluginSteps.Count} plugin step(s) may remain disabled"
+                });
             }
         }
 

--- a/tests/PPDS.Cli.Tests/Services/ProfileResolutionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ProfileResolutionServiceTests.cs
@@ -50,35 +50,35 @@ public class ProfileResolutionServiceTests
     }
 
     [Fact]
-    public void Constructor_RejectsReservedDboLabel()
+    public void Constructor_SkipsReservedDboLabel()
     {
         var configs = new List<EnvironmentConfig>
         {
-            new() { Url = "https://dbo.crm.dynamics.com/", Label = "dbo" }
+            new() { Url = "https://dbo.crm.dynamics.com/", Label = "dbo" },
+            new() { Url = "https://uat.crm.dynamics.com/", Label = "UAT" }
         };
 
-        var act = () => new ProfileResolutionService(configs);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("*dbo*reserved*");
+        // Should not throw — "dbo" is silently skipped
+        var service = new ProfileResolutionService(configs);
+        service.ResolveByLabel("dbo").Should().BeNull();
+        service.ResolveByLabel("UAT").Should().NotBeNull();
     }
 
     [Fact]
-    public void Constructor_RejectsReservedDboLabel_CaseInsensitive()
+    public void Constructor_SkipsReservedDboLabel_CaseInsensitive()
     {
         var configs = new List<EnvironmentConfig>
         {
             new() { Url = "https://dbo.crm.dynamics.com/", Label = "DBO" }
         };
 
-        var act = () => new ProfileResolutionService(configs);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("*DBO*reserved*");
+        // Should not throw — "DBO" is silently skipped (case-insensitive)
+        var service = new ProfileResolutionService(configs);
+        service.ResolveByLabel("DBO").Should().BeNull();
     }
 
     [Fact]
-    public void Constructor_DuplicateLabels_UsesLastWriteWins()
+    public void Constructor_DuplicateLabels_KeepsFirstOccurrence()
     {
         var configs = new[]
         {
@@ -86,12 +86,11 @@ public class ProfileResolutionServiceTests
             new EnvironmentConfig { Label = "uat", Url = "https://uat2.crm.dynamics.com/" }
         };
 
-        // Should not throw — last-write-wins prevents TUI crash on orphaned configs
+        // Should not throw — first occurrence wins, duplicate is skipped
         var service = new ProfileResolutionService(configs);
 
-        // The second config (uat2) should win
         var resolved = service.ResolveByLabel("UAT");
         resolved.Should().NotBeNull();
-        resolved!.Url.Should().Be("https://uat2.crm.dynamics.com/");
+        resolved!.Url.Should().Be("https://uat.crm.dynamics.com/");
     }
 }


### PR DESCRIPTION
## Summary

- **TUI crashes (2):** Handle duplicate/reserved environment labels gracefully instead of throwing (#602); remove redundant FireAndForget that caused "Background operation failed" on splash with no profile (#596)
- **Extension regex (1):** Fix greedy `[\s\S]*` → lazy `[\s\S]*?` in parseFilter for correct multi-entity FetchXML-to-SQL (#565)
- **Migration silent failures (6):** Surface M2M export errors in ExportResult (#446); surface plugin re-enable failures as warnings (#445); surface metadata cache load failures (#457); preserve all M2M exceptions via AggregateException (#456); upgrade LookupRoleByIdAsync logging to warning (#452); use inner XML for nested filter parsing in CmtSchemaReader (#500)

## Test Plan

- [x] .NET build: 0 errors, 0 warnings
- [x] .NET tests: 12,000+ passing across net8/9/10 (includes updated ProfileResolutionServiceTests)
- [x] Extension typecheck + lint: clean
- [x] Extension tests: 334/334 passing
- [x] TUI E2E: 12/12 tests, 4/4 snapshots match
- [x] TUI interactive: splash loads cleanly, no error messages, menu/profile/SQL query all functional

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: tui, ext)
- [x] /qa completed (surfaces: tui, ext)
- [x] /review completed (findings: 5 — 1 fixed, 4 dismissed as pre-existing or non-regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)