### PR TITLE
feat: env var auth + CSS class standardization (#40, #659)

### DIFF
--- a/.claude/rules/extension.md
+++ b/.claude/rules/extension.md
@@ -17,6 +17,10 @@ paths: ["src/PPDS.Extension/**"]
 - Styles: `src/panels/styles/{feature}-panel.css` (`@import './shared.css'`)
 - Discover panels dynamically via glob, not hardcoded lists
 
+## HTML Structure
+
+- Content wrapper uses `class="content"` (not `class="panel-content"`) — all panels follow this convention
+
 ## Code Rules
 
 - External CSS only (no inline styles) — VS Code silently drops inline scripts exceeding ~32KB

--- a/specs/authentication.md
+++ b/specs/authentication.md
@@ -1,7 +1,7 @@
 # Authentication
 
-**Status:** Implemented
-**Last Updated:** 2026-01-23
+**Status:** Implemented (env var auth: draft)
+**Last Updated:** 2026-03-26
 **Code:** [src/PPDS.Auth/](../src/PPDS.Auth/)
 **Surfaces:** All
 
@@ -103,6 +103,7 @@ The authentication system provides secure credential management, multi-method au
 2. **Silent authentication preferred**: MSAL cache enables token reuse without user interaction
 3. **Environment binding optional**: Profiles work across environments; explicit binding enables per-environment switching
 4. **Multi-cloud support**: Single codebase supports Public, GCC, GCCHigh, DoD, and China clouds
+5. **Environment variable authentication**: Fully stateless auth via `PPDS_CLIENT_ID`, `PPDS_CLIENT_SECRET`, `PPDS_TENANT_ID`, `PPDS_ENVIRONMENT_URL` — no profile on disk required
 
 ### Primary Flows
 
@@ -128,6 +129,14 @@ The authentication system provides secure credential management, multi-method au
 2. **Authenticate**: Interactive or silent via MSAL public client
 3. **Call Discovery API**: ServiceClient.DiscoverOnlineOrganizationsAsync
 4. **Map results**: DiscoveredEnvironment with Id, Name, Url, Region, Type
+
+**Environment Variable Authentication (Stateless):**
+
+1. **Check env vars**: `EnvironmentVariableAuth.TryCreateProfile()` checks for `PPDS_CLIENT_ID`, `PPDS_CLIENT_SECRET`, `PPDS_TENANT_ID`, `PPDS_ENVIRONMENT_URL`
+2. **Partial detection**: If any of the four are set but not all, throw `PpdsException` with `Auth.IncompleteEnvironmentConfig` listing which vars are missing
+3. **Synthesize profile**: Construct an in-memory `AuthProfile` with `AuthMethod.ClientSecret`, bound environment — no disk I/O, no ProfileStore. Cloud defaults to `Public`; override via optional `PPDS_CLOUD` env var (values: `Public`, `UsGov`, `UsGovHigh`, `UsGovDod`, `China`)
+4. **Priority**: `ConnectionResolver` calls `EnvironmentVariableAuth.TryCreateProfile()` before `ProfileResolver`. Env vars take precedence over all profile-based auth
+5. **No side effects**: No profile written to disk, no MSAL cache interaction, no credential store interaction. The synthetic profile flows through `CredentialProviderFactory` → `ClientSecretCredentialProvider`. The env var secret bypasses the credential store via the same mechanism as `PPDS_SPN_SECRET`: `CredentialProviderFactory.GetSpnSecretFromEnvironment()` already returns env var secrets and `ShouldBypassCredentialStore()` gates store access. The synthetic profile sets `PPDS_SPN_SECRET` in-process (or the factory is extended to accept a direct secret parameter) so no credential store lookup occurs
 
 ### Constraints
 
@@ -395,6 +404,23 @@ if (provider.HomeAccountId != null && profile.HomeAccountId != provider.HomeAcco
 - Positive: Profile-aware connection creation
 - Negative: Adapter layer adds indirection
 
+### Why EnvironmentVariableAuth as a Separate Class?
+
+**Context:** Env var auth needs a home. Options: extend `ProfileResolver`, add to `CredentialProviderFactory`, or create a new class.
+
+**Decision:** New `EnvironmentVariableAuth` class with a single `TryCreateProfile()` method. Called from `ConnectionResolver` before `ProfileResolver`.
+
+**Alternatives considered:**
+- Extend `ProfileResolver` with a 4th tier: Works but changes ProfileResolver's responsibility from "resolve persisted profiles" to "resolve auth config from any source." Becomes a dumping ground if more auth sources appear.
+- Add to `CredentialProviderFactory`: Wrong layer — the factory creates credential providers from profiles, not profiles from env vars.
+- Full `IAuthSource` chain-of-responsibility: YAGNI — two sources don't justify an abstraction. If a third source appears, extract the interface then.
+
+**Consequences:**
+- Positive: Single responsibility — ProfileResolver resolves profiles, EnvironmentVariableAuth synthesizes from env vars
+- Positive: Testable in isolation — mock env vars, assert AuthProfile fields
+- Positive: Trivial to refactor into an interface if a third auth source appears
+- Negative: One more class in PPDS.Auth (minimal — it's small and focused)
+
 ### Why Timeout on Seed Client Creation?
 
 **Context:** Credential provider creation and Dataverse connection can hang on network issues, blocking callers indefinitely.
@@ -464,12 +490,19 @@ public class MyCredentialProvider : ICredentialProvider
 
 | Setting | Type | Required | Default | Description |
 |---------|------|----------|---------|-------------|
-| `PPDS_PROFILE` | env var | No | - | Override active profile |
+| `PPDS_CLIENT_ID` | env var | No* | - | Stateless auth: application (client) ID |
+| `PPDS_CLIENT_SECRET` | env var | No* | - | Stateless auth: client secret |
+| `PPDS_TENANT_ID` | env var | No* | - | Stateless auth: Entra tenant ID |
+| `PPDS_ENVIRONMENT_URL` | env var | No* | - | Stateless auth: Dataverse environment URL |
+| `PPDS_CLOUD` | env var | No | `Public` | Stateless auth: cloud environment (`Public`, `UsGov`, `UsGovHigh`, `UsGovDod`, `China`) |
+| `PPDS_PROFILE` | env var | No | - | Override active profile (profile-based auth) |
 | `PPDS_CONFIG_DIR` | env var | No | Platform default | Override data directory |
-| `PPDS_SPN_SECRET` | env var | No | - | ClientSecret override (CI/CD) |
+| `PPDS_SPN_SECRET` | env var | No | - | ClientSecret override for existing profile (CI/CD) |
 | Profile.Cloud | enum | No | Public | Cloud environment |
 | Profile.TenantId | string | Varies | - | Entra tenant ID |
 | Profile.ApplicationId | string | Varies | - | App registration client ID |
+
+\* All four `PPDS_CLIENT_ID`, `PPDS_CLIENT_SECRET`, `PPDS_TENANT_ID`, `PPDS_ENVIRONMENT_URL` must be set together. Setting 1–3 of 4 is a hard error (`Auth.IncompleteEnvironmentConfig`). `PPDS_CLOUD` is optional and defaults to `Public`.
 
 ### Storage Locations
 
@@ -491,12 +524,20 @@ public class MyCredentialProvider : ICredentialProvider
 
 ### Acceptance Criteria
 
-- [ ] All 9 auth methods create valid ServiceClient
-- [ ] Silent auth succeeds with cached HomeAccountId
-- [ ] Secrets retrieved from native credential store
-- [ ] Profile CRUD operations persist correctly
-- [ ] Cloud endpoints return correct URLs per environment
-- [ ] Global discovery returns accessible environments
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | All 9 auth methods create valid ServiceClient | Integration tests | ✅ |
+| AC-02 | Silent auth succeeds with cached HomeAccountId | Integration tests | ✅ |
+| AC-03 | Secrets retrieved from native credential store | `NativeCredentialStoreTests` | ✅ |
+| AC-04 | Profile CRUD operations persist correctly | `ProfileStoreTests` | ✅ |
+| AC-05 | Cloud endpoints return correct URLs per environment | `CloudEndpointsTests` | ✅ |
+| AC-06 | Global discovery returns accessible environments | Integration tests | ✅ |
+| AC-07 | All four env vars set → `TryCreateProfile` returns synthetic `AuthProfile` with `AuthMethod.ClientSecret` and bound environment | `EnvironmentVariableAuthTests.AllVarsSet_ReturnsSyntheticProfile` | 🔲 |
+| AC-08 | No env vars set → `TryCreateProfile` returns null, profile resolution proceeds normally | `EnvironmentVariableAuthTests.NoVarsSet_ReturnsNull` | 🔲 |
+| AC-09 | Partial env vars (1-3 of 4) → throws `PpdsException` with `Auth.IncompleteEnvironmentConfig` listing missing vars | `EnvironmentVariableAuthTests.PartialVars_ThrowsWithMissingList` | 🔲 |
+| AC-10 | Env var auth takes precedence over `PPDS_PROFILE` and active profile | `EnvironmentVariableAuthTests.EnvVarAuth_TakesPrecedence` | 🔲 |
+| AC-11 | Synthetic profile produces working `ServiceClient` via `CredentialProviderFactory` | `EnvironmentVariableAuthTests.SyntheticProfile_CreatesProvider` | 🔲 |
+| AC-12 | No disk I/O: no profile written, no MSAL cache, no credential store access | `EnvironmentVariableAuthTests.NoSideEffects` | 🔲 |
 
 ### Edge Cases
 
@@ -507,6 +548,11 @@ public class MyCredentialProvider : ICredentialProvider
 | v1 profile file | Old format JSON | File deleted, empty collection returned |
 | Managed identity outside Azure | ManagedIdentity auth | `CredentialUnavailableException` |
 | Certificate thumbprint invalid | CertificateStore auth | Clear error with thumbprint |
+| All four env vars set | `PPDS_CLIENT_ID`, `PPDS_CLIENT_SECRET`, `PPDS_TENANT_ID`, `PPDS_ENVIRONMENT_URL` | Synthetic profile, no disk I/O |
+| Only `PPDS_CLIENT_ID` set | One of four vars | `PpdsException` listing 3 missing vars |
+| Env vars set + `--profile` flag | Both present | Env vars win (highest priority) |
+| `PPDS_ENVIRONMENT_URL` missing scheme | `myorg.crm.dynamics.com` | `PpdsException` with `Auth.InvalidEnvironmentUrl` — must be full URL with `https://` |
+| Env var values are whitespace | `PPDS_CLIENT_ID=" "` | Treated as not set (trimmed) |
 
 ### Test Examples
 
@@ -572,6 +618,7 @@ public void CloudEndpoints_ReturnsCorrectAuthority_ForEachCloud()
 
 | Date | Change |
 |------|--------|
+| 2026-03-26 | Added environment variable authentication (stateless auth via PPDS_CLIENT_ID/SECRET/TENANT_ID/ENVIRONMENT_URL) |
 | 2026-03-18 | Added Surfaces frontmatter, Changelog per spec governance |
 
 ## Roadmap

--- a/src/PPDS.Auth/Credentials/CredentialProviderFactory.cs
+++ b/src/PPDS.Auth/Credentials/CredentialProviderFactory.cs
@@ -44,6 +44,7 @@ public static class CredentialProviderFactory
     /// <param name="deviceCodeCallback">Optional callback for device code display.</param>
     /// <param name="beforeInteractiveAuth">Optional callback invoked before browser opens for interactive auth.
     /// Returns the user's choice (OpenBrowser, UseDeviceCode, or Cancel).</param>
+    /// <param name="clientSecretOverride">Optional client secret that takes priority over env var and credential store lookups.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A credential provider for the profile's auth method.</returns>
     public static async Task<ICredentialProvider> CreateAsync(
@@ -51,13 +52,14 @@ public static class CredentialProviderFactory
         ISecureCredentialStore? credentialStore = null,
         Action<DeviceCodeInfo>? deviceCodeCallback = null,
         Func<Action<DeviceCodeInfo>?, PreAuthDialogResult>? beforeInteractiveAuth = null,
+        string? clientSecretOverride = null,
         CancellationToken cancellationToken = default)
     {
         if (profile == null)
             throw new ArgumentNullException(nameof(profile));
 
         // Check for environment variable override for SPN secret
-        var envSecret = GetSpnSecretFromEnvironment();
+        var envSecret = clientSecretOverride ?? GetSpnSecretFromEnvironment();
 
         return profile.AuthMethod switch
         {

--- a/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
+++ b/src/PPDS.Auth/Discovery/EnvironmentResolutionService.cs
@@ -101,7 +101,7 @@ public sealed class EnvironmentResolutionService : IDisposable
 
             // Create credential provider using async factory (supports secure store lookups)
             _credentialProvider ??= await CredentialProviderFactory.CreateAsync(
-                _profile, _credentialStore, _deviceCodeCallback, beforeInteractiveAuth: null, cancellationToken)
+                _profile, _credentialStore, _deviceCodeCallback, beforeInteractiveAuth: null, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
             // Connect to Dataverse and get org metadata

--- a/src/PPDS.Auth/EnvironmentVariableAuth.cs
+++ b/src/PPDS.Auth/EnvironmentVariableAuth.cs
@@ -98,7 +98,7 @@ public static class EnvironmentVariableAuth
         if (Enum.TryParse<CloudEnvironment>(value, ignoreCase: true, out var cloud))
             return cloud;
         throw new AuthenticationException(
-            $"{CloudVar} must be one of: Public, UsGov, UsGovHigh, UsGovDod, China. Got: {value}",
+            $"{CloudVar} must be one of: {string.Join(", ", Enum.GetNames<CloudEnvironment>())}. Got: {value}",
             "Auth.InvalidCloud");
     }
 }

--- a/src/PPDS.Auth/EnvironmentVariableAuth.cs
+++ b/src/PPDS.Auth/EnvironmentVariableAuth.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PPDS.Auth.Cloud;
+using PPDS.Auth.Credentials;
+using PPDS.Auth.Profiles;
+
+namespace PPDS.Auth;
+
+/// <summary>
+/// Reads authentication configuration from environment variables for CI/CD scenarios.
+/// </summary>
+public static class EnvironmentVariableAuth
+{
+    /// <summary>Environment variable name for the application (client) ID.</summary>
+    public const string ClientIdVar = "PPDS_CLIENT_ID";
+
+    /// <summary>Environment variable name for the client secret.</summary>
+    public const string ClientSecretVar = "PPDS_CLIENT_SECRET";
+
+    /// <summary>Environment variable name for the tenant ID.</summary>
+    public const string TenantIdVar = "PPDS_TENANT_ID";
+
+    /// <summary>Environment variable name for the Dataverse environment URL.</summary>
+    public const string EnvironmentUrlVar = "PPDS_ENVIRONMENT_URL";
+
+    /// <summary>Environment variable name for the cloud environment (optional, defaults to Public).</summary>
+    public const string CloudVar = "PPDS_CLOUD";
+
+    /// <summary>
+    /// Returns a synthetic AuthProfile and client secret from environment variables,
+    /// or null if none are set.
+    /// Throws AuthenticationException if partially configured (1-3 of 4 required vars).
+    /// </summary>
+    public static (AuthProfile Profile, string ClientSecret)? TryCreateProfile()
+    {
+        var clientId = GetTrimmed(ClientIdVar);
+        var clientSecret = GetTrimmed(ClientSecretVar);
+        var tenantId = GetTrimmed(TenantIdVar);
+        var environmentUrl = GetTrimmed(EnvironmentUrlVar);
+
+        var vars = new Dictionary<string, string?>
+        {
+            [ClientIdVar] = clientId,
+            [ClientSecretVar] = clientSecret,
+            [TenantIdVar] = tenantId,
+            [EnvironmentUrlVar] = environmentUrl,
+        };
+
+        var setCount = vars.Values.Count(v => v != null);
+        if (setCount == 0) return null;
+
+        if (setCount < 4)
+        {
+            var missing = vars.Where(kv => kv.Value == null).Select(kv => kv.Key);
+            throw new AuthenticationException(
+                $"Incomplete environment variable auth configuration. " +
+                $"Set all four: {ClientIdVar}, {ClientSecretVar}, {TenantIdVar}, {EnvironmentUrlVar}. " +
+                $"Missing: {string.Join(", ", missing)}",
+                "Auth.IncompleteEnvironmentConfig");
+        }
+
+        // Validate URL scheme
+        if (!environmentUrl!.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new AuthenticationException(
+                $"{EnvironmentUrlVar} must be a full URL with https:// scheme. Got: {environmentUrl}",
+                "Auth.InvalidEnvironmentUrl");
+        }
+
+        // Normalize trailing slash for pool URL matching
+        var normalizedUrl = environmentUrl.TrimEnd('/');
+
+        var cloud = ParseCloud(GetTrimmed(CloudVar));
+
+        var profile = new AuthProfile
+        {
+            AuthMethod = AuthMethod.ClientSecret,
+            ApplicationId = clientId,
+            TenantId = tenantId,
+            Cloud = cloud,
+            Environment = new EnvironmentInfo { Url = normalizedUrl },
+            Name = "(env vars)",
+        };
+
+        return (profile, clientSecret!);
+    }
+
+    private static string? GetTrimmed(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name)?.Trim();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static CloudEnvironment ParseCloud(string? value)
+    {
+        if (value == null) return CloudEnvironment.Public;
+        if (Enum.TryParse<CloudEnvironment>(value, ignoreCase: true, out var cloud))
+            return cloud;
+        throw new AuthenticationException(
+            $"{CloudVar} must be one of: Public, UsGov, UsGovHigh, UsGovDod, China. Got: {value}",
+            "Auth.InvalidCloud");
+    }
+}

--- a/src/PPDS.Auth/Pooling/ConnectionResolver.cs
+++ b/src/PPDS.Auth/Pooling/ConnectionResolver.cs
@@ -46,6 +46,9 @@ public sealed class ConnectionResolver : IDisposable
         string? environmentOverride = null,
         CancellationToken cancellationToken = default)
     {
+        var envClient = await TryResolveFromEnvironmentAsync(cancellationToken).ConfigureAwait(false);
+        if (envClient != null) return envClient;
+
         var collection = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
 
         var profile = collection.ActiveProfile
@@ -69,6 +72,9 @@ public sealed class ConnectionResolver : IDisposable
         string? environmentOverride = null,
         CancellationToken cancellationToken = default)
     {
+        var envClient = await TryResolveFromEnvironmentAsync(cancellationToken).ConfigureAwait(false);
+        if (envClient != null) return envClient;
+
         var collection = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
 
         var profile = collection.GetByName(profileName)
@@ -94,6 +100,24 @@ public sealed class ConnectionResolver : IDisposable
         string? environmentDisplayName = null,
         CancellationToken cancellationToken = default)
     {
+        // Environment variable auth takes precedence — return single source from synthetic profile
+        var envAuth = EnvironmentVariableAuth.TryCreateProfile();
+        if (envAuth != null)
+        {
+            var (profile, clientSecret) = envAuth.Value;
+            var envUrl = profile.Environment!.Url;
+            var source = new ProfileConnectionSource(
+                profile,
+                envUrl,
+                maxPoolSizePerProfile,
+                _deviceCodeCallback,
+                beforeInteractiveAuth: null,
+                environmentDisplayName,
+                credentialStore: null,
+                clientSecretOverride: clientSecret);
+            return new[] { source };
+        }
+
         var names = profileNames.ToList();
         if (names.Count == 0)
             throw new ArgumentException("At least one profile name is required.", nameof(profileNames));
@@ -189,6 +213,26 @@ public sealed class ConnectionResolver : IDisposable
         return profileString
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .ToList();
+    }
+
+    private async Task<ServiceClient?> TryResolveFromEnvironmentAsync(
+        CancellationToken cancellationToken)
+    {
+        var envAuth = EnvironmentVariableAuth.TryCreateProfile();
+        if (envAuth == null) return null;
+
+        var (profile, clientSecret) = envAuth.Value;
+        var envUrl = profile.Environment!.Url;
+
+        using var provider = await CredentialProviderFactory.CreateAsync(
+            profile,
+            credentialStore: null,
+            clientSecretOverride: clientSecret,
+            cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return await provider.CreateServiceClientAsync(envUrl, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async Task<ServiceClient> ResolveProfileAsync(

--- a/src/PPDS.Auth/Pooling/ConnectionResolver.cs
+++ b/src/PPDS.Auth/Pooling/ConnectionResolver.cs
@@ -209,7 +209,7 @@ public sealed class ConnectionResolver : IDisposable
 
         // Create credential provider using async factory (supports secure store lookups)
         using var provider = await CredentialProviderFactory.CreateAsync(
-            profile, _credentialStore, _deviceCodeCallback, beforeInteractiveAuth: null, cancellationToken)
+            profile, _credentialStore, _deviceCodeCallback, beforeInteractiveAuth: null, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         return await provider.CreateServiceClientAsync(envUrl, cancellationToken)

--- a/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
+++ b/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
@@ -29,6 +29,7 @@ public sealed class ProfileConnectionSource : IDisposable
     private readonly Action<DeviceCodeInfo>? _deviceCodeCallback;
     private readonly Func<Action<DeviceCodeInfo>?, PreAuthDialogResult>? _beforeInteractiveAuth;
     private readonly ISecureCredentialStore? _credentialStore;
+    private readonly string? _clientSecretOverride;
     private readonly Action<AuthProfile>? _onProfileUpdated;
     private readonly int _maxPoolSize;
 
@@ -69,6 +70,7 @@ public sealed class ProfileConnectionSource : IDisposable
     /// Returns the user's choice (OpenBrowser, UseDeviceCode, or Cancel).</param>
     /// <param name="environmentDisplayName">Optional environment display name for connection naming.</param>
     /// <param name="credentialStore">Optional secure credential store for looking up secrets.</param>
+    /// <param name="clientSecretOverride">Optional client secret override (bypasses env var and store lookups).</param>
     /// <param name="onProfileUpdated">Optional callback invoked when profile metadata is updated (e.g., HomeAccountId after auth).</param>
     public ProfileConnectionSource(
         AuthProfile profile,
@@ -78,6 +80,7 @@ public sealed class ProfileConnectionSource : IDisposable
         Func<Action<DeviceCodeInfo>?, PreAuthDialogResult>? beforeInteractiveAuth = null,
         string? environmentDisplayName = null,
         ISecureCredentialStore? credentialStore = null,
+        string? clientSecretOverride = null,
         Action<AuthProfile>? onProfileUpdated = null)
     {
         _profile = profile ?? throw new ArgumentNullException(nameof(profile));
@@ -91,6 +94,7 @@ public sealed class ProfileConnectionSource : IDisposable
         _beforeInteractiveAuth = beforeInteractiveAuth;
         _environmentDisplayName = environmentDisplayName;
         _credentialStore = credentialStore;
+        _clientSecretOverride = clientSecretOverride;
         _onProfileUpdated = onProfileUpdated;
 
         // Format: "identity@environment" when environment name is available
@@ -139,6 +143,7 @@ public sealed class ProfileConnectionSource : IDisposable
             beforeInteractiveAuth,
             profile.Environment.DisplayName,
             credentialStore,
+            clientSecretOverride: null,
             onProfileUpdated);
     }
 
@@ -170,7 +175,7 @@ public sealed class ProfileConnectionSource : IDisposable
             try
             {
                 _provider = System.Threading.Tasks.Task.Run(() =>
-                    CredentialProviderFactory.CreateAsync(_profile, _credentialStore, _deviceCodeCallback, _beforeInteractiveAuth, cancellationToken: credCts.Token))
+                    CredentialProviderFactory.CreateAsync(_profile, _credentialStore, _deviceCodeCallback, _beforeInteractiveAuth, _clientSecretOverride, credCts.Token))
                     .WaitAsync(credCts.Token)
                     .GetAwaiter()
                     .GetResult();

--- a/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
+++ b/src/PPDS.Auth/Pooling/ProfileConnectionSource.cs
@@ -170,7 +170,7 @@ public sealed class ProfileConnectionSource : IDisposable
             try
             {
                 _provider = System.Threading.Tasks.Task.Run(() =>
-                    CredentialProviderFactory.CreateAsync(_profile, _credentialStore, _deviceCodeCallback, _beforeInteractiveAuth, credCts.Token))
+                    CredentialProviderFactory.CreateAsync(_profile, _credentialStore, _deviceCodeCallback, _beforeInteractiveAuth, cancellationToken: credCts.Token))
                     .WaitAsync(credCts.Token)
                     .GetAwaiter()
                     .GetResult();

--- a/src/PPDS.Cli/Infrastructure/ProfileServiceFactory.cs
+++ b/src/PPDS.Cli/Infrastructure/ProfileServiceFactory.cs
@@ -129,7 +129,7 @@ public static class ProfileServiceFactory
         };
 
         var source = new ProfileConnectionSource(
-            profile, envUrl, 52, deviceCodeCallback, beforeInteractiveAuth, envDisplayName, credentialStore, onProfileUpdated);
+            profile, envUrl, 52, deviceCodeCallback, beforeInteractiveAuth, envDisplayName, credentialStore, clientSecretOverride: null, onProfileUpdated);
         var adapter = new ProfileConnectionSourceAdapter(source);
 
         var connectionInfo = new ResolvedConnectionInfo

--- a/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginTracesPanel.ts
@@ -554,7 +554,7 @@ export class PluginTracesPanel extends WebviewPanelBase<PluginTracesPanelWebview
 </div>
 
 <!-- 6a: Side-by-side layout -->
-<div class="panel-content">
+<div class="content">
     <div id="table-pane" class="table-pane">
         <div class="empty-state" id="empty-state">Loading plugin traces...</div>
     </div>

--- a/src/PPDS.Extension/src/panels/PluginsPanel.ts
+++ b/src/PPDS.Extension/src/panels/PluginsPanel.ts
@@ -593,7 +593,7 @@ export class PluginsPanel extends WebviewPanelBase<PluginsPanelWebviewToHost, Pl
     ${getEnvironmentPickerHtml()}
 </div>
 
-<div class="panel-content">
+<div class="content">
     <div id="tree-container" class="tree-pane">
         <div class="empty-state" id="empty-state">Loading plugin registrations...</div>
     </div>

--- a/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugin-traces-panel.css
@@ -1,7 +1,7 @@
 @import './shared.css';
 
 /* ── 6a: Side-by-Side Split Pane ──────────────────────────────── */
-.panel-content {
+.content {
     display: flex;
     flex-direction: row;
     flex: 1;

--- a/src/PPDS.Extension/src/panels/styles/plugins-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/plugins-panel.css
@@ -90,7 +90,7 @@
 }
 
 /* ── Panel Content Layout ────────────────────────────────────────── */
-.panel-content {
+.content {
     display: flex;
     flex-direction: column;
     flex: 1;

--- a/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
+++ b/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using PPDS.Auth;
+using PPDS.Auth.Cloud;
+using PPDS.Auth.Credentials;
+using PPDS.Auth.Profiles;
+using Xunit;
+
+namespace PPDS.Auth.Tests;
+
+[Trait("Category", "Unit")]
+public sealed class EnvironmentVariableAuthTests : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalValues = new();
+
+    private void SetEnvVar(string name, string? value)
+    {
+        _originalValues.TryAdd(name, Environment.GetEnvironmentVariable(name));
+        Environment.SetEnvironmentVariable(name, value);
+    }
+
+    private void ClearAllEnvVars()
+    {
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, null);
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, null);
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, null);
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, null);
+        SetEnvVar(EnvironmentVariableAuth.CloudVar, null);
+    }
+
+    public void Dispose()
+    {
+        foreach (var (name, original) in _originalValues)
+            Environment.SetEnvironmentVariable(name, original);
+    }
+
+    [Fact]
+    public void TryCreateProfile_AllVarsSet_ReturnsSyntheticProfile()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        result.Should().NotBeNull();
+        var (profile, secret) = result!.Value;
+        profile.AuthMethod.Should().Be(AuthMethod.ClientSecret);
+        profile.ApplicationId.Should().Be("test-client-id");
+        profile.TenantId.Should().Be("test-tenant-id");
+        profile.Environment.Should().NotBeNull();
+        profile.Environment!.Url.Should().Be("https://org.crm.dynamics.com");
+        profile.Cloud.Should().Be(CloudEnvironment.Public);
+        secret.Should().Be("test-secret");
+    }
+
+    [Fact]
+    public void TryCreateProfile_AllVarsSet_WithCloud_UsesSpecifiedCloud()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+        SetEnvVar(EnvironmentVariableAuth.CloudVar, "UsGov");
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        result.Should().NotBeNull();
+        result!.Value.Profile.Cloud.Should().Be(CloudEnvironment.UsGov);
+    }
+
+    [Fact]
+    public void TryCreateProfile_NoVarsSet_ReturnsNull()
+    {
+        ClearAllEnvVars();
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryCreateProfile_PartialVars_ThrowsWithMissingList()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        // ClientSecret, TenantId, EnvironmentUrl are missing
+
+        var act = () => EnvironmentVariableAuth.TryCreateProfile();
+
+        act.Should().Throw<AuthenticationException>()
+            .Where(e => e.ErrorCode == "Auth.IncompleteEnvironmentConfig")
+            .WithMessage($"*{EnvironmentVariableAuth.ClientSecretVar}*")
+            .WithMessage($"*{EnvironmentVariableAuth.TenantIdVar}*")
+            .WithMessage($"*{EnvironmentVariableAuth.EnvironmentUrlVar}*");
+    }
+
+    [Fact]
+    public void TryCreateProfile_WhitespaceVars_TreatedAsNotSet()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, " ");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+
+        var act = () => EnvironmentVariableAuth.TryCreateProfile();
+
+        act.Should().Throw<AuthenticationException>()
+            .Where(e => e.ErrorCode == "Auth.IncompleteEnvironmentConfig")
+            .WithMessage($"*{EnvironmentVariableAuth.ClientIdVar}*");
+    }
+
+    [Fact]
+    public void TryCreateProfile_InvalidUrl_ThrowsInvalidEnvironmentUrl()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "http://org.crm.dynamics.com");
+
+        var act = () => EnvironmentVariableAuth.TryCreateProfile();
+
+        act.Should().Throw<AuthenticationException>()
+            .Where(e => e.ErrorCode == "Auth.InvalidEnvironmentUrl");
+    }
+
+    [Fact]
+    public void TryCreateProfile_InvalidCloud_ThrowsInvalidCloud()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+        SetEnvVar(EnvironmentVariableAuth.CloudVar, "invalid");
+
+        var act = () => EnvironmentVariableAuth.TryCreateProfile();
+
+        act.Should().Throw<AuthenticationException>()
+            .Where(e => e.ErrorCode == "Auth.InvalidCloud");
+    }
+
+    [Fact]
+    public void TryCreateProfile_TrailingSlash_Normalized()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com/");
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        result.Should().NotBeNull();
+        result!.Value.Profile.Environment!.Url.Should().Be("https://org.crm.dynamics.com");
+    }
+
+    [Fact]
+    public void TryCreateProfile_CloudOnlySet_NoRequiredVars_ReturnsNull()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.CloudVar, "UsGov");
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
+++ b/tests/PPDS.Auth.Tests/EnvironmentVariableAuthTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using PPDS.Auth;
 using PPDS.Auth.Cloud;
