### PR TITLE
fix: PpdsException compliance and error handling hardening

### DIFF
--- a/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
+++ b/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
@@ -149,7 +149,7 @@ public sealed class PowerPlatformTokenProvider : IPowerPlatformTokenProvider
 
         if (string.IsNullOrWhiteSpace(clientSecret))
             throw new AuthenticationException(
-                "Client secret is required for ClientSecret authentication. " +
+                $"Client secret not found for application '{profile.ApplicationId}'. " +
                 "Run 'ppds auth create' to recreate the profile with credentials.",
                 "Auth.InvalidCredentials");
 

--- a/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
+++ b/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
@@ -133,16 +133,25 @@ public sealed class PowerPlatformTokenProvider : IPowerPlatformTokenProvider
     public static PowerPlatformTokenProvider FromProfileWithSecret(AuthProfile profile, string clientSecret)
     {
         if (profile.AuthMethod != AuthMethod.ClientSecret)
-            throw new ArgumentException($"Profile auth method must be ClientSecret, got {profile.AuthMethod}", nameof(profile));
+            throw new AuthenticationException(
+                $"Profile auth method must be ClientSecret, got {profile.AuthMethod}.",
+                "Auth.InvalidCredentials");
 
         if (string.IsNullOrWhiteSpace(profile.ApplicationId))
-            throw new ArgumentException("Profile ApplicationId is required", nameof(profile));
+            throw new AuthenticationException(
+                "Profile ApplicationId is required for ClientSecret authentication.",
+                "Auth.InvalidCredentials");
 
         if (string.IsNullOrWhiteSpace(profile.TenantId))
-            throw new ArgumentException("Profile TenantId is required", nameof(profile));
+            throw new AuthenticationException(
+                "Profile TenantId is required for ClientSecret authentication.",
+                "Auth.InvalidCredentials");
 
         if (string.IsNullOrWhiteSpace(clientSecret))
-            throw new ArgumentException("Client secret is required", nameof(clientSecret));
+            throw new AuthenticationException(
+                "Client secret is required for ClientSecret authentication. " +
+                "Run 'ppds auth create' to recreate the profile with credentials.",
+                "Auth.InvalidCredentials");
 
         return new PowerPlatformTokenProvider(profile.ApplicationId, clientSecret, profile.TenantId, profile.Cloud);
     }

--- a/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
+++ b/src/PPDS.Auth/Credentials/PowerPlatformTokenProvider.cs
@@ -108,15 +108,15 @@ public sealed class PowerPlatformTokenProvider : IPowerPlatformTokenProvider
                 new PowerPlatformTokenProvider(profile.Cloud, profile.TenantId, profile.Username, profile.HomeAccountId),
 
             AuthMethod.ClientSecret =>
-                throw new ArgumentException(
+                throw new AuthenticationException(
                     "Cannot create user-delegated token provider from ClientSecret profile. " +
                     "Use FromProfileWithSecret() for SPN authentication.",
-                    nameof(profile)),
+                    "Auth.InvalidCredentials"),
 
-            _ => throw new ArgumentException(
+            _ => throw new AuthenticationException(
                 $"Auth method {profile.AuthMethod} is not supported for Power Platform API tokens. " +
                 "Supported methods: InteractiveBrowser, DeviceCode, ClientSecret.",
-                nameof(profile))
+                "Auth.InvalidCredentials")
         };
     }
 

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcException.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcException.cs
@@ -95,6 +95,50 @@ public class RpcErrorData
     /// </summary>
     [JsonPropertyName("target")]
     public string? Target { get; set; }
