### PR TITLE
fix: handle absolute paths in protect-main-branch hook

### DIFF
--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -30,8 +30,14 @@ def get_current_branch() -> str:
 
 def is_allowed_path(file_path: str) -> bool:
     normalized = file_path.replace("\\", "/").lower()
+    # Strip project dir prefix so absolute paths work the same as relative ones
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").replace("\\", "/").lower().rstrip("/")
+    if project_dir and normalized.startswith(project_dir + "/"):
+        normalized = normalized[len(project_dir) + 1:]
     allowed_prefixes = [
         ".plans/",
+        # specs/ allowed — design artifacts committed to main
+        "specs/",
     ]
     allowed_substrings = [
         "/tmp/",
@@ -39,12 +45,9 @@ def is_allowed_path(file_path: str) -> bool:
         "appdata/local/temp",
         ".worktrees/",
     ]
-    # specs/ allowed â€” design artifacts committed to main
-    allowed_prefixes.append("specs/")
     return any(normalized.startswith(p) for p in allowed_prefixes) or any(
         s in normalized for s in allowed_substrings
     )
-
 
 def main() -> None:
     branch = get_current_branch()


### PR DESCRIPTION
## Summary
- `is_allowed_path` compared relative prefixes (`specs/`, `.plans/`) against absolute `file_path` values passed by Claude Code, so writes to `specs/` and `.plans/` were incorrectly blocked on `main`
- Fix: strip `CLAUDE_PROJECT_DIR` prefix before prefix checks so both absolute and relative paths resolve correctly
- All 6 smoke-test cases pass (absolute + relative, allowed + blocked)

Closes #477

## Test Plan
- [x] Smoke-tested `is_allowed_path` with absolute and relative paths for `specs/`, `.plans/`, and `src/` — all pass
- [x] Verified `specs/migration.md` (absolute path) now allowed on `main`

## Verification
- No gates required (hook-only change, no C# or TS code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)