@@ -170,5 +172,118 @@ public sealed class EnvironmentVariableAuthTests : IDisposable
         var result = EnvironmentVariableAuth.TryCreateProfile();
 
         result.Should().BeNull();
+    }
+
+    /// <summary>
+    /// AC-10: Env var auth takes precedence — TryCreateProfile returns non-null
+    /// even when PPDS_PROFILE is set. ConnectionResolver calls TryCreateProfile
+    /// before ProfileResolver, so env vars structurally win.
+    /// </summary>
+    [Fact]
+    public void TryCreateProfile_EnvVarAuth_TakesPrecedence_OverPpdsProfile()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "env-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "env-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "env-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://env.crm.dynamics.com");
+        // Also set PPDS_PROFILE — env var auth should still win
+        SetEnvVar("PPDS_PROFILE", "my-named-profile");
+
+        var result = EnvironmentVariableAuth.TryCreateProfile();
+
+        // TryCreateProfile is independent of PPDS_PROFILE — it always returns
+        // when the 4 required vars are set. ConnectionResolver checks this first.
+        result.Should().NotBeNull();
+        result!.Value.Profile.ApplicationId.Should().Be("env-client-id");
+    }
+
+    /// <summary>
+    /// AC-11: Synthetic profile from env vars produces a working
+    /// ClientSecretCredentialProvider via CredentialProviderFactory.
+    /// </summary>
+    [Fact]
+    public async Task SyntheticProfile_CreatesClientSecretProvider()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+        // Clear PPDS_SPN_SECRET so it doesn't interfere
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
+
+        var envAuth = EnvironmentVariableAuth.TryCreateProfile();
+        envAuth.Should().NotBeNull();
+
+        var (profile, clientSecret) = envAuth!.Value;
+
+        using var provider = await CredentialProviderFactory.CreateAsync(
+            profile,
+            credentialStore: null,
+            clientSecretOverride: clientSecret);
+
+        provider.Should().BeOfType<ClientSecretCredentialProvider>();
+        provider.AuthMethod.Should().Be(AuthMethod.ClientSecret);
+        provider.Identity.Should().Be("test-client-id");
+        provider.TenantId.Should().Be("test-tenant-id");
+    }
+
+    /// <summary>
+    /// AC-12: When env var auth is used with clientSecretOverride, the credential
+    /// store is never accessed. Verified by passing a store that throws on any call.
+    /// </summary>
+    [Fact]
+    public async Task NoCredentialStoreAccess_WhenClientSecretOverrideProvided()
+    {
+        ClearAllEnvVars();
+        SetEnvVar(EnvironmentVariableAuth.ClientIdVar, "test-client-id");
+        SetEnvVar(EnvironmentVariableAuth.ClientSecretVar, "test-secret");
+        SetEnvVar(EnvironmentVariableAuth.TenantIdVar, "test-tenant-id");
+        SetEnvVar(EnvironmentVariableAuth.EnvironmentUrlVar, "https://org.crm.dynamics.com");
+        SetEnvVar(CredentialProviderFactory.SpnSecretEnvVar, null);
+        SetEnvVar(CredentialProviderFactory.TestClientSecretEnvVar, null);
+
+        var envAuth = EnvironmentVariableAuth.TryCreateProfile();
+        envAuth.Should().NotBeNull();
+
+        var (profile, clientSecret) = envAuth!.Value;
+
+        // Pass a credential store that throws on any access
+        var throwingStore = new ThrowingCredentialStore();
+
+        using var provider = await CredentialProviderFactory.CreateAsync(
+            profile,
+            credentialStore: throwingStore,
+            clientSecretOverride: clientSecret);
+
+        // If we reached here, the store was never accessed
+        provider.Should().NotBeNull();
+        provider.AuthMethod.Should().Be(AuthMethod.ClientSecret);
+    }
+
+    /// <summary>
+    /// Mock credential store that throws on any method call.
+    /// Used to verify the store is never accessed during env var auth.
+    /// </summary>
+    private sealed class ThrowingCredentialStore : ISecureCredentialStore
+    {
+        public bool IsCleartextCachingEnabled => throw new InvalidOperationException("Store should not be accessed");
+
+        public Task StoreAsync(StoredCredential credential, CancellationToken ct = default)
+            => throw new InvalidOperationException("Store should not be accessed");
+
+        public Task<StoredCredential?> GetAsync(string applicationId, CancellationToken ct = default)
+            => throw new InvalidOperationException("Store should not be accessed");
+
+        public Task<bool> RemoveAsync(string applicationId, CancellationToken ct = default)
+            => throw new InvalidOperationException("Store should not be accessed");
+
+        public Task ClearAsync(CancellationToken ct = default)
+            => throw new InvalidOperationException("Store should not be accessed");
+
+        public Task<bool> ExistsAsync(string applicationId, CancellationToken ct = default)
+            => throw new InvalidOperationException("Store should not be accessed");
     }
 }


