### PR TITLE
fix: design workflow — specs go through branches, not main

### DIFF
--- a/.claude/hooks/notify.py
+++ b/.claude/hooks/notify.py
@@ -13,6 +13,13 @@ import os
 import sys
 
 
+def _is_worktree(cwd):
+    """Return True if cwd is a git worktree (not the main repo)."""
+    git_path = os.path.join(cwd, ".git")
+    # In a worktree, .git is a file (not a directory) containing "gitdir: ..."
+    return os.path.isfile(git_path)
+
+
 def get_pr_url(cwd):
     """Read PR URL from workflow state if available."""
     state_path = os.path.join(cwd, ".workflow", "state.json")
@@ -56,13 +63,18 @@ def main():
         show_toast(args.title, args.msg, args.url)
         return
 
-    # Hook mode — read from stdin, get URL from workflow state
+    # Hook mode — only fires inside a worktree (never on main repo root)
     try:
         data = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         return
 
     cwd = data.get("cwd", ".")
+
+    # Worktree check: .workflow/state.json should only exist in .worktrees/<name>/
+    if not _is_worktree(cwd):
+        return
+
     pr_url = get_pr_url(cwd)
     if pr_url:
         show_toast(args.title, args.msg, pr_url)

--- a/.claude/hooks/notify.py
+++ b/.claude/hooks/notify.py
@@ -1,13 +1,13 @@
-"""Desktop toast notification hook for Claude Code.
+"""Desktop toast notification for Claude Code.
 
-Fires on idle_prompt only when a PR URL exists in workflow state.
-Clicking the toast opens the PR in the default browser.
-
-Hook event: Notification
-Matcher: idle_prompt
-Input: JSON on stdin with message, title, notification_type, cwd
+Two modes:
+  1. Direct invocation (from /pr skill or ad-hoc):
+       python notify.py --title "PR Ready" --msg "Click to open" --url "https://..."
+  2. Hook mode (Notification event, idle_prompt matcher):
+       Reads JSON from stdin, pulls PR URL from workflow state.
 """
 
+import argparse
 import json
 import os
 import sys
@@ -26,33 +26,46 @@ def get_pr_url(cwd):
         return None
 
 
-def main():
+def show_toast(title, msg, url):
+    """Show a Windows desktop toast notification."""
     try:
         from winotify import Notification, audio
     except ImportError:
         # winotify not installed — skip silently
         return
 
+    toast = Notification(
+        app_id="Claude Code",
+        title=title,
+        msg=msg,
+        launch=url,
+    )
+    toast.set_audio(audio.Default, loop=False)
+    toast.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Desktop toast notification")
+    parser.add_argument("--title", default="PR Ready")
+    parser.add_argument("--msg", default="Click to open pull request")
+    parser.add_argument("--url", default=None, help="URL to open on click")
+    args = parser.parse_args()
+
+    # Direct invocation — URL provided via CLI
+    if args.url:
+        show_toast(args.title, args.msg, args.url)
+        return
+
+    # Hook mode — read from stdin, get URL from workflow state
     try:
         data = json.load(sys.stdin)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, ValueError):
         return
 
     cwd = data.get("cwd", ".")
     pr_url = get_pr_url(cwd)
-
-    # Only notify when a PR is ready
-    if not pr_url:
-        return
-
-    toast = Notification(
-        app_id="Claude Code",
-        title="PR Ready",
-        msg="Click to open pull request",
-        launch=pr_url,
-    )
-    toast.set_audio(audio.Default, loop=False)
-    toast.show()
+    if pr_url:
+        show_toast(args.title, args.msg, pr_url)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -1,6 +1,6 @@
 """PreToolUse hook: block Edit/Write on main branch.
 