+
+    /// <summary>
+    /// Whether the user needs to re-authenticate (from PpdsAuthException).
+    /// </summary>
+    [JsonPropertyName("requiresReauthentication")]
+    public bool? RequiresReauthentication { get; set; }
+
+    /// <summary>
+    /// Seconds to wait before retrying (from PpdsThrottleException).
+    /// </summary>
+    [JsonPropertyName("retryAfterSeconds")]
+    public double? RetryAfterSeconds { get; set; }
+
+    /// <summary>
+    /// List of validation errors (from PpdsValidationException).
+    /// </summary>
+    [JsonPropertyName("validationErrors")]
+    public List<RpcValidationError>? ValidationErrors { get; set; }
+
+    /// <summary>
+    /// The type of resource that was not found (from PpdsNotFoundException).
+    /// </summary>
+    [JsonPropertyName("resourceType")]
+    public string? ResourceType { get; set; }
+
+    /// <summary>
+    /// The identifier of the resource that was not found (from PpdsNotFoundException).
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public string? ResourceId { get; set; }
+}
+
+/// <summary>
+/// A single validation error for RPC responses.
+/// </summary>
+public class RpcValidationError
+{
+    /// <summary>The field that failed validation.</summary>
+    [JsonPropertyName("field")]
+    public string Field { get; set; } = "";
+
+    /// <summary>The validation error message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = "";
 }
 
 /// <summary>

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -22,12 +22,14 @@ using PPDS.Dataverse.Metadata;
 using PPDS.Dataverse.Metadata.Models;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Query;
+using PPDS.Dataverse.Query.Execution;
 using PPDS.Dataverse.Security;
 using PPDS.Dataverse.Services;
 using PPDS.Cli.Services;
 using PPDS.Cli.Services.Query;
 using PPDS.Dataverse.Sql.Intellisense;
 using PPDS.Query.Intellisense;
+using PPDS.Query.Parsing;
 using System.Threading;
 using StreamJsonRpc;
 
@@ -1819,7 +1821,7 @@ public class RpcMethodHandler : IDisposable
                 }
                 catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.ParseError)
                 {
-                    throw new RpcException(ErrorCodes.Query.ParseError, ex.Message);
+                    throw new RpcException(ErrorCodes.Query.ParseError, ex.UserMessage);
                 }
             }
 
@@ -1920,17 +1922,17 @@ public class RpcMethodHandler : IDisposable
             }
             catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.ParseError)
             {
-                throw new RpcException(ErrorCodes.Query.ParseError, ex.Message);
+                throw new RpcException(ErrorCodes.Query.ParseError, ex.UserMessage);
             }
             catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.DmlConfirmationRequired)
             {
                 throw new RpcException(
                     ErrorCodes.Query.DmlConfirmationRequired,
-                    ex.Message,
+                    ex.UserMessage,
                     new DmlSafetyErrorData
                     {
                         Code = ErrorCodes.Query.DmlConfirmationRequired,
-                        Message = ex.Message,
+                        Message = ex.UserMessage,
                         DmlConfirmationRequired = true,
                     });
             }
@@ -1938,21 +1940,21 @@ public class RpcMethodHandler : IDisposable
             {
                 throw new RpcException(
                     ErrorCodes.Query.DmlBlocked,
-                    ex.Message,
+                    ex.UserMessage,
                     new DmlSafetyErrorData
                     {
                         Code = ErrorCodes.Query.DmlBlocked,
-                        Message = ex.Message,
+                        Message = ex.UserMessage,
                         DmlBlocked = true,
                     });
             }
             catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.TdsIncompatible)
             {
-                throw new RpcException(ErrorCodes.Query.TdsIncompatible, ex.Message);
+                throw new RpcException(ErrorCodes.Query.TdsIncompatible, ex.UserMessage);
             }
             catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.TdsConnectionFailed)
             {
-                throw new RpcException(ErrorCodes.Query.TdsConnectionFailed, ex.Message);
+                throw new RpcException(ErrorCodes.Query.TdsConnectionFailed, ex.UserMessage);
             }
             catch (PpdsException ex)
             {
@@ -2093,7 +2095,7 @@ public class RpcMethodHandler : IDisposable
                 }
                 catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.ParseError)
                 {
-                    throw new RpcException(ErrorCodes.Query.ParseError, ex.Message);
+                    throw new RpcException(ErrorCodes.Query.ParseError, ex.UserMessage);
                 }
             }
 
@@ -2182,7 +2184,7 @@ public class RpcMethodHandler : IDisposable
                 };
             }
             catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is PpdsException or QueryExecutionException or QueryParseException)
             {
                 _logger.LogWarning(ex, "Query plan building failed, falling back to FetchXML");
                 // Fall back to just the transpiled FetchXML if plan building fails
@@ -2198,7 +2200,7 @@ public class RpcMethodHandler : IDisposable
                 }
                 catch (PpdsException parseEx) when (parseEx.ErrorCode == ErrorCodes.Query.ParseError)
                 {
-                    throw new RpcException(ErrorCodes.Query.ParseError, parseEx.Message);
+                    throw new RpcException(ErrorCodes.Query.ParseError, parseEx.UserMessage);
                 }
             }
         }, cancellationToken);
