### PR TITLE
feat: session persistence for TUI filters and Extension (#288)

### DIFF
--- a/docs/plans/2026-03-23-session-persistence.md
+++ b/docs/plans/2026-03-23-session-persistence.md
@@ -1,0 +1,322 @@
+# Session Persistence — Implementation Plan
+
+**Date:** 2026-03-23
+**Spec:** [specs/session-persistence.md](../../specs/session-persistence.md)
+**Branch:** `feature/session-persistence`
+**Issue:** #288
+
+---
+
+## Dependency Graph
+
+```
+Step 1: TuiStateStore + state records + ProfilePaths ─────┐
+         │                                                  │
+Step 2: Wire into InteractiveSession (DI) ─────────────────┤
+         │                                                  │
+    ┌────┴────┬──────────┬──────────┐                       │
+    v         v          v          v                       │
+Step 3:   Step 4:    Step 5:    Step 6:                     │
+WebRes    ConnRef    EnvVars    PluginTr                    │
+                                                            │
+Step 7: Extension EnvironmentVariablesPanel (independent) ──┘
+         │
+Step 8: Cross-surface verification
+```
+
+Steps 3–6 are parallel (independent screens).
+Step 7 is independent of all TUI steps (can run in parallel with everything).
+
+---
+
+## Step 1: TuiStateStore + State Records
+
+**Files:**
+- `src/PPDS.Auth/Profiles/ProfilePaths.cs` — add `TuiStateFile` property
+- `src/PPDS.Cli/Services/Settings/TuiStateStore.cs` (new)
+- `src/PPDS.Cli/Services/Settings/ScreenState.cs` (new)
+- `tests/PPDS.Cli.Tests/Services/Settings/TuiStateStoreTests.cs` (new)
+
+### 1a. Add `TuiStateFile` to ProfilePaths
+
+Add property following the existing `EnvironmentsFile` pattern:
+
+```csharp
+public static string TuiStateFile => Path.Combine(ConfigDirectory, "tui-state.json");
+```
+
+### 1b. Create state records
+
+```csharp
+// ScreenState.cs
+internal sealed record WebResourcesScreenState
+{
+    public Guid? SelectedSolutionId { get; init; }
+    public bool TextOnly { get; init; } = true;
+}
+
+internal sealed record SolutionFilterScreenState
+{
+    public string? SolutionFilter { get; init; }
+}
+
+// PluginTraceFilter is already a serializable record in PPDS.Dataverse — reuse directly
+```
+
+### 1c. Create TuiStateStore
+
+Follow `EnvironmentConfigStore` patterns:
+- `SemaphoreSlim` for thread safety
+- In-memory cache after first load
+- Atomic file writes (write temp, rename)
+- Graceful handling of missing/corrupt files
+
+```csharp
+internal sealed class TuiStateStore
+{
+    Task<T?> LoadScreenStateAsync<T>(string screenKey, string environmentUrl, CancellationToken ct = default);
+    Task SaveScreenStateAsync<T>(string screenKey, string environmentUrl, T state, CancellationToken ct = default);
+    Task ClearScreenStateAsync(string screenKey, string environmentUrl, CancellationToken ct = default);
+}
+```
+
+Environment URLs normalized to lowercase with trailing slash (match `EnvironmentConfigStore` convention).
+
+JSON structure: `{ "version": 1, "screens": { "<envUrl>": { "<screenKey>": { ... } } } }`
+
+### 1d. Unit tests
+
+| Test | Validates |
+|------|-----------|
+| `SaveAndLoad_RoundTrips` | Basic save + load returns same state |
+| `Load_MissingFile_ReturnsNull` | No file → null, no exception |
+| `Load_CorruptFile_ReturnsNull` | Malformed JSON → null, no exception |
+| `Save_CreatesFileIfMissing` | First save creates file and directory |
+| `StateIsScopedPerEnvironment` | Same screen key, different env URLs → independent state |
+| `StateIsScopedPerScreen` | Same env URL, different screen keys → independent state |
+| `EnvironmentUrl_Normalized` | Case-insensitive, trailing slash normalized |
+| `Save_PreservesOtherScreenState` | Saving one screen doesn't clobber another |
+| `ConcurrentSaves_DoNotCorrupt` | Parallel saves don't produce malformed JSON |
+
+**Gate:** `dotnet test --filter "FullyQualifiedName~TuiStateStoreTests"`
+
+---
+
+## Step 2: Wire TuiStateStore into InteractiveSession
+
+**Files:**
+- `src/PPDS.Cli/Tui/InteractiveSession.cs` — add `TuiStateStore` field + accessor
+- `src/PPDS.Cli/Tui/PpdsApplication.cs` — create `TuiStateStore` and pass to `InteractiveSession`
+
+### 2a. Create TuiStateStore in PpdsApplication.Run()
+
+Construct alongside existing `ProfileStore`:
+
+```csharp
+var stateStore = new TuiStateStore(ProfilePaths.TuiStateFile);
+```
+
+Pass to `InteractiveSession` constructor.
+
+### 2b. Expose from InteractiveSession
+
+Add a `GetTuiStateStore()` method (or property) so screens can access it. Follow the existing `GetErrorService()` / `GetProfileService()` pattern.
+
+**Gate:** `dotnet build src/PPDS.Cli/PPDS.Cli.csproj`
+
+---
+
+## Step 3: WebResourcesScreen Integration
+
+**Files:**
+- `src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs`
+
+### 3a. Restore state on construction
+
+In the constructor (or `OnActivated`), after `EnvironmentUrl` is set:
+
+```csharp
+var state = await session.GetTuiStateStore()
+    .LoadScreenStateAsync<WebResourcesScreenState>("WebResources", EnvironmentUrl);
+if (state != null)
+{
+    _selectedSolutionId = state.SelectedSolutionId;
+    _textOnly = state.TextOnly;
+}
+```
+
+### 3b. Save state on filter change
+
+After `_selectedSolutionId` changes (in the solution filter dialog handler) and after `_textOnly` toggles (Ctrl+T handler):
+
+```csharp
+ErrorService.FireAndForget(
+    session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl,
+        new WebResourcesScreenState { SelectedSolutionId = _selectedSolutionId, TextOnly = _textOnly }),
+    "WebResources.SaveState");
+```
+
+### 3c. Stale reference handling
+
+After loading solutions list, check if `_selectedSolutionId` is in the list. If not:
+- Show status: "Previously filtered solution not found — showing all"
+- Clear `_selectedSolutionId` to null
+- Save cleared state
+
+**Gate:** `dotnet test --filter "Category=TuiUnit"` + manual verification
+
+---
+
+## Step 4: ConnectionReferencesScreen Integration
+
+**Files:**
+- `src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs`
+
+Same pattern as Step 3 but with `SolutionFilterScreenState` and `_solutionFilter` (string).
+
+### 4a. Restore state on construction
+
+```csharp
+var state = await session.GetTuiStateStore()
+    .LoadScreenStateAsync<SolutionFilterScreenState>("ConnectionReferences", EnvironmentUrl);
+if (state != null)
+    _solutionFilter = state.SolutionFilter;
+```
+
+### 4b. Save state on filter change
+
+After solution filter dialog sets `_solutionFilter`:
+
+```csharp
+ErrorService.FireAndForget(
+    session.GetTuiStateStore().SaveScreenStateAsync("ConnectionReferences", EnvironmentUrl,
+        new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
+    "ConnectionReferences.SaveState");
+```
+
+### 4c. Stale reference handling
+
+After loading solutions list in the filter dialog, check if `_solutionFilter` matches any solution name. If not, show message and clear.
+
+**Gate:** `dotnet test --filter "Category=TuiUnit"` + manual verification
+
+---
+
+## Step 5: EnvironmentVariablesScreen Integration
+
+**Files:**
+- `src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs`
+
+Identical pattern to Step 4 — uses `SolutionFilterScreenState` with screen key `"EnvironmentVariables"`.
+
+**Gate:** `dotnet test --filter "Category=TuiUnit"` + manual verification
+
+---
+
+## Step 6: PluginTracesScreen Integration
+
+**Files:**
+- `src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs`
+
+### 6a. Restore state on construction
+
+```csharp
+var filter = await session.GetTuiStateStore()
+    .LoadScreenStateAsync<PluginTraceFilter>("PluginTraces", EnvironmentUrl);
+if (filter != null)
+    _currentFilter = filter;
+```
+
+### 6b. Save state on filter change
+
+After `PluginTraceFilterDialog` returns a non-null filter:
+
+```csharp
+ErrorService.FireAndForget(
+    session.GetTuiStateStore().SaveScreenStateAsync("PluginTraces", EnvironmentUrl, _currentFilter),
+    "PluginTraces.SaveState");
+```
+
+Also save when filter is cleared (save null/clear state).
+
+### 6c. No stale reference handling needed
+
+PluginTraceFilter fields are query parameters, not references to entities that can be deleted. Stale date ranges simply return 0 results — which is expected and visible in the filter dialog.
+
+**Gate:** `dotnet test --filter "Category=TuiUnit"` + manual verification
+
+---
+
+## Step 7: Extension EnvironmentVariablesPanel
+
+**Files:**
+- `src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts`
+- Callers of `EnvironmentVariablesPanel.show()` (to pass `context`)
+
+This step is fully independent of TUI work.
+
+### 7a. Add `context` parameter
+
+Add `context: vscode.ExtensionContext` to the private constructor and `static show()` factory, matching WebResourcesPanel's signature.
+
+### 7b. Restore on creation
+
+In constructor, after existing initialization:
+
+```typescript
+this.solutionFilter = this.context.globalState.get<string | null>(
+    'ppds.environmentVariables.solutionFilter', null);
+```
+
+### 7c. Save on change
+
+In the `filterBySolution` message handler:
+
+```typescript
+case 'filterBySolution':
+    this.solutionFilter = message.solutionId;
+    void this.context.globalState.update('ppds.environmentVariables.solutionFilter', this.solutionFilter);
+    await this.loadEnvironmentVariables();
+    break;
+```
+
+### 7d. Clear on environment change
+
+In `onEnvironmentChanged()`:
+
+```typescript
+this.solutionFilter = null;
+void this.context.globalState.update('ppds.environmentVariables.solutionFilter', null);
+```
+
+### 7e. Update callers
+
+Find all call sites of `EnvironmentVariablesPanel.show()` and pass `context`. Follow the pattern from WebResourcesPanel call sites.
+
+**Gate:** `npm run ext:test` + `npm run ext:lint`
+
+---
+
+## Step 8: Cross-Surface Verification
+
+Manual verification checklist (not automated):
+
+- [ ] TUI: Open WebResources, filter to a solution, close TUI, reopen — filter restored
+- [ ] TUI: Open ConnectionReferences on env A with filter, switch to env B, open ConnectionReferences — no filter (independent)
+- [ ] TUI: Open PluginTraces, set filter with date range, close TUI, reopen — full filter restored including dates
+- [ ] TUI: Delete a solution, reopen screen that was filtered to it — stale message shown, view unfiltered
+- [ ] TUI: First launch (no tui-state.json) — all screens start unfiltered, no errors
+- [ ] Extension: Open EnvironmentVariablesPanel, filter to solution, close panel, reopen — filter restored
+- [ ] Extension: Switch environment — filter cleared
+- [ ] Confirm `tui-state.json` contains no secrets (only solution names/IDs and filter criteria)
+
+---
+
+## Risk Register
+
+| Risk | Mitigation |
+|------|------------|
+| Async state load delays screen rendering | Load state before `LoadDataAsync()` — state is local file I/O (~1ms), not a Dataverse call |
+| TuiStateStore generic deserialization fails for PluginTraceFilter enums | Use `System.Text.Json` with `JsonStringEnumConverter` — test in Step 1 |
+| Extension callers of `EnvironmentVariablesPanel.show()` are numerous | Grep for all call sites before starting Step 7 |
+| Concurrent TUI instances writing tui-state.json | SemaphoreSlim guards within-process; cross-process is last-write-wins (acceptable for filter state) |

--- a/specs/session-persistence.md
+++ b/specs/session-persistence.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Last Updated:** 2026-03-23
-**Code:** [src/PPDS.Cli/Tui/](../src/PPDS.Cli/Tui/), [src/PPDS.Extension/src/panels/](../src/PPDS.Extension/src/panels/)
+**Code:** [src/PPDS.Cli/Services/Settings/](../src/PPDS.Cli/Services/Settings/), [src/PPDS.Cli/Tui/](../src/PPDS.Cli/Tui/), [src/PPDS.Extension/src/panels/](../src/PPDS.Extension/src/panels/)
 **Surfaces:** TUI | Extension
 
 ---

--- a/specs/session-persistence.md
+++ b/specs/session-persistence.md
@@ -1,0 +1,387 @@
+# Session Persistence
+
+**Status:** Draft
+**Last Updated:** 2026-03-23
+**Code:** [src/PPDS.Cli/Tui/](../src/PPDS.Cli/Tui/), [src/PPDS.Extension/src/panels/](../src/PPDS.Extension/src/panels/)
+**Surfaces:** TUI | Extension
+
+---
+
+## Overview
+
+Persists user filter selections across sessions so users don't have to re-configure their view every time they open a screen. TUI screens remember solution filters and settings per environment in a dedicated state file. The Extension's EnvironmentVariablesPanel is updated to persist its solution filter to `globalState`, matching the existing WebResourcesPanel pattern.
+
+### Goals
+
+- **Reduce friction**: Filter selections survive TUI restarts — screens open pre-filtered to the user's last selection for that environment
+- **Extension parity**: EnvironmentVariablesPanel persists solution filter like WebResourcesPanel already does
+
+### Non-Goals
+
+- Persisting open tab layout or tab order across TUI sessions
+- TUI profile switch persistence (`activeProfileIndex` from Alt+P) — separate concern
+- CLI session persistence (CLI is stateless by design)
+- MCP session persistence (locked at startup per Constitution SS2)
+- Persisting scroll positions, selected rows, or cursor state
+- Query history persistence (separate feature)
+
+---
+
+## Architecture
+
+```
+TUI Screen                    TuiStateStore
+┌──────────────────┐         ┌──────────────────────┐
+│ WebResourcesScreen│────────▶│ LoadAsync(screenKey,  │
+│ _selectedSolutionId│        │           envUrl)     │
+│ _textOnly          │◀───────│ SaveAsync(screenKey,  │
+└──────────────────┘         │           envUrl,     │
+                             │           state)      │
+┌──────────────────┐         │                       │
+│ PluginTracesScreen│────────▶│                       │
+│ _currentFilter    │◀───────│  ~/.ppds/tui-state.json│
+└──────────────────┘         └──────────────────────┘
+
+Extension
+┌──────────────────────────┐
+│ EnvironmentVariablesPanel │──▶ context.globalState
+│ solutionFilter            │     ppds.environmentVariables.solutionFilter
+└──────────────────────────┘
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `TuiStateStore` | Read/write `tui-state.json` with async I/O and semaphore locking |
+| `TuiScreenState` | Serializable state models per screen type |
+| Screen integration | Each screen saves state on filter change, restores on construction |
+| `EnvironmentVariablesPanel` | Extension panel updated to persist solution filter to `globalState` |
+
+### Dependencies
+
+- Uses patterns from: [architecture.md](./architecture.md) (Application Services, `IProgressReporter`)
+- Related: [web-resources.md](./web-resources.md), [connection-references.md](./connection-references.md), [environment-variables.md](./environment-variables.md), [plugin-traces.md](./plugin-traces.md)
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. TUI filter selections persist to `~/.ppds/tui-state.json` (or `%LOCALAPPDATA%\PPDS\tui-state.json` on Windows), keyed by `(screenType, environmentUrl)`
+2. State is loaded when a screen is constructed and applied before first data load
+3. State is saved whenever the user changes a filter selection
+4. Persistence is always on — no setting to enable/disable
+5. Stale references (persisted solution no longer exists) produce a visible status message, clear the persisted value, and show unfiltered results
+6. Extension EnvironmentVariablesPanel persists `solutionFilter` to `context.globalState` following the WebResourcesPanel pattern
+
+### State Per Screen
+
+| Screen | Persisted Fields | Storage Key |
+|--------|-----------------|-------------|
+| WebResourcesScreen | `selectedSolutionId` (Guid?), `textOnly` (bool) | `WebResources` |
+| ConnectionReferencesScreen | `solutionFilter` (string?) | `ConnectionReferences` |
+| EnvironmentVariablesScreen | `solutionFilter` (string?) | `EnvironmentVariables` |
+| PluginTracesScreen | `currentFilter` (PluginTraceFilter?) | `PluginTraces` |
+
+### File Format
+
+```json
+{
+  "version": 1,
+  "screens": {
+    "https://contoso-dev.crm.dynamics.com": {
+      "WebResources": {
+        "selectedSolutionId": "a1b2c3d4-...",
+        "textOnly": true
+      },
+      "ConnectionReferences": {
+        "solutionFilter": "ContosoCore"
+      },
+      "EnvironmentVariables": {
+        "solutionFilter": "ContosoCore"
+      },
+      "PluginTraces": {
+        "currentFilter": {
+          "typeName": "ContosoPlugins.AccountHandler",
+          "messageName": "Update",
+          "hasException": true
+        }
+      }
+    },
+    "https://contoso-qa.crm.dynamics.com": {
+      "WebResources": {
+        "selectedSolutionId": "e5f6g7h8-...",
+        "textOnly": false
+      }
+    }
+  }
+}
+```
+
+Environment URLs are normalized (lowercase, trailing slash) to match `EnvironmentConfigStore` conventions.
+
+### Primary Flows
+
+**Save flow (on filter change):**
+
+1. **User changes filter**: User selects a solution in the filter dropdown or applies a PluginTraceFilter
+2. **Screen updates in-memory state**: Existing behavior, unchanged
+3. **Screen saves to store**: `await _stateStore.SaveAsync(screenKey, envUrl, state)`
+4. **Store writes file**: Merges into existing JSON, writes atomically
+
+**Restore flow (on screen construction):**
+
+1. **Screen constructs**: TuiScreenBase passes `TuiStateStore` to screen
+2. **Screen loads state**: `var state = await _stateStore.LoadAsync<T>(screenKey, envUrl)`
+3. **Screen applies state**: Sets `_solutionFilter` / `_selectedSolutionId` / `_currentFilter` from loaded state
+4. **Screen loads data**: Existing `LoadDataAsync()` runs with restored filter applied
+
+**Stale reference flow:**
+
+1. **Screen restores filter**: Loads persisted `solutionFilter = "DeletedSolution"`
+2. **Screen loads data**: Service returns results; filter yields 0 matches or solution not found in dropdown
+3. **Screen detects staleness**: Solution name/ID not present in the fetched solutions list
+4. **Screen shows message**: Status label shows "Previously filtered solution 'DeletedSolution' not found — showing all"
+5. **Screen clears filter**: Resets to unfiltered view and saves cleared state to store
+
+### Surface-Specific Behavior
+
+#### TUI Surface
+
+**TuiStateStore** follows `EnvironmentConfigStore` patterns:
+- JSON file at `ProfilePaths.TuiStateFile` (new property)
+- `SemaphoreSlim` for concurrent access safety
+- `LoadAsync()` / `SaveAsync()` with cancellation support
+- File created on first write (not on TUI startup)
+
+**Screen integration pattern** (each screen):
+```csharp
+// In constructor or OnActivated, after environment is known
+var state = await stateStore.LoadScreenStateAsync<WebResourcesState>(
+    "WebResources", EnvironmentUrl);
+if (state != null)
+{
+    _selectedSolutionId = state.SelectedSolutionId;
+    _textOnly = state.TextOnly;
+}
+
+// After filter change
+await stateStore.SaveScreenStateAsync(
+    "WebResources", EnvironmentUrl,
+    new WebResourcesState { SelectedSolutionId = _selectedSolutionId, TextOnly = _textOnly });
+```
+
+**State is saved fire-and-forget** via `ErrorService.FireAndForget()` — filter persistence should never block UI interaction.
+
+#### Extension Surface
+
+**EnvironmentVariablesPanel** changes:
+1. Add `context: vscode.ExtensionContext` parameter to constructor and `show()` factory
+2. Restore `solutionFilter` from `context.globalState.get<string | null>('ppds.environmentVariables.solutionFilter', null)` in constructor
+3. Save on change: `context.globalState.update('ppds.environmentVariables.solutionFilter', this.solutionFilter)` in `filterBySolution` handler
+4. Clear on environment change: `context.globalState.update('ppds.environmentVariables.solutionFilter', null)` in `onEnvironmentChanged`
+
+This matches the WebResourcesPanel pattern exactly.
+
+### Constraints
+
+- `tui-state.json` must not contain secrets — it stores only solution names, IDs, and filter criteria
+- File writes are atomic (write to temp file, rename) to prevent corruption from crashes
+- State store must tolerate missing or malformed files gracefully (treat as empty state)
+- PluginTraceFilter is serialized as-is — all fields including dates and GUIDs. Stale date filters are visible to the user in the filter dialog; they can clear them.
+- Constitution SS1 applies: persisted state is a default for new screens, not a live binding. Opening a second screen of the same type on the same environment does NOT share filter state with the first.
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | WebResourcesScreen restores `selectedSolutionId` and `textOnly` from `tui-state.json` on construction | `TuiStateStoreTests.RestoresWebResourcesState` | 🔲 |
+| AC-02 | WebResourcesScreen saves state to `tui-state.json` when solution filter changes | `TuiStateStoreTests.SavesWebResourcesState` | 🔲 |
+| AC-03 | ConnectionReferencesScreen restores `solutionFilter` from `tui-state.json` on construction | `TuiStateStoreTests.RestoresConnectionReferencesState` | 🔲 |
+| AC-04 | ConnectionReferencesScreen saves state when solution filter changes | `TuiStateStoreTests.SavesConnectionReferencesState` | 🔲 |
+| AC-05 | EnvironmentVariablesScreen restores `solutionFilter` from `tui-state.json` on construction | `TuiStateStoreTests.RestoresEnvironmentVariablesState` | 🔲 |
+| AC-06 | EnvironmentVariablesScreen saves state when solution filter changes | `TuiStateStoreTests.SavesEnvironmentVariablesState` | 🔲 |
+| AC-07 | PluginTracesScreen restores full `PluginTraceFilter` from `tui-state.json` on construction | `TuiStateStoreTests.RestoresPluginTracesState` | 🔲 |
+| AC-08 | PluginTracesScreen saves full `PluginTraceFilter` when filter is applied | `TuiStateStoreTests.SavesPluginTracesState` | 🔲 |
+| AC-09 | State is scoped per environment — same screen on different environments has independent state | `TuiStateStoreTests.StateIsScopedPerEnvironment` | 🔲 |
+| AC-10 | Stale solution filter shows visible message and clears to unfiltered view | `TuiStateStoreTests.StaleFilterShowsMessageAndClears` | 🔲 |
+| AC-11 | Missing or malformed `tui-state.json` is handled gracefully (treated as empty) | `TuiStateStoreTests.HandlesMissingFile` | 🔲 |
+| AC-12 | Extension EnvironmentVariablesPanel restores solution filter from `globalState` on creation | `EnvironmentVariablesPanelTests.RestoresSolutionFilter` | 🔲 |
+| AC-13 | Extension EnvironmentVariablesPanel saves solution filter to `globalState` on change | `EnvironmentVariablesPanelTests.SavesSolutionFilter` | 🔲 |
+| AC-14 | Extension EnvironmentVariablesPanel clears solution filter on environment change | `EnvironmentVariablesPanelTests.ClearsSolutionFilterOnEnvChange` | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| First launch (no tui-state.json) | File doesn't exist | All screens start unfiltered, file created on first filter change |
+| Corrupted JSON | Malformed file content | Log warning, treat as empty state, overwrite on next save |
+| Environment URL casing | `HTTPS://Contoso.CRM.dynamics.com` | Normalized to lowercase before lookup |
+| Concurrent TUI instances | Two TUI processes write simultaneously | SemaphoreSlim prevents corruption within process; last-write-wins across processes |
+| Unknown screen key in file | Future screen type added, old file lacks it | Returns null state, screen starts unfiltered |
+| Extra keys in file | Old screen type removed, file still has its state | Ignored on load, preserved on save (forward compatibility) |
+
+---
+
+## Core Types
+
+### TuiStateStore
+
+Persistent storage for TUI screen state, following `EnvironmentConfigStore` patterns.
+
+```csharp
+internal sealed class TuiStateStore
+{
+    Task<T?> LoadScreenStateAsync<T>(string screenKey, string environmentUrl, CancellationToken ct = default);
+    Task SaveScreenStateAsync<T>(string screenKey, string environmentUrl, T state, CancellationToken ct = default);
+    Task ClearScreenStateAsync(string screenKey, string environmentUrl, CancellationToken ct = default);
+}
+```
+
+### Screen State Records
+
+```csharp
+internal sealed record WebResourcesScreenState
+{
+    public Guid? SelectedSolutionId { get; init; }
+    public bool TextOnly { get; init; } = true;
+}
+
+internal sealed record SolutionFilterScreenState
+{
+    public string? SolutionFilter { get; init; }
+}
+
+// PluginTraceFilter is already a serializable record — used directly
+```
+
+`SolutionFilterScreenState` is shared by ConnectionReferencesScreen and EnvironmentVariablesScreen since they have identical state shape.
+
+---
+
+## Error Handling
+
+### Error Types
+
+| Error | Condition | Recovery |
+|-------|-----------|----------|
+| File not found | First launch or file deleted | Return null state; file created on first save |
+| JSON parse error | Corrupted or hand-edited file | Log warning, return null state, overwrite on next save |
+| IO exception on save | Disk full, permissions | Log error via `ErrorService`, don't block UI. State lost for this change only. |
+| Stale solution reference | Persisted solution not in environment | Show status message, clear filter, save cleared state |
+
+### Recovery Strategies
+
+- **Read failures**: Always recoverable — return empty state, let user start fresh
+- **Write failures**: Non-blocking — fire-and-forget save, log error, user's in-memory state is unaffected
+
+---
+
+## Design Decisions
+
+### Why a separate `tui-state.json` file?
+
+**Context:** Need to persist TUI screen filter state. Could extend `profiles.json`, `environments.json`, or create a new file.
+
+**Decision:** New dedicated file `tui-state.json` in the PPDS config directory.
+
+**Alternatives considered:**
+- Extend `environments.json`: Rejected — mixes UI state with environment metadata (labels, colors, safety settings). TUI state is irrelevant to Extension and CLI consumers of this file.
+- Extend `profiles.json`: Rejected — filters are per-environment, not per-profile. Data model mismatch.
+- Per-screen files: Rejected — unnecessary complexity. One file with nested keys is sufficient.
+
+**Consequences:**
+- Positive: Clean separation of concerns. Existing config files unchanged. Schema can evolve independently.
+- Negative: One more file in `~/.ppds/`. Acceptable — it's a config directory.
+
+### Why always-on (no setting)?
+
+**Context:** Original issue proposed `tui.rememberSession` defaulting to false.
+
+**Decision:** Persistence is always on. No setting.
+
+**Alternatives considered:**
+- Opt-in setting: Rejected — adds config surface area for a feature nobody would turn off. Remembering a dropdown selection is table-stakes UX, not a behavioral change that needs a toggle.
+
+**Consequences:**
+- Positive: Zero configuration. Every user benefits immediately.
+- Negative: No escape hatch. Acceptable — clearing a filter is one keypress.
+
+### Why visible fallback for stale references?
+
+**Context:** Persisted solution may no longer exist in the environment.
+
+**Decision:** Show a status message ("Previously filtered solution 'X' not found — showing all"), clear the stale value, and show unfiltered results.
+
+**Alternatives considered:**
+- Silent fallback: Rejected — violates the spirit of Constitution I4. Silently changing the user's view without explanation is confusing.
+- Keep stale filter (show empty): Rejected — "0 results" with no explanation of why is worse UX than the brief notification.
+
+**Consequences:**
+- Positive: User knows why their view changed. Stale state self-heals.
+- Negative: Requires staleness detection logic per screen. Acceptable — it's a simple "is my filter value in the loaded list?" check.
+
+### Why persist full PluginTraceFilter including dates?
+
+**Context:** PluginTraceFilter has ephemeral fields (dates, correlation IDs) that may be stale on next launch.
+
+**Decision:** Persist the full object. All fields including dates and GUIDs.
+
+**Alternatives considered:**
+- Persist only stable fields: Rejected — adds complexity (partial serialization), and the filter dialog already shows all fields visibly. Users can see stale dates and clear them.
+
+**Consequences:**
+- Positive: Simple serialization. No field-by-field logic.
+- Negative: Users may see 0 results from stale date filters. Acceptable — the filter is visible in the dialog and easy to modify.
+
+---
+
+## Extension Points
+
+### Adding Persistence to a New TUI Screen
+
+1. **Define state record**: Create a `record` with the fields to persist (or reuse `SolutionFilterScreenState`)
+2. **Choose screen key**: Add a constant string key (e.g., `"NewScreen"`)
+3. **Load on construction**: Call `stateStore.LoadScreenStateAsync<T>(key, envUrl)` and apply
+4. **Save on change**: Call `stateStore.SaveScreenStateAsync(key, envUrl, state)` after filter updates
+5. **Handle staleness**: Check if restored filter value exists in loaded data; show message and clear if not
+
+---
+
+## Configuration
+
+| Setting | Type | Required | Default | Description |
+|---------|------|----------|---------|-------------|
+| N/A | — | — | — | No configuration. Persistence is always on. |
+
+**File location:** `ProfilePaths.TuiStateFile` → `{configDir}/tui-state.json`
+
+---
+
+## Related Specs
+
+- [web-resources.md](./web-resources.md) - WebResourcesScreen filter persistence
+- [connection-references.md](./connection-references.md) - ConnectionReferencesScreen filter persistence
+- [environment-variables.md](./environment-variables.md) - EnvironmentVariablesScreen filter persistence (TUI + Extension)
+- [plugin-traces.md](./plugin-traces.md) - PluginTracesScreen filter persistence
+- [tui.md](./tui.md) - TUI architecture and screen lifecycle
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-03-23 | Initial spec |
+
+---
+
+## Roadmap
+
+- Persist TUI profile switch (`activeProfileIndex` on Alt+P) — currently session-only
+- Persist open tab layout across TUI sessions
+- Persist additional screen settings (e.g., SolutionsScreen managed/unmanaged toggle)

--- a/src/PPDS.Auth/Profiles/ProfilePaths.cs
+++ b/src/PPDS.Auth/Profiles/ProfilePaths.cs
@@ -39,6 +39,11 @@ public static class ProfilePaths
     public const string CredentialCacheFileName = "ppds.credentials.dat";
 
     /// <summary>
+    /// TUI state persistence file name.
+    /// </summary>
+    public const string TuiStateFileName = "tui-state.json";
+
+    /// <summary>
     /// Gets the PPDS data directory for the current platform.
     /// </summary>
     /// <remarks>
@@ -89,6 +94,11 @@ public static class ProfilePaths
     /// Gets the full path to the secure credential cache file.
     /// </summary>
     public static string CredentialCacheFile => Path.Combine(DataDirectory, CredentialCacheFileName);
+
+    /// <summary>
+    /// Gets the full path to the TUI state persistence file.
+    /// </summary>
+    public static string TuiStateFile => Path.Combine(DataDirectory, TuiStateFileName);
 
     /// <summary>
     /// Ensures the data directory exists.

--- a/src/PPDS.Cli/Services/Settings/ScreenState.cs
+++ b/src/PPDS.Cli/Services/Settings/ScreenState.cs
@@ -1,0 +1,18 @@
+namespace PPDS.Cli.Services.Settings;
+
+/// <summary>
+/// Persisted state for WebResourcesScreen.
+/// </summary>
+internal sealed record WebResourcesScreenState
+{
+    public Guid? SelectedSolutionId { get; init; }
+    public bool TextOnly { get; init; } = true;
+}
+
+/// <summary>
+/// Persisted state for screens with a solution name filter (ConnectionReferences, EnvironmentVariables).
+/// </summary>
+internal sealed record SolutionFilterScreenState
+{
+    public string? SolutionFilter { get; init; }
+}

--- a/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
+++ b/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
@@ -208,7 +208,7 @@ internal sealed class TuiStateStore : IDisposable
             _cached = JsonSerializer.Deserialize<TuiStateCollection>(json, JsonOptions);
             return _cached;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             return null;
         }