-Forces worktree workflow — all implementation changes must happen on a feature branch.
+Forces worktree workflow — all changes must happen on a feature branch.
 Exceptions: .plans/ (ephemeral, gitignored), temp directories.
 """
 
@@ -36,8 +36,6 @@ def is_allowed_path(file_path: str) -> bool:
         normalized = normalized[len(project_dir) + 1:]
     allowed_prefixes = [
         ".plans/",
-        # specs/ allowed � design artifacts committed to main
-        "specs/",
     ]
     allowed_substrings = [
         "/tmp/",

--- a/.claude/hooks/session-start-workflow.py
+++ b/.claude/hooks/session-start-workflow.py
@@ -202,8 +202,8 @@ def _show_main_guidance(project_dir):
         pass
 
     lines.append("")
-    lines.append("To start new work: /design or python scripts/pipeline.py <plan-path>")
-    lines.append("Planning and exploration are fine on main. Implementation requires a worktree.")
+    lines.append("To start new work: /design (creates spec branch) or python scripts/pipeline.py <plan-path>")
+    lines.append("Brainstorming is fine on main. All file changes (specs included) require a branch.")
 
     print("\n".join(lines), file=sys.stderr)
 

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -46,19 +46,19 @@ Ask clarifying questions **one at a time**:
 ### 5. Write Spec
 
 When the design is approved:
-1. Create a `spec/<name>` branch from main: `git checkout -b spec/<name>`
-2. Write the spec to `specs/<name>.md` using the spec template
+1. Create a worktree: `git worktree add .worktrees/spec-<name> -b spec/<name>`
+2. Write the spec to `.worktrees/spec-<name>/specs/<name>.md` using the spec template
 3. Include numbered acceptance criteria (Constitution I3)
-4. Commit the spec on the branch
+4. Commit the spec in the worktree: `git -C .worktrees/spec-<name> add specs/ && git -C .worktrees/spec-<name> commit -m "spec: <name>"`
 5. Present the spec path for user review
 
-**Why a branch?** GitHub branch protection blocks direct pushes to main. Specs go through PRs like everything else.
+**Why a worktree?** You stay on main, ready for the next design session. The spec lives in its own branch without switching context. GitHub branch protection blocks direct pushes to main, so specs go through PRs like everything else.
 
 ### 6. Transition
 
 After user approves the written spec:
 1. Write an implementation plan to `.plans/` (ephemeral, gitignored — do NOT commit plans)
-2. Push the spec branch and create a PR for the spec
+2. Push the spec branch and create a PR: `git -C .worktrees/spec-<name> push -u origin spec/<name>` then `gh pr create`
 3. Present the pipeline command for implementation:
 
 > Spec PR created: `<url>`

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -57,9 +57,8 @@ When the design is approved:
 ### 6. Transition
 
 After user approves the written spec:
-1. Write an implementation plan to `.plans/` (ephemeral, gitignored — do NOT commit plans)
-2. Push the spec branch and create a PR: `git -C .worktrees/spec-<name> push -u origin spec/<name>` then `gh pr create`
-3. Present the pipeline command for implementation:
+1. Push the spec branch and create a PR: `git -C .worktrees/spec-<name> push -u origin spec/<name>` then `gh pr create`
+2. Present the pipeline command for implementation:
 
 > Spec PR created: `<url>`
 >
@@ -73,7 +72,7 @@ python scripts/pipeline.py --spec specs/<name>.md --branch <branch-name>
 ```
 Run this in the background so the user can check `/status` while it runs.
 
-If deferring, note the plan path for the next session.
+If deferring, note the spec path for the next session.
 
 ## Key Principles
 

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -46,28 +46,30 @@ Ask clarifying questions **one at a time**:
 ### 5. Write Spec
 
 When the design is approved:
-1. Write the spec to `specs/<name>.md` on main using the spec template
-2. Include numbered acceptance criteria (Constitution I3)
-3. Commit the spec directly to main (`specs/` is allowed by protect-main-branch hook)
-4. Present the spec path for user review
+1. Create a `spec/<name>` branch from main: `git checkout -b spec/<name>`
+2. Write the spec to `specs/<name>.md` using the spec template
+3. Include numbered acceptance criteria (Constitution I3)
+4. Commit the spec on the branch
+5. Present the spec path for user review
+
+**Why a branch?** GitHub branch protection blocks direct pushes to main. Specs go through PRs like everything else.
 
 ### 6. Transition
 
 After user approves the written spec:
 1. Write an implementation plan to `.plans/` (ephemeral, gitignored — do NOT commit plans)
-2. Present the plan path and pipeline command:
+2. Push the spec branch and create a PR for the spec
+3. Present the pipeline command for implementation:
 
-> Plan saved to `.plans/<filename>.md`.
+> Spec PR created: `<url>`
 >
-> To execute: `python scripts/pipeline.py --plan .plans/<filename>.md --branch <branch-name>`
->
-> Or with spec only: `python scripts/pipeline.py --spec specs/<name>.md --branch <branch-name>`
+> To implement: `python scripts/pipeline.py --spec specs/<name>.md --branch <branch-name>`
 >
 > Or say "run it" and I'll invoke the pipeline from here.
 
 If the user wants to proceed immediately, invoke the pipeline:
 ```bash
-python scripts/pipeline.py --plan .plans/<filename>.md --branch <branch-name>
+python scripts/pipeline.py --spec specs/<name>.md --branch <branch-name>
 ```
 Run this in the background so the user can check `/status` while it runs.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -157,13 +157,23 @@ python scripts/workflow-state.py set pr.url "{pr-url}"
 python scripts/workflow-state.py set pr.created now
 ```
 
-After Gemini comments are triaged (step 4 complete):
+After Gemini comments are triaged (step 5 complete):
 
 ```bash
 python scripts/workflow-state.py set pr.gemini_triaged true
 ```
 
-The stop hook will BLOCK the session from ending if `gemini_triaged` is not set after PR creation. Do not skip step 4.
+The stop hook will BLOCK the session from ending if `gemini_triaged` is not set after PR creation. Do not skip step 5.
+
+### 8. Notify
+
+Fire a desktop toast so the user knows the PR is ready:
+
+```bash
+python .claude/hooks/notify.py --title "PR Ready" --msg "Gemini triaged — click to review" --url "{pr-url}"
+```
+
+This fires immediately — do not rely on idle_prompt for notification.
 
 ## Timeout Behavior
 

--- a/scripts/workflow-state.py
+++ b/scripts/workflow-state.py
@@ -23,13 +23,47 @@ Magic values for 'set':
 """
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 
 
