### PR TITLE
fix: prevent MSYS path mangling in hook commands

### DIFF
--- a/.claude/hooks/_pathfix.py
+++ b/.claude/hooks/_pathfix.py
@@ -1,0 +1,24 @@
+"""Normalize MSYS-style paths to Windows-native paths for Python on Windows.
+
+Defense-in-depth for Git Bash (MSYS) environments where CLAUDE_PROJECT_DIR
+may contain /c/VS/... style paths that Python interprets as C:\\c\\VS\\...
+"""
+import os
+import re
+import sys
+
+_MSYS_DRIVE_RE = re.compile(r"^/([a-zA-Z])/(.*)")
+
+
+def normalize_msys_path(path):
+    """Convert MSYS /c/... to C:/... on Windows. No-op elsewhere."""
+    if sys.platform == "win32":
+        m = _MSYS_DRIVE_RE.match(path)
+        if m:
+            return f"{m.group(1).upper()}:/{m.group(2)}"
+    return path
+
+
+def get_project_dir():
+    """Get CLAUDE_PROJECT_DIR as a platform-native path."""
+    return normalize_msys_path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))

--- a/.claude/hooks/checkout-guard.py
+++ b/.claude/hooks/checkout-guard.py
@@ -10,6 +10,9 @@ import re
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def is_main_repo(project_dir: str) -> bool:
     """Check if project_dir is the main repo root (not a worktree)."""
@@ -30,7 +33,7 @@ def is_main_repo(project_dir: str) -> bool:
 
 
 def main() -> None:
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
 
     # Only enforce in the main repo folder, not in worktrees
     if not is_main_repo(project_dir):

--- a/.claude/hooks/notify.py
+++ b/.claude/hooks/notify.py
@@ -12,6 +12,9 @@ import json
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import normalize_msys_path
+
 
 def _is_worktree(cwd):
     """Return True if cwd is a git worktree (not the main repo)."""
@@ -69,7 +72,7 @@ def main():
     except (json.JSONDecodeError, ValueError):
         return
 
-    cwd = data.get("cwd", ".")
+    cwd = normalize_msys_path(data.get("cwd", "."))
 
     # Worktree check: .workflow/state.json should only exist in .worktrees/<name>/
     if not _is_worktree(cwd):

--- a/.claude/hooks/post-commit-state.py
+++ b/.claude/hooks/post-commit-state.py
@@ -8,6 +8,9 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main():
     # Read stdin (Claude Code sends JSON with tool info)
@@ -16,7 +19,7 @@ def main():
     except (json.JSONDecodeError, EOFError):
         pass
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     state_path = os.path.join(project_dir, ".workflow", "state.json")
     os.makedirs(os.path.dirname(state_path), exist_ok=True)
 

--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -8,6 +8,9 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main():
     # Read stdin (Claude Code sends JSON with tool info)
@@ -23,7 +26,7 @@ def main():
     if "gh pr create" not in command:
         sys.exit(0)
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
 
     # Resolve the working directory for git checks.
     # If the gh pr create command includes a -C or --repo-dir flag, use that.

--- a/.claude/hooks/pre-commit-validate.py
+++ b/.claude/hooks/pre-commit-validate.py
@@ -11,6 +11,9 @@ import sys
 import os
 import json
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main():
     # Read stdin (Claude Code sends JSON with tool info)
@@ -19,8 +22,7 @@ def main():
     except (json.JSONDecodeError, EOFError):
         pass  # Input parsing is optional - matcher already filtered
 
-    # Get project directory from environment or use current directory
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
 
     # Block commits on main
     try:

--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -9,12 +9,15 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir, normalize_msys_path
+
 
 def get_current_branch() -> str:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=os.environ.get("CLAUDE_PROJECT_DIR", "."),
+            cwd=get_project_dir(),
             capture_output=True,
             text=True,
             timeout=5,
@@ -31,7 +34,7 @@ def get_current_branch() -> str:
 def is_allowed_path(file_path: str) -> bool:
     normalized = file_path.replace("\\", "/").lower()
     # Strip project dir prefix so absolute paths work the same as relative ones
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").replace("\\", "/").lower().rstrip("/")
+    project_dir = normalize_msys_path(os.environ.get("CLAUDE_PROJECT_DIR", "")).replace("\\", "/").lower().rstrip("/")
     if project_dir and normalized.startswith(project_dir + "/"):
         normalized = normalized[len(project_dir) + 1:]
     allowed_prefixes = []

--- a/.claude/hooks/review-guard.py
+++ b/.claude/hooks/review-guard.py
@@ -8,6 +8,9 @@ import json
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main() -> None:
     try:
@@ -21,7 +24,7 @@ def main() -> None:
     if "gh issue create" not in command:
         sys.exit(0)
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
     state_path = os.path.join(project_dir, ".workflow", "state.json")
 
     if not os.path.exists(state_path):

--- a/.claude/hooks/session-start-workflow.py
+++ b/.claude/hooks/session-start-workflow.py
@@ -18,6 +18,9 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main():
     # Read stdin
@@ -26,7 +29,7 @@ def main():
     except (json.JSONDecodeError, EOFError):
         pass
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
 
     # Get current branch
     branch = "unknown"

--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -9,6 +9,9 @@ import os
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import get_project_dir
+
 
 def main():
     # Read stdin
@@ -22,7 +25,7 @@ def main():
     if hook_input.get("stop_hook_active"):
         sys.exit(0)
 
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_dir = get_project_dir()
 
     # Get current branch
     branch = "unknown"

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -190,6 +190,9 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False):
     start = time.time()
     env = os.environ.copy()
     env["MSYS_NO_PATHCONV"] = "1"  # P1: Prevent Git Bash path expansion
+    # P7: Set CLAUDE_PROJECT_DIR to Windows-native path — prevents MSYS
+    # path mangling (/c/VS/... → C:\c\VS\...) in hook command expansion
+    env["CLAUDE_PROJECT_DIR"] = str(Path(worktree_path).resolve())
 
     try:
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- **Root cause fix**: `pipeline.py` now sets `CLAUDE_PROJECT_DIR` to a Windows-native path (`Path.resolve()`) before launching `claude -p`, preventing MSYS `/c/VS/...` paths from reaching hook command expansion
- **Defense-in-depth**: New shared `_pathfix.py` module normalizes MSYS paths; all 9 hook scripts use it instead of raw `os.environ.get("CLAUDE_PROJECT_DIR")`
- **Bug**: MSYS path mangling caused infinite stop-hook retry loop (3,662 iterations, 8+ hours) — Claude completed its work but could never exit

## Test Plan
- [ ] Run pipeline.py from MSYS bash with a worktree — hooks should resolve correct Windows paths
- [ ] Run interactive `claude` from PowerShell — hooks still work (no regression)
- [ ] Verify `_pathfix.normalize_msys_path` converts `/c/VS/...` → `C:/VS/...` and passes through Windows paths unchanged

## Verification
Infrastructure-only change (hooks + pipeline script) — no application code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)