@@ -232,7 +232,7 @@ internal sealed class TuiStateStore : IDisposable
             _cached = JsonSerializer.Deserialize<TuiStateCollection>(json, JsonOptions);
             return _cached;
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
             return null;
         }
@@ -244,7 +244,9 @@ internal sealed class TuiStateStore : IDisposable
     /// </summary>
     private async Task PersistAsync(TuiStateCollection collection, CancellationToken ct)
     {
-        ProfilePaths.EnsureDirectoryExists();
+        var dir = Path.GetDirectoryName(_filePath);
+        if (dir != null && !Directory.Exists(dir))
+            Directory.CreateDirectory(dir);
         collection.Version = 1;
 
         var json = JsonSerializer.Serialize(collection, JsonOptions);

--- a/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
+++ b/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
@@ -72,6 +72,43 @@ internal sealed class TuiStateStore : IDisposable
     }
 
     /// <summary>
+    /// Synchronously loads the state for a specific screen and environment.
+    /// Intended for use in constructors where async is not available.
+    /// Returns null if no state is persisted or the file is missing/corrupt.
+    /// </summary>
+    public T? LoadScreenState<T>(string screenKey, string environmentUrl) where T : class
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(screenKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentUrl);
+
+        _lock.Wait();
+        try
+        {
+            var collection = LoadCollection();
+            if (collection == null)
+                return null;
+
+            var normalizedUrl = NormalizeUrl(environmentUrl);
+            if (!collection.Screens.TryGetValue(normalizedUrl, out var screenDict))
+                return null;
+
+            if (!screenDict.TryGetValue(screenKey, out var element))
+                return null;
+
+            return JsonSerializer.Deserialize<T>(element, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
     /// Saves the state for a specific screen and environment, merging into existing data.
     /// </summary>
     public async Task SaveScreenStateAsync<T>(
@@ -168,6 +205,30 @@ internal sealed class TuiStateStore : IDisposable
         try
         {
             var json = await File.ReadAllTextAsync(_filePath, ct).ConfigureAwait(false);
+            _cached = JsonSerializer.Deserialize<TuiStateCollection>(json, JsonOptions);
+            return _cached;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Synchronously loads the collection from cache or disk. Returns null if file is missing or corrupt.
+    /// Must be called under the lock.
+    /// </summary>
+    private TuiStateCollection? LoadCollection()
+    {
+        if (_cached != null)
+            return _cached;
+
+        if (!File.Exists(_filePath))
+            return null;
+
+        try
+        {
+            var json = File.ReadAllText(_filePath);
             _cached = JsonSerializer.Deserialize<TuiStateCollection>(json, JsonOptions);
             return _cached;
         }

--- a/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
+++ b/src/PPDS.Cli/Services/Settings/TuiStateStore.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PPDS.Auth.Profiles;
+
+namespace PPDS.Cli.Services.Settings;
+
+/// <summary>
+/// Manages persistent storage of per-environment TUI screen state.
+/// </summary>
+internal sealed class TuiStateStore : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private readonly string _filePath;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private TuiStateCollection? _cached;
+    private bool _disposed;
+
+    /// <summary>Creates a store using the default TUI state file path.</summary>
+    public TuiStateStore() : this(ProfilePaths.TuiStateFile) { }
+
+    /// <summary>Creates a store using a custom file path.</summary>
+    public TuiStateStore(string filePath)
+    {
+        _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+    }
+
+    /// <summary>Gets the file path used for persistent storage.</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>
+    /// Loads the state for a specific screen and environment.
+    /// Returns null if no state is persisted or the file is missing/corrupt.
+    /// </summary>
+    public async Task<T?> LoadScreenStateAsync<T>(
+        string screenKey, string environmentUrl, CancellationToken ct = default) where T : class
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(screenKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentUrl);
+
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var collection = await LoadCollectionAsync(ct).ConfigureAwait(false);
+            if (collection == null)
+                return null;
+
+            var normalizedUrl = NormalizeUrl(environmentUrl);
+            if (!collection.Screens.TryGetValue(normalizedUrl, out var screenDict))
+                return null;
+
+            if (!screenDict.TryGetValue(screenKey, out var element))
+                return null;
+
+            return JsonSerializer.Deserialize<T>(element, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Saves the state for a specific screen and environment, merging into existing data.
+    /// </summary>
+    public async Task SaveScreenStateAsync<T>(
+        string screenKey, string environmentUrl, T state, CancellationToken ct = default) where T : class
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(screenKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentUrl);
+        ArgumentNullException.ThrowIfNull(state);
+
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var collection = await LoadCollectionAsync(ct).ConfigureAwait(false)
+                ?? new TuiStateCollection();
+
+            var normalizedUrl = NormalizeUrl(environmentUrl);
+            if (!collection.Screens.TryGetValue(normalizedUrl, out var screenDict))
+            {
+                screenDict = new Dictionary<string, JsonElement>();
+                collection.Screens[normalizedUrl] = screenDict;
+            }
+
+            // Serialize to JsonElement for storage
+            var element = JsonSerializer.SerializeToElement(state, JsonOptions);
+            screenDict[screenKey] = element;
+
+            await PersistAsync(collection, ct).ConfigureAwait(false);
+            _cached = collection;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Removes the state for a specific screen and environment.
+    /// </summary>
+    public async Task ClearScreenStateAsync(
+        string screenKey, string environmentUrl, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(screenKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentUrl);
+
+        await _lock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var collection = await LoadCollectionAsync(ct).ConfigureAwait(false);
+            if (collection == null)
+                return;
+
+            var normalizedUrl = NormalizeUrl(environmentUrl);
+            if (!collection.Screens.TryGetValue(normalizedUrl, out var screenDict))
+                return;
+
+            if (!screenDict.Remove(screenKey))
+                return;
+
+            // Clean up empty environment entries
+            if (screenDict.Count == 0)
+                collection.Screens.Remove(normalizedUrl);
+
+            await PersistAsync(collection, ct).ConfigureAwait(false);
+            _cached = collection;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _lock.Dispose();
+        _disposed = true;
+    }
+
+    /// <summary>
+    /// Loads the collection from cache or disk. Returns null if file is missing or corrupt.
+    /// Must be called under the lock.
+    /// </summary>
+    private async Task<TuiStateCollection?> LoadCollectionAsync(CancellationToken ct)
+    {
+        if (_cached != null)
+            return _cached;
+
+        if (!File.Exists(_filePath))
+            return null;
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(_filePath, ct).ConfigureAwait(false);
+            _cached = JsonSerializer.Deserialize<TuiStateCollection>(json, JsonOptions);
+            return _cached;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Persists the collection to disk atomically (write to temp, then move).
+    /// Must be called under the lock.
+    /// </summary>
+    private async Task PersistAsync(TuiStateCollection collection, CancellationToken ct)
+    {
+        ProfilePaths.EnsureDirectoryExists();
+        collection.Version = 1;
+
+        var json = JsonSerializer.Serialize(collection, JsonOptions);
+        var tempPath = _filePath + ".tmp";
+        await File.WriteAllTextAsync(tempPath, json, ct).ConfigureAwait(false);
+        File.Move(tempPath, _filePath, overwrite: true);
+    }
+
+    /// <summary>
+    /// Normalizes an environment URL: lowercase, trimmed, with trailing slash.
+    /// </summary>
+    private static string NormalizeUrl(string url)
+    {
+        var normalized = url.Trim().ToLowerInvariant();
+        if (!normalized.EndsWith('/'))
+            normalized += '/';
+        return normalized;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    /// <summary>
+    /// Internal JSON root structure for the TUI state file.
+    /// </summary>
+    private sealed class TuiStateCollection
+    {
+        [JsonPropertyName("version")]
+        public int Version { get; set; } = 1;
+
+        [JsonPropertyName("screens")]
+        public Dictionary<string, Dictionary<string, JsonElement>> Screens { get; set; } = new();
+    }
+}

--- a/src/PPDS.Cli/Tui/InteractiveSession.cs
+++ b/src/PPDS.Cli/Tui/InteractiveSession.cs
@@ -12,6 +12,7 @@ using PPDS.Cli.Services.Export;
 using PPDS.Cli.Services.History;
 using PPDS.Cli.Services.Profile;
 using PPDS.Cli.Services.Query;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.Query;
 using PPDS.Dataverse.Metadata;
@@ -50,6 +51,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
     private bool _disposed;
     private readonly EnvironmentConfigStore _envConfigStore;
     private readonly EnvironmentConfigService _envConfigService;
+    private readonly TuiStateStore _tuiStateStore;
     private ProfileResolutionService? _profileResolutionService;
     private readonly Lazy<ITuiErrorService> _errorService;
     private readonly Lazy<IHotkeyRegistry> _hotkeyRegistry;
@@ -105,6 +107,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
     /// <param name="profileName">The profile name (null for active profile).</param>
     /// <param name="profileStore">Shared profile store instance.</param>
     /// <param name="envConfigStore">Shared environment config store instance.</param>
+    /// <param name="tuiStateStore">Shared TUI state store for persisting screen filter state.</param>
     /// <param name="serviceProviderFactory">Factory for creating service providers (null for default).</param>
     /// <param name="deviceCodeCallback">Callback for device code display.</param>
     /// <param name="beforeInteractiveAuth">Callback invoked before browser opens for interactive auth.
@@ -113,6 +116,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
         string? profileName,
         ProfileStore profileStore,
         EnvironmentConfigStore envConfigStore,
+        TuiStateStore tuiStateStore,
         IServiceProviderFactory? serviceProviderFactory = null,
         Action<DeviceCodeInfo>? deviceCodeCallback = null,
         Func<Action<DeviceCodeInfo>?, PreAuthDialogResult>? beforeInteractiveAuth = null)
@@ -120,6 +124,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
         _profileName = profileName ?? string.Empty;
         _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
         _envConfigStore = envConfigStore ?? throw new ArgumentNullException(nameof(envConfigStore));
+        _tuiStateStore = tuiStateStore ?? throw new ArgumentNullException(nameof(tuiStateStore));
         _serviceProviderFactory = serviceProviderFactory ?? new ProfileBasedServiceProviderFactory();
         _deviceCodeCallback = deviceCodeCallback;
         _beforeInteractiveAuth = beforeInteractiveAuth;
@@ -654,6 +659,15 @@ internal sealed class InteractiveSession : IAsyncDisposable
         return _exportService.Value;
     }
 
+    /// <summary>
+    /// Gets the TUI state store for persisting screen filter selections across sessions.
+    /// </summary>
+    /// <returns>The shared TUI state store.</returns>
+    public TuiStateStore GetTuiStateStore()
+    {
+        return _tuiStateStore;
+    }
+
     #endregion
 
     /// <inheritdoc />
@@ -699,6 +713,7 @@ internal sealed class InteractiveSession : IAsyncDisposable
         }
 
         _envConfigStore.Dispose();
+        _tuiStateStore.Dispose();
         _lock.Dispose();
         TuiDebugLog.Log("InteractiveSession disposed");
     }

--- a/src/PPDS.Cli/Tui/PpdsApplication.cs
+++ b/src/PPDS.Cli/Tui/PpdsApplication.cs
@@ -3,6 +3,7 @@ using PPDS.Auth;
 using PPDS.Auth.Credentials;
 using PPDS.Auth.Profiles;
 using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Infrastructure;
 using Terminal.Gui;
 
@@ -87,11 +88,15 @@ internal sealed class PpdsApplication : IDisposable
             return result;
         };
 
+        // Create TUI state store for persisting screen filter selections
+        var tuiStateStore = new TuiStateStore(ProfilePaths.TuiStateFile);
+
         // Create session for connection pool reuse across screens
         _session = new InteractiveSession(
             _profileName,
             _profileStore,
             authProvider.GetRequiredService<EnvironmentConfigStore>(),
+            tuiStateStore,
             serviceProviderFactory: null,
             _deviceCodeCallback,
             beforeInteractiveAuth);

--- a/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Services;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.Services;
 using Terminal.Gui;
@@ -50,6 +51,11 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
 
         if (EnvironmentUrl != null)
         {
+            var savedState = Session.GetTuiStateStore()
+                .LoadScreenState<SolutionFilterScreenState>("ConnectionReferences", EnvironmentUrl);
+            if (savedState != null)
+                _solutionFilter = savedState.SolutionFilter;
+
             ErrorService.FireAndForget(LoadDataAsync(), "ConnectionReferences.InitialLoad");
         }
         else
@@ -77,6 +83,31 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
             Application.Refresh();
 
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+
+            // Stale filter check: verify persisted solution still exists
+            if (_solutionFilter != null)
+            {
+                var solutionService = provider.GetRequiredService<ISolutionService>();
+                var solutions = await solutionService.ListAsync(
+                    includeManaged: false,
+                    cancellationToken: ScreenCancellation);
+                var exists = solutions.Items.Any(s =>
+                    string.Equals(s.UniqueName, _solutionFilter, StringComparison.OrdinalIgnoreCase));
+                if (!exists)
+                {
+                    var staleName = _solutionFilter;
+                    _solutionFilter = null;
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("ConnectionReferences", EnvironmentUrl!,
+                            new SolutionFilterScreenState { SolutionFilter = null }),
+                        "ConnectionReferences.ClearStaleState");
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        _statusLabel.Text = $"Previously filtered solution '{staleName}' not found \u2014 showing all";
+                    });
+                }
+            }
+
             var crService = provider.GetRequiredService<IConnectionReferenceService>();
 
             var crResult = await crService.ListAsync(
@@ -457,6 +488,10 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
                 {
                     var idx = listView.SelectedItem;
                     _solutionFilter = idx == 0 ? null : names[idx];
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("ConnectionReferences", EnvironmentUrl!,
+                            new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
+                        "ConnectionReferences.SaveState");
                     ErrorService.FireAndForget(LoadDataAsync(), "ConnectionReferences.FilterApply");
                 }
             });