@@ -2347,6 +2349,36 @@ public class RpcMethodHandler : IDisposable
 
         var insertPoint = fetchIndex + "<fetch".Length;
         return fetchXml.Substring(0, insertPoint) + $" top=\"{top}\"" + fetchXml.Substring(insertPoint);
+    }
+
+    /// <summary>
+    /// Maps a PpdsException (or subclass) to an RpcException with structured error data.
+    /// Preserves subclass-specific properties (RequiresReauthentication, RetryAfter, etc.).
+    /// </summary>
+    private static RpcException MapPpdsToRpcException(PpdsException ex)
+    {
+        var data = new RpcErrorData { Code = ex.ErrorCode, Message = ex.UserMessage };
+
+        switch (ex)
+        {
+            case PpdsAuthException authEx:
+                data.RequiresReauthentication = authEx.RequiresReauthentication;
+                break;
+            case PpdsThrottleException throttleEx:
+                data.RetryAfterSeconds = throttleEx.RetryAfter.TotalSeconds;
+                break;
+            case PpdsValidationException validationEx:
+                data.ValidationErrors = validationEx.Errors
+                    .Select(e => new RpcValidationError { Field = e.Field, Message = e.Message })
+                    .ToList();
+                break;
+            case PpdsNotFoundException notFoundEx:
+                data.ResourceType = notFoundEx.ResourceType;
+                data.ResourceId = notFoundEx.ResourceId;
+                break;
+        }
+
+        return new RpcException(ex.ErrorCode, ex.UserMessage, data);
     }
 
     private static QueryResultResponse MapToResponse(QueryResult result, string? fetchXml)
@@ -2641,46 +2673,9 @@ public class RpcMethodHandler : IDisposable
                 Environment = result.EnvironmentUrl,
             };
         }
-        catch (PpdsAuthException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RequiresReauthentication = ex.RequiresReauthentication
-            });
-        }
-        catch (PpdsThrottleException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
-            });
-        }
-        catch (PpdsValidationException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
-            });
-        }
-        catch (PpdsNotFoundException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ResourceType = ex.ResourceType,
-                ResourceId = ex.ResourceId
-            });
-        }
         catch (PpdsException ex)
         {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+            throw MapPpdsToRpcException(ex);
         }
     }
 
@@ -2720,46 +2715,9 @@ public class RpcMethodHandler : IDisposable
                 ProfileName = nameOrIndex,
             };
         }
-        catch (PpdsAuthException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RequiresReauthentication = ex.RequiresReauthentication
-            });
-        }
-        catch (PpdsThrottleException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
-            });
-        }
-        catch (PpdsValidationException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
-            });
-        }
-        catch (PpdsNotFoundException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ResourceType = ex.ResourceType,
-                ResourceId = ex.ResourceId
-            });
-        }
         catch (PpdsException ex)
         {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+            throw MapPpdsToRpcException(ex);
         }
     }
 
@@ -2802,46 +2760,9 @@ public class RpcMethodHandler : IDisposable
                 NewName = result.Name ?? newName,
             };
         }
-        catch (PpdsAuthException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RequiresReauthentication = ex.RequiresReauthentication
-            });
-        }
-        catch (PpdsThrottleException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
-            });
-        }
-        catch (PpdsValidationException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
-            });
-        }
-        catch (PpdsNotFoundException ex)
-        {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
-            {
-                Code = ex.ErrorCode,
-                Message = ex.UserMessage,
-                ResourceType = ex.ResourceType,
-                ResourceId = ex.ResourceId
-            });
-        }
         catch (PpdsException ex)
         {
-            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+            throw MapPpdsToRpcException(ex);
         }
     }
 

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -173,9 +173,9 @@ public class RpcMethodHandler : IDisposable
                 using var provider = CredentialProviderFactory.Create(profile);
                 tokenInfo = await provider.GetCachedTokenInfoAsync(profile.Environment.Url, cancellationToken);
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore errors - token info will be null
+                _logger.LogDebug(ex, "Failed to get cached token info");
             }
         }
 
