### PR TITLE
fix: restore superpowers plugin disable for ppds

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": false
+  },
   "permissions": {
     "allow": [
       "Bash(ls:*)",


### PR DESCRIPTION
## Summary

- Restores `enabledPlugins: { "superpowers@claude-plugins-official": false }` to `.claude/settings.json`
- Originally added in `5c0a3a64f` (March 16), erroneously removed in `a0c388298` (March 18)
- The AI thought removing the `false` entry meant "already disabled" — but removing the project-level override just falls through to the global `true` in `~/.claude/settings.json`

## Test plan

- [ ] Start a new Claude Code session in ppds — superpowers skills should not appear in the skill list
- [ ] Start a session in a ppds worktree — same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)