--- a/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
@@ -17,6 +17,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
     private List<ConnectionReferenceInfo> _references = [];
     private List<ConnectionInfo> _connections = [];
     private string? _solutionFilter;
+    private bool _staleFilterChecked;
     private Dialog? _detailDialog;
     private bool _isShowingDetail;
 
@@ -84,9 +85,10 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
 
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
 
-            // Stale filter check: verify persisted solution still exists
-            if (_solutionFilter != null)
+            // Stale filter check: verify persisted solution still exists (first load only)
+            if (_solutionFilter != null && !_staleFilterChecked)
             {
+                _staleFilterChecked = true;
                 var solutionService = provider.GetRequiredService<ISolutionService>();
                 var solutions = await solutionService.ListAsync(
                     includeManaged: false,

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.Services;
 using Terminal.Gui;
@@ -49,6 +50,12 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
 
         if (EnvironmentUrl != null)
         {
+            // Restore persisted filter state
+            var savedState = Session.GetTuiStateStore()
+                .LoadScreenState<SolutionFilterScreenState>("EnvironmentVariables", EnvironmentUrl);
+            if (savedState != null)
+                _solutionFilter = savedState.SolutionFilter;
+
             ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.InitialLoad");
         }
         else
@@ -77,6 +84,33 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
 
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
             var service = provider.GetRequiredService<IEnvironmentVariableService>();
+
+            // Validate persisted solution filter still exists
+            if (_solutionFilter != null)
+            {
+                var solutionService = provider.GetRequiredService<ISolutionService>();
+                var solutionsResult = await solutionService.ListAsync(
+                    includeManaged: false,
+                    cancellationToken: ScreenCancellation);
+
+                var solutionNames = solutionsResult.Items.Select(s => s.UniqueName).ToList();
+                if (!solutionNames.Contains(_solutionFilter))
+                {
+                    var staleName = _solutionFilter;
+                    _solutionFilter = null;
+
+                    // Persist cleared state
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
+                            new SolutionFilterScreenState { SolutionFilter = null }),
+                        "EnvironmentVariables.ClearStaleState");
+
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        _statusLabel.Text = $"Solution '{staleName}' no longer exists — filter cleared";
+                    });
+                }
+            }
 
             var evResult = await service.ListAsync(
                 solutionName: _solutionFilter,
@@ -526,6 +560,13 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 {
                     var idx = listView.SelectedItem;
                     _solutionFilter = idx == 0 ? null : names[idx];
+
+                    // Persist updated filter state
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
+                            new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
+                        "EnvironmentVariables.SaveState");
+
                     ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
                 }
             });

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -16,6 +16,7 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
     private readonly Label _statusLabel;
     private List<EnvironmentVariableInfo> _variables = [];
     private string? _solutionFilter;