@@ -1956,7 +1956,7 @@ public class RpcMethodHandler : IDisposable
             }
             catch (PpdsException ex)
             {
-                throw new RpcException(ErrorCodes.Query.ExecutionFailed, ex.Message);
+                throw new RpcException(ex.ErrorCode, ex.UserMessage);
             }
         }, cancellationToken);
 
@@ -2182,8 +2182,9 @@ public class RpcMethodHandler : IDisposable
                 };
             }
             catch (OperationCanceledException) { throw; }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogWarning(ex, "Query plan building failed, falling back to FetchXML");
                 // Fall back to just the transpiled FetchXML if plan building fails
                 try
                 {
@@ -2195,9 +2196,9 @@ public class RpcMethodHandler : IDisposable
                         FetchXml = fetchXml
                     };
                 }
-                catch (PpdsException ex) when (ex.ErrorCode == ErrorCodes.Query.ParseError)
+                catch (PpdsException parseEx) when (parseEx.ErrorCode == ErrorCodes.Query.ParseError)
                 {
-                    throw new RpcException(ErrorCodes.Query.ParseError, ex.Message);
+                    throw new RpcException(ErrorCodes.Query.ParseError, parseEx.Message);
                 }
             }
         }, cancellationToken);
@@ -2469,7 +2470,7 @@ public class RpcMethodHandler : IDisposable
             var config = await configStore.GetConfigAsync(url, ct);
             if (config?.Label != null) return config.Label;
         }
-        catch { /* config lookup is best-effort */ }
+        catch (Exception ex) { _logger.LogDebug(ex, "Config label lookup failed for {Url}", url); }
         return fallbackDisplayName;
     }
 
@@ -2622,21 +2623,65 @@ public class RpcMethodHandler : IDisposable
             Password = password,
         };
 
-        var profileService = _authServices.GetRequiredService<IProfileService>();
-        var result = await profileService.CreateProfileAsync(
-            request,
-            deviceCodeCallback: DaemonDeviceCodeHandler.CreateCallback(_rpc),
-            beforeInteractiveAuth: null,
-            cancellationToken: cancellationToken);
-
-        return new ProfileCreateResponse
+        try
         {
-            Index = result.Index,
-            Name = result.Name,
-            Identity = result.Identity,
-            AuthMethod = result.AuthMethod.ToString(),
-            Environment = result.EnvironmentUrl,
-        };
+            var profileService = _authServices.GetRequiredService<IProfileService>();
+            var result = await profileService.CreateProfileAsync(
+                request,
+                deviceCodeCallback: DaemonDeviceCodeHandler.CreateCallback(_rpc),
+                beforeInteractiveAuth: null,
+                cancellationToken: cancellationToken);
+
+            return new ProfileCreateResponse
+            {
+                Index = result.Index,
+                Name = result.Name,
+                Identity = result.Identity,
+                AuthMethod = result.AuthMethod.ToString(),
+                Environment = result.EnvironmentUrl,
+            };
+        }
+        catch (PpdsAuthException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RequiresReauthentication = ex.RequiresReauthentication
+            });
+        }
+        catch (PpdsThrottleException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
+            });
+        }
+        catch (PpdsValidationException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
+            });
+        }
+        catch (PpdsNotFoundException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ResourceType = ex.ResourceType,
+                ResourceId = ex.ResourceId
+            });
+        }
+        catch (PpdsException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+        }
     }
 
     /// <summary>
@@ -2664,14 +2709,58 @@ public class RpcMethodHandler : IDisposable
         }
 
         var nameOrIndex = index != null ? index.Value.ToString() : name!;
-        var profileService = _authServices.GetRequiredService<IProfileService>();
-        var deleted = await profileService.DeleteProfileAsync(nameOrIndex, cancellationToken);
-
-        return new ProfileDeleteResponse
+        try
         {
-            Deleted = deleted,
-            ProfileName = nameOrIndex,
-        };
+            var profileService = _authServices.GetRequiredService<IProfileService>();
+            var deleted = await profileService.DeleteProfileAsync(nameOrIndex, cancellationToken);
+
+            return new ProfileDeleteResponse
+            {
+                Deleted = deleted,
+                ProfileName = nameOrIndex,
+            };
+        }
+        catch (PpdsAuthException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RequiresReauthentication = ex.RequiresReauthentication
+            });
+        }
+        catch (PpdsThrottleException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
+            });
+        }
+        catch (PpdsValidationException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
+            });
+        }
+        catch (PpdsNotFoundException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ResourceType = ex.ResourceType,
+                ResourceId = ex.ResourceId
+            });
+        }
+        catch (PpdsException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+        }
     }
 
     /// <summary>