### PR DESCRIPTION
## Summary

- **#40 — Environment variable authentication:** New `EnvironmentVariableAuth` class enables fully stateless auth via `PPDS_CLIENT_ID`, `PPDS_CLIENT_SECRET`, `PPDS_TENANT_ID`, `PPDS_ENVIRONMENT_URL` (optional `PPDS_CLOUD`). No profile on disk required. Partial config (1-3 of 4 vars) is a hard error with clear message. Wired into `ConnectionResolver` with `clientSecretOverride` parameter threaded through `CredentialProviderFactory` and `ProfileConnectionSource`.
- **#659 — CSS class standardization:** Renamed `panel-content` → `content` in PluginsPanel and PluginTracesPanel (HTML + CSS) to match the convention used by all other panels. Added convention to `.claude/rules/extension.md`.

## Test plan

- [x] 12 unit tests covering AC-07 through AC-12 (all vars set, no vars, partial vars, precedence, factory integration, no credential store access, trailing slash, invalid URL/cloud, whitespace, cloud-only)
- [x] All .NET tests pass (0 failures across net8.0/9.0/10.0)
- [x] All extension tests pass (409/409 Vitest)
- [x] TS build, typecheck, lint, CSS lint all clean
- [x] QA: Plugins and PluginTraces panels visually verified via CDP — 44 interactive elements tested, all pass
- [x] Review: 8 findings triaged — 1 real gap noted (ProfileServiceFactory CLI path not yet integrated, follow-up needed)

### Known gap

`ProfileServiceFactory` (used by CLI commands) does not yet check env vars — env var auth currently works through `ConnectionResolver` (daemon/RPC path). CLI integration is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)