+    private bool _staleFilterChecked;
     private Dialog? _detailDialog;
     private bool _isShowingDetail;
 
@@ -85,16 +86,18 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
             var service = provider.GetRequiredService<IEnvironmentVariableService>();
 
-            // Validate persisted solution filter still exists
-            if (_solutionFilter != null)
+            // Validate persisted solution filter still exists (first load only)
+            if (_solutionFilter != null && !_staleFilterChecked)
             {
+                _staleFilterChecked = true;
                 var solutionService = provider.GetRequiredService<ISolutionService>();
                 var solutionsResult = await solutionService.ListAsync(
                     includeManaged: false,
                     cancellationToken: ScreenCancellation);
 
-                var solutionNames = solutionsResult.Items.Select(s => s.UniqueName).ToList();
-                if (!solutionNames.Contains(_solutionFilter))
+                var exists = solutionsResult.Items.Any(s =>
+                    string.Equals(s.UniqueName, _solutionFilter, StringComparison.OrdinalIgnoreCase));
+                if (!exists)
                 {
                     var staleName = _solutionFilter;
                     _solutionFilter = null;

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Dialogs;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.Services;
@@ -51,6 +52,11 @@ internal sealed class PluginTracesScreen : TuiScreenBase
 
         if (EnvironmentUrl != null)
         {
+            var savedFilter = Session.GetTuiStateStore()
+                .LoadScreenState<PluginTraceFilter>("PluginTraces", EnvironmentUrl);
+            if (savedFilter != null)
+                _currentFilter = savedFilter;
+
             ErrorService.FireAndForget(LoadTracesAsync(), "PluginTraces.InitialLoad");
         }
         else
@@ -357,6 +363,13 @@ internal sealed class PluginTracesScreen : TuiScreenBase
         if (dialog.Filter != _currentFilter)
         {
             _currentFilter = dialog.Filter;
+
+            ErrorService.FireAndForget(
+                _currentFilter != null
+                    ? Session.GetTuiStateStore().SaveScreenStateAsync("PluginTraces", EnvironmentUrl!, _currentFilter)
+                    : Session.GetTuiStateStore().ClearScreenStateAsync("PluginTraces", EnvironmentUrl!),
+                "PluginTraces.SaveState");
+
             ErrorService.FireAndForget(LoadTracesAsync(), "PluginTraces.FilterApply");
         }
     }

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -48,9 +48,21 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
         Content.Add(_table, _statusLabel);
 
+        // Restore persisted filter state before initial load
         if (EnvironmentUrl != null)
         {
-            ErrorService.FireAndForget(LoadDataAsync(restoreState: true), "WebResources.InitialLoad");
+            var savedState = Session.GetTuiStateStore()
+                .LoadScreenState<WebResourcesScreenState>("WebResources", EnvironmentUrl);
+            if (savedState != null)
+            {
+                _selectedSolutionId = savedState.SelectedSolutionId;
+                _textOnly = savedState.TextOnly;
+            }
+        }
+
+        if (EnvironmentUrl != null)
+        {
+            ErrorService.FireAndForget(LoadDataAsync(), "WebResources.InitialLoad");
         }
         else
         {
@@ -69,24 +81,12 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             ErrorService.FireAndForget(PublishAllAsync(), "WebResources.PublishAll"));
     }
 