@@ -2698,18 +2787,62 @@ public class RpcMethodHandler : IDisposable
                 "The 'newName' parameter is required");
         }
 
-        var profileService = _authServices.GetRequiredService<IProfileService>();
-        var result = await profileService.UpdateProfileAsync(
-            currentName,
-            newName: newName,
-            cancellationToken: cancellationToken);
-
-        return new ProfileRenameResponse
+        try
         {
-            Index = result.Index,
-            PreviousName = currentName,
-            NewName = result.Name ?? newName,
-        };
+            var profileService = _authServices.GetRequiredService<IProfileService>();
+            var result = await profileService.UpdateProfileAsync(
+                currentName,
+                newName: newName,
+                cancellationToken: cancellationToken);
+
+            return new ProfileRenameResponse
+            {
+                Index = result.Index,
+                PreviousName = currentName,
+                NewName = result.Name ?? newName,
+            };
+        }
+        catch (PpdsAuthException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RequiresReauthentication = ex.RequiresReauthentication
+            });
+        }
+        catch (PpdsThrottleException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                RetryAfterSeconds = ex.RetryAfter.TotalSeconds
+            });
+        }
+        catch (PpdsValidationException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ValidationErrors = ex.Errors.Select(e => new RpcValidationError { Field = e.Field, Message = e.Message }).ToList()
+            });
+        }
+        catch (PpdsNotFoundException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage, new RpcErrorData
+            {
+                Code = ex.ErrorCode,
+                Message = ex.UserMessage,
+                ResourceType = ex.ResourceType,
+                ResourceId = ex.ResourceId
+            });
+        }
+        catch (PpdsException ex)
+        {
+            throw new RpcException(ex.ErrorCode, ex.UserMessage);
+        }
     }
 
     #endregion

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -1958,7 +1958,7 @@ public class RpcMethodHandler : IDisposable
             }
             catch (PpdsException ex)
             {
-                throw new RpcException(ex.ErrorCode, ex.UserMessage);
+                throw MapPpdsToRpcException(ex);
             }
         }, cancellationToken);
 

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -186,6 +186,9 @@ public static class ErrorCodes
 
         /// <summary>TDS Endpoint connection failed (endpoint may be disabled on environment).</summary>
         public const string TdsConnectionFailed = "Query.TdsConnectionFailed";
+
+        /// <summary>Subquery returned more than one row.</summary>
+        public const string SubqueryMultipleRows = "Query.SubqueryMultipleRows";
     }
 
     /// <summary>

--- a/src/PPDS.Cli/Infrastructure/Errors/ExceptionMapper.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ExceptionMapper.cs
@@ -30,7 +30,8 @@ public static class ExceptionMapper
         var (code, target) = MapExceptionToCode(ex);
         var details = BuildDetails(context, ex, debug);
 
-        return StructuredError.Create(code, ex.Message, details, target, debug);
+        var message = ex is PpdsException ppdsEx ? ppdsEx.UserMessage : ex.Message;
+        return StructuredError.Create(code, message, details, target, debug);
     }
 
     /// <summary>
@@ -70,6 +71,7 @@ public static class ExceptionMapper
             PpdsValidationException => ExitCodes.InvalidArguments,
             PpdsAuthException => ExitCodes.AuthError,
             PpdsThrottleException => ExitCodes.ConnectionError,
+            PpdsException { ErrorCode: ErrorCodes.Operation.Timeout } => ExitCodes.ConnectionError,
             PpdsException { ErrorCode: var code } when code.StartsWith("Plugin.") => ExitCodes.Failure,
             PpdsException { ErrorCode: var code } when code.StartsWith("Validation.") => ExitCodes.InvalidArguments,
             PpdsException { ErrorCode: var code } when code.StartsWith("Auth.") => ExitCodes.AuthError,

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -121,7 +121,33 @@ public static class Program
         // No manual CancelKeyPress handler is needed.
 
         var parseResult = rootCommand.Parse(args);