+def _get_worktree_root():
+    """Return the git toplevel for the current working tree.
+
+    In a worktree this returns .worktrees/<name>/, on main it returns
+    the repo root.  We use this instead of CLAUDE_PROJECT_DIR so that
+    workflow state lands in the worktree, not the main repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+
+
+def _is_main_branch():
+    """Return True if the current branch is main/master."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() in ("main", "master")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return False
+
+
 def get_state_path():
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
-    state_dir = os.path.join(project_dir, ".workflow")
+    root = _get_worktree_root()
+    state_dir = os.path.join(root, ".workflow")
     os.makedirs(state_dir, exist_ok=True)
     return os.path.join(state_dir, "state.json")
 
@@ -88,6 +122,16 @@ def main():
         sys.exit(1)
 
     command = sys.argv[1]
+
+    # Read-only commands are fine anywhere; writes are blocked on main
+    write_commands = ("set", "set-null", "init", "append", "delete")
+    if command in write_commands and _is_main_branch():
+        print(
+            "BLOCKED: Cannot write workflow state on main. "
+            "Workflow state belongs in a worktree.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     if command == "show":
         state = read_state()


### PR DESCRIPTION
## Summary

- `/design` skill was writing specs directly to main and committing there. GitHub branch protection blocks the push, creating a dead end.
- Now Step 5 creates a `spec/<name>` branch before writing any files. Brainstorming (Steps 1-4) stays on main since no files are changed.
- Removed `specs/` exception from `protect-main-branch` hook — specs go through PRs like everything else.
- Updated session-start guidance to reflect the new flow.

## Test plan

- [ ] Run `/design` on main — verify it creates a `spec/<name>` branch before writing
- [ ] Try editing a file in `specs/` on main — verify hook blocks it
- [ ] Start a session on main — verify updated guidance message

🤖 Generated with [Claude Code](https://claude.com/claude-code)