-    private async Task LoadDataAsync(bool restoreState = false)
+    private async Task LoadDataAsync()
     {
         if (EnvironmentUrl == null)
         {
             _statusLabel.Text = "No environment selected. Use the status bar to connect.";
             return;
-        }
-
-        // Restore persisted filter state before first load
-        if (restoreState)
-        {
-            var savedState = await Session.GetTuiStateStore()
-                .LoadScreenStateAsync<WebResourcesScreenState>("WebResources", EnvironmentUrl);
-            if (savedState != null)
-            {
-                _selectedSolutionId = savedState.SelectedSolutionId;
-                _textOnly = savedState.TextOnly;
-            }
         }
 
         // Cancel any previous load
@@ -329,6 +329,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
                         new WebResourcesScreenState { SelectedSolutionId = null, TextOnly = _textOnly }),
                     "WebResources.ClearStaleState");
                 ErrorService.FireAndForget(LoadDataAsync(), "WebResources.StaleFilterReload");
+                return;
             }
 
             Application.MainLoop.Invoke(() =>

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -18,6 +18,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
     private CancellationTokenSource? _loadCts;
     private bool _textOnly = true;
     private Guid? _selectedSolutionId;
+    private bool _staleFilterChecked;
 
     public override string Title => "Web Resources";
 
@@ -103,6 +104,26 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
             var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ct);
             var service = provider.GetRequiredService<IWebResourceService>();