-        return await parseResult.InvokeAsync();
+
+        try
+        {
+            return await parseResult.InvokeAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            return ExitCodes.Success;
+        }
+        catch (Exception ex)
+        {
+            var debug = args.Any(a => a == "--debug");
+            var (error, exitCode) = ExceptionMapper.MapWithExitCode(ex, debug: debug);
+
+            if (debug)
+            {
+                Console.Error.WriteLine(ex.ToString());
+            }
+            else
+            {
+                Console.Error.WriteLine($"Error: {error.Message}");
+                if (error.Details != null)
+                    Console.Error.WriteLine(error.Details);
+            }
+
+            return exitCode;
+        }
     }
 
     /// <summary>

--- a/src/PPDS.Cli/Services/ConnectionService.cs
+++ b/src/PPDS.Cli/Services/ConnectionService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Credentials;
+using PPDS.Cli.Infrastructure.Errors;
 
 namespace PPDS.Cli.Services;
 
@@ -83,13 +84,15 @@ public class ConnectionService : IConnectionService
             if (response.StatusCode == System.Net.HttpStatusCode.Forbidden ||
                 response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
-                throw new InvalidOperationException(
+                throw new PpdsAuthException(
+                    ErrorCodes.Auth.InsufficientPermissions,
                     $"Cannot access connections API. Status: {response.StatusCode}. " +
                     "Service principals have limited access to the Connections API. " +
-                    "Use interactive or device code authentication for full functionality.");
+                    "Use interactive or device code authentication for full functionality.")
+                { RequiresReauthentication = true };
             }
 
-            throw new HttpRequestException($"Power Apps Admin API error: {response.StatusCode} - {errorContent}");
+            throw new PpdsException(ErrorCodes.External.ServiceUnavailable, $"Power Apps Admin API error: {response.StatusCode} - {errorContent}");
         }
 
         var content = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -134,7 +137,7 @@ public class ConnectionService : IConnectionService
         {
             var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
             _logger.LogError("Power Apps Admin API error: {StatusCode} - {Content}", response.StatusCode, errorContent);
-            throw new HttpRequestException($"Power Apps Admin API error: {response.StatusCode}");
+            throw new PpdsException(ErrorCodes.External.ServiceUnavailable, $"Power Apps Admin API error: {response.StatusCode}");
         }
 
         var content = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
+++ b/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
@@ -28,7 +28,7 @@ public static class TdsQueryExecutorFactory
         if (profile.AuthMethod == AuthMethod.ClientSecret)
         {
 #pragma warning disable PPDS012
-            var storedCredential = credentialStore.GetAsync(profile.ApplicationId!).GetAwaiter().GetResult();
+            var storedCredential = credentialStore.GetAsync(profile.ApplicationId ?? "").GetAwaiter().GetResult();
 #pragma warning restore PPDS012
             tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
         }