+
+            // Stale reference check: verify persisted solution still exists (first load only)
+            if (_selectedSolutionId.HasValue && !_staleFilterChecked)
+            {
+                _staleFilterChecked = true;
+                var solutionService = provider.GetRequiredService<ISolutionService>();
+                var solutions = await solutionService.ListAsync(cancellationToken: ct);
+                if (!solutions.Items.Any(s => s.Id == _selectedSolutionId.Value))
+                {
+                    _selectedSolutionId = null;
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl!,
+                            new WebResourcesScreenState { SelectedSolutionId = null, TextOnly = _textOnly }),
+                        "WebResources.ClearStaleState");
+                    Application.MainLoop.Invoke(() =>
+                    {
+                        _statusLabel.Text = "Previously filtered solution not found \u2014 showing all";
+                    });
+                }
+            }
 
             var wrResult = await service.ListAsync(_selectedSolutionId, _textOnly, cancellationToken: ct);
             _resources = wrResult.Items.ToList();
@@ -315,22 +336,6 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
             var solutionsResult = await solutionService.ListAsync(cancellationToken: ScreenCancellation);
             var solutions = solutionsResult.Items;
-
-            // Stale reference check: persisted solution may no longer exist
-            if (_selectedSolutionId.HasValue && !solutions.Any(s => s.Id == _selectedSolutionId.Value))
-            {
-                _selectedSolutionId = null;
-                Application.MainLoop.Invoke(() =>
-                {
-                    _statusLabel.Text = "Previously filtered solution not found \u2014 showing all";
-                });
-                ErrorService.FireAndForget(
-                    Session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl!,
-                        new WebResourcesScreenState { SelectedSolutionId = null, TextOnly = _textOnly }),
-                    "WebResources.ClearStaleState");
-                ErrorService.FireAndForget(LoadDataAsync(), "WebResources.StaleFilterReload");
-                return;
-            }
 
             Application.MainLoop.Invoke(() =>
             {

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.Services;
 using Terminal.Gui;
@@ -49,7 +50,7 @@ internal sealed class WebResourcesScreen : TuiScreenBase
 
         if (EnvironmentUrl != null)
         {
-            ErrorService.FireAndForget(LoadDataAsync(), "WebResources.InitialLoad");
+            ErrorService.FireAndForget(LoadDataAsync(restoreState: true), "WebResources.InitialLoad");
         }
         else
         {
@@ -68,12 +69,24 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             ErrorService.FireAndForget(PublishAllAsync(), "WebResources.PublishAll"));
     }
 
-    private async Task LoadDataAsync()
+    private async Task LoadDataAsync(bool restoreState = false)
     {
         if (EnvironmentUrl == null)
         {
             _statusLabel.Text = "No environment selected. Use the status bar to connect.";
             return;
+        }
+
+        // Restore persisted filter state before first load
+        if (restoreState)
+        {
+            var savedState = await Session.GetTuiStateStore()
+                .LoadScreenStateAsync<WebResourcesScreenState>("WebResources", EnvironmentUrl);
+            if (savedState != null)
+            {
+                _selectedSolutionId = savedState.SelectedSolutionId;
+                _textOnly = savedState.TextOnly;
+            }
         }
 
         // Cancel any previous load
@@ -303,6 +316,21 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             var solutionsResult = await solutionService.ListAsync(cancellationToken: ScreenCancellation);
             var solutions = solutionsResult.Items;
 
+            // Stale reference check: persisted solution may no longer exist
+            if (_selectedSolutionId.HasValue && !solutions.Any(s => s.Id == _selectedSolutionId.Value))
+            {
+                _selectedSolutionId = null;
+                Application.MainLoop.Invoke(() =>
+                {
+                    _statusLabel.Text = "Previously filtered solution not found \u2014 showing all";
+                });
+                ErrorService.FireAndForget(
+                    Session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl!,
+                        new WebResourcesScreenState { SelectedSolutionId = null, TextOnly = _textOnly }),
+                    "WebResources.ClearStaleState");
+                ErrorService.FireAndForget(LoadDataAsync(), "WebResources.StaleFilterReload");
+            }
+
             Application.MainLoop.Invoke(() =>
             {
                 // Build list with "All Solutions" option at top
@@ -340,6 +368,12 @@ internal sealed class WebResourcesScreen : TuiScreenBase
                 Application.Run(dialog);
                 dialog.Dispose();
 
+                // Persist updated filter state
+                ErrorService.FireAndForget(
+                    Session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl!,
+                        new WebResourcesScreenState { SelectedSolutionId = _selectedSolutionId, TextOnly = _textOnly }),
+                    "WebResources.SaveState");
+
                 // Reload with new filter
                 ErrorService.FireAndForget(LoadDataAsync(), "WebResources.FilterReload");
             });
@@ -357,6 +391,16 @@ internal sealed class WebResourcesScreen : TuiScreenBase
     private void ToggleTextOnly()
     {
         _textOnly = !_textOnly;
+
+        if (EnvironmentUrl != null)
+        {
+            // Persist updated filter state
+            ErrorService.FireAndForget(
+                Session.GetTuiStateStore().SaveScreenStateAsync("WebResources", EnvironmentUrl,
+                    new WebResourcesScreenState { SelectedSolutionId = _selectedSolutionId, TextOnly = _textOnly }),
+                "WebResources.SaveState");
+        }
+
         ErrorService.FireAndForget(LoadDataAsync(), "WebResources.ToggleTextOnly");
     }
 