--- a/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
+++ b/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
@@ -27,17 +27,10 @@ public static class TdsQueryExecutorFactory
         IPowerPlatformTokenProvider tokenProvider;
         if (profile.AuthMethod == AuthMethod.ClientSecret)
         {
-            if (string.IsNullOrEmpty(profile.ApplicationId))
-                throw new InvalidOperationException(
-                    $"Profile '{profile.DisplayIdentifier}' is configured for ClientSecret auth but has no ApplicationId.");
-
 #pragma warning disable PPDS012
-            var storedCredential = credentialStore.GetAsync(profile.ApplicationId).GetAwaiter().GetResult();
+            var storedCredential = credentialStore.GetAsync(profile.ApplicationId!).GetAwaiter().GetResult();
 #pragma warning restore PPDS012
-            if (storedCredential?.ClientSecret == null)
-                throw new InvalidOperationException(
-                    $"Client secret not found for application '{profile.ApplicationId}'.");
-            tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential.ClientSecret);
+            tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
         }
         else
         {

--- a/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
+++ b/src/PPDS.Cli/Services/Query/TdsQueryExecutorFactory.cs
@@ -27,8 +27,13 @@ public static class TdsQueryExecutorFactory
         IPowerPlatformTokenProvider tokenProvider;
         if (profile.AuthMethod == AuthMethod.ClientSecret)
         {
+            if (string.IsNullOrEmpty(profile.ApplicationId))
+                throw new AuthenticationException(
+                    $"Profile '{profile.DisplayIdentifier}' is configured for ClientSecret auth but has no ApplicationId.",
+                    "Auth.InvalidCredentials");
+
 #pragma warning disable PPDS012
-            var storedCredential = credentialStore.GetAsync(profile.ApplicationId ?? "").GetAwaiter().GetResult();
+            var storedCredential = credentialStore.GetAsync(profile.ApplicationId).GetAwaiter().GetResult();
 #pragma warning restore PPDS012
             tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
         }

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -143,10 +143,17 @@ public static class ServiceRegistration
 
             if (profile.AuthMethod == AuthMethod.ClientSecret)
             {
+                if (string.IsNullOrEmpty(profile.ApplicationId))
+                {
+                    throw new AuthenticationException(
+                        $"Profile '{profile.DisplayIdentifier}' is configured for ClientSecret auth but has no ApplicationId.",
+                        "Auth.InvalidCredentials");
+                }
+
                 // DI factory delegates are synchronous; GetAsync is safe here because
                 // credential store uses file I/O, not network calls that would benefit from async.
 #pragma warning disable PPDS012 // Sync-over-async: DI factory cannot be async
-                var storedCredential = credentialStore.GetAsync(profile.ApplicationId ?? "").GetAwaiter().GetResult();
+                var storedCredential = credentialStore.GetAsync(profile.ApplicationId).GetAwaiter().GetResult();
 #pragma warning restore PPDS012
                 tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
             }

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -143,25 +143,12 @@ public static class ServiceRegistration
 
             if (profile.AuthMethod == AuthMethod.ClientSecret)
             {
-                // SPN - need secret from credential store (keyed by ApplicationId)
-                if (string.IsNullOrEmpty(profile.ApplicationId))
-                {
-                    throw new InvalidOperationException(
-                        $"Profile '{profile.DisplayIdentifier}' is configured for ClientSecret auth but has no ApplicationId.");
-                }
-
                 // DI factory delegates are synchronous; GetAsync is safe here because
                 // credential store uses file I/O, not network calls that would benefit from async.
 #pragma warning disable PPDS012 // Sync-over-async: DI factory cannot be async
-                var storedCredential = credentialStore.GetAsync(profile.ApplicationId).GetAwaiter().GetResult();
+                var storedCredential = credentialStore.GetAsync(profile.ApplicationId!).GetAwaiter().GetResult();
 #pragma warning restore PPDS012
-                if (storedCredential?.ClientSecret == null)
-                {
-                    throw new InvalidOperationException(
-                        $"Client secret not found for application '{profile.ApplicationId}'. " +
-                        "Run 'ppds auth create' to recreate the profile with credentials.");
-                }
-                tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential.ClientSecret);
+                tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
             }
             else
             {

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -146,7 +146,7 @@ public static class ServiceRegistration
                 // DI factory delegates are synchronous; GetAsync is safe here because
                 // credential store uses file I/O, not network calls that would benefit from async.
 #pragma warning disable PPDS012 // Sync-over-async: DI factory cannot be async
-                var storedCredential = credentialStore.GetAsync(profile.ApplicationId!).GetAwaiter().GetResult();
+                var storedCredential = credentialStore.GetAsync(profile.ApplicationId ?? "").GetAwaiter().GetResult();
 #pragma warning restore PPDS012
                 tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
             }

--- a/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
+++ b/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
@@ -82,7 +82,7 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfile(profile);
 
-        act.Should().Throw<ArgumentException>()
+        act.Should().Throw<AuthenticationException>()
             .WithMessage("*Cannot create user-delegated*FromProfileWithSecret*");
     }
 
@@ -97,7 +97,7 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfile(profile);
 
-        act.Should().Throw<ArgumentException>()
+        act.Should().Throw<AuthenticationException>()
             .WithMessage("*not supported for Power Platform API tokens*");
     }
 

--- a/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
+++ b/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
@@ -179,7 +179,7 @@ public class PowerPlatformTokenProviderTests
         var act = () => PowerPlatformTokenProvider.FromProfileWithSecret(profile, null!);
 
         act.Should().Throw<AuthenticationException>()
-            .WithMessage("*Client secret is required*");
+            .WithMessage("*Client secret not found*");
     }
 
     [Fact]

--- a/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
+++ b/tests/PPDS.Auth.Tests/Credentials/PowerPlatformTokenProviderTests.cs
@@ -129,7 +129,7 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfileWithSecret(profile, "secret");
 