--- a/src/PPDS.Extension/src/extension.ts
+++ b/src/PPDS.Extension/src/extension.ts
@@ -85,7 +85,7 @@ function registerPanelCommands(
             ConnectionReferencesPanel.show(context.extensionUri, client);
         }),
         vscode.commands.registerCommand('ppds.openEnvironmentVariables', () => {
-            EnvironmentVariablesPanel.show(context.extensionUri, client);
+            EnvironmentVariablesPanel.show(context.extensionUri, client, context);
         }),
         vscode.commands.registerCommand('ppds.openWebResources', () => {
             WebResourcesPanel.show(context.extensionUri, client, context, undefined, undefined, fsp);
@@ -307,7 +307,7 @@ export function activate(context: vscode.ExtensionContext): void {
         // Open Environment Variables targeting this environment
         vscode.commands.registerCommand('ppds.openEnvironmentVariablesForEnv', cmd((item: { envUrl: string; envDisplayName: string }) => {
             if (!item?.envUrl) return;
-            EnvironmentVariablesPanel.show(context.extensionUri, client, item.envUrl, item.envDisplayName);
+            EnvironmentVariablesPanel.show(context.extensionUri, client, context, item.envUrl, item.envDisplayName);
         })),
 
         // Open Web Resources targeting this environment

--- a/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
+++ b/src/PPDS.Extension/src/panels/EnvironmentVariablesPanel.ts
@@ -30,19 +30,20 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
         return EnvironmentVariablesPanel.instances.length;
     }
 
-    static show(extensionUri: vscode.Uri, daemon: DaemonClient, envUrl?: string, envDisplayName?: string): EnvironmentVariablesPanel {
+    static show(extensionUri: vscode.Uri, daemon: DaemonClient, context: vscode.ExtensionContext, envUrl?: string, envDisplayName?: string): EnvironmentVariablesPanel {
         if (EnvironmentVariablesPanel.instances.length >= EnvironmentVariablesPanel.MAX_PANELS) {
             const oldest = EnvironmentVariablesPanel.instances[0];
             oldest.panel?.reveal();
             return oldest;
         }
-        const panel = new EnvironmentVariablesPanel(extensionUri, daemon, envUrl, envDisplayName);
+        const panel = new EnvironmentVariablesPanel(extensionUri, daemon, context, envUrl, envDisplayName);
         return panel;
     }
 
     private constructor(
         private readonly extensionUri: vscode.Uri,
         private readonly daemon: DaemonClient,
+        private readonly context: vscode.ExtensionContext,
         initialEnvUrl?: string,
         initialEnvDisplayName?: string,
     ) {
@@ -52,6 +53,9 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
             this.environmentUrl = initialEnvUrl;
             this.environmentDisplayName = initialEnvDisplayName ?? initialEnvUrl;
         }
+
+        // Restore persisted filter state
+        this.solutionFilter = this.context.globalState.get<string | null>('ppds.environmentVariables.solutionFilter', null);
 
         this.panelId = EnvironmentVariablesPanel.nextId++;
         EnvironmentVariablesPanel.instances.push(this);
@@ -95,6 +99,7 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
                 break;
             case 'filterBySolution':
                 this.solutionFilter = message.solutionId;
+                void this.context.globalState.update('ppds.environmentVariables.solutionFilter', this.solutionFilter);
                 await this.loadEnvironmentVariables();
                 break;
             case 'requestSolutionList':
@@ -142,6 +147,9 @@ export class EnvironmentVariablesPanel extends WebviewPanelBase<EnvironmentVaria
     }
 
     protected override async onEnvironmentChanged(): Promise<void> {
+        // Reset solution filter on environment change
+        this.solutionFilter = null;
+        void this.context.globalState.update('ppds.environmentVariables.solutionFilter', null);
         await this.loadEnvironmentVariables();
     }
 

--- a/tests/PPDS.Cli.Tests/Services/Settings/TuiStateStoreTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Settings/TuiStateStoreTests.cs
@@ -1,0 +1,243 @@
+using PPDS.Cli.Services.Settings;
+using PPDS.Dataverse.Services;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Settings;
+
+[Trait("Category", "TuiUnit")]
+public class TuiStateStoreTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _filePath;
+    private readonly TuiStateStore _store;
+
+    public TuiStateStoreTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ppds-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        System.Environment.SetEnvironmentVariable("PPDS_CONFIG_DIR", _tempDir);
+        _filePath = Path.Combine(_tempDir, "tui-state.json");
+        _store = new TuiStateStore(_filePath);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTrips()
+    {
+        var state = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TextOnly = false
+        };
+
+        await _store.SaveScreenStateAsync("WebResources", "https://contoso.crm.dynamics.com", state);
+
+        var loaded = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(state.SelectedSolutionId, loaded!.SelectedSolutionId);
+        Assert.Equal(state.TextOnly, loaded.TextOnly);
+    }
+
+    [Fact]
+    public async Task Load_MissingFile_ReturnsNull()
+    {
+        var result = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Load_CorruptFile_ReturnsNull()
+    {
+        await File.WriteAllTextAsync(_filePath, "not valid json {{{{");
+
+        var result = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Save_CreatesFileIfMissing()
+    {
+        var newPath = Path.Combine(_tempDir, "subdir", "tui-state.json");
+        // PPDS_CONFIG_DIR points to _tempDir but we need a custom path in a subdirectory
+        // The store uses ProfilePaths.EnsureDirectoryExists() which creates the PPDS_CONFIG_DIR,
+        // but the file path's own directory must exist. We set PPDS_CONFIG_DIR to the subdir.
+        var subDir = Path.Combine(_tempDir, "subdir");
+        System.Environment.SetEnvironmentVariable("PPDS_CONFIG_DIR", subDir);
+
+        using var store = new TuiStateStore(newPath);
+        var state = new WebResourcesScreenState { TextOnly = true };
+
+        await store.SaveScreenStateAsync("WebResources", "https://contoso.crm.dynamics.com", state);
+
+        Assert.True(File.Exists(newPath));
+    }
+
+    [Fact]
+    public async Task StateIsScopedPerEnvironment()
+    {
+        var stateA = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            TextOnly = true
+        };
+        var stateB = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            TextOnly = false
+        };
+
+        await _store.SaveScreenStateAsync("WebResources", "https://envA.crm.dynamics.com", stateA);
+        await _store.SaveScreenStateAsync("WebResources", "https://envB.crm.dynamics.com", stateB);
+
+        var loadedA = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://envA.crm.dynamics.com");
+        var loadedB = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://envB.crm.dynamics.com");
+
+        Assert.NotNull(loadedA);
+        Assert.NotNull(loadedB);
+        Assert.Equal(stateA.SelectedSolutionId, loadedA!.SelectedSolutionId);
+        Assert.Equal(stateB.SelectedSolutionId, loadedB!.SelectedSolutionId);
+    }
+
+    [Fact]
+    public async Task StateIsScopedPerScreen()
+    {
+        var webState = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TextOnly = false
+        };
+        var connState = new SolutionFilterScreenState
+        {
+            SolutionFilter = "ContosoCore"
+        };
+
+        await _store.SaveScreenStateAsync("WebResources", "https://contoso.crm.dynamics.com", webState);
+        await _store.SaveScreenStateAsync("ConnectionReferences", "https://contoso.crm.dynamics.com", connState);
+
+        var loadedWeb = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com");
+        var loadedConn = await _store.LoadScreenStateAsync<SolutionFilterScreenState>(
+            "ConnectionReferences", "https://contoso.crm.dynamics.com");
+
+        Assert.NotNull(loadedWeb);
+        Assert.NotNull(loadedConn);
+        Assert.Equal(webState.SelectedSolutionId, loadedWeb!.SelectedSolutionId);
+        Assert.Equal(connState.SolutionFilter, loadedConn!.SolutionFilter);
+    }
+
+    [Fact]
+    public async Task EnvironmentUrl_Normalized()
+    {
+        var state = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TextOnly = true
+        };
+
+        await _store.SaveScreenStateAsync(
+            "WebResources", "HTTPS://Contoso.CRM.Dynamics.COM", state);
+
+        var loaded = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com/");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(state.SelectedSolutionId, loaded!.SelectedSolutionId);
+    }
+
+    [Fact]
+    public async Task Save_PreservesOtherScreenState()
+    {
+        var webState = new WebResourcesScreenState
+        {
+            SelectedSolutionId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TextOnly = false
+        };
+        var connState = new SolutionFilterScreenState
+        {
+            SolutionFilter = "ContosoCore"
+        };
+
+        await _store.SaveScreenStateAsync("WebResources", "https://contoso.crm.dynamics.com", webState);
+        await _store.SaveScreenStateAsync("ConnectionReferences", "https://contoso.crm.dynamics.com", connState);
+
+        // Load WebResources to verify it's still intact after ConnectionReferences was saved
+        var loadedWeb = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+            "WebResources", "https://contoso.crm.dynamics.com");
+
+        Assert.NotNull(loadedWeb);
+        Assert.Equal(webState.SelectedSolutionId, loadedWeb!.SelectedSolutionId);
+        Assert.Equal(webState.TextOnly, loadedWeb.TextOnly);
+    }
+
+    [Fact]
+    public async Task ConcurrentSaves_DoNotCorrupt()
+    {
+        var tasks = Enumerable.Range(0, 10).Select(i =>
+        {
+            var state = new WebResourcesScreenState
+            {
+                SelectedSolutionId = Guid.NewGuid(),
+                TextOnly = i % 2 == 0
+            };
+            return _store.SaveScreenStateAsync(
+                $"Screen{i}", "https://contoso.crm.dynamics.com", state);
+        });
+
+        await Task.WhenAll(tasks);
+
+        // Verify all reads succeed
+        for (var i = 0; i < 10; i++)
+        {
+            var loaded = await _store.LoadScreenStateAsync<WebResourcesScreenState>(
+                $"Screen{i}", "https://contoso.crm.dynamics.com");
+            Assert.NotNull(loaded);
+        }
+    }
+
+    [Fact]
+    public async Task PluginTraceFilter_RoundTrips()
+    {
+        var filter = new PluginTraceFilter
+        {
+            TypeName = "MyPlugin",
+            MessageName = "Create",
+            Mode = PluginTraceMode.Synchronous,
+            OperationType = PluginTraceOperationType.Plugin,
+            CreatedAfter = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc),
+            CreatedBefore = new DateTime(2026, 3, 20, 23, 59, 59, DateTimeKind.Utc),
+            HasException = true,
+            MinDurationMs = 500
+        };
+
+        await _store.SaveScreenStateAsync(
+            "PluginTraces", "https://contoso.crm.dynamics.com", filter);
+
+        var loaded = await _store.LoadScreenStateAsync<PluginTraceFilter>(
+            "PluginTraces", "https://contoso.crm.dynamics.com");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("MyPlugin", loaded!.TypeName);
+        Assert.Equal("Create", loaded.MessageName);
+        Assert.Equal(PluginTraceMode.Synchronous, loaded.Mode);
+        Assert.Equal(PluginTraceOperationType.Plugin, loaded.OperationType);
+        Assert.Equal(filter.CreatedAfter, loaded.CreatedAfter);
+        Assert.Equal(filter.CreatedBefore, loaded.CreatedBefore);
+        Assert.True(loaded.HasException);
+        Assert.Equal(500, loaded.MinDurationMs);
+    }
+
+    public void Dispose()
+    {
+        _store.Dispose();
+        System.Environment.SetEnvironmentVariable("PPDS_CONFIG_DIR", null);
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); }
+        catch { /* best effort */ }
+    }
+}

--- a/tests/PPDS.Cli.Tests/Tui/Infrastructure/ServiceCachingTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Infrastructure/ServiceCachingTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using Xunit;
@@ -18,6 +20,7 @@ public sealed class ServiceCachingTests : IDisposable
             null,
             _tempStore.Store,
             new EnvironmentConfigStore(),
+            new TuiStateStore(Path.GetTempFileName()),
             new MockServiceProviderFactory());
     }
 

--- a/tests/PPDS.Cli.Tests/Tui/Infrastructure/TabManagerTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Infrastructure/TabManagerTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using PPDS.Cli.Tui.Infrastructure;
@@ -18,7 +20,7 @@ public sealed class TabManagerTests : IDisposable
     public TabManagerTests()
     {
         _tempStore = new TempProfileStore();
-        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new MockServiceProviderFactory());
+        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), new MockServiceProviderFactory());
         _manager = new TabManager(new TuiThemeService());
     }
 

--- a/tests/PPDS.Cli.Tests/Tui/InteractiveSessionLifecycleTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/InteractiveSessionLifecycleTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using Xunit;
@@ -52,6 +53,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             profileName: null, // Use active
             _tempStore.Store,
             _envConfigStore,
+            new TuiStateStore(Path.GetTempFileName()),
             _mockFactory);
 
         string? eventUrl = null;
@@ -82,6 +84,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             profileName: null,
             _tempStore.Store,
             _envConfigStore,
+            new TuiStateStore(Path.GetTempFileName()),
             _mockFactory);
 
         // Act
@@ -109,6 +112,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             profileName: "Profile2", // Explicit profile
             _tempStore.Store,
             _envConfigStore,
+            new TuiStateStore(Path.GetTempFileName()),
             _mockFactory);
 
         string? eventUrl = null;
@@ -139,7 +143,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task GetServiceProviderAsync_CreatesProviderOnFirstCall()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act
         await session.GetServiceProviderAsync("https://test.crm.dynamics.com");
@@ -153,7 +157,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task GetServiceProviderAsync_ReusesSameUrlProvider()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         const string url = "https://test.crm.dynamics.com";
 
         // Act - Call twice with same URL
@@ -169,7 +173,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task GetServiceProviderAsync_RecreatesForDifferentUrl()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act
         await session.GetServiceProviderAsync("https://env1.crm.dynamics.com");
@@ -197,7 +201,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             environmentUrl: "https://env2.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("Profile1", profile1, profile2);
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         await session.InitializeAsync();
         _mockFactory.Reset();
 
@@ -223,7 +227,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             environmentUrl: "https://test.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("TestProfile", profile);
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         await session.GetServiceProviderAsync("https://test.crm.dynamics.com");
         _mockFactory.Reset();
 
@@ -248,7 +252,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             environmentUrl: "https://test.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("TestProfile", profile);
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         string? receivedUrl = null;
         string? receivedName = null;
         session.EnvironmentChanged += (url, name) =>
@@ -279,7 +283,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void UpdateDisplayedEnvironment_FiresEventWithCorrectValues()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         string? eventUrl = null;
         string? eventName = null;
         session.EnvironmentChanged += (url, name) =>
@@ -300,7 +304,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void UpdateDisplayedEnvironment_UpdatesProperties()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act
         session.UpdateDisplayedEnvironment("https://dev.crm.dynamics.com", "Dev Env");