-        act.Should().Throw<ArgumentException>()
+        act.Should().Throw<AuthenticationException>()
             .WithMessage("*must be ClientSecret*");
     }
 
@@ -145,7 +145,7 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfileWithSecret(profile, "secret");
 
-        act.Should().Throw<ArgumentException>()
+        act.Should().Throw<AuthenticationException>()
             .WithMessage("*ApplicationId is required*");
     }
 
@@ -161,7 +161,7 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfileWithSecret(profile, "secret");
 
-        act.Should().Throw<ArgumentException>()
+        act.Should().Throw<AuthenticationException>()
             .WithMessage("*TenantId is required*");
     }
 
@@ -178,8 +178,8 @@ public class PowerPlatformTokenProviderTests
 
         var act = () => PowerPlatformTokenProvider.FromProfileWithSecret(profile, null!);
 
-        act.Should().Throw<ArgumentException>()
-            .WithParameterName("clientSecret");
+        act.Should().Throw<AuthenticationException>()
+            .WithMessage("*Client secret is required*");
     }
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Services/ConnectionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ConnectionServiceTests.cs
@@ -95,7 +95,7 @@ public class ConnectionServiceTests
         {
             await service.ListAsync();
         }
-        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException or PpdsAuthException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException)
         {
             // Expected - no mock HTTP client (may throw HttpRequestException, PpdsException, or PpdsAuthException)
         }
@@ -131,7 +131,7 @@ public class ConnectionServiceTests
         {
             await service.GetAsync("test-connection-id");
         }
-        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException or PpdsAuthException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException)
         {
             // Expected - no mock HTTP client (may throw HttpRequestException, PpdsException, or PpdsAuthException)
         }

--- a/tests/PPDS.Cli.Tests/Services/ConnectionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ConnectionServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using PPDS.Auth.Cloud;
 using PPDS.Auth.Credentials;
+using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Services;
 using Xunit;
 
@@ -94,9 +95,9 @@ public class ConnectionServiceTests
         {
             await service.ListAsync();
         }
-        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException or PpdsAuthException)
         {
-            // Expected - no mock HTTP client (may throw HttpRequestException or InvalidOperationException for auth)
+            // Expected - no mock HTTP client (may throw HttpRequestException, PpdsException, or PpdsAuthException)
         }
 
         _mockTokenProvider.Verify(x => x.GetFlowApiTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -130,9 +131,9 @@ public class ConnectionServiceTests
         {
             await service.GetAsync("test-connection-id");
         }
-        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException or PpdsException or PpdsAuthException)
         {
-            // Expected - no mock HTTP client (may throw HttpRequestException or InvalidOperationException for auth)
+            // Expected - no mock HTTP client (may throw HttpRequestException, PpdsException, or PpdsAuthException)
         }
 
         _mockTokenProvider.Verify(x => x.GetFlowApiTokenAsync(It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
## Summary
- Wrap 3 raw exception throws in `ConnectionService` with `PpdsException`/`PpdsAuthException` (Constitution D4)
- Consolidate duplicate credential validation into `PowerPlatformTokenProvider.FromProfileWithSecret()`, throwing `AuthenticationException` with error codes
- Fix `ExceptionMapper` to use `PpdsException.UserMessage`, add missing `SubqueryMultipleRows` error code, map `Operation.Timeout` exit code
- Add global exception handler safety net in `Program.cs` (structured error to stderr, not raw stack traces)
- Harden RPC error handling: add try/catch to 3 unhandled profile methods, extract `MapPpdsToRpcException` helper, extend `RpcErrorData` with subclass-specific properties (RequiresReauthentication, RetryAfterSeconds, ValidationErrors, ResourceType/ResourceId), use `ex.UserMessage` consistently, narrow query explain fallback catch, log bare catch blocks
- Filed PPDS004 UseStructuredExceptions analyzer issue (#675) for ongoing enforcement

Closes #477

## Test Plan
- [x] All .NET unit tests pass (0 failures across net8.0/9.0/10.0)
- [x] Build succeeds with 0 errors, 0 warnings
- [x] CLI boots, auth list, env list, invalid SQL error all verified
- [x] Existing ConnectionService and PowerPlatformTokenProvider tests updated for new exception types

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: cli)
- [x] /qa completed (surfaces: cli)
- [x] /review completed (findings: 2 — both addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)