@@ -314,7 +318,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void UpdateDisplayedEnvironment_NoOpsWhenUnchanged()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         session.UpdateDisplayedEnvironment("https://dev.crm.dynamics.com", "Dev Env");
 
         var eventCount = 0;
@@ -331,7 +335,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void UpdateDisplayedEnvironment_DoesNotPersistToProfile()
     {
         // Arrange - session with no seeded profiles (no real profile store backing)
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act - should not throw even without a real profile store
         var exception = Record.Exception(() =>
@@ -355,7 +359,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             environmentUrl: "https://old.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("TestProfile", profile);
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act
         await session.SetEnvironmentAsync(
@@ -376,7 +380,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
             environmentUrl: "https://old.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("TestProfile", profile);
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         var oldProvider = await session.GetServiceProviderAsync("https://old.crm.dynamics.com");
         _mockFactory.Reset();
 
@@ -405,7 +409,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task DisposeAsync_CompletesWithinTimeout()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         await session.GetServiceProviderAsync("https://test.crm.dynamics.com");
 
         // Act & Assert - Should complete within 3 seconds
@@ -418,7 +422,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task DisposeAsync_IsIdempotent()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         await session.GetServiceProviderAsync("https://test.crm.dynamics.com");
 
         // Act - Dispose twice
@@ -437,7 +441,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void NotifyConfigChanged_FiresConfigChangedEvent()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         var fired = false;
         session.ConfigChanged += () => fired = true;
 
@@ -452,7 +456,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public void NotifyConfigChanged_NoSubscribers_DoesNotThrow()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act & Assert - should not throw
         var ex = Record.Exception(() => session.NotifyConfigChanged());
@@ -470,7 +474,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
         var expectedException = new InvalidOperationException("Connection failed");
         _mockFactory.ExceptionToThrow = expectedException;
 
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -482,7 +486,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task InvalidateAsync_WhenNoProvider_DoesNotThrow()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         // Act & Assert - Should not throw
         await session.InvalidateAsync();
@@ -493,7 +497,7 @@ public sealed class InteractiveSessionLifecycleTests : IDisposable
     public async Task GetServiceProviderAsync_AfterDispose_ThrowsObjectDisposedException()
     {
         // Arrange
-        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, _mockFactory);
+        var session = new InteractiveSession(null, _tempStore.Store, _envConfigStore, new TuiStateStore(Path.GetTempFileName()), _mockFactory);
         await session.DisposeAsync();
 
         // Act & Assert

--- a/tests/PPDS.Cli.Tests/Tui/InteractiveSessionTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/InteractiveSessionTests.cs
@@ -1,6 +1,8 @@
+using System.IO;
 using PPDS.Auth.Profiles;
 using PPDS.Cli.Services.Environment;
 using PPDS.Cli.Services.Profile;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tui;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Cli.Tests.Mocks;
@@ -23,7 +25,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public Task InitializeAsync()
     {
         _profileStore = new ProfileStore();
-        _session = new InteractiveSession(profileName: null, _profileStore, new EnvironmentConfigStore());
+        _session = new InteractiveSession(profileName: null, _profileStore, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
         return Task.CompletedTask;
     }
 
@@ -38,7 +40,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public void Constructor_WithNullProfileName_DoesNotThrow()
     {
         using var store = new ProfileStore();
-        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore());
+        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
 
         Assert.NotNull(session);
     }
@@ -47,7 +49,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public void Constructor_WithProfileName_DoesNotThrow()
     {
         using var store = new ProfileStore();
-        var session = new InteractiveSession(profileName: "TestProfile", store, new EnvironmentConfigStore());
+        var session = new InteractiveSession(profileName: "TestProfile", store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
 
         Assert.NotNull(session);
     }
@@ -56,7 +58,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public void Constructor_WithNullProfileStore_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() =>
-            new InteractiveSession(profileName: null, profileStore: null!, envConfigStore: new EnvironmentConfigStore()));
+            new InteractiveSession(profileName: null, profileStore: null!, envConfigStore: new EnvironmentConfigStore(), tuiStateStore: new TuiStateStore(Path.GetTempFileName())));
     }
 
     [Fact]
@@ -67,6 +69,7 @@ public class InteractiveSessionTests : IAsyncLifetime
             profileName: null,
             store,
             new EnvironmentConfigStore(),
+            new TuiStateStore(Path.GetTempFileName()),
             deviceCodeCallback: info => { /* handle device code */ });
 
         Assert.NotNull(session);
@@ -149,7 +152,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public void CurrentEnvironmentUrl_InitiallyNull()
     {
         using var store = new ProfileStore();
-        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore());
+        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
 
         Assert.Null(session.CurrentEnvironmentUrl);
     }
@@ -182,7 +185,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public async Task DisposeAsync_MultipleCallsDoNotThrow()
     {
         using var store = new ProfileStore();
-        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore());
+        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
 
         // Multiple dispose calls should be safe
         await session.DisposeAsync();
@@ -194,7 +197,7 @@ public class InteractiveSessionTests : IAsyncLifetime
     public async Task DisposeAsync_LocalServicesStillWork()
     {
         using var store = new ProfileStore();
-        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore());
+        var session = new InteractiveSession(profileName: null, store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()));
 
         await session.DisposeAsync();
 

--- a/tests/PPDS.Cli.Tests/Tui/MultiEnvironmentSessionTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/MultiEnvironmentSessionTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using Xunit;
@@ -23,7 +25,7 @@ public sealed class MultiEnvironmentSessionTests : IDisposable
     }
 
     private InteractiveSession CreateSession() =>
-        new(null, _tempStore.Store, new EnvironmentConfigStore(), _mockFactory);
+        new(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
     [Fact]
     public async Task GetServiceProvider_CachesByUrl_IndependentProviders()
@@ -93,7 +95,7 @@ public sealed class MultiEnvironmentSessionTests : IDisposable
         var profile2 = TempProfileStore.CreateTestProfile("profile2", environmentUrl: "https://dev.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("profile1", profile1, profile2);
 
-        await using var session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), _mockFactory);
+        await using var session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         await session.GetServiceProviderAsync("https://dev.crm.dynamics.com");
         await session.GetServiceProviderAsync("https://prod.crm.dynamics.com");
@@ -115,7 +117,7 @@ public sealed class MultiEnvironmentSessionTests : IDisposable
         var profile = TempProfileStore.CreateTestProfile("TestProfile", environmentUrl: "https://dev.crm.dynamics.com");
         await _tempStore.SeedProfilesAsync("TestProfile", profile);
 
-        await using var session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), _mockFactory);
+        await using var session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), _mockFactory);
 
         var providerDev = await session.GetServiceProviderAsync("https://dev.crm.dynamics.com");
 

--- a/tests/PPDS.Cli.Tests/Tui/Screens/SqlQueryScreenTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Screens/SqlQueryScreenTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using PPDS.Cli.Tui.Infrastructure;
@@ -22,7 +24,7 @@ public sealed class SqlQueryScreenTests : IDisposable
     public SqlQueryScreenTests()
     {
         _tempStore = new TempProfileStore();
-        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new MockServiceProviderFactory());
+        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), new MockServiceProviderFactory());
     }
 
     public void Dispose()

--- a/tests/PPDS.Cli.Tests/Tui/Screens/TuiScreenBaseTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Screens/TuiScreenBaseTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using PPDS.Cli.Tui.Infrastructure;
@@ -17,7 +19,7 @@ public sealed class TuiScreenBaseTests : IDisposable
     public TuiScreenBaseTests()
     {
         _tempStore = new TempProfileStore();
-        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new MockServiceProviderFactory());
+        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), new MockServiceProviderFactory());
     }
 
     public void Dispose()

--- a/tests/PPDS.Cli.Tests/Tui/Views/TabBarTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Views/TabBarTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.Settings;
 using PPDS.Cli.Tests.Mocks;
 using PPDS.Cli.Tui;
 using PPDS.Cli.Tui.Infrastructure;
@@ -19,7 +21,7 @@ public sealed class TabBarTests : IDisposable
     public TabBarTests()
     {
         _tempStore = new TempProfileStore();
-        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new MockServiceProviderFactory());
+        _session = new InteractiveSession(null, _tempStore.Store, new EnvironmentConfigStore(), new TuiStateStore(Path.GetTempFileName()), new MockServiceProviderFactory());
         _tabManager = new TabManager(new TuiThemeService());
         _tabBar = new TabBar(_tabManager, new TuiThemeService());
     }


### PR DESCRIPTION
## Summary

- **TUI:** Persist filter selections (solution dropdowns, plugin trace filters) across sessions in `~/.ppds/tui-state.json`, scoped per screen and environment
- **Extension:** Add `globalState` persistence to `EnvironmentVariablesPanel` matching the existing `WebResourcesPanel` pattern
- **Stale references:** Visible fallback — notify user, clear stale value, show unfiltered results

## Changes

### New files
- `src/PPDS.Cli/Services/Settings/TuiStateStore.cs` — JSON state store with semaphore locking, atomic writes, graceful corruption handling
- `src/PPDS.Cli/Services/Settings/ScreenState.cs` — `WebResourcesScreenState` and `SolutionFilterScreenState` records
- `tests/PPDS.Cli.Tests/Services/Settings/TuiStateStoreTests.cs` — 10 unit tests

### Modified files
- `ProfilePaths.cs` — add `TuiStateFile` property
- `InteractiveSession.cs` — accept and expose `TuiStateStore`
- `PpdsApplication.cs` — create `TuiStateStore` on startup
- `WebResourcesScreen.cs` — restore/save selectedSolutionId + textOnly
- `ConnectionReferencesScreen.cs` — restore/save solutionFilter
- `EnvironmentVariablesScreen.cs` — restore/save solutionFilter
- `PluginTracesScreen.cs` — restore/save full PluginTraceFilter
- `EnvironmentVariablesPanel.ts` — add globalState persistence
- `extension.ts` — pass ExtensionContext to EnvironmentVariablesPanel

## Test plan

- [x] `dotnet build PPDS.sln` — 0 errors, 0 warnings
- [x] `dotnet test PPDS.sln --filter "Category!=Integration"` — all pass (2159 CLI tests × 3 TFMs)
- [x] `npm run typecheck:all` — clean
- [x] `npx eslint --quiet` on changed TS files — clean
- [x] TuiStateStoreTests: 10/10 pass (round-trip, scoping, normalization, corruption, concurrency)
- [ ] Manual: TUI filter persists across restart
- [ ] Manual: Extension EnvironmentVariablesPanel filter persists across panel close/reopen

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)