### PR TITLE
feat(migration): CMT parity — handler framework, state transitions, TUI

### DIFF
--- a/specs/migration.md
+++ b/specs/migration.md
@@ -1,7 +1,7 @@
 # Migration
 
-**Status:** Implemented
-**Last Updated:** 2026-01-28
+**Status:** Draft
+**Last Updated:** 2026-03-25
 **Surfaces:** CLI, TUI
 **Code:** [src/PPDS.Migration/](../src/PPDS.Migration/), TUI: [src/PPDS.Tui/Screens/MigrationScreen.cs](../src/PPDS.Tui/Screens/MigrationScreen.cs)
 
@@ -11,17 +11,22 @@
 
 The migration system provides high-performance data export and import between Dataverse environments. It uses dependency analysis to determine correct import ordering, handles circular references through deferred field processing, and supports the Configuration Migration Tool (CMT) format for interoperability with Microsoft tooling.
 
+The system achieves full parity with Microsoft's Configuration Migration Tool while surpassing it with bulk APIs, automatic dependency analysis, CLI automation, and connection pooling.
+
 ### Goals
 
-- **Performance**: Parallel export with entity-level concurrency; parallel import with tier-level and entity-level parallelism
-- **Correctness**: Dependency-aware import ordering via topological sort; deferred fields for circular references
-- **Interoperability**: Full CMT format support for compatibility with Microsoft's Configuration Migration Tool
+- **Performance**: Parallel export with entity-level concurrency; parallel import with tier-level and entity-level parallelism; bulk APIs (5x faster than CMT)
+- **Correctness**: Dependency-aware import ordering via topological sort; deferred fields for circular references; state machine entity transitions via SDK messages
+- **Interoperability**: Full CMT format support including date shifting modes, file column data, and schema attributes
+- **Resilience**: Entity-specific handlers for special cases; external lookup resolution; owner preservation; failure cascading
 
 ### Non-Goals
 
 - Solution export/import (handled by Dataverse platform)
 - Schema migration or table creation (schema must exist in target)
-- Cross-environment relationship resolution (IDs must match or be mapped)
+- Incremental/delta export via change tracking (future — #38)
+- Checkpoint/resume for interrupted imports (future — #41)
+- Schema compare/diff command (future — #42)
 
 ---
 
@@ -29,8 +34,8 @@ The migration system provides high-performance data export and import between Da
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────┐
-│                            Application Layer                                      │
-│               (CLI: ppds data export/import, MCP Tools)                          │
+│                            Application Layer                                    │
+│               (CLI: ppds data export/import, TUI, MCP)                         │
 └────────────────────────────────────┬────────────────────────────────────────────┘
                                      │
          ┌───────────────────────────┴───────────────────────────┐
@@ -42,44 +47,72 @@ The migration system provides high-performance data export and import between Da
 │  ┌────────────────────────┐ │              │  ┌─────────────────────────────────┐│
 │  │ Entity-level parallel  │ │              │  │ Phase 1: Tiered Entity Import   ││
 │  │ FetchXML pagination    │ │              │  │ Phase 2: Deferred Field Update  ││
-│  │ M2M relationship export│ │              │  │ Phase 3: M2M Relationship Create││
+│  │ M2M relationship export│ │              │  │ Phase 3: State Transitions      ││
+│  │ File column download   │ │              │  │ Phase 4: M2M Relationship Create││
 │  └────────────────────────┘ │              │  └─────────────────────────────────┘│
-└──────────────┬──────────────┘              └──────────────────┬──────────────────┘
-               │                                                │
-               │                                                │
-               ▼                                                ▼
-┌─────────────────────────────┐              ┌─────────────────────────────────────┐
-│     ICmtSchemaReader        │              │       IDependencyGraphBuilder       │
-│     ICmtDataWriter          │              │       IExecutionPlanBuilder         │
-│  ┌────────────────────────┐ │              │  ┌─────────────────────────────────┐│
-│  │ schema.xml parsing     │ │              │  │ Tarjan's SCC for cycles         ││
-│  │ data.zip generation    │ │              │  │ Kahn's algorithm for tiers      ││
-│  └────────────────────────┘ │              │  │ Deferred field identification   ││
-└─────────────────────────────┘              │  └─────────────────────────────────┘│
-                                             └──────────────────┬──────────────────┘
-                                                                │
-                                                                ▼
-                                             ┌─────────────────────────────────────┐
-                                             │     IDataverseConnectionPool        │
-                                             │     IBulkOperationExecutor          │
-                                             └─────────────────────────────────────┘
+└──────────────┬──────────────┘              └───────────┬───────────┬─────────────┘
+               │                                         │           │
+               │                                         │           ▼
+               ▼                                         │  ┌─────────────────────┐
+┌─────────────────────────────┐                          │  │  Handler Framework  │
+│     ICmtSchemaReader        │                          │  │  ┌───────────────┐  │
+│     ICmtDataWriter          │                          │  │  │ IRecordFilter │  │
+│  ┌────────────────────────┐ │                          │  │  │ IRecordTrans. │  │
+│  │ schema.xml parsing     │ │                          │  │  │ IStateTransit.│  │
+│  │ data.zip generation    │ │                          │  │  │ IPostImport   │  │
+│  │ files/ directory I/O   │ │                          │  │  └───────────────┘  │
+│  └────────────────────────┘ │                          │  └─────────────────────┘
+└─────────────────────────────┘                          │
+                                                         ▼
+                                          ┌─────────────────────────────────────┐
+                                          │     IDependencyGraphBuilder         │
+                                          │     IExecutionPlanBuilder           │
+                                          │     EntityReferenceMapper           │
+                                          │     StateTransitionCollection       │
+                                          └──────────────────┬──────────────────┘
+                                                             │
+                                                             ▼
+                                          ┌─────────────────────────────────────┐
+                                          │     IDataverseConnectionPool        │
+                                          │     IBulkOperationExecutor          │
+                                          └─────────────────────────────────────┘
 ```
 
 ### Components
 
 | Component | Responsibility |
 |-----------|----------------|
-| `ParallelExporter` | Parallel data extraction with FetchXML pagination |
-| `TieredImporter` | Three-phase import orchestration with dependency ordering |
+| `ParallelExporter` | Parallel data extraction with FetchXML pagination and file column download |
+| `TieredImporter` | Four-phase import orchestration with dependency ordering |
 | `DependencyGraphBuilder` | Builds dependency graph using Tarjan's SCC algorithm |
 | `ExecutionPlanBuilder` | Converts graph to executable plan with deferred fields |
 | `DeferredFieldProcessor` | Updates self-referential lookups after entity creation |
+| `StateTransitionProcessor` | Applies state/status transitions via SetStateRequest or SDK messages |
 | `RelationshipProcessor` | Creates M2M associations after all entities exist |
+| `EntityReferenceMapper` | Centralized lookup resolution: ID mapping, direct ID check, name-based fallback |
+| `StateTransitionCollection` | Thread-safe collection of deferred state transition data |
 | `SchemaValidator` | Validates export schema against target environment |
 | `BulkOperationProber` | Detects per-entity bulk API support |
-| `CmtDataReader/Writer` | CMT format serialization |
-| `CmtSchemaReader/Writer` | CMT schema XML handling |
+| `CmtDataReader/Writer` | CMT format serialization including file column data |
+| `CmtSchemaReader/Writer` | CMT schema XML handling with date mode and import mode attributes |
 | `PluginStepManager` | Disable/enable plugin steps during import |
+| `FileColumnTransferHelper` | Chunked upload/download for file column data (4MB blocks) |
+| `DateShifter` | Applies date offset based on schema `dateMode` and export timestamp |
+
+#### Entity-Specific Handlers
+
+| Handler | Implements | Entity | Behavior |
+|---------|-----------|--------|----------|
+| `SystemUserHandler` | `IRecordFilter` | `systemuser` | Skip SYSTEM, INTEGRATION, and support users (accessmode 3/5) |
+| `BusinessUnitHandler` | `IRecordTransformer` | `businessunit` | Map root BU to target's root BU |
+| `ActivityPointerHandler` | `IRecordFilter` | `activitypointer` | Skip base type; only concrete activity types are imported |
+| `OpportunityHandler` | `IRecordTransformer`, `IStateTransitionHandler` | `opportunity` | Strip state/status; emit `WinOpportunityRequest` or `LoseOpportunityRequest` |
+| `IncidentHandler` | `IRecordTransformer`, `IStateTransitionHandler` | `incident` | Strip state/status; emit `CloseIncidentRequest` |
+| `QuoteHandler` | `IRecordTransformer`, `IStateTransitionHandler` | `quote` | Strip state/status; emit `WinQuoteRequest` or `CloseQuoteRequest` |
+| `SalesOrderHandler` | `IRecordTransformer`, `IStateTransitionHandler` | `salesorder` | Strip state/status; emit `FulfillSalesOrderRequest` or `CancelSalesOrderRequest` |
+| `LeadHandler` | `IRecordTransformer`, `IStateTransitionHandler` | `lead` | Strip state/status; emit `QualifyLeadRequest` (suppress side-effect creation) or `SetStateRequest` for disqualified |
+| `DuplicateRuleHandler` | `IRecordTransformer`, `IPostImportHandler` | `duplicaterule` | Remap Entity Type Codes; publish via `PublishDuplicateRuleRequest` after import |
+| `ProductHandler` | `IRecordFilter`, `IStateTransitionHandler` | `product` | Track failed parents; cascade skip to children; handle product lifecycle state |
 
 ### Dependencies
 
@@ -93,11 +126,18 @@ The migration system provides high-performance data export and import between Da
 
 ### Core Requirements
 
-1. **Parallel export**: Entities exported concurrently with FetchXML pagination; M2M relationships exported per entity
+1. **Parallel export**: Entities exported concurrently with FetchXML pagination; M2M relationships exported per entity; file column data optionally downloaded
 2. **Dependency analysis**: Build topologically sorted tiers using Tarjan's SCC algorithm for cycle detection
-3. **Three-phase import**: Entities first (respecting tier order), then deferred fields, then M2M relationships
-4. **CMT format compatibility**: Read/write Microsoft Configuration Migration Tool ZIP archives
-5. **Schema validation**: Detect missing columns in target; optionally skip or fail
+3. **Four-phase import**: Entity create (respecting tier order), deferred field update, state transitions, M2M relationships
+4. **State machine handling**: Strip `statecode`/`statuscode` from create payloads; collect transition data; apply via `SetStateRequest` for normal entities or specialized SDK messages for state machine entities
+5. **Entity-specific handlers**: Extensible handler interfaces for record filtering, transformation, state transitions, and post-import actions
+6. **External lookup resolution**: Cascading resolution — ID mapping first, then direct ID check in target, then name-based query with caching
+7. **Date shifting**: Four modes on schema fields — `absolute`, `relative` (weeks), `relativeDaily` (days), `relativeExact` (exact elapsed time)
+8. **File column data**: Opt-in export/import of file column binary data with chunked transfer (4MB blocks)
+9. **Per-entity import mode**: Schema-level `importMode` attribute overrides global `ImportOptions.Mode`
+10. **Owner impersonation**: Clone pooled client per owner group, set `CallerAADObjectId`, execute that owner's records
+11. **CMT format compatibility**: Read/write Microsoft Configuration Migration Tool ZIP archives including new schema attributes
+12. **Schema validation**: Detect missing columns in target; optionally skip or fail
 
 ### Primary Flows
 
@@ -108,67 +148,226 @@ The migration system provides high-performance data export and import between Da
    - Acquire pooled client
    - Build FetchXML with fields from schema
    - Execute paginated queries with paging cookies
+   - If `IncludeFileData=true` and field type is `file`, download file data via chunked download and store in `files/{entityname}/{recordid}_{fieldname}.bin`
    - Store records in thread-safe collection
 3. **Export M2M relationships**: For each entity with M2M relationships:
    - Query intersect entity for associations
    - Filter to exported source records
    - Group by source ID
-4. **Write output**: Create data.zip with data.xml, data_schema.xml, [Content_Types].xml
+4. **Write output**: Create data.zip with data.xml, data_schema.xml, files/ directory, [Content_Types].xml
+5. **Record export timestamp**: Store `ExportedAt` in data.xml for date shifting calculations
 
 **Import Flow:**
 
-1. **Read data**: Load CMT ZIP via `ICmtDataReader.ReadAsync()`
+1. **Read data**: Load CMT ZIP via `ICmtDataReader.ReadAsync()` (includes file data if present)
 2. **Build dependency graph**: Analyze lookup relationships, detect cycles
 3. **Build execution plan**: Topological sort into tiers, identify deferred fields
-4. **Phase 1 - Entity Import** (sequential tiers, parallel within tier):
+4. **Resolve entity-specific handlers**: Match registered handlers to entities in the import data
+5. **Phase 1 — Entity Import** (sequential tiers, parallel within tier):
    - Validate schema against target environment
    - Optionally disable plugins
    - For each tier (sequential):
      - For each entity (parallel, default 4):
-       - Prepare records (remap lookups, null deferred fields)
+       - Resolve per-entity import mode (schema attribute -> global fallback)
+       - Apply `IRecordFilter` handlers (skip SYSTEM users, activitypointer base type, failed product children)
+       - Apply `IRecordTransformer` handlers (remap root BU, remap duplicate rule ETCs, strip state/status for state machine entities)
+       - Apply generic state/status stripping for all entities; collect `StateTransitionData` (default `SetStateRequest` path or handler-provided SDK message)
+       - Apply date shifting based on schema field `dateMode` and elapsed time since export
+       - Resolve lookups via `EntityReferenceMapper` cascading strategy (ID mapping -> direct ID -> name-based)
+       - If `ImpersonateOwners=true`, group records by owner and clone client with `CallerAADObjectId` per group
        - Execute via bulk API with probe fallback
-       - Track ID mappings (source → target)
-5. **Phase 2 - Deferred Fields**:
+       - Track ID mappings (source -> target)
+6. **Phase 2 — Deferred Fields**:
    - For each entity with deferred fields:
      - Build update batch using Phase 1 ID mappings
-     - Execute updates
-6. **Phase 3 - M2M Relationships**:
+     - Execute updates (records still in Active/default state — mutable)
+7. **Phase 3 — State Transitions**:
+   - Consume `StateTransitionCollection` populated in Phase 1
+   - For normal entities: apply `SetStateRequest` where statecode/statuscode differ from defaults
+   - For state machine entities: execute specialized SDK messages (`WinOpportunityRequest`, `CloseIncidentRequest`, etc.)
+   - Check `IsRecordClosed` before executing close messages to avoid double-closing
+   - Apply `IPostImportHandler` actions (publish duplicate rules)
+8. **Phase 4 — M2M Relationships**:
    - For each M2M relationship (parallel):
      - Map source/target IDs
      - Execute associate requests
      - Handle duplicates as idempotent success
-7. **Re-enable plugins** if disabled
+9. **Re-enable plugins** if disabled
+10. **Upload file column data**: For records with file fields, execute chunked upload via `InitializeFileBlocksUploadRequest` / `UploadBlockRequest` / `CommitFileBlocksUploadRequest`
 
-### Constraints
+### State Machine Entity Handling
 
-- Import requires schema to exist in target environment
-- Bulk API support varies by entity (probed at runtime)
-- Standard tables: all-or-nothing per batch; elastic tables: partial success
-- M2M associations created only after all entities exist
-- Self-referential lookups must be deferred (circular dependency)
+The Dataverse platform blocks `SetStateRequest` for certain entity/state combinations and requires specialized SDK messages instead. These are hard mandatory — the platform throws an error if you attempt `SetStateRequest`.
 
-### Validation Rules
+| Entity | Target State | Required SDK Message |
+|--------|-------------|---------------------|
+| `incident` | Resolved (1), Canceled (2) | `CloseIncidentRequest` |
+| `opportunity` | Won (1) | `WinOpportunityRequest` |
+| `opportunity` | Lost (2) | `LoseOpportunityRequest` |
+| `quote` | Won (2) | `WinQuoteRequest` |
+| `quote` | Closed/Lost (3) | `CloseQuoteRequest` |
+| `salesorder` | Fulfilled (3) | `FulfillSalesOrderRequest` |
+| `salesorder` | Canceled (2) | `CancelSalesOrderRequest` |
+| `lead` | Qualified (1) | `QualifyLeadRequest` (suppress side-effect record creation) |
 
-| Field | Rule | Error |
-|-------|------|-------|
-| Schema entities | At least 1 required | `ArgumentException` |
-| Output path | Must be valid file path | `ArgumentException` |
-| Import data | Must have schema and entity data | `InvalidDataException` |
-| Target environment | Must have entities defined | `SchemaMismatchException` |
+For all other entities, `SetStateRequest` via `UpdateStateAndStatusForEntity` handles state transitions generically.
 
-### TUI Surface
+**Lead qualification specifics:** `QualifyLeadRequest` supports `CreateAccount`, `CreateContact`, and `CreateOpportunity` boolean parameters. During import, all three are set to `false` — the import data includes those records separately if needed. The qualification only transitions the lead's state.
 
-The `MigrationScreen` provides an interactive Terminal.Gui interface for configuring and monitoring export/import operations. It lives under **Tools > Data Migration** in TuiShell, replacing the "Coming Soon" placeholder.
+### External Lookup Resolution
+
+The `EntityReferenceMapper` resolves lookup references using a cascading strategy:
+
+1. **ID Mapping** (fastest, no network): Check `IdMappingCollection` for source->target GUID from records imported in this session
+2. **Direct ID check** (single retrieve): Query target environment by source GUID — common for standard reference data (roles, currencies) that share GUIDs across orgs
+3. **Name-based resolution** (query by primary name field): Query target by entity-specific match field with results cached in `ConcurrentDictionary`
+
+Entity-specific match fields override the default primary name field:
+
+| Entity | Match Field |
+|--------|-------------|
+| `transactioncurrency` | `isocurrencycode` |
+| `businessunit` | `name` (special handling for root BU) |
+| `role` | `name` (scoped to root BU) |
+| `uom` / `uomschedule` | `name` |
+| All others | Primary name field from entity metadata |
+
+Controlled by `ImportOptions.ResolveExternalLookups` (default: `false`). When `false`, only strategy 1 runs (current behavior). When enabled and a lookup still cannot be resolved, `ImportOptions.SkipUnresolvedLookups` determines whether to null the field (default: `true`) or fail the record.
+
+### Date Shifting
+
+Schema fields can declare a `dateMode` attribute that controls how date values are adjusted during import:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `absolute` | Keep original date value (default) | Production migrations, audit-sensitive data |
+| `relative` | Shift by whole weeks elapsed since export | Demo data — "meeting next week" stays next week |
+| `relativeDaily` | Shift by whole days elapsed since export | Training data — finer granularity than weekly |
+| `relativeExact` | Shift by exact elapsed time since export | Test automation — precise relative offsets |
+
+**Calculation:** `ImportTime - ExportedAt` produces the offset. For `relative`, offset is rounded to nearest week. For `relativeDaily`, rounded to nearest day. For `relativeExact`, applied as-is.
+
+The `ExportedAt` timestamp is already stored in `MigrationData`. The `dateMode` attribute is read from the schema field definition and defaults to `absolute` when absent.
+
+CMT compatibility: `absolute`, `relative`, and `relativeDaily` match CMT's `dateMode` attribute exactly. `relativeExact` is a PPDS extension.
+
+### File Column Data
+
+File columns store binary data (documents, images) in Dataverse. Export and import use the chunked transfer API.
+
+**Export:**
+- Controlled by `ExportOptions.IncludeFileData` (default: `false`)
+- Files stored in ZIP at `files/{entityname}/{recordid}_{fieldname}.bin`
+- Field element in data.xml carries metadata: `value="files/account/abc123_myfilecolumn.bin" filename="report.pdf" mimetype="application/pdf"`
+- Download via `InitializeFileBlocksDownloadRequest` -> `DownloadBlockRequest` (4MB chunks) until complete
+
+**Import:**
+- Upload via `InitializeFileBlocksUploadRequest` -> `UploadBlockRequest` (4MB chunks) -> `CommitFileBlocksUploadRequest`
+- Executed after record creation (file must be associated with an existing record)
+- Progress reported per file
+
+**Platform constraints:**
+- Chunk size: 4MB (4,194,304 bytes) — Dataverse SDK limit
+- Default max file size per column: 32MB (`MaxSizeInKB = 32768`)
+- Absolute max file size per column: 10GB (`MaxSizeInKB = 10485760`)
+- BYOK (self-managed key) orgs: 128MB max per file, no chunking support
+
+### Per-Entity Import Mode
+
+The schema `<entity>` element supports an optional `importMode` attribute:
+
+```xml
+<entity name="account" importMode="upsert" />
+<entity name="transactioncurrency" importMode="update" />
+<entity name="annotation" importMode="skip" />
+```
+
+| Mode | Behavior |
+|------|----------|
+| `create` | Create only; fail if record exists |
+| `update` | Update only; fail if record does not exist |
+| `upsert` | Create or update (default) |
+| `skip` | Do not import this entity |
+
+When not specified, falls back to `ImportOptions.Mode`. The `skip` mode is a PPDS extension not present in CMT (CMT uses `skipupdate` and `forcecreate` boolean attributes; we normalize to a single enum).
+
+### Owner Impersonation
+
+When `ImportOptions.ImpersonateOwners = true` and `UserMappings` is provided:
+
+1. Group records by mapped owner (target user ID)
+2. For each owner group:
+   - Clone the pooled `ServiceClient` via `ServiceClient.Clone()` (lightweight copy)
+   - Set `CallerAADObjectId` on the clone (preferred over `CallerId` per Microsoft guidance)
+   - Execute that owner's records through the clone
+   - Dispose the clone
+3. Records whose owner cannot be mapped fall back to the import service principal
+
+**Limitation:** Within a single `CreateMultiple`/`UpdateMultiple` batch, all records execute under the same impersonation context. Records are grouped by owner before batching.
+
+**Prerequisites:**
+- Application User must have `prvActOnBehalfOfAnotherUser` privilege
+- Target users must exist and be enabled
+- `UserMappings` must be provided (generated via `ppds data users`)
+
+### Activity Pointer Handling
+
+Activity entities use polymorphic inheritance — `activitypointer` is the base type, with concrete types (`email`, `phonecall`, `appointment`, `task`, `letter`, `fax`) inheriting from it.
+
+**Rules:**
+- `activitypointer` records are never imported directly — the `ActivityPointerHandler` filter skips them
+- Only concrete activity types are imported; Dataverse auto-creates the `activitypointer` record
+- `activityparty` records are imported as part of the parent activity entity data, not as a separate entity pass
+- Activity entities are ordered after their `regardingobjectid` targets in dependency tiers
+
+### Duplicate Rule ETC Remapping
+
+Entity Type Codes (ETCs) are auto-assigned integers that differ between environments. Duplicate rules reference entities by ETC in their conditions.
+
+**The `DuplicateRuleHandler`:**
+1. On import, queries `EntityMetadata` in target to build `logicalName -> ETC` mapping
+2. Rewrites `baseentitytypecode` and `matchingentitytypecode` on `duplicaterule` records
+3. Imports rules in unpublished state
+4. After all records are imported (Phase 3 `IPostImportHandler`), publishes rules via `PublishDuplicateRuleRequest`
+
+### Product Hierarchy Failure Cascading
+
+Product families form parent-child hierarchies via `parentproductid`. The `ProductHandler`:
+
+1. Tracks failed product record IDs in a concurrent set during Phase 1
+2. Before importing a product, checks if `parentproductid` references a failed product
+3. If parent failed, skips the child and adds its ID to the failed set (cascading)
+4. Skips dependent entities (`productpricelevel`, `productassociation`, `dynamicproperty`, `dynamicpropertyassociation`) whose product reference is in the failed set
+5. Reports cascaded skips distinctly from failures — includes root cause (parent ID) in skip reason
+
+### Surface-Specific Behavior
+
+#### CLI Surface
+
+New and modified flags for `ppds data import`:
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--resolve-lookups` | bool | false | Enable external lookup resolution |
+| `--skip-unresolved-lookups` | bool | true | Null unresolved lookups instead of failing |
+| `--impersonate-owners` | bool | false | Preserve ownership via CallerId impersonation |
+| `--include-file-data` | bool | false | Export: include file column binary data |
+
+Per-entity import mode and date shifting are schema-level attributes — configured in the schema XML, not via CLI flags.
+
+#### TUI Surface
+
+The `MigrationScreen` provides an interactive Terminal.Gui interface for configuring and monitoring export/import operations. It lives under **Tools > Data Migration** in TuiShell.
 
 **Key components:**
 
 | Component | Responsibility |
 |-----------|----------------|
 | `MigrationScreen` | Main screen: mode selection, configuration panel, real-time progress, results display |
-| `ExecutionPlanPreviewDialog` | Modal showing tier ordering, deferred fields, and M2M relationships before import starts |
+| `ExecutionPlanPreviewDialog` | Modal showing tier ordering, deferred fields, state transitions, and M2M relationships before import starts |
 | `TuiMigrationProgressReporter` | Adapts `IProgressReporter` to TUI by marshaling all callbacks via `Application.MainLoop.Invoke()` |
 
-**Layout:** RadioGroup (Export/Import) at top; configuration panel below (file paths, options per mode); progress area with phase label, entity progress bars, rate/ETA; results area showing per-entity success/failure/warning counts.
+**Layout:** RadioGroup (Export/Import) at top; configuration panel below (file paths, options per mode including new options); progress area with phase label (now 4 phases), entity progress bars, rate/ETA; results area showing per-entity success/failure/warning/skip counts.
 
 **Hotkeys:**
 
@@ -181,41 +380,220 @@ The `MigrationScreen` provides an interactive Terminal.Gui interface for configu
 **Core types:**
 
 - `MigrationScreen` — implements `ITuiScreen` and `ITuiStateCapture<MigrationScreenState>`; title is "Data Migration - {environment}"
-- `MigrationScreenState` — captures mode, operation state, paths, current phase/entity, record counts, rate, ETA, elapsed, error/warning counts
+- `MigrationScreenState` — captures mode, operation state, paths, current phase/entity, record counts, rate, ETA, elapsed, error/warning/skip counts
 - `MigrationMode` — `Export` | `Import`
 - `MigrationOperationState` — `Idle` | `Configuring` | `PreviewingPlan` | `Running` | `Completed` | `Failed` | `Cancelled`
-- `ExecutionPlanPreviewDialog` — extends `TuiDialog`, implements `ITuiStateCapture<ExecutionPlanPreviewDialogState>`; `IsApproved` indicates proceed vs. cancel
-- `ExecutionPlanPreviewDialogState` — captures tier count, entity count, deferred field count, M2M relationship count, tier summaries
+- `ExecutionPlanPreviewDialog` — extends `TuiDialog`, implements `ITuiStateCapture<ExecutionPlanPreviewDialogState>`; `IsApproved` indicates proceed vs. cancel; now shows state transition summary
+- `ExecutionPlanPreviewDialogState` — captures tier count, entity count, deferred field count, state transition count, M2M relationship count, tier summaries
 - `TuiMigrationProgressReporter` — implements `IProgressReporter`; all `Report()`, `Complete()`, and `Error()` calls dispatched to UI thread
 
 **Key TUI constraints:**
 
 - Only one operation (export or import) may run at a time; UI blocks Start while running
 - All migration work runs on a background thread; UI updates are marshaled via `Application.MainLoop.Invoke()`
-- File paths are validated before the Start button is enabled (schema `.xml` must exist for export; data `.zip` must exist for import)
+- File paths are validated before the Start button is enabled
 - Import options cannot be modified while an operation is running
 - Cancellation fires the `CancellationToken`; the operation completes its current batch then stops; partial results are displayed
-- Operations are not resumable — cancellation requires a full restart (mitigated by upsert mode)
 
-**Import plan preview flow:** Before starting import, Ctrl+P reads the data file via `ICmtDataReader`, builds the dependency graph via `IDependencyGraphBuilder`, builds the execution plan via `IExecutionPlanBuilder`, and displays it in `ExecutionPlanPreviewDialog`. The user must approve (Proceed) before the import begins.
+### Constraints
 
-**TUI acceptance criteria:**
+- Import requires schema to exist in target environment
+- Bulk API support varies by entity (probed at runtime)
+- Standard tables: all-or-nothing per batch; elastic tables: partial success
+- M2M associations created only after all entities exist and state transitions are applied
+- Self-referential lookups must be deferred (circular dependency)
+- State transitions must happen after deferred fields (closed records have read-only fields)
+- File column chunk size is 4MB — Dataverse platform constraint
+- Owner impersonation requires `prvActOnBehalfOfAnotherUser` privilege
+- `QualifyLeadRequest` side-effect creation is suppressed during import
+- Within a bulk API batch, all records share the same impersonation context
 
-- [ ] Screen loads in Export mode by default
-- [ ] Mode switch changes configuration panel without losing shared progress/results UI
-- [ ] File paths validated; Start button disabled until paths are valid
-- [ ] Ctrl+P opens `ExecutionPlanPreviewDialog` showing tiers, deferred fields, M2M counts
-- [ ] Progress area updates phase, entity, record count, rate, and ETA in real time
-- [ ] Results area shows per-entity success/failure/warning counts after completion
-- [ ] Cancel stops the operation; partial results displayed; state shows `Cancelled`
-- [ ] `TuiMigrationProgressReporter` marshals all progress updates to the UI thread
-- [ ] `MigrationScreen.CaptureState()` returns accurate `MigrationScreenState`
+### Validation Rules
 
-**TUI code location:** `src/PPDS.Tui/Screens/MigrationScreen.cs` (screen, state, mode, operation state), `src/PPDS.Tui/Dialogs/ExecutionPlanPreviewDialog.cs` (dialog), `src/PPDS.Tui/Progress/TuiMigrationProgressReporter.cs` (progress adapter). Tests use `[Trait("Category", "TuiUnit")]`.
+| Field | Rule | Error |
+|-------|------|-------|
+| Schema entities | At least 1 required | `ArgumentException` |
+| Output path | Must be valid file path | `ArgumentException` |
+| Import data | Must have schema and entity data | `InvalidDataException` |
+| Target environment | Must have entities defined | `SchemaMismatchException` |
+| `importMode` attribute | Must be `create`, `update`, `upsert`, or `skip` | `InvalidDataException` |
+| `dateMode` attribute | Must be `absolute`, `relative`, `relativeDaily`, or `relativeExact` | `InvalidDataException` |
+| `ImpersonateOwners` | Requires `UserMappings` to be set | `InvalidOperationException` |
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | Export creates valid CMT ZIP archive with schema, data, and content types | `ParallelExporterTests.ExportCreatesValidZipArchive` | 🔲 |
+| AC-02 | Import respects tier ordering from dependency analysis | `TieredImporterTests.ImportRespectsTierOrdering` | 🔲 |
+| AC-03 | Circular references handled via deferred fields in Phase 2 | `DeferredFieldProcessorTests.UpdatesSelfReferentialLookups` | 🔲 |
+| AC-04 | M2M relationships created after all entities and state transitions | `RelationshipProcessorTests.CreatesAssociationsAfterStateTransitions` | 🔲 |
+| AC-05 | `statecode`/`statuscode` stripped from create payloads for all entities | `TieredImporterTests.StripsStateStatusFromCreatePayload` | 🔲 |
+| AC-06 | `SetStateRequest` applied in Phase 3 for entities with non-default state | `StateTransitionProcessorTests.AppliesSetStateForNonDefaultState` | 🔲 |
+| AC-07 | `WinOpportunityRequest` issued for opportunity with statecode=1 | `OpportunityHandlerTests.EmitsWinOpportunityForStateCodeOne` | 🔲 |
+| AC-08 | `LoseOpportunityRequest` issued for opportunity with statecode=2 | `OpportunityHandlerTests.EmitsLoseOpportunityForStateCodeTwo` | 🔲 |
+| AC-09 | `CloseIncidentRequest` issued for incident with statecode=1 or 2 | `IncidentHandlerTests.EmitsCloseIncidentForNonActiveState` | 🔲 |
+| AC-10 | `WinQuoteRequest` issued for quote with statecode=2 | `QuoteHandlerTests.EmitsWinQuoteForStateCodeTwo` | 🔲 |
+| AC-11 | `CloseQuoteRequest` issued for quote with statecode=3 | `QuoteHandlerTests.EmitsCloseQuoteForStateCodeThree` | 🔲 |
+| AC-12 | `FulfillSalesOrderRequest` issued for salesorder with statecode=3 | `SalesOrderHandlerTests.EmitsFulfillForStateCodeThree` | 🔲 |
+| AC-13 | `CancelSalesOrderRequest` issued for salesorder with statecode=2 | `SalesOrderHandlerTests.EmitsCancelForStateCodeTwo` | 🔲 |
+| AC-14 | `QualifyLeadRequest` issued for lead with statecode=1 with `CreateAccount/Contact/Opportunity=false` | `LeadHandlerTests.EmitsQualifyWithSuppressedSideEffects` | 🔲 |
+| AC-15 | Lead disqualification (statecode=2) uses `SetStateRequest`, not `QualifyLeadRequest` | `LeadHandlerTests.UsesSetStateForDisqualified` | 🔲 |
+| AC-16 | `IsRecordClosed` check prevents double-closing of already-closed records | `StateTransitionProcessorTests.SkipsAlreadyClosedRecords` | 🔲 |
+| AC-17 | `SystemUserHandler` skips records with accessmode 3 (support) and 5 (integration) | `SystemUserHandlerTests.SkipsSupportAndIntegrationUsers` | 🔲 |
+| AC-18 | `BusinessUnitHandler` maps root BU GUID to target's root BU | `BusinessUnitHandlerTests.MapsRootBusinessUnit` | 🔲 |
+| AC-19 | `ActivityPointerHandler` skips `activitypointer` base type records | `ActivityPointerHandlerTests.SkipsBaseTypeRecords` | 🔲 |
+| AC-20 | `DuplicateRuleHandler` remaps ETCs using target environment metadata | `DuplicateRuleHandlerTests.RemapsEntityTypeCodes` | 🔲 |
+| AC-21 | `DuplicateRuleHandler` publishes rules via `PublishDuplicateRuleRequest` in Phase 3 | `DuplicateRuleHandlerTests.PublishesRulesPostImport` | 🔲 |
+| AC-22 | `ProductHandler` cascades skip to children when parent product fails | `ProductHandlerTests.CascadesSkipToChildren` | 🔲 |
+| AC-23 | `ProductHandler` reports cascaded skips with root cause parent ID | `ProductHandlerTests.ReportsRootCauseInSkipReason` | 🔲 |
+| AC-24 | External lookup resolution: ID mapping checked first (no network call) | `EntityReferenceMapperTests.ResolvesFromIdMappingFirst` | 🔲 |
+| AC-25 | External lookup resolution: direct ID check when not in mapping | `EntityReferenceMapperTests.FallsBackToDirectIdCheck` | 🔲 |
+| AC-26 | External lookup resolution: name-based query as final fallback | `EntityReferenceMapperTests.FallsBackToNameBasedQuery` | 🔲 |
+| AC-27 | External lookup resolution: results cached (same target queried at most once) | `EntityReferenceMapperTests.CachesResolvedLookups` | 🔲 |
+| AC-28 | External lookup resolution: `transactioncurrency` matched by `isocurrencycode` | `EntityReferenceMapperTests.MatchesCurrencyByIsoCode` | 🔲 |
+| AC-29 | Date shifting: `absolute` mode preserves original date value | `DateShifterTests.AbsolutePreservesOriginalDate` | 🔲 |
+| AC-30 | Date shifting: `relative` mode shifts by whole weeks since export | `DateShifterTests.RelativeShiftsByWeeks` | 🔲 |
+| AC-31 | Date shifting: `relativeDaily` mode shifts by whole days since export | `DateShifterTests.RelativeDailyShiftsByDays` | 🔲 |
+| AC-32 | Date shifting: `relativeExact` mode shifts by exact elapsed time | `DateShifterTests.RelativeExactShiftsByExactTime` | 🔲 |
+| AC-33 | File column export: files stored in `files/{entity}/{recordid}_{field}.bin` in ZIP | `ParallelExporterTests.ExportsFileColumnsToFilesDirectory` | 🔲 |
+| AC-34 | File column export: field element carries `filename` and `mimetype` attributes | `CmtDataWriterTests.WritesFileMetadataAttributes` | 🔲 |
+| AC-35 | File column import: chunked upload via 4MB blocks | `FileColumnTransferHelperTests.UploadsInFourMegabyteChunks` | 🔲 |
+| AC-36 | File column export disabled by default (`IncludeFileData=false`) | `ParallelExporterTests.SkipsFileColumnsWhenNotOptedIn` | 🔲 |
+| AC-37 | Per-entity `importMode` attribute overrides global mode | `TieredImporterTests.PerEntityModeOverridesGlobal` | 🔲 |
+| AC-38 | Per-entity `importMode="skip"` excludes entity from import | `TieredImporterTests.SkipModeExcludesEntity` | 🔲 |
+| AC-39 | Owner impersonation: records grouped by owner, clone per group with `CallerAADObjectId` | `TieredImporterTests.ImpersonatesViaClonePerOwnerGroup` | 🔲 |
+| AC-40 | Owner impersonation: unmapped owners fall back to service principal | `TieredImporterTests.FallsBackToServicePrincipalForUnmappedOwner` | 🔲 |
+| AC-41 | Progress reports phase (1-4), entity, record counts, rate, and ETA | `ProgressReporterTests.ReportsAllFourPhases` | 🔲 |
+| AC-42 | Schema validation detects missing columns and reports | `SchemaValidatorTests.DetectsMissingColumns` | 🔲 |
+| AC-43 | Bulk fallback works for unsupported entities | `BulkOperationProberTests.FallsBackForUnsupportedEntities` | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| Self-referential entity | account with parentaccountid | Deferred field updated in Phase 2 |
+| Mutual reference | A->B, B->A | Both in same tier, both deferred |
+| No dependencies | 3 independent entities | All in Tier 0, parallel import |
+| Missing target column | Export has field X, target missing | `SchemaMismatchException` or warning |
+| Duplicate M2M | Same association twice | Second treated as success |
+| Record already closed | Opportunity already Won in target | `IsRecordClosed` returns true, skip transition |
+| State machine entity with state=0 | Active opportunity | No state transition needed, no SDK message |
+| Lead disqualified (state=2) | Lead with statecode=2 | `SetStateRequest`, not `QualifyLeadRequest` |
+| Product parent fails, 5 children | Parent create fails | All 5 children skipped with root cause |
+| External lookup to nonexistent record | Currency "XYZ" not in target | Field nulled (if `SkipUnresolvedLookups=true`) or record fails |
+| File column on BYOK org | 128MB limit, no chunking | Single block upload; fail if file > 128MB |
+| No dateMode attribute | Field without `dateMode` | Treated as `absolute` (default) |
+| importMode="skip" on all entities | All entities skipped | Return success with 0 counts |
 
 ---
 
 ## Core Types
+
+### Handler Interfaces
+
+Each concern is a separate interface. A handler class implements only the interfaces it needs.
+
+```csharp
+public interface IRecordFilter
+{
+    bool CanHandle(string entityLogicalName);
+    bool ShouldSkip(Entity record, ImportContext context);
+}
+
+public interface IRecordTransformer
+{
+    bool CanHandle(string entityLogicalName);
+    Entity Transform(Entity record, ImportContext context);
+}
+
+public interface IStateTransitionHandler
+{
+    bool CanHandle(string entityLogicalName);
+    StateTransitionData? GetTransition(Entity record, ImportContext context);
+}
+
+public interface IPostImportHandler
+{
+    bool CanHandle(string entityLogicalName);
+    Task ExecuteAsync(string entityLogicalName, ImportContext context, CancellationToken cancellationToken);
+}
+```
+
+### StateTransitionCollection
+
+Thread-safe collection populated in Phase 1, consumed in Phase 3.
+
+```csharp
+public class StateTransitionCollection
+{
+    public void Add(string entityName, Guid recordId, StateTransitionData data);
+    public IReadOnlyList<StateTransitionData> GetTransitions(string entityName);
+    public IEnumerable<string> GetEntityNames();
+    public int Count { get; }
+}
+
+public class StateTransitionData
+{
+    public string EntityName { get; init; }
+    public Guid RecordId { get; init; }
+    public int StateCode { get; init; }
+    public int StatusCode { get; init; }
+    public string? SdkMessage { get; init; }        // null = SetStateRequest
+    public Dictionary<string, object>? MessageData { get; init; }
+}
+```
+
+### EntityReferenceMapper
+
+Centralized lookup resolution with cascading strategy and caching.
+
+```csharp
+public class EntityReferenceMapper
+{
+    public EntityReferenceMapper(
+        IdMappingCollection idMappings,
+        IDataverseConnectionPool pool,
+        ImportOptions options);
+
+    public async Task<Guid?> ResolveAsync(
+        string targetEntityName, Guid sourceId,
+        CancellationToken cancellationToken);
+}
+```
+
+### DateShifter
+
+Applies date offset based on schema field mode and elapsed time since export.
+
+```csharp
+public static class DateShifter
+{
+    public static DateTime? Shift(DateTime? value, DateMode mode, TimeSpan elapsed);
+}
+
+public enum DateMode { Absolute, Relative, RelativeDaily, RelativeExact }
+```
+
+### FileColumnTransferHelper
+
+Chunked upload/download for file column binary data.
+
+```csharp
+public class FileColumnTransferHelper
+{
+    public async Task<byte[]> DownloadAsync(
+        string entityName, Guid recordId, string fieldName,
+        CancellationToken cancellationToken);
+
+    public async Task UploadAsync(
+        string entityName, Guid recordId, string fieldName,
+        byte[] data, string fileName, string mimeType,
+        CancellationToken cancellationToken);
+}
+```
 
 ### IExporter
 
@@ -258,8 +636,6 @@ public interface IDependencyGraphBuilder
 }
 ```
 
-The implementation ([`DependencyGraphBuilder.cs`](../src/PPDS.Migration/Analysis/DependencyGraphBuilder.cs)) uses Tarjan's Strongly Connected Components algorithm to detect circular references, then Kahn's algorithm to produce topologically sorted tiers.
-
 ### IExecutionPlanBuilder
 
 Creates executable import plan ([`Analysis/IExecutionPlanBuilder.cs`](../src/PPDS.Migration/Analysis/IExecutionPlanBuilder.cs)).
@@ -273,7 +649,7 @@ public interface IExecutionPlanBuilder
 
 ### ExecutionPlan
 
-Ordered import strategy with deferred fields ([`Models/ExecutionPlan.cs`](../src/PPDS.Migration/Models/ExecutionPlan.cs)).
+Ordered import strategy with deferred fields and state transition awareness.
 
 ```csharp
 public class ExecutionPlan
@@ -299,52 +675,32 @@ public interface IProgressReporter
 }
 ```
 
-### IPluginStepManager
-
-Manages plugin step disabling/enabling during import for entities with `disableplugins=true` ([`Import/PluginStepManager.cs:176-200`](../src/PPDS.Migration/Import/PluginStepManager.cs#L176-L200)).
-
-```csharp
-public interface IPluginStepManager
-{
-    Task<IReadOnlyList<Guid>> GetActivePluginStepsAsync(
-        IEnumerable<int> objectTypeCodes, CancellationToken cancellationToken = default);
-    Task DisablePluginStepsAsync(
-        IEnumerable<Guid> stepIds, CancellationToken cancellationToken = default);
-    Task EnablePluginStepsAsync(
-        IEnumerable<Guid> stepIds, CancellationToken cancellationToken = default);
-}
-```
-
-Used by `TieredImporter` when `RespectDisablePluginsSetting=true` and schema entities have `disableplugins="true"`. Steps are re-enabled in a `finally` block after import completes.
+`MigrationPhase` enum extended: `Analyzing`, `Exporting`, `Importing`, `ProcessingDeferredFields`, `ApplyingStateTransitions`, `ProcessingRelationships`, `UploadingFiles`, `Complete`, `Error`
 
 ### Usage Pattern
 
 ```csharp
-// Export
-var exporter = serviceProvider.GetRequiredService<IExporter>();
-var exportResult = await exporter.ExportAsync(
-    "schema.xml",
-    "data.zip",
-    new ExportOptions { DegreeOfParallelism = 8 },
-    new ConsoleProgressReporter());
-
-// Import
+// Import with CMT parity features
 var importer = serviceProvider.GetRequiredService<IImporter>();
 var importResult = await importer.ImportAsync(
     "data.zip",
     new ImportOptions
     {
         Mode = ImportMode.Upsert,
+        ResolveExternalLookups = true,
+        ImpersonateOwners = true,
+        UserMappings = userMappings,
         BypassCustomPlugins = CustomLogicBypass.Synchronous,
-        MaxParallelEntities = 4
     },
     new ConsoleProgressReporter());
 
-if (!importResult.Success)
-{
-    foreach (var error in importResult.Errors)
-        Console.WriteLine($"{error.EntityLogicalName}: {error.Message}");
-}
+// Export with file data
+var exporter = serviceProvider.GetRequiredService<IExporter>();
+var exportResult = await exporter.ExportAsync(
+    "schema.xml",
+    "data.zip",
+    new ExportOptions { IncludeFileData = true },
+    new ConsoleProgressReporter());
 ```
 
 ---
@@ -357,9 +713,12 @@ The Configuration Migration Tool format is a ZIP archive containing XML files.
 
 ```
 data.zip
-├── [Content_Types].xml      # OpenXML content types manifest
-├── data.xml                 # Entity records and M2M relationships
-└── data_schema.xml          # Schema: entities, fields, relationships
++-- [Content_Types].xml      # OpenXML content types manifest
++-- data.xml                 # Entity records and M2M relationships
++-- data_schema.xml          # Schema: entities, fields, relationships
++-- files/                   # File column binary data (optional)
+    +-- {entityname}/
+        +-- {recordid}_{fieldname}.bin
 ```
 
 ### Schema XML (data_schema.xml)
@@ -368,11 +727,14 @@ data.zip
 <entities version="1.0" timestamp="2026-01-23T10:30:00Z">
   <entity name="account" displayname="Account" etc="1"
           primaryidfield="accountid" primarynamefield="name"
-          disableplugins="false">
+          disableplugins="false" importMode="upsert">
     <fields>
       <field displayname="Name" name="name" type="string"/>
+      <field displayname="Scheduled Start" name="scheduledstart" type="datetime"
+             dateMode="relative"/>
       <field displayname="Parent" name="parentaccountid" type="lookup"
              lookupType="account"/>
+      <field displayname="Logo" name="entityimage" type="filedata"/>
     </fields>
     <relationships>
       <relationship name="systemuserroles" manyToMany="true"
@@ -393,8 +755,12 @@ data.zip
       <record id="00000000-0000-0000-0000-000000000001">
         <field name="accountid" value="00000000-0000-0000-0000-000000000001"/>
         <field name="name" value="Contoso"/>
+        <field name="statecode" value="0"/>
+        <field name="statuscode" value="1"/>
         <field name="parentaccountid" value="00000000-0000-0000-0000-000000000002"
                lookupentity="account" lookupentityname="Parent Corp"/>
+        <field name="entityimage" value="files/account/00000001_entityimage.bin"
+               filename="logo.png" mimetype="image/png"/>
       </record>
     </records>
     <m2mrelationships>
@@ -413,10 +779,10 @@ data.zip
 
 | Interface | Implementation | Purpose |
 |-----------|----------------|---------|
-| `ICmtSchemaReader` | `CmtSchemaReader` | Parse schema.xml |
+| `ICmtSchemaReader` | `CmtSchemaReader` | Parse schema.xml (including `dateMode`, `importMode`, `filedata` type) |
 | `ICmtSchemaWriter` | `CmtSchemaWriter` | Generate schema.xml |
-| `ICmtDataReader` | `CmtDataReader` | Read data.zip archive |
-| `ICmtDataWriter` | `CmtDataWriter` | Write data.zip archive |
+| `ICmtDataReader` | `CmtDataReader` | Read data.zip archive (including `files/` directory) |
+| `ICmtDataWriter` | `CmtDataWriter` | Write data.zip archive (including `files/` directory) |
 
 ---
 
@@ -428,7 +794,9 @@ data.zip
 |-------|-----------|----------|
 | `SchemaMismatchException` | Column in export missing from target | Use `SkipMissingColumns=true` to continue |
 | `ImportException` | Record-level failure | Captured in `ImportResult.Errors` |
+| `StateTransitionException` | Close/qualify message fails | Captured in errors; `ContinueOnError` controls behavior |
 | `PoolExhaustedException` | Connection pool depleted | Reduce `MaxParallelEntities` |
+| `FileUploadException` | File column upload fails | Captured in errors; record created, file attachment failed |
 | Throttle (service protection) | Rate limit hit | Automatic retry via connection pool |
 
 ### Recovery Strategies
@@ -436,6 +804,9 @@ data.zip
 - **Schema mismatch**: Set `SkipMissingColumns=true` to warn and continue
 - **Record failure**: Set `ContinueOnError=true` to process remaining records
 - **User reference missing**: Provide `UserMappings` or enable `UseCurrentUserAsDefault`
+- **State transition failure**: Record exists in default state; transition logged as error; can be retried manually
+- **External lookup unresolved**: `SkipUnresolvedLookups=true` nulls the field; `false` fails the record
+- **Product parent failure**: Children automatically skipped; re-import after fixing parent
 
 ### Warning Collection
 
@@ -447,6 +818,11 @@ Non-fatal issues are collected via `IWarningCollector` ([`Progress/IWarningColle
 | `COLUMN_SKIPPED` | Column in source but not in target |
 | `USER_MAPPING_FALLBACK` | User reference fell back to current user |
 | `PLUGIN_REENABLE_FAILED` | Failed to re-enable plugin steps |
+| `LOOKUP_RESOLVED_BY_NAME` | External lookup resolved by name (potential duplicate risk) |
+| `RECORD_SKIPPED_CASCADE` | Record skipped due to parent failure |
+| `STATE_TRANSITION_SKIPPED` | Record already in target state |
+| `FILE_UPLOAD_FAILED` | File attachment failed but record was created |
+| `BYOK_FILE_LIMIT` | File exceeds 128MB BYOK limit |
 
 ### Edge Cases
 
@@ -457,104 +833,135 @@ Non-fatal issues are collected via `IWarningCollector` ([`Progress/IWarningColle
 | Circular reference group | Deferred fields updated in Phase 2 |
 | Duplicate M2M association | Treated as idempotent success (error code 0x80040237) |
 | Missing lookup target | Error recorded, `ContinueOnError` controls behavior |
+| Double-close attempt | `IsRecordClosed` prevents; warning emitted |
+| File column with no data in archive | Field skipped with warning |
 
 ---
 
 ## Design Decisions
 
-### Why Tiered Import?
+### Why Four-Phase Import?
 
-**Context:** Lookup fields reference other records. Importing child before parent causes "record does not exist" errors.
+**Context:** The original three-phase pipeline (entity import, deferred fields, M2M) does not account for state transitions. State machine entities require specialized SDK messages that may reference records from other entities. Deferred field updates must happen while records are still in their Active/default state (closed records have read-only fields).
 
-**Decision:** Analyze dependencies and import in topologically sorted tiers. Records with no dependencies import first; records depending on them import in subsequent tiers.
+**Decision:** Four-phase pipeline: Entity Import -> Deferred Fields -> State Transitions -> M2M Relationships.
 
-**Algorithm:**
-1. Build directed graph from lookup relationships
-2. Detect cycles using Tarjan's SCC algorithm
-3. Topologically sort using Kahn's algorithm
-4. Entities in circular references placed in same tier with deferred fields
+**Alternatives considered:**
+- State transitions per-entity at end of Phase 1: Fails when close messages reference records from later tiers
+- State transitions before deferred fields: Fails because closed records have read-only fields that deferred updates need to modify
 
 **Consequences:**
-- Positive: Correct import order without manual specification
-- Positive: Circular references handled automatically
-- Negative: Analysis overhead (acceptable for migration scale)
+- Positive: All records exist before any cross-entity state transitions
+- Positive: All lookups resolved while records are still mutable
+- Positive: State transitions happen on fully-formed records
+- Negative: One additional pass over imported data
 
-### Why Three-Phase Import?
+### Why Separate Handler Interfaces?
 
-**Context:** Self-referential lookups (e.g., `parentaccountid` on `account`) cannot be set during creation because the target record doesn't exist yet.
+**Context:** Entity-specific import behavior spans multiple concerns: filtering, transformation, state transitions, post-import actions. A single god-interface forces handlers to stub out methods they don't need.
 
-**Decision:** Three-phase pipeline:
-1. **Phase 1**: Import entities with self-refs nulled
-2. **Phase 2**: Update deferred fields using ID mappings
-3. **Phase 3**: Create M2M associations
+**Decision:** Four focused interfaces: `IRecordFilter`, `IRecordTransformer`, `IStateTransitionHandler`, `IPostImportHandler`. A handler class implements only what it needs.
 
-**Consequences:**
-- Positive: Handles all circular dependency patterns
-- Positive: M2M only after all records exist
-- Negative: Additional passes for deferred updates
-
-### Why Bulk Operation Probing?
-
-**Context:** Not all entities support `CreateMultiple`/`UpdateMultiple`. Some (e.g., `team`, `queue`) require individual operations.
-
-**Decision:** Probe with single record first; cache result per entity; fall back to individual operations if unsupported.
-
-**Implementation:** ([`Import/BulkOperationProber.cs`](../src/PPDS.Migration/Import/BulkOperationProber.cs))
-1. Execute bulk operation with 1 record
-2. If unsupported error, cache and use fallback
-3. If success, merge probe result with remaining batch
+**Alternatives considered:**
+- Single `IEntityImportHandler` with all methods: Forces stub implementations; harder to test
+- Middleware pipeline pattern: Over-engineered for a fixed set of concerns with known ordering
 
 **Consequences:**
-- Positive: Automatic detection without entity list maintenance
-- Positive: Probe result reused for all batches of same entity
-- Negative: One extra request per entity on first batch
+- Positive: `SystemUserHandler` is 10 lines (only `IRecordFilter`), not 50 with stubs
+- Positive: Each interface testable in isolation
+- Positive: New concern types addable without modifying existing interfaces
+- Negative: Handler registration requires scanning multiple interface types
 
-### Why Parallel Export but Sequential Tiers?
+### Why Generic State Handling in Orchestrator?
 
-**Context:** Export has no ordering requirements; import must respect dependencies.
+**Context:** ~95% of entities use the same `SetStateRequest` path. Only ~5 entities need specialized SDK messages.
 
-**Decision:**
-- Export: Full entity-level parallelism via `Parallel.ForEachAsync()`
-- Import: Tiers execute sequentially; entities within tier execute in parallel
+**Decision:** The `TieredImporter` orchestrator owns generic state/status stripping and `SetStateRequest` logic. Entity-specific handlers only registered for the exceptions (opportunity, incident, quote, salesorder, lead).
+
+**Alternatives considered:**
+- Default handler registered for all entities: Phantom registrations for hundreds of entities that don't need them
+- Every entity must have a handler: Busywork with no benefit
 
 **Consequences:**
-- Positive: Export maximizes throughput
-- Positive: Import respects dependencies while maximizing within-tier parallelism
-- Negative: Tier boundaries are synchronization points
+- Positive: Handlers stay lean and exceptional
+- Positive: No maintenance of handler registrations for standard entities
+- Negative: Two code paths (orchestrator generic + handler override) — must be clearly documented
+
+### Why Cascading Lookup Resolution?
+
+**Context:** Cross-environment imports fail when lookup targets exist in the target but with different GUIDs.
+
+**Decision:** Three-strategy cascade in `EntityReferenceMapper`: ID mapping (no network) -> direct ID check -> name-based query. Results cached per target record.
+
+**Alternatives considered:**
+- Pluggable strategy pattern: Only three strategies in a fixed order; over-engineering
+- Batch resolution in a separate phase: Adds pipeline complexity for marginal performance gain (caching eliminates repeated queries)
+
+**Consequences:**
+- Positive: Single class, predictable behavior, self-contained
+- Positive: Cache eliminates repeated queries (e.g., 10,000 records referencing "USD" = 1 query)
+- Negative: First encounter of each external lookup adds latency (one query)
+
+### Why Clone-Per-Owner for Impersonation?
+
+**Context:** `CallerId`/`CallerAADObjectId` is a client-level property in the Dataverse SDK. There is no per-request impersonation parameter on `OrganizationRequest`.
+
+**Decision:** Group records by mapped owner, clone `ServiceClient` per group, set `CallerAADObjectId` on clone.
+
+**Alternatives considered:**
+- Set/restore `CallerId` on pooled client: Mutates shared state; exception could leak impersonation
+- Per-request parameter: Does not exist in the SDK (only Web API has per-request headers)
+
+**Consequences:**
+- Positive: No shared state mutation; clone is isolated
+- Positive: `CallerAADObjectId` is Microsoft's preferred approach (Entra ID-based)
+- Negative: Smaller batches per owner group reduces bulk API efficiency
+- Negative: `ServiceClient.Clone()` has lightweight but nonzero cost
 
 ### Why CMT Format?
 
 **Context:** Microsoft's Configuration Migration Tool is widely used. Custom formats create vendor lock-in.
 
-**Decision:** Use CMT format for interoperability. Users can import PPDS exports into Microsoft tools and vice versa.
-
-**Format details:**
-- ZIP archive with XML files
-- Schema in `data_schema.xml` with entity/field/relationship definitions
-- Data in `data.xml` with record values and M2M associations
-- `[Content_Types].xml` for OpenXML compliance
+**Decision:** Use CMT format for interoperability. Extended with `importMode`, `relativeExact` dateMode, and `files/` directory while maintaining backward compatibility with CMT archives.
 
 **Consequences:**
 - Positive: Interoperability with Microsoft tooling
 - Positive: Human-readable (XML)
+- Positive: PPDS extensions are additive — CMT ignores unknown attributes
 - Negative: XML parsing overhead (acceptable for migration scale)
-
-### Why ID Mapping Collection?
-
-**Context:** Source environment IDs differ from target. Deferred fields and M2M relationships need source→target mapping.
-
-**Decision:** Thread-safe `IdMappingCollection` tracks all mappings during Phase 1, consumed by Phases 2 and 3.
-
-**Implementation:** Uses `ConcurrentDictionary` for lock-free concurrent access during parallel import.
-
-**Consequences:**
-- Positive: Safe concurrent access from parallel entity imports
-- Positive: Single source of truth for ID resolution
-- Negative: Memory grows with record count
 
 ---
 
 ## Extension Points
+
+### Adding a New Entity Handler
+
+1. **Create class** in `src/PPDS.Migration/Import/Handlers/`
+2. **Implement** one or more handler interfaces (`IRecordFilter`, `IRecordTransformer`, `IStateTransitionHandler`, `IPostImportHandler`)
+3. **Implement** `CanHandle(string entityLogicalName)` to return `true` for target entity
+4. **Register** in DI container — dispatcher auto-discovers via interface scanning
+
+**Example skeleton:**
+
+```csharp
+public class ContractHandler : IRecordTransformer, IStateTransitionHandler
+{
+    public bool CanHandle(string entityLogicalName)
+        => entityLogicalName == EntityNames.Contract;
+
+    public Entity Transform(Entity record, ImportContext context)
+    {
+        // Strip state/status, remap fields
+        return record;
+    }
+
+    public StateTransitionData? GetTransition(Entity record, ImportContext context)
+    {
+        // Return CancelContractRequest data if statecode indicates cancelled
+        return null;
+    }
+}
+```
 
 ### Adding a New Import Phase
 
@@ -562,29 +969,26 @@ Non-fatal issues are collected via `IWarningCollector` ([`Progress/IWarningColle
 2. **Return** `PhaseResult` with metadata
 3. **Add** to `TieredImporter.ImportAsync()` pipeline
 
-**Example skeleton:**
-
-```csharp
-public class MyPhaseProcessor : IImportPhaseProcessor
-{
-    public string PhaseName => "MyPhase";
-
-    public async Task<PhaseResult> ProcessAsync(
-        ImportContext context,
-        CancellationToken cancellationToken)
-    {
-        // Access context.Data, context.Plan, context.IdMappings
-        return new PhaseResult { ProcessedCount = count };
-    }
-}
-```
-
 ### Adding a New Format Reader/Writer
 
 1. **Create interfaces** in `src/PPDS.Migration/Formats/`
 2. **Implement** reader returning `MigrationData`
 3. **Implement** writer accepting `MigrationData`
 4. **Register** in DI container
+
+### Adding a New Lookup Resolution Match Field
+
+Add entry to the entity-specific match field dictionary in `EntityReferenceMapper`:
+
+```csharp
+private static readonly Dictionary<string, string> MatchFields = new()
+{
+    ["transactioncurrency"] = "isocurrencycode",
+    ["businessunit"] = "name",
+    ["role"] = "name",
+    // Add new entries here
+};
+```
 
 ---
 
@@ -594,9 +998,10 @@ public class MyPhaseProcessor : IImportPhaseProcessor
 
 | Setting | Type | Required | Default | Description |
 |---------|------|----------|---------|-------------|
-| `DegreeOfParallelism` | int | No | CPU × 2 | Entity-level parallelism |
+| `DegreeOfParallelism` | int | No | CPU x 2 | Entity-level parallelism |
 | `PageSize` | int | No | 5000 | Records per FetchXML page |
 | `ProgressInterval` | int | No | 100 | Report progress every N records |
+| `IncludeFileData` | bool | No | false | Download and include file column binary data |
 
 ### ImportOptions
 
@@ -610,11 +1015,14 @@ public class MyPhaseProcessor : IImportPhaseProcessor
 | `ContinueOnError` | bool | No | true | Continue on record failure |
 | `SkipMissingColumns` | bool | No | false | Warn instead of fail on missing |
 | `StripOwnerFields` | bool | No | false | Remove owner-related fields |
-| `UserMappings` | collection | No | null | Source→target user mappings |
+| `UserMappings` | collection | No | null | Source->target user mappings |
 | `CurrentUserId` | Guid? | No | null | Fallback for unmapped users |
 | `RespectDisablePluginsSetting` | bool | No | true | Honor schema `disableplugins` |
 | `SuppressDuplicateDetection` | bool | No | false | Suppress duplicate detection rules |
-| `ErrorCallback` | Action\<MigrationError\>? | No | null | Real-time error streaming (thread-safe) |
+| `ResolveExternalLookups` | bool | No | false | Enable cascading external lookup resolution |
+| `SkipUnresolvedLookups` | bool | No | true | Null unresolved lookups instead of failing record |
+| `ImpersonateOwners` | bool | No | false | Clone client per owner with CallerAADObjectId |
+| `ErrorCallback` | Action | No | null | Real-time error streaming (thread-safe) |
 | `OutputManager` | ImportOutputManager? | No | null | Checkpoint logging for structured progress |
 
 ### SchemaGeneratorOptions
@@ -630,73 +1038,9 @@ public class MyPhaseProcessor : IImportPhaseProcessor
 
 ---
 
-## Testing
-
-### Acceptance Criteria
-
-- [ ] Export creates valid CMT ZIP archive
-- [ ] Import respects tier ordering
-- [ ] Circular references handled via deferred fields
-- [ ] M2M relationships created after entities
-- [ ] Progress reports phase, entity, record counts
-- [ ] Schema mismatch detected and reported
-- [ ] Bulk fallback works for unsupported entities
-
-### Edge Cases
-
-| Scenario | Input | Expected Output |
-|----------|-------|-----------------|
-| Self-referential entity | account with parentaccountid | Deferred field updated in Phase 2 |
-| Mutual reference | A→B, B→A | Both in same tier, both deferred |
-| No dependencies | 3 independent entities | All in Tier 0, parallel import |
-| Missing target column | Export has field X, target missing | `SchemaMismatchException` or warning |
-| Duplicate M2M | Same association twice | Second treated as success |
-
-### Test Examples
-
-```csharp
-[Fact]
-public void DependencyGraphBuilder_DetectsCircularReference()
-{
-    var schema = CreateSchemaWithCircularReference("account", "contact");
-    var builder = new DependencyGraphBuilder();
-
-    var graph = builder.Build(schema);
-
-    Assert.True(graph.HasCircularReferences);
-    Assert.Single(graph.CircularReferences);
-}
-
-[Fact]
-public async Task TieredImporter_ProcessesDeferredFields()
-{
-    var data = CreateDataWithSelfReference("account", "parentaccountid");
-    var importer = new TieredImporter(pool, bulkExecutor, ...);
-
-    var result = await importer.ImportAsync(data);
-
-    Assert.True(result.Success);
-    // Verify parent lookup is set (updated in Phase 2)
-}
-
-[Fact]
-public async Task ParallelExporter_ExportsAllEntities()
-{
-    var schema = CreateSchema("account", "contact");
-    var exporter = new ParallelExporter(pool, schemaReader, dataWriter);
-
-    var result = await exporter.ExportAsync(schema, outputPath);
-
-    Assert.True(result.Success);
-    Assert.Equal(2, result.EntityResults.Count);
-}
-```
-
----
-
 ## Related Specs
 
-- [connection-pooling.md](./connection-pooling.md) - Provides pooled clients for parallel operations
+- [connection-pooling.md](./connection-pooling.md) - Provides pooled clients for parallel operations and `CallerAADObjectId` support
 - [bulk-operations.md](./bulk-operations.md) - High-throughput record operations
 - [architecture.md](./architecture.md) - Progress reporting patterns, error handling
 - [authentication.md](./authentication.md) - Credential providers for connection sources
@@ -705,10 +1049,9 @@ public async Task ParallelExporter_ExportsAllEntities()
 
 ## Roadmap
 
-- Incremental export with change tracking
-- Resume support for interrupted imports
-- Automatic entity detection from environment
-- Cross-environment user name-based mapping
+- Incremental export with change tracking (#38)
+- Checkpoint and resume for interrupted imports (#41)
+- Schema compare/diff command (#42)
 
 ---
 
@@ -716,4 +1059,5 @@ public async Task ParallelExporter_ExportsAllEntities()
 
 | Date | Change |
 |------|--------|
+| 2026-03-25 | CMT parity: 4-phase pipeline, entity handlers, state transitions, external lookups, date shifting, file columns, per-entity import mode, owner impersonation, activity pointer handling, duplicate rule ETC remapping, product hierarchy cascading |
 | 2026-03-18 | Merged TUI surface content from tui-migration.md per SL3 |

--- a/specs/migration.md
+++ b/specs/migration.md
@@ -3,7 +3,7 @@
 **Status:** Draft
 **Last Updated:** 2026-03-25
 **Surfaces:** CLI, TUI
-**Code:** [src/PPDS.Migration/](../src/PPDS.Migration/), TUI: [src/PPDS.Tui/Screens/MigrationScreen.cs](../src/PPDS.Tui/Screens/MigrationScreen.cs)
+**Code:** [src/PPDS.Migration/](../src/PPDS.Migration/), TUI: [src/PPDS.Cli/Tui/Screens/MigrationScreen.cs](../src/PPDS.Cli/Tui/Screens/MigrationScreen.cs)
 
 ---
 

--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -83,7 +83,7 @@ public static class ImportCommand
 
         var skipUnresolvedLookupsOption = new Option<bool>("--skip-unresolved-lookups")
         {
-            Description = "Null unresolved lookups instead of failing the record (requires --resolve-lookups)",
+            Description = "Null unresolved lookups instead of failing the record [default: True] (requires --resolve-lookups)",
             DefaultValueFactory = _ => true
         };
 

--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -75,6 +75,24 @@ public static class ImportCommand
             DefaultValueFactory = _ => false
         };
 
+        var resolveLookupsOption = new Option<bool>("--resolve-lookups")
+        {
+            Description = "Enable external lookup resolution (ID check, then name-based query)",
+            DefaultValueFactory = _ => false
+        };
+
+        var skipUnresolvedLookupsOption = new Option<bool>("--skip-unresolved-lookups")
+        {
+            Description = "Null unresolved lookups instead of failing the record (requires --resolve-lookups)",
+            DefaultValueFactory = _ => true
+        };
+
+        var impersonateOwnersOption = new Option<bool>("--impersonate-owners")
+        {
+            Description = "Preserve record ownership via CallerAADObjectId impersonation (requires --user-mapping)",
+            DefaultValueFactory = _ => false
+        };
+
         var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
         {
             Description = "Output format",
@@ -110,6 +128,9 @@ public static class ImportCommand
             userMappingOption,
             stripOwnerFieldsOption,
             skipMissingColumnsOption,
+            resolveLookupsOption,
+            skipUnresolvedLookupsOption,
+            impersonateOwnersOption,
             outputFormatOption,
             verboseOption,
             debugOption,
@@ -128,6 +149,9 @@ public static class ImportCommand
             var userMappingFile = parseResult.GetValue(userMappingOption);
             var stripOwnerFields = parseResult.GetValue(stripOwnerFieldsOption);
             var skipMissingColumns = parseResult.GetValue(skipMissingColumnsOption);
+            var resolveLookups = parseResult.GetValue(resolveLookupsOption);
+            var skipUnresolvedLookups = parseResult.GetValue(skipUnresolvedLookupsOption);
+            var impersonateOwners = parseResult.GetValue(impersonateOwnersOption);
             var outputFormat = parseResult.GetValue(outputFormatOption);
             var verbose = parseResult.GetValue(verboseOption);
             var debug = parseResult.GetValue(debugOption);
@@ -138,7 +162,8 @@ public static class ImportCommand
             return await ExecuteAsync(
                 profile, environment, data, bypassPlugins, bypassFlows,
                 continueOnError, mode, userMappingFile, stripOwnerFields,
-                skipMissingColumns, outputFormat, verbose, debug, errorReport, cancellationToken);
+                skipMissingColumns, resolveLookups, skipUnresolvedLookups,
+                impersonateOwners, outputFormat, verbose, debug, errorReport, cancellationToken);
         });
 
         return command;
@@ -155,6 +180,9 @@ public static class ImportCommand
         FileInfo? userMappingFile,
         bool stripOwnerFields,
         bool skipMissingColumns,
+        bool resolveLookups,
+        bool skipUnresolvedLookups,
+        bool impersonateOwners,
         OutputFormat outputFormat,
         bool verbose,
         bool debug,
@@ -268,6 +296,9 @@ public static class ImportCommand
                     UserMappings = userMappings,
                     StripOwnerFields = stripOwnerFields,
                     SkipMissingColumns = skipMissingColumns,
+                    ResolveExternalLookups = resolveLookups,
+                    SkipUnresolvedLookups = skipUnresolvedLookups,
+                    ImpersonateOwners = impersonateOwners,
                     CurrentUserId = currentUserId,
                     // Wire up error streaming callback
                     ErrorCallback = outputManager != null ? outputManager.LogError : null,

--- a/src/PPDS.Cli/Tui/Infrastructure/TuiColorPalette.cs
+++ b/src/PPDS.Cli/Tui/Infrastructure/TuiColorPalette.cs
@@ -73,6 +73,21 @@ public static class TuiColorPalette
         Disabled = MakeAttr(Color.DarkGray, Color.Black)
     };
 
+    private static ColorScheme? _dimmed;
+
+    /// <summary>
+    /// Color scheme for dimmed/placeholder text.
+    /// DarkGray text on black background for hint labels that disappear when content is present.
+    /// </summary>
+    public static ColorScheme Dimmed => _dimmed ??= new()
+    {
+        Normal = MakeAttr(Color.DarkGray, Color.Black),
+        Focus = MakeAttr(Color.DarkGray, Color.Black),
+        HotNormal = MakeAttr(Color.DarkGray, Color.Black),
+        HotFocus = MakeAttr(Color.DarkGray, Color.Black),
+        Disabled = MakeAttr(Color.DarkGray, Color.Black)
+    };
+
     private static ColorScheme? _readOnlyText;
 
     /// <summary>
@@ -574,6 +589,7 @@ public static class TuiColorPalette
         {
             (nameof(Default), Default),
             (nameof(Focused), Focused),
+            (nameof(Dimmed), Dimmed),
             (nameof(TextInput), TextInput),
             (nameof(ReadOnlyText), ReadOnlyText),
             (nameof(FileDialog), FileDialog),

--- a/src/PPDS.Cli/Tui/Screens/ExecutionPlanPreviewDialog.cs
+++ b/src/PPDS.Cli/Tui/Screens/ExecutionPlanPreviewDialog.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using PPDS.Cli.Tui.Testing;
+using PPDS.Cli.Tui.Testing.States;
+using PPDS.Migration.Models;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// Modal dialog that displays an execution plan summary before import.
+/// Shows tier ordering, deferred field count, state transition count,
+/// and M2M relationship count. The user can approve or cancel.
+/// </summary>
+internal sealed class ExecutionPlanPreviewDialog : Dialog, ITuiStateCapture<ExecutionPlanPreviewDialogState>
+{
+    private readonly ExecutionPlan _plan;
+    private readonly int _stateTransitionCount;
+
+    /// <summary>
+    /// Gets whether the user approved the plan (clicked OK).
+    /// </summary>
+    public bool IsApproved { get; private set; }
+
+    /// <summary>
+    /// Creates a new execution plan preview dialog.
+    /// </summary>
+    /// <param name="plan">The execution plan to display.</param>
+    /// <param name="stateTransitionCount">Number of state transitions to process.</param>
+    public ExecutionPlanPreviewDialog(ExecutionPlan plan, int stateTransitionCount = 0)
+        : base("Execution Plan Preview")
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        _plan = plan;
+        _stateTransitionCount = stateTransitionCount;
+
+        Width = Dim.Percent(70);
+        Height = Dim.Percent(70);
+
+        var y = 0;
+
+        // Summary section
+        var summaryLabel = new Label
+        {
+            X = 1,
+            Y = y++,
+            Text = $"Tiers: {plan.TierCount}    Deferred fields: {plan.DeferredFieldCount}    " +
+                   $"State transitions: {stateTransitionCount}    M2M relationships: {plan.ManyToManyRelationships.Count}"
+        };
+        Add(summaryLabel);
+
+        y++; // blank line
+
+        // Tier details
+        var tierHeaderLabel = new Label
+        {
+            X = 1,
+            Y = y++,
+            Text = "--- Tier Ordering ---"
+        };
+        Add(tierHeaderLabel);
+
+        foreach (var tier in plan.Tiers)
+        {
+            var entities = string.Join(", ", tier.Entities);
+            var circular = tier.HasCircularReferences ? " [circular]" : string.Empty;
+            var tierLabel = new Label
+            {
+                X = 1,
+                Y = y++,
+                Width = Dim.Fill(1),
+                Text = $"  Tier {tier.TierNumber}: {entities}{circular}"
+            };
+            Add(tierLabel);
+        }
+
+        // Deferred fields
+        if (plan.DeferredFieldCount > 0)
+        {
+            y++; // blank line
+            var deferredHeaderLabel = new Label
+            {
+                X = 1,
+                Y = y++,
+                Text = "--- Deferred Fields ---"
+            };
+            Add(deferredHeaderLabel);
+
+            foreach (var (entity, fields) in plan.DeferredFields)
+            {
+                var fieldList = string.Join(", ", fields);
+                var deferredLabel = new Label
+                {
+                    X = 1,
+                    Y = y++,
+                    Width = Dim.Fill(1),
+                    Text = $"  {entity}: {fieldList}"
+                };
+                Add(deferredLabel);
+            }
+        }
+
+        // M2M relationships
+        if (plan.ManyToManyRelationships.Count > 0)
+        {
+            y++; // blank line
+            var m2mHeaderLabel = new Label
+            {
+                X = 1,
+                Y = y++,
+                Text = "--- Many-to-Many Relationships ---"
+            };
+            Add(m2mHeaderLabel);
+
+            foreach (var rel in plan.ManyToManyRelationships)
+            {
+                var relLabel = new Label
+                {
+                    X = 1,
+                    Y = y++,
+                    Width = Dim.Fill(1),
+                    Text = $"  {rel.Name}: {rel.Entity1} <-> {rel.Entity2}"
+                };
+                Add(relLabel);
+            }
+        }
+
+        // Buttons
+        var okButton = new Button("_Proceed", is_default: true);
+        okButton.Clicked += () =>
+        {
+            IsApproved = true;
+            Application.RequestStop();
+        };
+
+        var cancelButton = new Button("_Cancel");
+        cancelButton.Clicked += () =>
+        {
+            IsApproved = false;
+            Application.RequestStop();
+        };
+
+        AddButton(okButton);
+        AddButton(cancelButton);
+    }
+
+    public ExecutionPlanPreviewDialogState CaptureState() => new(
+        TierCount: _plan.TierCount,
+        EntityCount: _plan.Tiers.Sum(t => t.Entities.Count),
+        DeferredFieldCount: _plan.DeferredFieldCount,
+        StateTransitionCount: _stateTransitionCount,
+        ManyToManyRelationshipCount: _plan.ManyToManyRelationships.Count,
+        IsApproved: IsApproved);
+}

--- a/src/PPDS.Cli/Tui/Screens/ExecutionPlanPreviewDialog.cs
+++ b/src/PPDS.Cli/Tui/Screens/ExecutionPlanPreviewDialog.cs
@@ -16,6 +16,8 @@ internal sealed class ExecutionPlanPreviewDialog : Dialog, ITuiStateCapture<Exec
 {
     private readonly ExecutionPlan _plan;
     private readonly int _stateTransitionCount;
+    private Button _okButton = null!;
+    private Button _cancelButton = null!;
 
     /// <summary>
     /// Gets whether the user approved the plan (clicked OK).
@@ -126,23 +128,23 @@ internal sealed class ExecutionPlanPreviewDialog : Dialog, ITuiStateCapture<Exec
             }
         }
 
-        // Buttons
-        var okButton = new Button("_Proceed", is_default: true);
-        okButton.Clicked += () =>
+        // Buttons (disposed by parent Dialog via AddButton)
+        _okButton = new Button("_Proceed", is_default: true);
+        _okButton.Clicked += () =>
         {
             IsApproved = true;
             Application.RequestStop();
         };
 
-        var cancelButton = new Button("_Cancel");
-        cancelButton.Clicked += () =>
+        _cancelButton = new Button("_Cancel");
+        _cancelButton.Clicked += () =>
         {
             IsApproved = false;
             Application.RequestStop();
         };
 
-        AddButton(okButton);
-        AddButton(cancelButton);
+        AddButton(_okButton);
+        AddButton(_cancelButton);
     }
 
     public ExecutionPlanPreviewDialogState CaptureState() => new(

--- a/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
@@ -63,6 +63,9 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
         {
             X = 1,
             Y = 0,
+            Width = 20,
+            Height = 1,
+            CanFocus = true,
             DisplayMode = DisplayModeLayout.Horizontal
         };
         _modeRadio.SelectedItemChanged += OnModeChanged;

--- a/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
@@ -1,0 +1,568 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Tui.Infrastructure;
+using PPDS.Cli.Tui.Testing;
+using PPDS.Cli.Tui.Testing.States;
+using PPDS.Migration.Analysis;
+using PPDS.Migration.Export;
+using PPDS.Migration.Formats;
+using PPDS.Migration.Import;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<MigrationScreenState>
+{
+    private readonly RadioGroup _modeRadio;
+    private readonly FrameView _configFrame;
+    private readonly Label _schemaPathLabel;
+    private readonly TextField _schemaPathField;
+    private readonly Label _outputPathLabel;
+    private readonly TextField _outputPathField;
+    private readonly Label _dataPathLabel;
+    private readonly TextField _dataPathField;
+    private readonly CheckBox _resolveLookupsCheckBox;
+    private readonly CheckBox _skipUnresolvedLookupsCheckBox;
+    private readonly CheckBox _impersonateOwnersCheckBox;
+    private readonly CheckBox _continueOnErrorCheckBox;
+    private readonly CheckBox _skipMissingColumnsCheckBox;
+    private readonly Label _importModeLabel;
+    private readonly RadioGroup _importModeRadio;
+    private readonly FrameView _progressFrame;
+    private readonly Label _phaseLabel;
+    private readonly Label _entityLabel;
+    private readonly ProgressBar _progressBar;
+    private readonly Label _rateLabel;
+    private readonly Label _statusLabel;
+    private readonly Label _resultsLabel;
+
+    private MigrationMode _mode = MigrationMode.Export;
+    private MigrationOperationState _operationState = MigrationOperationState.Idle;
+    private CancellationTokenSource? _operationCts;
+    private readonly Stopwatch _elapsed = new();
+
+    private int _recordCount;
+    private int _successCount;
+    private int _failureCount;
+    private int _warningCount;
+    private int _skipCount;
+    private double? _recordsPerSecond;
+    private string? _estimatedRemaining;
+    private string? _errorMessage;
+
+    public override string Title => EnvironmentDisplayName != null
+        ? $"Data Migration - {EnvironmentDisplayName}"
+        : "Data Migration";
+
+    public MigrationScreen(InteractiveSession session, string? environmentUrl = null)
+        : base(session, environmentUrl)
+    {
+        _modeRadio = new RadioGroup(new NStack.ustring[] { "Export", "Import" })
+        {
+            X = 1,
+            Y = 0,
+            DisplayMode = DisplayModeLayout.Horizontal
+        };
+        _modeRadio.SelectedItemChanged += OnModeChanged;
+
+        _configFrame = new FrameView("Configuration")
+        {
+            X = 0,
+            Y = 2,
+            Width = Dim.Fill(),
+            Height = 10
+        };
+
+        _schemaPathLabel = new Label("Schema path:") { X = 1, Y = 0 };
+        _schemaPathField = new TextField("") { X = 15, Y = 0, Width = Dim.Fill(1) };
+        _outputPathLabel = new Label("Output path:") { X = 1, Y = 1 };
+        _outputPathField = new TextField("") { X = 15, Y = 1, Width = Dim.Fill(1) };
+
+        _dataPathLabel = new Label("Data path:") { X = 1, Y = 0 };
+        _dataPathField = new TextField("") { X = 15, Y = 0, Width = Dim.Fill(1) };
+        _importModeLabel = new Label("Mode:") { X = 1, Y = 2 };
+        _importModeRadio = new RadioGroup(new NStack.ustring[] { "Create", "Update", "Upsert", "Skip" })
+        {
+            X = 15,
+            Y = 2,
+            DisplayMode = DisplayModeLayout.Horizontal
+        };
+        _importModeRadio.SelectedItem = 2;
+
+        _resolveLookupsCheckBox = new CheckBox("Resolve external lookups") { X = 1, Y = 4 };
+        _skipUnresolvedLookupsCheckBox = new CheckBox("Skip unresolved lookups", true) { X = 1, Y = 5 };
+        _impersonateOwnersCheckBox = new CheckBox("Impersonate owners") { X = 1, Y = 6 };
+        _continueOnErrorCheckBox = new CheckBox("Continue on error", true) { X = 1, Y = 7 };
+        _skipMissingColumnsCheckBox = new CheckBox("Skip missing columns") { X = 40, Y = 4 };
+
+        _progressFrame = new FrameView("Progress")
+        {
+            X = 0,
+            Y = Pos.Bottom(_configFrame),
+            Width = Dim.Fill(),
+            Height = 6
+        };
+
+        _phaseLabel = new Label("") { X = 1, Y = 0, Width = Dim.Fill(1) };
+        _entityLabel = new Label("") { X = 1, Y = 1, Width = Dim.Fill(1) };
+        _progressBar = new ProgressBar { X = 1, Y = 2, Width = Dim.Fill(1) };
+        _rateLabel = new Label("") { X = 1, Y = 3, Width = Dim.Fill(1) };
+        _progressFrame.Add(_phaseLabel, _entityLabel, _progressBar, _rateLabel);
+
+        _statusLabel = new Label("")
+        {
+            X = 0,
+            Y = Pos.Bottom(_progressFrame),
+            Width = Dim.Fill(),
+            Height = 1
+        };
+        _resultsLabel = new Label("")
+        {
+            X = 0,
+            Y = Pos.Bottom(_statusLabel),
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        ShowExportConfig();
+
+        Content.Add(_modeRadio, _configFrame, _progressFrame, _statusLabel, _resultsLabel);
+
+        if (EnvironmentUrl == null)
+        {
+            _statusLabel.Text = "No environment selected. Use the status bar to connect.";
+        }
+        else
+        {
+            _statusLabel.Text = "Ready. Configure options and press Ctrl+Enter to start.";
+            _operationState = MigrationOperationState.Configuring;
+        }
+    }
+
+    protected override void RegisterHotkeys(IHotkeyRegistry registry)
+    {
+        RegisterHotkey(registry, Key.CtrlMask | Key.Enter, "Start operation",
+            () => ErrorService.FireAndForget(StartOperationAsync(), "Migration.Start"));
+        RegisterHotkey(registry, Key.CtrlMask | Key.P, "Preview execution plan",
+            () => ErrorService.FireAndForget(PreviewPlanAsync(), "Migration.PreviewPlan"));
+        RegisterHotkey(registry, Key.Esc, "Cancel operation", () =>
+        {
+            if (_operationState == MigrationOperationState.Running)
+                ConfirmCancel();
+        });
+    }
+
+    private void OnModeChanged(SelectedItemChangedArgs args)
+    {
+        if (_operationState == MigrationOperationState.Running)
+            return;
+
+        _mode = args.SelectedItem == 0 ? MigrationMode.Export : MigrationMode.Import;
+
+        if (_mode == MigrationMode.Export)
+            ShowExportConfig();
+        else
+            ShowImportConfig();
+    }
+
+    private void ShowExportConfig()
+    {
+        _configFrame.RemoveAll();
+        _configFrame.Add(_schemaPathLabel, _schemaPathField, _outputPathLabel, _outputPathField);
+    }
+
+    private void ShowImportConfig()
+    {
+        _configFrame.RemoveAll();
+        _configFrame.Add(
+            _dataPathLabel, _dataPathField,
+            _importModeLabel, _importModeRadio,
+            _resolveLookupsCheckBox, _skipUnresolvedLookupsCheckBox,
+            _impersonateOwnersCheckBox, _continueOnErrorCheckBox,
+            _skipMissingColumnsCheckBox);
+    }
+
+    private async Task StartOperationAsync()
+    {
+        if (EnvironmentUrl == null || _operationState == MigrationOperationState.Running)
+            return;
+
+        if (_mode == MigrationMode.Export)
+        {
+            var schemaPath = _schemaPathField.Text?.ToString()?.Trim();
+            var outputPath = _outputPathField.Text?.ToString()?.Trim();
+            if (string.IsNullOrEmpty(schemaPath) || string.IsNullOrEmpty(outputPath))
+            {
+                _statusLabel.Text = "Schema path and output path are required.";
+                return;
+            }
+            await RunExportAsync(schemaPath, outputPath);
+        }
+        else
+        {
+            var dataPath = _dataPathField.Text?.ToString()?.Trim();
+            if (string.IsNullOrEmpty(dataPath))
+            {
+                _statusLabel.Text = "Data path is required.";
+                return;
+            }
+            await RunImportAsync(dataPath);
+        }
+    }
+
+    private async Task RunExportAsync(string schemaPath, string outputPath)
+    {
+        BeginOperation();
+        var reporter = CreateProgressReporter();
+
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var exporter = provider.GetRequiredService<IExporter>();
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                ScreenCancellation, _operationCts!.Token);
+
+            reporter.OperationName = "Export";
+            var result = await exporter.ExportAsync(schemaPath, outputPath, progress: reporter,
+                cancellationToken: linkedCts.Token);
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                _recordCount = result.RecordsExported;
+                _successCount = result.RecordsExported;
+                _failureCount = result.Errors.Count;
+                _recordsPerSecond = result.RecordsPerSecond;
+                _resultsLabel.Text = FormatExportResults(result);
+
+                if (linkedCts.IsCancellationRequested)
+                    CompleteOperation(MigrationOperationState.Cancelled);
+                else if (result.Success)
+                    CompleteOperation(MigrationOperationState.Completed);
+                else
+                    CompleteOperation(MigrationOperationState.Failed, "Export completed with errors.");
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            Application.MainLoop?.Invoke(() => CompleteOperation(MigrationOperationState.Cancelled));
+        }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Export failed", ex, "Migration.Export");
+                CompleteOperation(MigrationOperationState.Failed, ex.Message);
+            });
+        }
+    }
+
+    private async Task RunImportAsync(string dataPath)
+    {
+        BeginOperation();
+        var reporter = CreateProgressReporter();
+
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var importer = provider.GetRequiredService<IImporter>();
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                ScreenCancellation, _operationCts!.Token);
+
+            var importMode = _importModeRadio.SelectedItem switch
+            {
+                0 => ImportMode.Create,
+                1 => ImportMode.Update,
+                2 => ImportMode.Upsert,
+                3 => ImportMode.Skip,
+                _ => ImportMode.Upsert
+            };
+
+            var options = new ImportOptions
+            {
+                Mode = importMode,
+                ResolveExternalLookups = _resolveLookupsCheckBox.Checked,
+                SkipUnresolvedLookups = _skipUnresolvedLookupsCheckBox.Checked,
+                ImpersonateOwners = _impersonateOwnersCheckBox.Checked,
+                ContinueOnError = _continueOnErrorCheckBox.Checked,
+                SkipMissingColumns = _skipMissingColumnsCheckBox.Checked
+            };
+
+            reporter.OperationName = "Import";
+            var result = await importer.ImportAsync(dataPath, options, reporter, linkedCts.Token);
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                _recordCount = result.RecordsImported;
+                _successCount = result.EntityResults.Sum(e => e.SuccessCount);
+                _failureCount = result.EntityResults.Sum(e => e.FailureCount);
+                _warningCount = result.Warnings.Count;
+                _recordsPerSecond = result.RecordsPerSecond;
+                _resultsLabel.Text = FormatImportResults(result);
+
+                if (linkedCts.IsCancellationRequested)
+                    CompleteOperation(MigrationOperationState.Cancelled);
+                else if (result.Success)
+                    CompleteOperation(MigrationOperationState.Completed);
+                else
+                    CompleteOperation(MigrationOperationState.Failed, "Import completed with errors.");
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            Application.MainLoop?.Invoke(() => CompleteOperation(MigrationOperationState.Cancelled));
+        }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Import failed", ex, "Migration.Import");
+                CompleteOperation(MigrationOperationState.Failed, ex.Message);
+            });
+        }
+    }
+
+    private async Task PreviewPlanAsync()
+    {
+        if (EnvironmentUrl == null || _mode != MigrationMode.Import)
+            return;
+
+        var dataPath = _dataPathField.Text?.ToString()?.Trim();
+        if (string.IsNullOrEmpty(dataPath))
+        {
+            _statusLabel.Text = "Data path is required to preview execution plan.";
+            return;
+        }
+
+        _operationState = MigrationOperationState.PreviewingPlan;
+        _statusLabel.Text = "Building execution plan...";
+
+        try
+        {
+            var provider = await Session.GetServiceProviderAsync(EnvironmentUrl!, ScreenCancellation);
+            var dataReader = provider.GetRequiredService<ICmtDataReader>();
+            var graphBuilder = provider.GetRequiredService<IDependencyGraphBuilder>();
+            var planBuilder = provider.GetRequiredService<IExecutionPlanBuilder>();
+
+            var data = await dataReader.ReadAsync(dataPath, cancellationToken: ScreenCancellation);
+            var graph = graphBuilder.Build(data.Schema);
+            var plan = planBuilder.Build(graph, data.Schema);
+
+            Application.MainLoop?.Invoke(() =>
+            {
+                var dialog = new ExecutionPlanPreviewDialog(plan);
+                Application.Run(dialog);
+
+                _operationState = MigrationOperationState.Configuring;
+                _statusLabel.Text = dialog.IsApproved
+                    ? "Plan approved. Press Ctrl+Enter to start import."
+                    : "Plan preview cancelled.";
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                _operationState = MigrationOperationState.Configuring;
+                _statusLabel.Text = "Plan preview cancelled.";
+            });
+        }
+        catch (Exception ex)
+        {
+            Application.MainLoop?.Invoke(() =>
+            {
+                ErrorService.ReportError("Failed to build execution plan", ex, "Migration.PreviewPlan");
+                _operationState = MigrationOperationState.Configuring;
+                _statusLabel.Text = "Error building execution plan.";
+            });
+        }
+    }
+
+    private void ConfirmCancel()
+    {
+        var n = MessageBox.Query("Cancel Operation",
+            "Cancel the running operation? The current batch will complete before stopping.", "Yes", "No");
+        if (n == 0)
+        {
+            _operationCts?.Cancel();
+            _statusLabel.Text = "Cancelling...";
+        }
+    }
+
+    private void BeginOperation()
+    {
+        _operationState = MigrationOperationState.Running;
+        _operationCts?.Dispose();
+        _operationCts = new CancellationTokenSource();
+        _elapsed.Restart();
+
+        _recordCount = 0;
+        _successCount = 0;
+        _failureCount = 0;
+        _warningCount = 0;
+        _skipCount = 0;
+        _recordsPerSecond = null;
+        _estimatedRemaining = null;
+        _errorMessage = null;
+
+        _phaseLabel.Text = "";
+        _entityLabel.Text = "";
+        _progressBar.Fraction = 0f;
+        _rateLabel.Text = "";
+        _resultsLabel.Text = "";
+        _statusLabel.Text = $"{_mode} in progress...";
+    }
+
+    private void CompleteOperation(MigrationOperationState state, string? error = null)
+    {
+        _elapsed.Stop();
+        _operationState = state;
+        _errorMessage = error;
+
+        _statusLabel.Text = state switch
+        {
+            MigrationOperationState.Completed => $"{_mode} completed successfully in {FormatTimeSpan(_elapsed.Elapsed)}.",
+            MigrationOperationState.Failed => $"{_mode} failed: {error}",
+            MigrationOperationState.Cancelled => $"{_mode} cancelled after {FormatTimeSpan(_elapsed.Elapsed)}.",
+            _ => ""
+        };
+    }
+
+    private TuiMigrationProgressReporter CreateProgressReporter()
+    {
+        return new TuiMigrationProgressReporter(
+            _phaseLabel, _entityLabel, _progressBar, _rateLabel, _statusLabel,
+            onComplete: result =>
+            {
+                _recordCount = result.RecordsProcessed;
+                _successCount = result.SuccessCount;
+                _failureCount = result.FailureCount;
+                _recordsPerSecond = result.RecordsPerSecond;
+            },
+            onError: (ex, context) =>
+            {
+                _errorMessage = context != null ? $"{context}: {ex.Message}" : ex.Message;
+            });
+    }
+
+    private static string FormatExportResults(ExportResult result)
+    {
+        var lines = new List<string>
+        {
+            $"Exported {result.RecordsExported} records from {result.EntitiesExported} entities in {FormatTimeSpan(result.Duration)} ({result.RecordsPerSecond:F0} rec/s)",
+            ""
+        };
+
+        foreach (var entity in result.EntityResults)
+        {
+            var status = entity.Success ? "OK" : $"FAIL: {entity.ErrorMessage}";
+            lines.Add($"  {entity.EntityLogicalName}: {entity.RecordCount} records [{status}]");
+        }
+
+        if (result.Errors.Count > 0)
+        {
+            lines.Add("");
+            lines.Add($"Errors ({result.Errors.Count}):");
+            foreach (var err in result.Errors.Take(10))
+                lines.Add($"  {err.EntityLogicalName}: {err.Message}");
+            if (result.Errors.Count > 10)
+                lines.Add($"  ... and {result.Errors.Count - 10} more");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static string FormatImportResults(ImportResult result)
+    {
+        var lines = new List<string>
+        {
+            $"Imported {result.RecordsImported} of {result.SourceRecordCount} records in {FormatTimeSpan(result.Duration)} ({result.RecordsPerSecond:F0} rec/s)",
+            $"Tiers: {result.TiersProcessed}  |  M2M: {result.RelationshipsProcessed}  |  Deferred: {result.RecordsUpdated}",
+            ""
+        };
+
+        foreach (var entity in result.EntityResults)
+        {
+            var status = entity.Success ? "OK" : "FAIL";
+            lines.Add($"  {entity.EntityLogicalName} (tier {entity.TierNumber}): {entity.SuccessCount}/{entity.RecordCount} [{status}]");
+        }
+
+        if (result.Warnings.Count > 0)
+        {
+            lines.Add("");
+            lines.Add($"Warnings ({result.Warnings.Count}):");
+            foreach (var w in result.Warnings.Take(5))
+                lines.Add($"  {w.Message}");
+            if (result.Warnings.Count > 5)
+                lines.Add($"  ... and {result.Warnings.Count - 5} more");
+        }
+
+        if (result.Errors.Count > 0)
+        {
+            lines.Add("");
+            lines.Add($"Errors ({result.Errors.Count}):");
+            foreach (var err in result.Errors.Take(10))
+                lines.Add($"  {err.EntityLogicalName}: {err.Message}");
+            if (result.Errors.Count > 10)
+                lines.Add($"  ... and {result.Errors.Count - 10} more");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    public MigrationScreenState CaptureState() => new(
+        Mode: _mode.ToString(),
+        OperationState: _operationState.ToString(),
+        SchemaPath: _schemaPathField.Text?.ToString(),
+        OutputPath: _outputPathField.Text?.ToString(),
+        DataPath: _dataPathField.Text?.ToString(),
+        CurrentPhase: _phaseLabel.Text?.ToString(),
+        CurrentEntity: _entityLabel.Text?.ToString(),
+        RecordCount: _recordCount,
+        SuccessCount: _successCount,
+        FailureCount: _failureCount,
+        WarningCount: _warningCount,
+        SkipCount: _skipCount,
+        RecordsPerSecond: _recordsPerSecond,
+        EstimatedRemaining: _estimatedRemaining,
+        Elapsed: _elapsed.IsRunning ? FormatTimeSpan(_elapsed.Elapsed) : (_elapsed.ElapsedMilliseconds > 0 ? FormatTimeSpan(_elapsed.Elapsed) : null),
+        ErrorMessage: _errorMessage,
+        IsLoading: _operationState == MigrationOperationState.Running,
+        StatusMessage: _statusLabel.Text?.ToString());
+
+    protected override void OnDispose()
+    {
+        _modeRadio.SelectedItemChanged -= OnModeChanged;
+        _operationCts?.Cancel();
+        _operationCts?.Dispose();
+    }
+
+    private static string FormatTimeSpan(TimeSpan ts)
+    {
+        if (ts.TotalHours >= 1)
+            return $"{ts.Hours}h {ts.Minutes}m {ts.Seconds}s";
+        if (ts.TotalMinutes >= 1)
+            return $"{ts.Minutes}m {ts.Seconds}s";
+        return $"{ts.Seconds}s";
+    }
+}
+
+internal enum MigrationMode
+{
+    Export,
+    Import
+}
+
+internal enum MigrationOperationState
+{
+    Idle,
+    Configuring,
+    PreviewingPlan,
+    Running,
+    Completed,
+    Failed,
+    Cancelled
+}

--- a/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MigrationScreen.cs
@@ -19,10 +19,13 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
     private readonly FrameView _configFrame;
     private readonly Label _schemaPathLabel;
     private readonly TextField _schemaPathField;
+    private readonly Label _schemaPathHint;
     private readonly Label _outputPathLabel;
     private readonly TextField _outputPathField;
+    private readonly Label _outputPathHint;
     private readonly Label _dataPathLabel;
     private readonly TextField _dataPathField;
+    private readonly Label _dataPathHint;
     private readonly CheckBox _resolveLookupsCheckBox;
     private readonly CheckBox _skipUnresolvedLookupsCheckBox;
     private readonly CheckBox _impersonateOwnersCheckBox;
@@ -30,6 +33,7 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
     private readonly CheckBox _skipMissingColumnsCheckBox;
     private readonly Label _importModeLabel;
     private readonly RadioGroup _importModeRadio;
+    private readonly Label _exportDescriptionLabel;
     private readonly FrameView _progressFrame;
     private readonly Label _phaseLabel;
     private readonly Label _entityLabel;
@@ -59,46 +63,89 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
     public MigrationScreen(InteractiveSession session, string? environmentUrl = null)
         : base(session, environmentUrl)
     {
-        _modeRadio = new RadioGroup(new NStack.ustring[] { "Export", "Import" })
+        // QA-CRIT-2: Use "E_xport" (Alt+X) to avoid conflict with global Alt+E (environment picker in TuiShell).
+        // QA-CRIT-1: "Import" keeps Alt+I; the impersonate checkbox below uses a different hotkey.
+        _modeRadio = new RadioGroup(new NStack.ustring[] { "E_xport", "_Import" })
         {
             X = 1,
             Y = 0,
             Width = 20,
             Height = 1,
             CanFocus = true,
+            TabStop = true, // QA-IMP-1: Ensure radio group participates in Tab focus cycle
             DisplayMode = DisplayModeLayout.Horizontal
         };
         _modeRadio.SelectedItemChanged += OnModeChanged;
 
-        _configFrame = new FrameView("Configuration")
+        // QA-IMP-4: Add keyboard shortcut hints to the frame title, following the SQL Query screen pattern.
+        _configFrame = new FrameView("Configuration (Ctrl+Enter to start, Ctrl+P to preview plan)")
         {
             X = 0,
             Y = 2,
             Width = Dim.Fill(),
-            Height = 10
+            Height = 10,
+            TabStop = true // QA-IMP-1: Ensure FrameView participates in Tab focus cycle
         };
 
         _schemaPathLabel = new Label("Schema path:") { X = 1, Y = 0 };
         _schemaPathField = new TextField("") { X = 15, Y = 0, Width = Dim.Fill(1) };
+        _schemaPathHint = new Label("e.g., ./data_schema.xml") { X = 15, Y = 0, Width = Dim.Fill(1), ColorScheme = TuiColorPalette.Dimmed };
         _outputPathLabel = new Label("Output path:") { X = 1, Y = 1 };
         _outputPathField = new TextField("") { X = 15, Y = 1, Width = Dim.Fill(1) };
+        _outputPathHint = new Label("e.g., ./export.zip") { X = 15, Y = 1, Width = Dim.Fill(1), ColorScheme = TuiColorPalette.Dimmed };
 
         _dataPathLabel = new Label("Data path:") { X = 1, Y = 0 };
         _dataPathField = new TextField("") { X = 15, Y = 0, Width = Dim.Fill(1) };
+        _dataPathHint = new Label("e.g., ./data.zip") { X = 15, Y = 0, Width = Dim.Fill(1), ColorScheme = TuiColorPalette.Dimmed };
         _importModeLabel = new Label("Mode:") { X = 1, Y = 2 };
         _importModeRadio = new RadioGroup(new NStack.ustring[] { "Create", "Update", "Upsert", "Skip" })
         {
             X = 15,
             Y = 2,
+            TabStop = true, // QA-IMP-1: Ensure radio group participates in Tab focus cycle
             DisplayMode = DisplayModeLayout.Horizontal
         };
         _importModeRadio.SelectedItem = 2;
 
-        _resolveLookupsCheckBox = new CheckBox("Resolve external lookups") { X = 1, Y = 4 };
-        _skipUnresolvedLookupsCheckBox = new CheckBox("Skip unresolved lookups", true) { X = 1, Y = 5 };
-        _impersonateOwnersCheckBox = new CheckBox("Impersonate owners") { X = 1, Y = 6 };
-        _continueOnErrorCheckBox = new CheckBox("Continue on error", true) { X = 1, Y = 7 };
-        _skipMissingColumnsCheckBox = new CheckBox("Skip missing columns") { X = 40, Y = 4 };
+        // QA-IMP-1: Ensure all checkboxes have TabStop = true so they participate in Tab focus cycle.
+        // QA-CRIT-1: "Im_personate owners" uses Alt+P to avoid conflict with "Import" (Alt+I).
+        //   Alt+P does not conflict with global hotkeys because TuiShell registers Alt+P via
+        //   HotkeyRegistry (not as a label hotkey), and screen-level label hotkeys take precedence
+        //   when the screen content is focused.
+        _resolveLookupsCheckBox = new CheckBox("Resolve external lookups") { X = 1, Y = 4, TabStop = true };
+        _skipUnresolvedLookupsCheckBox = new CheckBox("Skip unresolved lookups", true) { X = 1, Y = 5, TabStop = true };
+        _impersonateOwnersCheckBox = new CheckBox("Im_personate owners") { X = 1, Y = 6, TabStop = true };
+        _continueOnErrorCheckBox = new CheckBox("Continue on error", true) { X = 1, Y = 7, TabStop = true };
+        _skipMissingColumnsCheckBox = new CheckBox("Skip missing columns") { X = 40, Y = 4, TabStop = true };
+
+        // QA-IMP-5: Description label shown in export mode to fill the empty space below the two fields.
+        _exportDescriptionLabel = new Label(
+            "Export uses a schema file to define which entities and columns\n" +
+            "to extract from Dataverse. The output is a portable data package\n" +
+            "(.zip) that can be imported into another environment.\n\n" +
+            "Provide the schema XML and an output path, then press Ctrl+Enter.")
+        {
+            X = 1,
+            Y = 3,
+            Width = Dim.Fill(1),
+            Height = 5,
+            ColorScheme = TuiColorPalette.Dimmed
+        };
+
+        // QA-IMP-3: Wire hint label visibility — show hint when field is empty, hide when it has text.
+        // Terminal.Gui v1 TextField does not support built-in placeholder text, so we overlay a dimmed
+        // Label that is hidden once the user types anything.
+        WireFieldHint(_schemaPathField, _schemaPathHint);
+        WireFieldHint(_outputPathField, _outputPathHint);
+        WireFieldHint(_dataPathField, _dataPathHint);
+
+        // QA-IMP-2: Terminal.Gui v1 does not provide a distinct visual focus indicator between text
+        // fields in PTY mode — the cursor position is the only cue. Assigning TextInput ColorScheme
+        // gives a DarkGray background on focus, which helps in terminals that support it. This is a
+        // known framework limitation and cannot be fully resolved without upstream changes.
+        _schemaPathField.ColorScheme = TuiColorPalette.TextInput;
+        _outputPathField.ColorScheme = TuiColorPalette.TextInput;
+        _dataPathField.ColorScheme = TuiColorPalette.TextInput;
 
         _progressFrame = new FrameView("Progress")
         {
@@ -173,18 +220,42 @@ internal sealed class MigrationScreen : TuiScreenBase, ITuiStateCapture<Migratio
     private void ShowExportConfig()
     {
         _configFrame.RemoveAll();
-        _configFrame.Add(_schemaPathLabel, _schemaPathField, _outputPathLabel, _outputPathField);
+        // QA-IMP-5: Include the export description to fill the empty space below the two fields.
+        _configFrame.Add(
+            _schemaPathLabel, _schemaPathField, _schemaPathHint,
+            _outputPathLabel, _outputPathField, _outputPathHint,
+            _exportDescriptionLabel);
+        // Frame height stays at 10 — the description fills the space that import checkboxes would use.
+        _configFrame.Height = 10;
+        UpdateHintVisibility(_schemaPathField, _schemaPathHint);
+        UpdateHintVisibility(_outputPathField, _outputPathHint);
     }
 
     private void ShowImportConfig()
     {
         _configFrame.RemoveAll();
         _configFrame.Add(
-            _dataPathLabel, _dataPathField,
+            _dataPathLabel, _dataPathField, _dataPathHint,
             _importModeLabel, _importModeRadio,
             _resolveLookupsCheckBox, _skipUnresolvedLookupsCheckBox,
             _impersonateOwnersCheckBox, _continueOnErrorCheckBox,
             _skipMissingColumnsCheckBox);
+        _configFrame.Height = 10;
+        UpdateHintVisibility(_dataPathField, _dataPathHint);
+    }
+
+    /// <summary>
+    /// Wires a TextField to show/hide a hint label based on whether the field has text.
+    /// </summary>
+    private static void WireFieldHint(TextField field, Label hint)
+    {
+        field.TextChanged += _ => UpdateHintVisibility(field, hint);
+    }
+
+    private static void UpdateHintVisibility(TextField field, Label hint)
+    {
+        var text = field.Text?.ToString();
+        hint.Visible = string.IsNullOrEmpty(text);
     }
 
     private async Task StartOperationAsync()

--- a/src/PPDS.Cli/Tui/Screens/TuiMigrationProgressReporter.cs
+++ b/src/PPDS.Cli/Tui/Screens/TuiMigrationProgressReporter.cs
@@ -1,0 +1,161 @@
+using System;
+using PPDS.Migration.Progress;
+using Terminal.Gui;
+
+namespace PPDS.Cli.Tui.Screens;
+
+/// <summary>
+/// Adapts <see cref="IProgressReporter"/> to TUI controls.
+/// All Report/Complete/Error calls are dispatched to the UI thread via
+/// <see cref="Application.MainLoop"/>.Invoke() so Terminal.Gui views
+/// can be updated safely from background migration threads.
+/// </summary>
+internal sealed class TuiMigrationProgressReporter : IProgressReporter
+{
+    private readonly Label _phaseLabel;
+    private readonly Label _entityLabel;
+    private readonly ProgressBar _progressBar;
+    private readonly Label _rateLabel;
+    private readonly Label _statusLabel;
+    private readonly Action<MigrationResult>? _onComplete;
+    private readonly Action<Exception, string?>? _onError;
+
+    /// <inheritdoc />
+    public string OperationName { get; set; } = "Migration";
+
+    /// <summary>
+    /// Creates a new TUI migration progress reporter.
+    /// </summary>
+    /// <param name="phaseLabel">Label showing the current phase.</param>
+    /// <param name="entityLabel">Label showing the current entity name.</param>
+    /// <param name="progressBar">Progress bar to update.</param>
+    /// <param name="rateLabel">Label showing rate and ETA.</param>
+    /// <param name="statusLabel">Label for overall status messages.</param>
+    /// <param name="onComplete">Callback when operation completes.</param>
+    /// <param name="onError">Callback when an error occurs.</param>
+    public TuiMigrationProgressReporter(
+        Label phaseLabel,
+        Label entityLabel,
+        ProgressBar progressBar,
+        Label rateLabel,
+        Label statusLabel,
+        Action<MigrationResult>? onComplete = null,
+        Action<Exception, string?>? onError = null)
+    {
+        _phaseLabel = phaseLabel ?? throw new ArgumentNullException(nameof(phaseLabel));
+        _entityLabel = entityLabel ?? throw new ArgumentNullException(nameof(entityLabel));
+        _progressBar = progressBar ?? throw new ArgumentNullException(nameof(progressBar));
+        _rateLabel = rateLabel ?? throw new ArgumentNullException(nameof(rateLabel));
+        _statusLabel = statusLabel ?? throw new ArgumentNullException(nameof(statusLabel));
+        _onComplete = onComplete;
+        _onError = onError;
+    }
+
+    /// <inheritdoc />
+    public void Report(ProgressEventArgs args)
+    {
+        Application.MainLoop?.Invoke(() =>
+        {
+            _phaseLabel.Text = FormatPhase(args.Phase);
+
+            var entityText = args.Entity ?? string.Empty;
+            if (args.TierNumber.HasValue && args.TotalTiers.HasValue)
+            {
+                entityText = $"Tier {args.TierNumber}/{args.TotalTiers} - {entityText}";
+            }
+            _entityLabel.Text = entityText;
+
+            // Use overall progress if available, otherwise per-entity progress
+            if (args.OverallTotal > 0 && args.OverallProcessed.HasValue)
+            {
+                _progressBar.Fraction = (float)((double)args.OverallProcessed.Value / args.OverallTotal.Value);
+            }
+            else if (args.Total > 0)
+            {
+                _progressBar.Fraction = (float)((double)args.Current / args.Total);
+            }
+
+            var rateParts = new System.Collections.Generic.List<string>();
+            if (args.RecordsPerSecond.HasValue && args.RecordsPerSecond.Value > 0)
+            {
+                rateParts.Add($"{args.RecordsPerSecond.Value:F0} rec/s");
+            }
+            if (args.EstimatedRemaining.HasValue)
+            {
+                rateParts.Add($"ETA: {FormatTimeSpan(args.EstimatedRemaining.Value)}");
+            }
+            if (args.SuccessCount > 0 || args.FailureCount > 0)
+            {
+                rateParts.Add($"{args.SuccessCount} ok / {args.FailureCount} fail");
+            }
+            _rateLabel.Text = string.Join("  |  ", rateParts);
+
+            if (!string.IsNullOrEmpty(args.Message))
+            {
+                _statusLabel.Text = args.Message;
+            }
+        });
+    }
+
+    /// <inheritdoc />
+    public void Complete(MigrationResult result)
+    {
+        Application.MainLoop?.Invoke(() =>
+        {
+            _phaseLabel.Text = result.Success ? "Complete" : "Completed with errors";
+            _progressBar.Fraction = 1.0f;
+            _rateLabel.Text = $"{result.RecordsProcessed} records in {FormatTimeSpan(result.Duration)} ({result.RecordsPerSecond:F0} rec/s)";
+            _statusLabel.Text = result.Success
+                ? $"{OperationName} completed successfully."
+                : $"{OperationName} completed with {result.FailureCount} error(s).";
+            _onComplete?.Invoke(result);
+        });
+    }
+
+    /// <inheritdoc />
+    public void Error(Exception exception, string? context = null)
+    {
+        Application.MainLoop?.Invoke(() =>
+        {
+            _phaseLabel.Text = "Error";
+            _statusLabel.Text = context != null
+                ? $"Error during {context}: {exception.Message}"
+                : $"Error: {exception.Message}";
+            _onError?.Invoke(exception, context);
+        });
+    }
+
+    /// <inheritdoc />
+    public void Reset()
+    {
+        Application.MainLoop?.Invoke(() =>
+        {
+            _phaseLabel.Text = string.Empty;
+            _entityLabel.Text = string.Empty;
+            _progressBar.Fraction = 0f;
+            _rateLabel.Text = string.Empty;
+        });
+    }
+
+    private static string FormatPhase(MigrationPhase phase) => phase switch
+    {
+        MigrationPhase.Analyzing => "Analyzing schema...",
+        MigrationPhase.Exporting => "Exporting data...",
+        MigrationPhase.Importing => "Importing records...",
+        MigrationPhase.ProcessingDeferredFields => "Processing deferred fields...",
+        MigrationPhase.ProcessingStateTransitions => "Processing state transitions...",
+        MigrationPhase.ProcessingRelationships => "Processing M2M relationships...",
+        MigrationPhase.Complete => "Complete",
+        MigrationPhase.Error => "Error",
+        _ => phase.ToString()
+    };
+
+    private static string FormatTimeSpan(TimeSpan ts)
+    {
+        if (ts.TotalHours >= 1)
+            return $"{ts.Hours}h {ts.Minutes}m {ts.Seconds}s";
+        if (ts.TotalMinutes >= 1)
+            return $"{ts.Minutes}m {ts.Seconds}s";
+        return $"{ts.Seconds}s";
+    }
+}

--- a/src/PPDS.Cli/Tui/Testing/States/ExecutionPlanPreviewDialogState.cs
+++ b/src/PPDS.Cli/Tui/Testing/States/ExecutionPlanPreviewDialogState.cs
@@ -1,0 +1,18 @@
+namespace PPDS.Cli.Tui.Testing.States;
+
+/// <summary>
+/// Captures the state of the ExecutionPlanPreviewDialog for testing.
+/// </summary>
+/// <param name="TierCount">Number of tiers in the execution plan.</param>
+/// <param name="EntityCount">Number of entities in the execution plan.</param>
+/// <param name="DeferredFieldCount">Number of deferred fields.</param>
+/// <param name="StateTransitionCount">Number of state transitions.</param>
+/// <param name="ManyToManyRelationshipCount">Number of many-to-many relationships.</param>
+/// <param name="IsApproved">Whether the plan was approved.</param>
+public sealed record ExecutionPlanPreviewDialogState(
+    int TierCount,
+    int EntityCount,
+    int DeferredFieldCount,
+    int StateTransitionCount,
+    int ManyToManyRelationshipCount,
+    bool IsApproved);

--- a/src/PPDS.Cli/Tui/Testing/States/MigrationScreenState.cs
+++ b/src/PPDS.Cli/Tui/Testing/States/MigrationScreenState.cs
@@ -1,0 +1,42 @@
+namespace PPDS.Cli.Tui.Testing.States;
+
+/// <summary>
+/// Captures the state of the MigrationScreen for testing.
+/// </summary>
+/// <param name="Mode">"Export" or "Import".</param>
+/// <param name="OperationState">"Idle", "Configuring", "Running", "Completed", "Failed", or "Cancelled".</param>
+/// <param name="SchemaPath">Export: schema file path.</param>
+/// <param name="OutputPath">Export: output file path.</param>
+/// <param name="DataPath">Import: data file path.</param>
+/// <param name="CurrentPhase">Current migration phase label.</param>
+/// <param name="CurrentEntity">Current entity being processed.</param>
+/// <param name="RecordCount">Total records processed.</param>
+/// <param name="SuccessCount">Successful records.</param>
+/// <param name="FailureCount">Failed records.</param>
+/// <param name="WarningCount">Warning count.</param>
+/// <param name="SkipCount">Skipped records.</param>
+/// <param name="RecordsPerSecond">Processing rate.</param>
+/// <param name="EstimatedRemaining">ETA string.</param>
+/// <param name="Elapsed">Elapsed time string.</param>
+/// <param name="ErrorMessage">Error message if failed (null if no error).</param>
+/// <param name="IsLoading">Whether operation is running.</param>
+/// <param name="StatusMessage">Current status bar message.</param>
+public sealed record MigrationScreenState(
+    string Mode,
+    string OperationState,
+    string? SchemaPath,
+    string? OutputPath,
+    string? DataPath,
+    string? CurrentPhase,
+    string? CurrentEntity,
+    int RecordCount,
+    int SuccessCount,
+    int FailureCount,
+    int WarningCount,
+    int SkipCount,
+    double? RecordsPerSecond,
+    string? EstimatedRemaining,
+    string? Elapsed,
+    string? ErrorMessage,
+    bool IsLoading,
+    string? StatusMessage);

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -287,6 +287,7 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             new("Plugin Registration", "Browse and manage plugin registrations", () => NavigateToPluginRegistration()),
             new("Metadata Browser", "Browse entity metadata", () => NavigateToMetadataBrowser()),
             new("Web Resources", "Browse and manage web resources", () => NavigateToWebResources()),
+            new("Data Migration", "Export and import Dataverse data", () => NavigateToMigration()),
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Environment Details...", "View organization and connection info",
                 hasEnvironment ? () => ShowEnvironmentDetails() : (Action?)null),
@@ -635,6 +636,31 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
             _contentArea.Remove(loadingLabel);
 
             var screen = new WebResourcesScreen(_session);
+            NavigateTo(screen);
+
+            return false;
+        });
+    }
+
+    private void NavigateToMigration()
+    {
+        HideSplash();
+
+        var loadingLabel = new Label("Loading Data Migration...")
+        {
+            X = Pos.Center(),
+            Y = Pos.Center()
+        };
+        _contentArea.Add(loadingLabel);
+        _contentArea.Title = "Loading";
+
+        Application.Refresh();
+
+        Application.MainLoop?.AddIdle(() =>
+        {
+            _contentArea.Remove(loadingLabel);
+
+            var screen = new MigrationScreen(_session);
             NavigateTo(screen);
 
             return false;

--- a/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using PPDS.Migration.Analysis;
 using PPDS.Migration.Export;
 using PPDS.Migration.Formats;
 using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
 using PPDS.Migration.Progress;
 using PPDS.Migration.Schema;
 
@@ -62,6 +63,30 @@ namespace PPDS.Migration.DependencyInjection
             services.AddTransient<BulkOperationProber>();
             services.AddTransient<DeferredFieldProcessor>();
             services.AddTransient<RelationshipProcessor>();
+
+            // Import - Handlers
+            services.AddTransient<IRecordFilter, SystemUserHandler>();
+            services.AddTransient<IRecordFilter, ActivityPointerHandler>();
+            services.AddTransient<IRecordFilter, ProductHandler>();
+            services.AddTransient<IRecordTransformer, BusinessUnitHandler>();
+            services.AddTransient<IRecordTransformer, OpportunityHandler>();
+            services.AddTransient<IRecordTransformer, IncidentHandler>();
+            services.AddTransient<IRecordTransformer, QuoteHandler>();
+            services.AddTransient<IRecordTransformer, SalesOrderHandler>();
+            services.AddTransient<IRecordTransformer, LeadHandler>();
+            services.AddTransient<IRecordTransformer, DuplicateRuleHandler>();
+            services.AddTransient<IStateTransitionHandler, OpportunityHandler>();
+            services.AddTransient<IStateTransitionHandler, IncidentHandler>();
+            services.AddTransient<IStateTransitionHandler, QuoteHandler>();
+            services.AddTransient<IStateTransitionHandler, SalesOrderHandler>();
+            services.AddTransient<IStateTransitionHandler, LeadHandler>();
+            services.AddTransient<IStateTransitionHandler, ProductHandler>();
+            services.AddTransient<IPostImportHandler, DuplicateRuleHandler>();
+
+            // Import - Components
+            services.AddTransient<StateTransitionProcessor>();
+            services.AddTransient<EntityReferenceMapper>();
+            services.AddTransient<FileColumnTransferHelper>();
 
             // Import - Orchestration
             services.AddTransient<IPluginStepManager, PluginStepManager>();

--- a/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
@@ -64,24 +64,39 @@ namespace PPDS.Migration.DependencyInjection
             services.AddTransient<DeferredFieldProcessor>();
             services.AddTransient<RelationshipProcessor>();
 
-            // Import - Handlers
+            // Import - Handlers (single-interface)
             services.AddTransient<IRecordFilter, SystemUserHandler>();
             services.AddTransient<IRecordFilter, ActivityPointerHandler>();
-            services.AddTransient<IRecordFilter, ProductHandler>();
             services.AddTransient<IRecordTransformer, BusinessUnitHandler>();
-            services.AddTransient<IRecordTransformer, OpportunityHandler>();
-            services.AddTransient<IRecordTransformer, IncidentHandler>();
-            services.AddTransient<IRecordTransformer, QuoteHandler>();
-            services.AddTransient<IRecordTransformer, SalesOrderHandler>();
-            services.AddTransient<IRecordTransformer, LeadHandler>();
-            services.AddTransient<IRecordTransformer, DuplicateRuleHandler>();
-            services.AddTransient<IStateTransitionHandler, OpportunityHandler>();
-            services.AddTransient<IStateTransitionHandler, IncidentHandler>();
-            services.AddTransient<IStateTransitionHandler, QuoteHandler>();
-            services.AddTransient<IStateTransitionHandler, SalesOrderHandler>();
-            services.AddTransient<IStateTransitionHandler, LeadHandler>();
-            services.AddTransient<IStateTransitionHandler, ProductHandler>();
-            services.AddTransient<IPostImportHandler, DuplicateRuleHandler>();
+
+            // Import - Handlers (multi-interface: singleton forwarding pattern)
+            services.AddSingleton<ProductHandler>();
+            services.AddSingleton<IRecordFilter>(sp => sp.GetRequiredService<ProductHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<ProductHandler>());
+
+            services.AddSingleton<DuplicateRuleHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<DuplicateRuleHandler>());
+            services.AddSingleton<IPostImportHandler>(sp => sp.GetRequiredService<DuplicateRuleHandler>());
+
+            services.AddSingleton<OpportunityHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<OpportunityHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<OpportunityHandler>());
+
+            services.AddSingleton<IncidentHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<IncidentHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<IncidentHandler>());
+
+            services.AddSingleton<QuoteHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<QuoteHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<QuoteHandler>());
+
+            services.AddSingleton<SalesOrderHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<SalesOrderHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<SalesOrderHandler>());
+
+            services.AddSingleton<LeadHandler>();
+            services.AddSingleton<IRecordTransformer>(sp => sp.GetRequiredService<LeadHandler>());
+            services.AddSingleton<IStateTransitionHandler>(sp => sp.GetRequiredService<LeadHandler>());
 
             // Import - Components
             services.AddTransient<StateTransitionProcessor>();

--- a/src/PPDS.Migration/Formats/CmtSchemaReader.cs
+++ b/src/PPDS.Migration/Formats/CmtSchemaReader.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
+using PPDS.Migration.Import;
 using PPDS.Migration.Models;
 
 namespace PPDS.Migration.Formats
@@ -115,6 +116,8 @@ namespace PPDS.Migration.Formats
             var primaryIdField = element.Attribute("primaryidfield")?.Value ?? $"{logicalName}id";
             var primaryNameField = element.Attribute("primarynamefield")?.Value ?? "name";
             var disablePlugins = ParseBool(element.Attribute("disableplugins")?.Value);
+            var importModeAttr = element.Attribute("importMode")?.Value;
+            var importMode = ParseImportMode(importModeAttr);
 
             var fields = new List<FieldSchema>();
             var fieldsElement = element.Element("fields");
@@ -157,6 +160,7 @@ namespace PPDS.Migration.Formats
                 PrimaryNameField = primaryNameField,
                 DisablePlugins = disablePlugins,
                 ObjectTypeCode = objectTypeCode,
+                ImportMode = importMode,
                 Fields = fields,
                 Relationships = relationships,
                 FetchXmlFilter = fetchXmlFilter
@@ -180,6 +184,8 @@ namespace PPDS.Migration.Formats
             // Parse validity flags - default to true for backwards compatibility
             var isValidForCreate = ParseBool(element.Attribute("isValidForCreate")?.Value, defaultValue: true);
             var isValidForUpdate = ParseBool(element.Attribute("isValidForUpdate")?.Value, defaultValue: true);
+            var dateModeAttr = element.Attribute("dateMode")?.Value;
+            var dateMode = ParseDateMode(dateModeAttr);
 
             return new FieldSchema
             {
@@ -192,6 +198,7 @@ namespace PPDS.Migration.Formats
                 IsPrimaryKey = isPrimaryKey,
                 IsValidForCreate = isValidForCreate,
                 IsValidForUpdate = isValidForUpdate,
+                DateMode = dateMode,
                 MaxLength = ParseInt(element.Attribute("maxlength")?.Value),
                 Precision = ParseInt(element.Attribute("precision")?.Value)
             };
@@ -276,6 +283,39 @@ namespace PPDS.Migration.Formats
             }
 
             return DateTime.TryParse(value, out var result) ? result : null;
+        }
+
+        private static DateMode ParseDateMode(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return DateMode.Absolute;
+            }
+
+            return value.ToLowerInvariant() switch
+            {
+                "relative" => DateMode.Relative,
+                "relativedaily" => DateMode.RelativeDaily,
+                "relativeexact" => DateMode.RelativeExact,
+                _ => DateMode.Absolute
+            };
+        }
+
+        private static ImportMode? ParseImportMode(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            return value.ToLowerInvariant() switch
+            {
+                "create" => ImportMode.Create,
+                "update" => ImportMode.Update,
+                "upsert" => ImportMode.Upsert,
+                "skip" => ImportMode.Skip,
+                _ => null
+            };
         }
     }
 }

--- a/src/PPDS.Migration/Formats/CmtSchemaWriter.cs
+++ b/src/PPDS.Migration/Formats/CmtSchemaWriter.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Extensions.Logging;
+using PPDS.Migration.Import;
 using PPDS.Migration.Models;
 
 namespace PPDS.Migration.Formats
@@ -93,6 +94,23 @@ namespace PPDS.Migration.Formats
             await writer.WriteAttributeStringAsync(null, "primarynamefield", null, entity.PrimaryNameField).ConfigureAwait(false);
             await writer.WriteAttributeStringAsync(null, "disableplugins", null, entity.DisablePlugins.ToString().ToLowerInvariant()).ConfigureAwait(false);
 
+            // Write importMode if set
+            if (entity.ImportMode.HasValue)
+            {
+                var importModeStr = entity.ImportMode.Value switch
+                {
+                    ImportMode.Create => "create",
+                    ImportMode.Update => "update",
+                    ImportMode.Upsert => "upsert",
+                    ImportMode.Skip => "skip",
+                    _ => null
+                };
+                if (importModeStr != null)
+                {
+                    await writer.WriteAttributeStringAsync(null, "importMode", null, importModeStr).ConfigureAwait(false);
+                }
+            }
+
             // Write fields
             await writer.WriteStartElementAsync(null, "fields", null).ConfigureAwait(false);
             foreach (var field in entity.Fields)
@@ -148,6 +166,22 @@ namespace PPDS.Migration.Formats
             if (!field.IsValidForUpdate)
             {
                 await writer.WriteAttributeStringAsync(null, "isValidForUpdate", null, "false").ConfigureAwait(false);
+            }
+
+            // Write dateMode if not Absolute (Absolute is the default)
+            if (field.DateMode != DateMode.Absolute)
+            {
+                var dateModeStr = field.DateMode switch
+                {
+                    DateMode.Relative => "relative",
+                    DateMode.RelativeDaily => "relativedaily",
+                    DateMode.RelativeExact => "relativeexact",
+                    _ => null
+                };
+                if (dateModeStr != null)
+                {
+                    await writer.WriteAttributeStringAsync(null, "dateMode", null, dateModeStr).ConfigureAwait(false);
+                }
             }
 
             await writer.WriteEndElementAsync().ConfigureAwait(false); // field

--- a/src/PPDS.Migration/Import/DateShifter.cs
+++ b/src/PPDS.Migration/Import/DateShifter.cs
@@ -1,0 +1,45 @@
+using System;
+using PPDS.Migration.Models;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Shifts date/time values based on the configured <see cref="DateMode"/>.
+    /// </summary>
+    public static class DateShifter
+    {
+        /// <summary>
+        /// Shifts a date/time value based on the specified mode and elapsed time.
+        /// </summary>
+        /// <param name="value">The original date/time value, or null.</param>
+        /// <param name="mode">The date shifting mode.</param>
+        /// <param name="elapsed">The elapsed time since the original export.</param>
+        /// <returns>The shifted date/time value, or null if <paramref name="value"/> is null.</returns>
+        public static DateTime? Shift(DateTime? value, DateMode mode, TimeSpan elapsed)
+        {
+            if (value is null)
+                return null;
+
+            return mode switch
+            {
+                DateMode.Absolute => value,
+                DateMode.Relative => value.Value.Add(RoundToWeeks(elapsed)),
+                DateMode.RelativeDaily => value.Value.Add(RoundToDays(elapsed)),
+                DateMode.RelativeExact => value.Value.Add(elapsed),
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown DateMode.")
+            };
+        }
+
+        private static TimeSpan RoundToWeeks(TimeSpan elapsed)
+        {
+            var weeks = (long)Math.Round(elapsed.TotalDays / 7.0);
+            return TimeSpan.FromDays(weeks * 7);
+        }
+
+        private static TimeSpan RoundToDays(TimeSpan elapsed)
+        {
+            var days = (long)Math.Round(elapsed.TotalDays);
+            return TimeSpan.FromDays(days);
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/DateShifter.cs
+++ b/src/PPDS.Migration/Import/DateShifter.cs
@@ -33,7 +33,7 @@ namespace PPDS.Migration.Import
         private static TimeSpan RoundToWeeks(TimeSpan elapsed)
         {
             var weeks = (long)Math.Round(elapsed.TotalDays / 7.0);
-            return TimeSpan.FromDays(weeks * 7);
+            return TimeSpan.FromDays((double)weeks * 7);
         }
 
         private static TimeSpan RoundToDays(TimeSpan elapsed)

--- a/src/PPDS.Migration/Import/EntityReferenceMapper.cs
+++ b/src/PPDS.Migration/Import/EntityReferenceMapper.cs
@@ -96,10 +96,11 @@ namespace PPDS.Migration.Import
         /// Gets the match field for name-based resolution.
         /// </summary>
         /// <param name="entityName">The entity logical name.</param>
-        /// <returns>The match field name, or empty string.</returns>
-        public static string GetMatchField(string entityName)
+        /// <returns>The match field name, or null if no match field is known.
+        /// Full implementation would require entity metadata lookup for primary name attribute.</returns>
+        public static string? GetMatchField(string entityName)
         {
-            return MatchFieldOverrides.TryGetValue(entityName, out var f) ? f : string.Empty;
+            return MatchFieldOverrides.TryGetValue(entityName, out var f) ? f : null;
         }
 
         private async Task<Guid?> TryDirectIdCheckAsync(string en, Guid sid, CancellationToken ct)

--- a/src/PPDS.Migration/Import/EntityReferenceMapper.cs
+++ b/src/PPDS.Migration/Import/EntityReferenceMapper.cs
@@ -108,7 +108,7 @@ namespace PPDS.Migration.Import
             {
                 await using var c = await _pool.GetClientAsync(cancellationToken: ct).ConfigureAwait(false);
                 var req = new RetrieveRequest { Target = new EntityReference(en, sid), ColumnSet = new ColumnSet(false) };
-                await c.ExecuteAsync(req).ConfigureAwait(false);
+                await c.ExecuteAsync(req, ct).ConfigureAwait(false);
                 return sid;
             }
             catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
@@ -121,7 +121,7 @@ namespace PPDS.Migration.Import
                 await using var c = await _pool.GetClientAsync(cancellationToken: ct).ConfigureAwait(false);
                 var q = new QueryExpression(en) { ColumnSet = new ColumnSet(false), TopCount = 1 };
                 q.Criteria.AddCondition(mf, ConditionOperator.Equal, nv);
-                var r = await c.RetrieveMultipleAsync(q).ConfigureAwait(false);
+                var r = await c.RetrieveMultipleAsync(q, ct).ConfigureAwait(false);
                 return r.Entities.Count > 0 ? r.Entities[0].Id : null;
             }
             catch (Exception ex) when (ex is not OperationCanceledException) { return null; }

--- a/src/PPDS.Migration/Import/EntityReferenceMapper.cs
+++ b/src/PPDS.Migration/Import/EntityReferenceMapper.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Models;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Resolves entity references using cascading lookup resolution.
+    /// </summary>
+    public class EntityReferenceMapper
+    {
+        private readonly IdMappingCollection _idMappings;
+        private readonly IDataverseConnectionPool _pool;
+        private readonly ImportOptions _options;
+        private readonly ILogger? _logger;
+        private readonly ConcurrentDictionary<(string entityName, Guid sourceId), Guid?> _cache = new();
+
+        private static readonly Dictionary<string, string> MatchFieldOverrides = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["transactioncurrency"] = "isocurrencycode",
+            ["businessunit"] = "name",
+            ["role"] = "name",
+            ["uom"] = "name",
+            ["uomschedule"] = "name"
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityReferenceMapper"/> class.
+        /// </summary>
+        /// <param name="idMappings">The ID mapping collection.</param>
+        /// <param name="pool">The connection pool.</param>
+        /// <param name="options">The import options.</param>
+        /// <param name="logger">Optional logger.</param>
+        public EntityReferenceMapper(IdMappingCollection idMappings, IDataverseConnectionPool pool, ImportOptions options, ILogger<EntityReferenceMapper>? logger = null)
+        {
+            _idMappings = idMappings ?? throw new ArgumentNullException(nameof(idMappings));
+            _pool = pool ?? throw new ArgumentNullException(nameof(pool));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Resolves a source entity reference to its target GUID.
+        /// </summary>
+        /// <param name="targetEntityName">The target entity logical name.</param>
+        /// <param name="sourceId">The source record GUID.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The resolved target GUID, or null if unresolved.</returns>
+        public async Task<Guid?> ResolveAsync(string targetEntityName, Guid sourceId, CancellationToken cancellationToken)
+        {
+            if (_idMappings.TryGetNewId(targetEntityName, sourceId, out var mappedId)) return mappedId;
+            if (!_options.ResolveExternalLookups) return null;
+            var ck = (targetEntityName, sourceId);
+            if (_cache.TryGetValue(ck, out var cached)) return cached;
+            var dr = await TryDirectIdCheckAsync(targetEntityName, sourceId, cancellationToken).ConfigureAwait(false);
+            if (dr.HasValue) { _cache[ck] = dr.Value; return dr.Value; }
+            _cache[ck] = null;
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves a lookup with name-based fallback.
+        /// </summary>
+        /// <param name="targetEntityName">The target entity logical name.</param>
+        /// <param name="sourceId">The source record GUID.</param>
+        /// <param name="nameValue">The name value for name-based resolution.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The resolved target GUID, or null if unresolved.</returns>
+        public async Task<Guid?> ResolveWithNameAsync(string targetEntityName, Guid sourceId, string? nameValue, CancellationToken cancellationToken)
+        {
+            if (_idMappings.TryGetNewId(targetEntityName, sourceId, out var mappedId)) return mappedId;
+            if (!_options.ResolveExternalLookups) return null;
+            var ck = (targetEntityName, sourceId);
+            if (_cache.TryGetValue(ck, out var cached)) return cached;
+            var dr = await TryDirectIdCheckAsync(targetEntityName, sourceId, cancellationToken).ConfigureAwait(false);
+            if (dr.HasValue) { _cache[ck] = dr.Value; return dr.Value; }
+            if (string.IsNullOrEmpty(nameValue)) { _cache[ck] = null; return null; }
+            var mf = GetMatchField(targetEntityName);
+            if (string.IsNullOrEmpty(mf)) { _cache[ck] = null; return null; }
+            var nr = await QueryByNameAsync(targetEntityName, mf, nameValue, cancellationToken).ConfigureAwait(false);
+            _cache[ck] = nr;
+            return nr;
+        }
+
+        /// <summary>
+        /// Gets the match field for name-based resolution.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <returns>The match field name, or empty string.</returns>
+        public static string GetMatchField(string entityName)
+        {
+            return MatchFieldOverrides.TryGetValue(entityName, out var f) ? f : string.Empty;
+        }
+
+        private async Task<Guid?> TryDirectIdCheckAsync(string en, Guid sid, CancellationToken ct)
+        {
+            try
+            {
+                await using var c = await _pool.GetClientAsync(cancellationToken: ct).ConfigureAwait(false);
+                var req = new RetrieveRequest { Target = new EntityReference(en, sid), ColumnSet = new ColumnSet(false) };
+                await c.ExecuteAsync(req).ConfigureAwait(false);
+                return sid;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
+        }
+
+        private async Task<Guid?> QueryByNameAsync(string en, string mf, string nv, CancellationToken ct)
+        {
+            try
+            {
+                await using var c = await _pool.GetClientAsync(cancellationToken: ct).ConfigureAwait(false);
+                var q = new QueryExpression(en) { ColumnSet = new ColumnSet(false), TopCount = 1 };
+                q.Criteria.AddCondition(mf, ConditionOperator.Equal, nv);
+                var r = await c.RetrieveMultipleAsync(q).ConfigureAwait(false);
+                return r.Entities.Count > 0 ? r.Entities[0].Id : null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException) { return null; }
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/FileColumnTransferHelper.cs
+++ b/src/PPDS.Migration/Import/FileColumnTransferHelper.cs
@@ -38,6 +38,7 @@ namespace PPDS.Migration.Import
             string entityName, Guid recordId, string fieldName,
             CancellationToken cancellationToken)
         {
+            // D2 exception: FileContinuationToken is session-bound; must use same client for all chunks.
             await using var client = await _connectionPool.GetClientAsync(
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -53,7 +54,7 @@ namespace PPDS.Migration.Import
             var fileSizeInBytes = (long)initResponse["FileSizeInBytes"];
 
             // Step 2: Download all blocks
-            var allData = new List<byte>();
+            var allData = new List<byte>((int)Math.Min(fileSizeInBytes, int.MaxValue));
             long offset = 0;
 
             while (offset < fileSizeInBytes)
@@ -95,6 +96,7 @@ namespace PPDS.Migration.Import
             byte[] data, string fileName, string mimeType,
             CancellationToken cancellationToken)
         {
+            // D2 exception: FileContinuationToken is session-bound; must use same client for all chunks.
             await using var client = await _connectionPool.GetClientAsync(
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/PPDS.Migration/Import/FileColumnTransferHelper.cs
+++ b/src/PPDS.Migration/Import/FileColumnTransferHelper.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Pooling;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Handles chunked upload/download of file column binary data.
+    /// Uses 4MB (4,194,304 byte) chunks per Dataverse SDK limit.
+    /// </summary>
+    public class FileColumnTransferHelper
+    {
+        private const int ChunkSize = 4_194_304; // 4MB
+
+        private readonly IDataverseConnectionPool _connectionPool;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileColumnTransferHelper"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The connection pool.</param>
+        public FileColumnTransferHelper(IDataverseConnectionPool connectionPool)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+        }
+
+        /// <summary>
+        /// Downloads file column data in chunks.
+        /// </summary>
+        /// <param name="entityName">The logical name of the entity.</param>
+        /// <param name="recordId">The record identifier.</param>
+        /// <param name="fieldName">The file column attribute name.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The complete file data as a byte array.</returns>
+        public async Task<byte[]> DownloadAsync(
+            string entityName, Guid recordId, string fieldName,
+            CancellationToken cancellationToken)
+        {
+            await using var client = await _connectionPool.GetClientAsync(
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // Step 1: Initialize the download
+            var initRequest = new OrganizationRequest("InitializeFileBlocksDownload")
+            {
+                ["Target"] = new EntityReference(entityName, recordId),
+                ["FileAttributeName"] = fieldName
+            };
+
+            var initResponse = await client.ExecuteAsync(initRequest, cancellationToken).ConfigureAwait(false);
+            var fileContinuationToken = (string)initResponse["FileContinuationToken"];
+            var fileSizeInBytes = (long)initResponse["FileSizeInBytes"];
+
+            // Step 2: Download all blocks
+            var allData = new List<byte>();
+            long offset = 0;
+
+            while (offset < fileSizeInBytes)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var blockLength = (int)Math.Min(ChunkSize, fileSizeInBytes - offset);
+
+                var downloadRequest = new OrganizationRequest("DownloadBlock")
+                {
+                    ["FileContinuationToken"] = fileContinuationToken,
+                    ["Offset"] = offset,
+                    ["BlockLength"] = blockLength
+                };
+
+                var downloadResponse = await client.ExecuteAsync(downloadRequest, cancellationToken).ConfigureAwait(false);
+                var blockData = (byte[])downloadResponse["Data"];
+                allData.AddRange(blockData);
+
+                offset += blockData.Length;
+            }
+
+            return allData.ToArray();
+        }
+
+        /// <summary>
+        /// Uploads file column data in 4MB chunks. AC-35.
+        /// Uses InitializeFileBlocksUploadRequest -> UploadBlockRequest -> CommitFileBlocksUploadRequest.
+        /// </summary>
+        /// <param name="entityName">The logical name of the entity.</param>
+        /// <param name="recordId">The record identifier.</param>
+        /// <param name="fieldName">The file column attribute name.</param>
+        /// <param name="data">The file data to upload.</param>
+        /// <param name="fileName">The original file name.</param>
+        /// <param name="mimeType">The MIME type of the file.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public async Task UploadAsync(
+            string entityName, Guid recordId, string fieldName,
+            byte[] data, string fileName, string mimeType,
+            CancellationToken cancellationToken)
+        {
+            await using var client = await _connectionPool.GetClientAsync(
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // Step 1: Initialize the upload
+            var initRequest = new OrganizationRequest("InitializeFileBlocksUpload")
+            {
+                ["Target"] = new EntityReference(entityName, recordId),
+                ["FileAttributeName"] = fieldName,
+                ["FileName"] = fileName
+            };
+
+            var initResponse = await client.ExecuteAsync(initRequest, cancellationToken).ConfigureAwait(false);
+            var fileContinuationToken = (string)initResponse["FileContinuationToken"];
+
+            // Step 2: Upload chunks
+            var blockIds = new List<string>();
+            var offset = 0;
+
+            while (offset < data.Length)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var blockLength = Math.Min(ChunkSize, data.Length - offset);
+                var blockData = new byte[blockLength];
+                Array.Copy(data, offset, blockData, 0, blockLength);
+
+                var blockId = Convert.ToBase64String(
+                    System.Text.Encoding.UTF8.GetBytes(blockIds.Count.ToString("D6")));
+
+                var uploadRequest = new OrganizationRequest("UploadBlock")
+                {
+                    ["FileContinuationToken"] = fileContinuationToken,
+                    ["BlockData"] = blockData,
+                    ["BlockId"] = blockId
+                };
+
+                await client.ExecuteAsync(uploadRequest, cancellationToken).ConfigureAwait(false);
+                blockIds.Add(blockId);
+
+                offset += blockLength;
+            }
+
+            // Step 3: Commit the upload
+            var commitRequest = new OrganizationRequest("CommitFileBlocksUpload")
+            {
+                ["FileName"] = fileName,
+                ["MimeType"] = mimeType,
+                ["FileContinuationToken"] = fileContinuationToken,
+                ["BlockIds"] = blockIds.ToArray()
+            };
+
+            await client.ExecuteAsync(commitRequest, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/ActivityPointerHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/ActivityPointerHandler.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Filters activitypointer base type records — always skipped because
+    /// concrete activity types (email, task, etc.) are imported directly.
+    /// </summary>
+    public class ActivityPointerHandler : IRecordFilter
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("activitypointer", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public bool ShouldSkip(Entity record, ImportContext context)
+            => true; // Always skip activitypointer base type
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/BusinessUnitHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/BusinessUnitHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Transforms business unit records during import.
+    /// Remaps the root business unit to the target environment's root BU.
+    /// </summary>
+    public class BusinessUnitHandler : IRecordTransformer
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("businessunit", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            // Check if this is the root BU (parentbusinessunitid is null)
+            if (!record.Contains("parentbusinessunitid") || record["parentbusinessunitid"] == null)
+            {
+                // This is the root BU — remap its ID to the target's root BU
+                if (context.TargetRootBusinessUnitId.HasValue)
+                {
+                    record.Id = context.TargetRootBusinessUnitId.Value;
+                    var primaryKey = $"{record.LogicalName}id";
+                    if (record.Contains(primaryKey))
+                        record[primaryKey] = context.TargetRootBusinessUnitId.Value;
+                }
+            }
+            return record;
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
@@ -49,16 +49,15 @@ namespace PPDS.Migration.Import.Handlers
             var rules = context.IdMappings.GetMappingsForEntity("duplicaterule");
             if (rules == null || rules.Count == 0) return;
 
-            await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
-
             foreach (var (_, targetId) in rules)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
                 var request = new OrganizationRequest("PublishDuplicateRule")
                 {
                     ["DuplicateRuleId"] = targetId
                 };
-                await client.ExecuteAsync(request).ConfigureAwait(false);
+                await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Pooling;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles duplicate rule records during import.
+    /// Remaps Entity Type Codes during transform and publishes rules after import.
+    /// </summary>
+    public class DuplicateRuleHandler : IRecordTransformer, IPostImportHandler
+    {
+        private readonly IDataverseConnectionPool _connectionPool;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuplicateRuleHandler"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The Dataverse connection pool.</param>
+        public DuplicateRuleHandler(IDataverseConnectionPool connectionPool)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+        }
+
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("duplicaterule", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            // Remap baseentitytypecode and matchingentitytypecode.
+            // These are stored as integer Entity Type Codes that differ between environments.
+            if (context.TargetEntityTypeCodes != null)
+            {
+                RemapEtc(record, "baseentitytypecode", context);
+                RemapEtc(record, "matchingentitytypecode", context);
+            }
+
+            return record;
+        }
+
+        /// <inheritdoc />
+        public async Task ExecuteAsync(string entityLogicalName, ImportContext context, CancellationToken cancellationToken)
+        {
+            // Publish all imported duplicate rules
+            var rules = context.IdMappings.GetMappingsForEntity("duplicaterule");
+            if (rules == null || rules.Count == 0) return;
+
+            await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            foreach (var (_, targetId) in rules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var request = new OrganizationRequest("PublishDuplicateRule")
+                {
+                    ["DuplicateRuleId"] = targetId
+                };
+                await client.ExecuteAsync(request).ConfigureAwait(false);
+            }
+        }
+
+        private static void RemapEtc(Entity record, string fieldName, ImportContext context)
+        {
+            if (record.Contains(fieldName))
+            {
+                var sourceEtc = record.GetAttributeValue<int>(fieldName);
+                // Look up the logical name for this ETC in source, then get target ETC
+                if (context.SourceEntityTypeCodes != null &&
+                    context.SourceEntityTypeCodes.TryGetValue(sourceEtc, out var logicalName) &&
+                    context.TargetEntityTypeCodes!.TryGetValue(logicalName, out var targetEtc))
+                {
+                    record[fieldName] = targetEtc;
+                }
+            }
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/DuplicateRuleHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Xrm.Sdk;
 using PPDS.Dataverse.Pooling;
 
@@ -14,14 +15,17 @@ namespace PPDS.Migration.Import.Handlers
     public class DuplicateRuleHandler : IRecordTransformer, IPostImportHandler
     {
         private readonly IDataverseConnectionPool _connectionPool;
+        private readonly ILogger<DuplicateRuleHandler>? _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DuplicateRuleHandler"/> class.
         /// </summary>
         /// <param name="connectionPool">The Dataverse connection pool.</param>
-        public DuplicateRuleHandler(IDataverseConnectionPool connectionPool)
+        /// <param name="logger">Optional logger.</param>
+        public DuplicateRuleHandler(IDataverseConnectionPool connectionPool, ILogger<DuplicateRuleHandler>? logger = null)
         {
             _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -52,12 +56,19 @@ namespace PPDS.Migration.Import.Handlers
             foreach (var (_, targetId) in rules)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
-                var request = new OrganizationRequest("PublishDuplicateRule")
+                try
                 {
-                    ["DuplicateRuleId"] = targetId
-                };
-                await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+                    await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var request = new OrganizationRequest("PublishDuplicateRule")
+                    {
+                        ["DuplicateRuleId"] = targetId
+                    };
+                    await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger?.LogWarning(ex, "Failed to publish duplicate rule {RuleId}", targetId);
+                }
             }
         }
 

--- a/src/PPDS.Migration/Import/Handlers/IPostImportHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/IPostImportHandler.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Executes post-import processing for an entity.
+    /// </summary>
+    public interface IPostImportHandler
+    {
+        /// <summary>
+        /// Determines whether this handler applies to the given entity.
+        /// </summary>
+        /// <param name="entityLogicalName">The entity logical name.</param>
+        /// <returns>True if this handler handles the entity.</returns>
+        bool CanHandle(string entityLogicalName);
+
+        /// <summary>
+        /// Executes post-import processing for the given entity.
+        /// </summary>
+        /// <param name="entityLogicalName">The entity logical name.</param>
+        /// <param name="context">The import context.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task ExecuteAsync(string entityLogicalName, ImportContext context, CancellationToken cancellationToken);
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/IRecordFilter.cs
+++ b/src/PPDS.Migration/Import/Handlers/IRecordFilter.cs
@@ -1,0 +1,25 @@
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Filters records during import, determining which should be skipped.
+    /// </summary>
+    public interface IRecordFilter
+    {
+        /// <summary>
+        /// Determines whether this filter applies to the given entity.
+        /// </summary>
+        /// <param name="entityLogicalName">The entity logical name.</param>
+        /// <returns>True if this filter handles the entity.</returns>
+        bool CanHandle(string entityLogicalName);
+
+        /// <summary>
+        /// Determines whether the given record should be skipped during import.
+        /// </summary>
+        /// <param name="record">The record to evaluate.</param>
+        /// <param name="context">The import context.</param>
+        /// <returns>True if the record should be skipped.</returns>
+        bool ShouldSkip(Entity record, ImportContext context);
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/IRecordTransformer.cs
+++ b/src/PPDS.Migration/Import/Handlers/IRecordTransformer.cs
@@ -1,0 +1,25 @@
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Transforms records before they are imported.
+    /// </summary>
+    public interface IRecordTransformer
+    {
+        /// <summary>
+        /// Determines whether this transformer applies to the given entity.
+        /// </summary>
+        /// <param name="entityLogicalName">The entity logical name.</param>
+        /// <returns>True if this transformer handles the entity.</returns>
+        bool CanHandle(string entityLogicalName);
+
+        /// <summary>
+        /// Transforms a record before import.
+        /// </summary>
+        /// <param name="record">The record to transform.</param>
+        /// <param name="context">The import context.</param>
+        /// <returns>The transformed record.</returns>
+        Entity Transform(Entity record, ImportContext context);
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/IStateTransitionHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/IStateTransitionHandler.cs
@@ -1,0 +1,25 @@
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Determines state transitions to apply to records after import.
+    /// </summary>
+    public interface IStateTransitionHandler
+    {
+        /// <summary>
+        /// Determines whether this handler applies to the given entity.
+        /// </summary>
+        /// <param name="entityLogicalName">The entity logical name.</param>
+        /// <returns>True if this handler handles the entity.</returns>
+        bool CanHandle(string entityLogicalName);
+
+        /// <summary>
+        /// Gets the state transition data for a record, or null if no transition is needed.
+        /// </summary>
+        /// <param name="record">The record to evaluate.</param>
+        /// <param name="context">The import context.</param>
+        /// <returns>The state transition data, or null.</returns>
+        StateTransitionData? GetTransition(Entity record, ImportContext context);
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/IncidentHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/IncidentHandler.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles state transitions for incident (case) records.
+    /// Both resolved and canceled states use CloseIncident.
+    /// </summary>
+    public class IncidentHandler : IRecordTransformer, IStateTransitionHandler
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("incident", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            record.Attributes.Remove("statecode");
+            record.Attributes.Remove("statuscode");
+            return record;
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            if (stateCode == 0) return null; // Active
+
+            // Both Resolved (1) and Canceled (2) use CloseIncidentRequest
+            return new StateTransitionData
+            {
+                EntityName = "incident",
+                RecordId = record.Id,
+                StateCode = stateCode,
+                StatusCode = statusCode,
+                SdkMessage = "CloseIncident",
+                MessageData = new Dictionary<string, object>
+                {
+                    ["IncidentResolution"] = new Entity("incidentresolution")
+                    {
+                        ["incidentid"] = new EntityReference("incident", record.Id),
+                        ["subject"] = stateCode == 1 ? "Resolved (migrated)" : "Canceled (migrated)"
+                    },
+                    ["Status"] = new OptionSetValue(statusCode)
+                }
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/IncidentHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/IncidentHandler.cs
@@ -17,8 +17,7 @@ namespace PPDS.Migration.Import.Handlers
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)
         {
-            record.Attributes.Remove("statecode");
-            record.Attributes.Remove("statuscode");
+            // statecode/statuscode already stripped by TieredImporter before Transform is called
             return record;
         }
 

--- a/src/PPDS.Migration/Import/Handlers/LeadHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/LeadHandler.cs
@@ -18,8 +18,7 @@ namespace PPDS.Migration.Import.Handlers
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)
         {
-            record.Attributes.Remove("statecode");
-            record.Attributes.Remove("statuscode");
+            // statecode/statuscode already stripped by TieredImporter before Transform is called
             return record;
         }
 

--- a/src/PPDS.Migration/Import/Handlers/LeadHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/LeadHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles state transitions for lead records.
+    /// Qualified leads use QualifyLead with suppressed side-effects;
+    /// disqualified leads use SetStateRequest (null SdkMessage).
+    /// </summary>
+    public class LeadHandler : IRecordTransformer, IStateTransitionHandler
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("lead", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            record.Attributes.Remove("statecode");
+            record.Attributes.Remove("statuscode");
+            return record;
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            return stateCode switch
+            {
+                1 => new StateTransitionData // Qualified
+                {
+                    EntityName = "lead",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "QualifyLead",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["LeadId"] = new EntityReference("lead", record.Id),
+                        ["CreateAccount"] = false,
+                        ["CreateContact"] = false,
+                        ["CreateOpportunity"] = false,
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                2 => new StateTransitionData // Disqualified — use SetStateRequest, NOT QualifyLead
+                {
+                    EntityName = "lead",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = null // null means SetStateRequest
+                },
+                _ => null // Open (0) — no transition needed
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/OpportunityHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/OpportunityHandler.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles state transitions for opportunity records.
+    /// Won opportunities use WinOpportunity; lost use LoseOpportunity.
+    /// </summary>
+    public class OpportunityHandler : IRecordTransformer, IStateTransitionHandler
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("opportunity", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            record.Attributes.Remove("statecode");
+            record.Attributes.Remove("statuscode");
+            return record;
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            if (stateCode == 0) return null; // Active -- no transition needed
+
+            return stateCode switch
+            {
+                1 => new StateTransitionData // Won
+                {
+                    EntityName = "opportunity",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "WinOpportunity",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["OpportunityClose"] = new Entity("opportunityclose")
+                        {
+                            ["opportunityid"] = new EntityReference("opportunity", record.Id),
+                            ["subject"] = "Won (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                2 => new StateTransitionData // Lost
+                {
+                    EntityName = "opportunity",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "LoseOpportunity",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["OpportunityClose"] = new Entity("opportunityclose")
+                        {
+                            ["opportunityid"] = new EntityReference("opportunity", record.Id),
+                            ["subject"] = "Lost (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                _ => new StateTransitionData
+                {
+                    EntityName = "opportunity",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode
+                }
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/OpportunityHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/OpportunityHandler.cs
@@ -17,8 +17,7 @@ namespace PPDS.Migration.Import.Handlers
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)
         {
-            record.Attributes.Remove("statecode");
-            record.Attributes.Remove("statuscode");
+            // statecode/statuscode already stripped by TieredImporter before Transform is called
             return record;
         }
 

--- a/src/PPDS.Migration/Import/Handlers/ProductHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/ProductHandler.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Concurrent;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles product records during import.
+    /// Cascades skip to child products when a parent product fails,
+    /// and handles state transitions for non-draft products.
+    /// </summary>
+    public class ProductHandler : IRecordFilter, IStateTransitionHandler
+    {
+        private readonly ConcurrentDictionary<Guid, byte> _failedProductIds = new();
+
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("product", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public bool ShouldSkip(Entity record, ImportContext context)
+        {
+            // Check if parent product failed
+            var parentRef = record.GetAttributeValue<EntityReference>("parentproductid");
+            if (parentRef != null && _failedProductIds.ContainsKey(parentRef.Id))
+            {
+                // Parent failed — cascade skip to this child
+                _failedProductIds.TryAdd(record.Id, 0);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tracks a product record that failed during import.
+        /// This enables cascade-skip for child products that reference this parent.
+        /// </summary>
+        /// <param name="productId">The ID of the failed product.</param>
+        public void TrackFailure(Guid productId)
+        {
+            _failedProductIds.TryAdd(productId, 0);
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            if (stateCode == 0) return null; // Draft — no transition
+
+            return new StateTransitionData
+            {
+                EntityName = "product",
+                RecordId = record.Id,
+                StateCode = stateCode,
+                StatusCode = statusCode
+                // null SdkMessage = SetStateRequest
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/QuoteHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/QuoteHandler.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles state transitions for quote records.
+    /// Won quotes use WinQuote; closed quotes use CloseQuote.
+    /// </summary>
+    public class QuoteHandler : IRecordTransformer, IStateTransitionHandler
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("quote", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            record.Attributes.Remove("statecode");
+            record.Attributes.Remove("statuscode");
+            return record;
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            return stateCode switch
+            {
+                0 or 1 => null, // Draft (0) or Active (1) -- no transition needed
+                2 => new StateTransitionData // Won
+                {
+                    EntityName = "quote",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "WinQuote",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["QuoteClose"] = new Entity("quoteclose")
+                        {
+                            ["quoteid"] = new EntityReference("quote", record.Id),
+                            ["subject"] = "Won (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                3 => new StateTransitionData // Closed
+                {
+                    EntityName = "quote",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "CloseQuote",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["QuoteClose"] = new Entity("quoteclose")
+                        {
+                            ["quoteid"] = new EntityReference("quote", record.Id),
+                            ["subject"] = "Closed (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                _ => new StateTransitionData
+                {
+                    EntityName = "quote",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode
+                }
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/QuoteHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/QuoteHandler.cs
@@ -17,8 +17,7 @@ namespace PPDS.Migration.Import.Handlers
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)
         {
-            record.Attributes.Remove("statecode");
-            record.Attributes.Remove("statuscode");
+            // statecode/statuscode already stripped by TieredImporter before Transform is called
             return record;
         }
 

--- a/src/PPDS.Migration/Import/Handlers/SalesOrderHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/SalesOrderHandler.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Handles state transitions for sales order records.
+    /// Fulfilled orders use FulfillSalesOrder; canceled orders use CancelSalesOrder.
+    /// </summary>
+    public class SalesOrderHandler : IRecordTransformer, IStateTransitionHandler
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("salesorder", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public Entity Transform(Entity record, ImportContext context)
+        {
+            record.Attributes.Remove("statecode");
+            record.Attributes.Remove("statuscode");
+            return record;
+        }
+
+        /// <inheritdoc />
+        public StateTransitionData? GetTransition(Entity record, ImportContext context)
+        {
+            var stateCode = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+            var statusCode = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+
+            return stateCode switch
+            {
+                3 => new StateTransitionData // Fulfilled
+                {
+                    EntityName = "salesorder",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "FulfillSalesOrder",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["OrderClose"] = new Entity("orderclose")
+                        {
+                            ["salesorderid"] = new EntityReference("salesorder", record.Id),
+                            ["subject"] = "Fulfilled (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                2 => new StateTransitionData // Canceled
+                {
+                    EntityName = "salesorder",
+                    RecordId = record.Id,
+                    StateCode = stateCode,
+                    StatusCode = statusCode,
+                    SdkMessage = "CancelSalesOrder",
+                    MessageData = new Dictionary<string, object>
+                    {
+                        ["OrderClose"] = new Entity("orderclose")
+                        {
+                            ["salesorderid"] = new EntityReference("salesorder", record.Id),
+                            ["subject"] = "Canceled (migrated)"
+                        },
+                        ["Status"] = new OptionSetValue(statusCode)
+                    }
+                },
+                _ => null // Active (0) or Submitted (1) — no transition needed
+            };
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/Handlers/SalesOrderHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/SalesOrderHandler.cs
@@ -17,8 +17,7 @@ namespace PPDS.Migration.Import.Handlers
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)
         {
-            record.Attributes.Remove("statecode");
-            record.Attributes.Remove("statuscode");
+            // statecode/statuscode already stripped by TieredImporter before Transform is called
             return record;
         }
 

--- a/src/PPDS.Migration/Import/Handlers/SystemUserHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/SystemUserHandler.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Xrm.Sdk;
+
+namespace PPDS.Migration.Import.Handlers
+{
+    /// <summary>
+    /// Filters system, integration, and support users during import.
+    /// </summary>
+    public class SystemUserHandler : IRecordFilter
+    {
+        /// <inheritdoc />
+        public bool CanHandle(string entityLogicalName)
+            => entityLogicalName.Equals("systemuser", StringComparison.OrdinalIgnoreCase);
+
+        /// <inheritdoc />
+        public bool ShouldSkip(Entity record, ImportContext context)
+        {
+            // Skip SYSTEM user (fullname == "SYSTEM") and INTEGRATION user (fullname == "INTEGRATION")
+            var fullname = record.GetAttributeValue<string>("fullname");
+            if (string.Equals(fullname, "SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(fullname, "INTEGRATION", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Skip support users (accessmode = 3) and integration users (accessmode = 5)
+            var accessMode = record.GetAttributeValue<OptionSetValue>("accessmode")?.Value;
+            return accessMode == 3 || accessMode == 5;
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/ImportContext.cs
+++ b/src/PPDS.Migration/Import/ImportContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using PPDS.Migration.Models;
 using PPDS.Migration.Progress;
 
@@ -69,9 +70,35 @@ namespace PPDS.Migration.Import
         public IProgressReporter? Progress { get; }
 
         /// <summary>
+        /// Gets or sets the target environment's root business unit ID.
+        /// Used by BusinessUnitHandler to remap the root BU during import.
+        /// </summary>
+        public Guid? TargetRootBusinessUnitId { get; set; }
+
+        /// <summary>
         /// Gets or sets the optional output manager for checkpoint logging.
         /// When set, tier starts, entity completions, and phase transitions are logged to the progress file.
         /// </summary>
         public ImportOutputManager? OutputManager { get; set; }
+
+        /// <summary>
+        /// Gets the collection of state transitions to apply after record import.
+        /// Thread-safe for concurrent access during parallel import.
+        /// </summary>
+        public StateTransitionCollection StateTransitions { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the source Entity Type Code to logical name mapping.
+        /// Used by DuplicateRuleHandler to remap baseentitytypecode and matchingentitytypecode fields.
+        /// Key is the source ETC (int), value is the entity logical name.
+        /// </summary>
+        public Dictionary<int, string>? SourceEntityTypeCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target logical name to Entity Type Code mapping.
+        /// Used by DuplicateRuleHandler to remap baseentitytypecode and matchingentitytypecode fields.
+        /// Key is the entity logical name, value is the target ETC (int).
+        /// </summary>
+        public Dictionary<string, int>? TargetEntityTypeCodes { get; set; }
     }
 }

--- a/src/PPDS.Migration/Import/ImportOptions.cs
+++ b/src/PPDS.Migration/Import/ImportOptions.cs
@@ -152,6 +152,27 @@ namespace PPDS.Migration.Import
         /// to the progress file, providing a structured record of import progress.
         /// </remarks>
         public ImportOutputManager? OutputManager { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to resolve lookups to entities not in the migration schema
+        /// by querying the target environment.
+        /// Default: false
+        /// </summary>
+        public bool ResolveExternalLookups { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets whether to skip (null out) lookup references that cannot be resolved.
+        /// When false, unresolved lookups cause an error.
+        /// Default: true
+        /// </summary>
+        public bool SkipUnresolvedLookups { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether to impersonate record owners during import.
+        /// When true, records are created/updated as the original owner using caller-object-id impersonation.
+        /// Default: false
+        /// </summary>
+        public bool ImpersonateOwners { get; set; } = false;
     }
 
     /// <summary>
@@ -166,6 +187,9 @@ namespace PPDS.Migration.Import
         Update,
 
         /// <summary>Create or update records as needed.</summary>
-        Upsert
+        Upsert,
+
+        /// <summary>Skip this entity entirely during import.</summary>
+        Skip
     }
 }

--- a/src/PPDS.Migration/Import/StateTransitionCollection.cs
+++ b/src/PPDS.Migration/Import/StateTransitionCollection.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Thread-safe collection of state transitions to apply after record import.
+    /// </summary>
+    public class StateTransitionCollection
+    {
+        private readonly ConcurrentDictionary<string, ConcurrentBag<StateTransitionData>> _transitions
+            = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Adds a state transition for a record.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <param name="recordId">The record ID.</param>
+        /// <param name="data">The state transition data.</param>
+        public void Add(string entityName, Guid recordId, StateTransitionData data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            var bag = _transitions.GetOrAdd(entityName, _ => new ConcurrentBag<StateTransitionData>());
+            bag.Add(data);
+        }
+
+        /// <summary>
+        /// Gets all transitions for a given entity.
+        /// </summary>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <returns>A read-only list of transitions, or an empty list if none exist.</returns>
+        public IReadOnlyList<StateTransitionData> GetTransitions(string entityName)
+        {
+            if (_transitions.TryGetValue(entityName, out var bag))
+            {
+                return bag.ToList();
+            }
+            return Array.Empty<StateTransitionData>();
+        }
+
+        /// <summary>
+        /// Gets all entity names that have transitions.
+        /// </summary>
+        public IEnumerable<string> GetEntityNames() => _transitions.Keys;
+
+        /// <summary>
+        /// Gets the total number of transitions across all entities.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                var total = 0;
+                foreach (var bag in _transitions.Values)
+                {
+                    total += bag.Count;
+                }
+                return total;
+            }
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/StateTransitionData.cs
+++ b/src/PPDS.Migration/Import/StateTransitionData.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Describes a state/status transition to apply to a record after import.
+    /// </summary>
+    public class StateTransitionData
+    {
+        /// <summary>
+        /// Gets the entity logical name.
+        /// </summary>
+        public string EntityName { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets the record ID.
+        /// </summary>
+        public Guid RecordId { get; init; }
+
+        /// <summary>
+        /// Gets the target state code.
+        /// </summary>
+        public int StateCode { get; init; }
+
+        /// <summary>
+        /// Gets the target status code.
+        /// </summary>
+        public int StatusCode { get; init; }
+
+        /// <summary>
+        /// Gets the SDK message to use for the transition, or null to use SetStateRequest.
+        /// </summary>
+        public string? SdkMessage { get; init; }
+
+        /// <summary>
+        /// Gets extra parameters for the SDK message.
+        /// </summary>
+        public Dictionary<string, object>? MessageData { get; init; }
+    }
+}

--- a/src/PPDS.Migration/Import/StateTransitionProcessor.cs
+++ b/src/PPDS.Migration/Import/StateTransitionProcessor.cs
@@ -85,10 +85,10 @@ namespace PPDS.Migration.Import
 
                         await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                        // Check if record is already closed (AC-16)
-                        if (await IsRecordClosedAsync(client, entityName, targetId, cancellationToken).ConfigureAwait(false))
+                        // Check if record is already in target state (AC-16)
+                        if (await IsAlreadyInTargetStateAsync(client, entityName, targetId, transition, cancellationToken).ConfigureAwait(false))
                         {
-                            _logger?.LogDebug("Skipping already-closed {Entity}/{Id}", entityName, targetId);
+                            _logger?.LogDebug("Skipping already-in-target-state {Entity}/{Id}", entityName, targetId);
                             successCount++; // Count as success - already in desired state
                             continue;
                         }
@@ -162,26 +162,28 @@ namespace PPDS.Migration.Import
         }
 
         /// <summary>
-        /// Checks if a record is already in a closed/non-active state.
+        /// Checks if a record is already in the desired target state.
         /// </summary>
         /// <param name="client">The Dataverse client.</param>
         /// <param name="entityName">The entity logical name.</param>
         /// <param name="recordId">The record ID to check.</param>
+        /// <param name="target">The desired target state transition.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>True if the record is already closed (statecode != 0), false otherwise.</returns>
-        private static async Task<bool> IsRecordClosedAsync(
-            IPooledClient client, string entityName, Guid recordId, CancellationToken cancellationToken)
+        /// <returns>True if the record already matches the target statecode and statuscode, false otherwise.</returns>
+        private static async Task<bool> IsAlreadyInTargetStateAsync(
+            IPooledClient client, string entityName, Guid recordId, StateTransitionData target, CancellationToken cancellationToken)
         {
             try
             {
                 var request = new RetrieveRequest
                 {
                     Target = new EntityReference(entityName, recordId),
-                    ColumnSet = new ColumnSet("statecode")
+                    ColumnSet = new ColumnSet("statecode", "statuscode")
                 };
                 var response = (RetrieveResponse)await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
                 var stateCode = response.Entity.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
-                return stateCode != 0;
+                var statusCode = response.Entity.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+                return stateCode == target.StateCode && statusCode == target.StatusCode;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/PPDS.Migration/Import/StateTransitionProcessor.cs
+++ b/src/PPDS.Migration/Import/StateTransitionProcessor.cs
@@ -1,22 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.ServiceModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using PPDS.Dataverse.Pooling;
-using PPDS.Migration.Models;
 using PPDS.Migration.Progress;
 
 namespace PPDS.Migration.Import
 {
     /// <summary>
-    /// Processes Phase 3 of import: applies state/status transitions to records
-    /// that were imported in their default (active) state but need to be set to
-    /// a non-default state (e.g., closed, won, lost, cancelled).
+    /// Processes Phase 3 of the import pipeline: applying state transitions
+    /// collected during Phase 1 entity import.
     /// </summary>
     public class StateTransitionProcessor : IImportPhaseProcessor
     {
@@ -29,7 +28,7 @@ namespace PPDS.Migration.Import
         /// <summary>
         /// Initializes a new instance of the <see cref="StateTransitionProcessor"/> class.
         /// </summary>
-        /// <param name="connectionPool">The connection pool.</param>
+        /// <param name="connectionPool">The connection pool for Dataverse operations.</param>
         /// <param name="logger">Optional logger.</param>
         public StateTransitionProcessor(
             IDataverseConnectionPool connectionPool,
@@ -61,6 +60,15 @@ namespace PPDS.Migration.Import
                 return PhaseResult.Skipped();
             }
 
+            // Report initial progress
+            context.Progress?.Report(new ProgressEventArgs
+            {
+                Phase = MigrationPhase.ProcessingStateTransitions,
+                Current = 0,
+                Total = allTransitions.Count,
+                Message = "Processing state transitions"
+            });
+
             var sw = Stopwatch.StartNew();
             var successCount = 0;
             var failureCount = 0;
@@ -70,10 +78,17 @@ namespace PPDS.Migration.Import
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // Map source record ID to target environment ID
+                var targetRecordId = transition.RecordId;
+                if (context.IdMappings.TryGetNewId(transition.EntityName, transition.RecordId, out var mappedId))
+                {
+                    targetRecordId = mappedId;
+                }
+
                 try
                 {
                     // Check if the record is already in the target state (AC-16)
-                    if (await IsRecordAlreadyInStateAsync(transition, cancellationToken).ConfigureAwait(false))
+                    if (await IsRecordAlreadyInStateAsync(transition.EntityName, targetRecordId, cancellationToken).ConfigureAwait(false))
                     {
                         _logger?.LogDebug(
                             "Record {EntityName}/{RecordId} already in statecode={StateCode}, skipping transition",
@@ -85,11 +100,11 @@ namespace PPDS.Migration.Import
                     // Apply the transition
                     if (!string.IsNullOrEmpty(transition.SdkMessage))
                     {
-                        await ExecuteSdkMessageAsync(transition, cancellationToken).ConfigureAwait(false);
+                        await ExecuteSdkMessageAsync(transition, targetRecordId, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        await ExecuteSetStateAsync(transition, cancellationToken).ConfigureAwait(false);
+                        await ExecuteSetStateAsync(transition, targetRecordId, cancellationToken).ConfigureAwait(false);
                     }
 
                     successCount++;
@@ -133,7 +148,8 @@ namespace PPDS.Migration.Import
         /// Checks if a record is already in the target state to avoid double-closing.
         /// </summary>
         private async Task<bool> IsRecordAlreadyInStateAsync(
-            StateTransitionData transition,
+            string entityName,
+            Guid recordId,
             CancellationToken cancellationToken)
         {
             try
@@ -142,13 +158,13 @@ namespace PPDS.Migration.Import
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 var retrieved = await client.RetrieveAsync(
-                    transition.EntityName,
-                    transition.RecordId,
+                    entityName,
+                    recordId,
                     new ColumnSet("statecode"),
                     cancellationToken).ConfigureAwait(false);
 
                 var currentState = retrieved.GetAttributeValue<OptionSetValue>("statecode");
-                return currentState?.Value == transition.StateCode;
+                return currentState != null && currentState.Value != 0;
             }
             catch (FaultException)
             {
@@ -162,11 +178,12 @@ namespace PPDS.Migration.Import
         /// </summary>
         private async Task ExecuteSetStateAsync(
             StateTransitionData transition,
+            Guid targetRecordId,
             CancellationToken cancellationToken)
         {
             var request = new OrganizationRequest("SetState")
             {
-                ["EntityMoniker"] = new EntityReference(transition.EntityName, transition.RecordId),
+                ["EntityMoniker"] = new EntityReference(transition.EntityName, targetRecordId),
                 ["State"] = new OptionSetValue(transition.StateCode),
                 ["Status"] = new OptionSetValue(transition.StatusCode)
             };
@@ -184,6 +201,7 @@ namespace PPDS.Migration.Import
         /// </summary>
         private async Task ExecuteSdkMessageAsync(
             StateTransitionData transition,
+            Guid targetRecordId,
             CancellationToken cancellationToken)
         {
             var request = new OrganizationRequest(transition.SdkMessage!);

--- a/src/PPDS.Migration/Import/StateTransitionProcessor.cs
+++ b/src/PPDS.Migration/Import/StateTransitionProcessor.cs
@@ -86,7 +86,7 @@ namespace PPDS.Migration.Import
                         await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
                         // Check if record is already closed (AC-16)
-                        if (await IsRecordClosedAsync(client, entityName, targetId).ConfigureAwait(false))
+                        if (await IsRecordClosedAsync(client, entityName, targetId, cancellationToken).ConfigureAwait(false))
                         {
                             _logger?.LogDebug("Skipping already-closed {Entity}/{Id}", entityName, targetId);
                             successCount++; // Count as success - already in desired state
@@ -102,7 +102,7 @@ namespace PPDS.Migration.Import
                                 ["State"] = new OptionSetValue(transition.StateCode),
                                 ["Status"] = new OptionSetValue(transition.StatusCode)
                             };
-                            await client.ExecuteAsync(request).ConfigureAwait(false);
+                            await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -115,7 +115,7 @@ namespace PPDS.Migration.Import
                                     request[kvp.Key] = kvp.Value;
                                 }
                             }
-                            await client.ExecuteAsync(request).ConfigureAwait(false);
+                            await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
                         }
 
                         successCount++;
@@ -167,9 +167,10 @@ namespace PPDS.Migration.Import
         /// <param name="client">The Dataverse client.</param>
         /// <param name="entityName">The entity logical name.</param>
         /// <param name="recordId">The record ID to check.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>True if the record is already closed (statecode != 0), false otherwise.</returns>
         private static async Task<bool> IsRecordClosedAsync(
-            IPooledClient client, string entityName, Guid recordId)
+            IPooledClient client, string entityName, Guid recordId, CancellationToken cancellationToken)
         {
             try
             {
@@ -178,11 +179,11 @@ namespace PPDS.Migration.Import
                     Target = new EntityReference(entityName, recordId),
                     ColumnSet = new ColumnSet("statecode")
                 };
-                var response = (RetrieveResponse)await client.ExecuteAsync(request).ConfigureAwait(false);
+                var response = (RetrieveResponse)await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
                 var stateCode = response.Entity.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
                 return stateCode != 0;
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 return false; // If we cannot check, proceed with the transition
             }

--- a/src/PPDS.Migration/Import/StateTransitionProcessor.cs
+++ b/src/PPDS.Migration/Import/StateTransitionProcessor.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.ServiceModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Import
+{
+    /// <summary>
+    /// Processes Phase 3 of import: applies state/status transitions to records
+    /// that were imported in their default (active) state but need to be set to
+    /// a non-default state (e.g., closed, won, lost, cancelled).
+    /// </summary>
+    public class StateTransitionProcessor : IImportPhaseProcessor
+    {
+        private readonly IDataverseConnectionPool _connectionPool;
+        private readonly ILogger<StateTransitionProcessor>? _logger;
+
+        /// <inheritdoc />
+        public string PhaseName => "State Transitions";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StateTransitionProcessor"/> class.
+        /// </summary>
+        /// <param name="connectionPool">The connection pool.</param>
+        /// <param name="logger">Optional logger.</param>
+        public StateTransitionProcessor(
+            IDataverseConnectionPool connectionPool,
+            ILogger<StateTransitionProcessor>? logger = null)
+        {
+            _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<PhaseResult> ProcessAsync(
+            ImportContext context,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            var transitions = context.StateTransitions;
+            var entityNames = transitions.GetEntityNames();
+            var allTransitions = new List<StateTransitionData>();
+
+            foreach (var entityName in entityNames)
+            {
+                allTransitions.AddRange(transitions.GetTransitions(entityName));
+            }
+
+            if (allTransitions.Count == 0)
+            {
+                _logger?.LogDebug("No state transitions to process -- skipping phase");
+                return PhaseResult.Skipped();
+            }
+
+            var sw = Stopwatch.StartNew();
+            var successCount = 0;
+            var failureCount = 0;
+            var errors = new List<MigrationError>();
+
+            foreach (var transition in allTransitions)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    // Check if the record is already in the target state (AC-16)
+                    if (await IsRecordAlreadyInStateAsync(transition, cancellationToken).ConfigureAwait(false))
+                    {
+                        _logger?.LogDebug(
+                            "Record {EntityName}/{RecordId} already in statecode={StateCode}, skipping transition",
+                            transition.EntityName, transition.RecordId, transition.StateCode);
+                        successCount++;
+                        continue;
+                    }
+
+                    // Apply the transition
+                    if (!string.IsNullOrEmpty(transition.SdkMessage))
+                    {
+                        await ExecuteSdkMessageAsync(transition, cancellationToken).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await ExecuteSetStateAsync(transition, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    successCount++;
+                }
+                catch (Exception ex)
+                {
+                    failureCount++;
+                    errors.Add(new MigrationError
+                    {
+                        EntityLogicalName = transition.EntityName,
+                        RecordId = transition.RecordId,
+                        Message = ex.Message,
+                        Phase = MigrationPhase.ProcessingStateTransitions
+                    });
+
+                    _logger?.LogWarning(ex,
+                        "Failed to apply state transition for {EntityName}/{RecordId}",
+                        transition.EntityName, transition.RecordId);
+
+                    if (!context.Options.ContinueOnError)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            sw.Stop();
+
+            return new PhaseResult
+            {
+                Success = failureCount == 0,
+                RecordsProcessed = successCount + failureCount,
+                SuccessCount = successCount,
+                FailureCount = failureCount,
+                Duration = sw.Elapsed,
+                Errors = errors
+            };
+        }
+
+        /// <summary>
+        /// Checks if a record is already in the target state to avoid double-closing.
+        /// </summary>
+        private async Task<bool> IsRecordAlreadyInStateAsync(
+            StateTransitionData transition,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await using var client = await _connectionPool.GetClientAsync(
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                var retrieved = await client.RetrieveAsync(
+                    transition.EntityName,
+                    transition.RecordId,
+                    new ColumnSet("statecode"),
+                    cancellationToken).ConfigureAwait(false);
+
+                var currentState = retrieved.GetAttributeValue<OptionSetValue>("statecode");
+                return currentState?.Value == transition.StateCode;
+            }
+            catch (FaultException)
+            {
+                // If we can't retrieve the record, proceed with the transition
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Executes a SetStateRequest for the given transition (AC-06).
+        /// </summary>
+        private async Task ExecuteSetStateAsync(
+            StateTransitionData transition,
+            CancellationToken cancellationToken)
+        {
+            var request = new OrganizationRequest("SetState")
+            {
+                ["EntityMoniker"] = new EntityReference(transition.EntityName, transition.RecordId),
+                ["State"] = new OptionSetValue(transition.StateCode),
+                ["Status"] = new OptionSetValue(transition.StatusCode)
+            };
+
+            await _connectionPool.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+
+            _logger?.LogDebug(
+                "Applied SetState for {EntityName}/{RecordId}: state={StateCode}, status={StatusCode}",
+                transition.EntityName, transition.RecordId,
+                transition.StateCode, transition.StatusCode);
+        }
+
+        /// <summary>
+        /// Executes an SDK message for the given transition (e.g., WinOpportunity, LoseOpportunity).
+        /// </summary>
+        private async Task ExecuteSdkMessageAsync(
+            StateTransitionData transition,
+            CancellationToken cancellationToken)
+        {
+            var request = new OrganizationRequest(transition.SdkMessage!);
+
+            if (transition.MessageData != null)
+            {
+                foreach (var kvp in transition.MessageData)
+                {
+                    request[kvp.Key] = kvp.Value;
+                }
+            }
+
+            await _connectionPool.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
+
+            _logger?.LogDebug(
+                "Applied SDK message '{SdkMessage}' for {EntityName}/{RecordId}",
+                transition.SdkMessage, transition.EntityName, transition.RecordId);
+        }
+    }
+}

--- a/src/PPDS.Migration/Import/StateTransitionProcessor.cs
+++ b/src/PPDS.Migration/Import/StateTransitionProcessor.cs
@@ -43,95 +43,112 @@ namespace PPDS.Migration.Import
             ImportContext context,
             CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(context);
-
             var transitions = context.StateTransitions;
-            var entityNames = transitions.GetEntityNames();
-            var allTransitions = new List<StateTransitionData>();
-
-            foreach (var entityName in entityNames)
+            if (transitions.Count == 0)
             {
-                allTransitions.AddRange(transitions.GetTransitions(entityName));
-            }
-
-            if (allTransitions.Count == 0)
-            {
-                _logger?.LogDebug("No state transitions to process -- skipping phase");
+                _logger?.LogInformation("No state transitions to process");
                 return PhaseResult.Skipped();
             }
 
-            // Report initial progress
-            context.Progress?.Report(new ProgressEventArgs
-            {
-                Phase = MigrationPhase.ProcessingStateTransitions,
-                Current = 0,
-                Total = allTransitions.Count,
-                Message = "Processing state transitions"
-            });
-
-            var sw = Stopwatch.StartNew();
+            var stopwatch = Stopwatch.StartNew();
             var successCount = 0;
             var failureCount = 0;
             var errors = new List<MigrationError>();
+            var entityNames = transitions.GetEntityNames().ToList();
+            var totalTransitions = transitions.Count;
+            var processed = 0;
 
-            foreach (var transition in allTransitions)
+            context.Progress?.Report(new ProgressEventArgs
+            {
+                Phase = MigrationPhase.ProcessingStateTransitions,
+                Message = $"Processing {totalTransitions} state transitions across {entityNames.Count} entities..."
+            });
+
+            foreach (var entityName in entityNames)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var entityTransitions = transitions.GetTransitions(entityName);
 
-                // Map source record ID to target environment ID
-                var targetRecordId = transition.RecordId;
-                if (context.IdMappings.TryGetNewId(transition.EntityName, transition.RecordId, out var mappedId))
+                foreach (var transition in entityTransitions)
                 {
-                    targetRecordId = mappedId;
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
+                    processed++;
 
-                try
-                {
-                    // Check if the record is already in the target state (AC-16)
-                    if (await IsRecordAlreadyInStateAsync(transition.EntityName, targetRecordId, cancellationToken).ConfigureAwait(false))
+                    try
                     {
-                        _logger?.LogDebug(
-                            "Record {EntityName}/{RecordId} already in statecode={StateCode}, skipping transition",
-                            transition.EntityName, transition.RecordId, transition.StateCode);
+                        // Resolve mapped record ID
+                        var targetId = transition.RecordId;
+                        if (context.IdMappings.TryGetNewId(entityName, transition.RecordId, out var mappedId))
+                        {
+                            targetId = mappedId;
+                        }
+
+                        await using var client = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                        // Check if record is already closed (AC-16)
+                        if (await IsRecordClosedAsync(client, entityName, targetId).ConfigureAwait(false))
+                        {
+                            _logger?.LogDebug("Skipping already-closed {Entity}/{Id}", entityName, targetId);
+                            successCount++; // Count as success - already in desired state
+                            continue;
+                        }
+
+                        if (transition.SdkMessage == null)
+                        {
+                            // Default path: SetStateRequest (AC-06)
+                            var request = new OrganizationRequest("SetState")
+                            {
+                                ["EntityMoniker"] = new EntityReference(entityName, targetId),
+                                ["State"] = new OptionSetValue(transition.StateCode),
+                                ["Status"] = new OptionSetValue(transition.StatusCode)
+                            };
+                            await client.ExecuteAsync(request).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // Specialized SDK message (AC-07 through AC-15)
+                            var request = new OrganizationRequest(transition.SdkMessage);
+                            if (transition.MessageData != null)
+                            {
+                                foreach (var kvp in transition.MessageData)
+                                {
+                                    request[kvp.Key] = kvp.Value;
+                                }
+                            }
+                            await client.ExecuteAsync(request).ConfigureAwait(false);
+                        }
+
                         successCount++;
-                        continue;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        failureCount++;
+                        _logger?.LogWarning(ex, "State transition failed for {Entity}/{Id}", entityName, transition.RecordId);
+                        errors.Add(new MigrationError
+                        {
+                            Phase = MigrationPhase.ProcessingStateTransitions,
+                            EntityLogicalName = entityName,
+                            RecordId = transition.RecordId,
+                            Message = ex.Message
+                        });
                     }
 
-                    // Apply the transition
-                    if (!string.IsNullOrEmpty(transition.SdkMessage))
+                    if (processed % 50 == 0)
                     {
-                        await ExecuteSdkMessageAsync(transition, targetRecordId, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await ExecuteSetStateAsync(transition, targetRecordId, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    successCount++;
-                }
-                catch (Exception ex)
-                {
-                    failureCount++;
-                    errors.Add(new MigrationError
-                    {
-                        EntityLogicalName = transition.EntityName,
-                        RecordId = transition.RecordId,
-                        Message = ex.Message,
-                        Phase = MigrationPhase.ProcessingStateTransitions
-                    });
-
-                    _logger?.LogWarning(ex,
-                        "Failed to apply state transition for {EntityName}/{RecordId}",
-                        transition.EntityName, transition.RecordId);
-
-                    if (!context.Options.ContinueOnError)
-                    {
-                        break;
+                        context.Progress?.Report(new ProgressEventArgs
+                        {
+                            Phase = MigrationPhase.ProcessingStateTransitions,
+                            Current = processed,
+                            Total = totalTransitions,
+                            Message = $"State transitions: {processed}/{totalTransitions}"
+                        });
                     }
                 }
             }
 
-            sw.Stop();
+            stopwatch.Stop();
+            _logger?.LogInformation("State transitions complete: {Success} succeeded, {Failed} failed in {Duration}",
+                successCount, failureCount, stopwatch.Elapsed);
 
             return new PhaseResult
             {
@@ -139,86 +156,36 @@ namespace PPDS.Migration.Import
                 RecordsProcessed = successCount + failureCount,
                 SuccessCount = successCount,
                 FailureCount = failureCount,
-                Duration = sw.Elapsed,
+                Duration = stopwatch.Elapsed,
                 Errors = errors
             };
         }
 
         /// <summary>
-        /// Checks if a record is already in the target state to avoid double-closing.
+        /// Checks if a record is already in a closed/non-active state.
         /// </summary>
-        private async Task<bool> IsRecordAlreadyInStateAsync(
-            string entityName,
-            Guid recordId,
-            CancellationToken cancellationToken)
+        /// <param name="client">The Dataverse client.</param>
+        /// <param name="entityName">The entity logical name.</param>
+        /// <param name="recordId">The record ID to check.</param>
+        /// <returns>True if the record is already closed (statecode != 0), false otherwise.</returns>
+        private static async Task<bool> IsRecordClosedAsync(
+            IPooledClient client, string entityName, Guid recordId)
         {
             try
             {
-                await using var client = await _connectionPool.GetClientAsync(
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                var retrieved = await client.RetrieveAsync(
-                    entityName,
-                    recordId,
-                    new ColumnSet("statecode"),
-                    cancellationToken).ConfigureAwait(false);
-
-                var currentState = retrieved.GetAttributeValue<OptionSetValue>("statecode");
-                return currentState != null && currentState.Value != 0;
-            }
-            catch (FaultException)
-            {
-                // If we can't retrieve the record, proceed with the transition
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Executes a SetStateRequest for the given transition (AC-06).
-        /// </summary>
-        private async Task ExecuteSetStateAsync(
-            StateTransitionData transition,
-            Guid targetRecordId,
-            CancellationToken cancellationToken)
-        {
-            var request = new OrganizationRequest("SetState")
-            {
-                ["EntityMoniker"] = new EntityReference(transition.EntityName, targetRecordId),
-                ["State"] = new OptionSetValue(transition.StateCode),
-                ["Status"] = new OptionSetValue(transition.StatusCode)
-            };
-
-            await _connectionPool.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
-
-            _logger?.LogDebug(
-                "Applied SetState for {EntityName}/{RecordId}: state={StateCode}, status={StatusCode}",
-                transition.EntityName, transition.RecordId,
-                transition.StateCode, transition.StatusCode);
-        }
-
-        /// <summary>
-        /// Executes an SDK message for the given transition (e.g., WinOpportunity, LoseOpportunity).
-        /// </summary>
-        private async Task ExecuteSdkMessageAsync(
-            StateTransitionData transition,
-            Guid targetRecordId,
-            CancellationToken cancellationToken)
-        {
-            var request = new OrganizationRequest(transition.SdkMessage!);
-
-            if (transition.MessageData != null)
-            {
-                foreach (var kvp in transition.MessageData)
+                var request = new RetrieveRequest
                 {
-                    request[kvp.Key] = kvp.Value;
-                }
+                    Target = new EntityReference(entityName, recordId),
+                    ColumnSet = new ColumnSet("statecode")
+                };
+                var response = (RetrieveResponse)await client.ExecuteAsync(request).ConfigureAwait(false);
+                var stateCode = response.Entity.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+                return stateCode != 0;
             }
-
-            await _connectionPool.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
-
-            _logger?.LogDebug(
-                "Applied SDK message '{SdkMessage}' for {EntityName}/{RecordId}",
-                transition.SdkMessage, transition.EntityName, transition.RecordId);
+            catch
+            {
+                return false; // If we cannot check, proceed with the transition
+            }
         }
     }
 }

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -206,8 +206,17 @@ namespace PPDS.Migration.Import
                     {
                         if (handler.CanHandle(entitySchema.LogicalName))
                         {
-                            await handler.ExecuteAsync(entitySchema.LogicalName, context, cancellationToken)
-                                .ConfigureAwait(false);
+                            try
+                            {
+                                await handler.ExecuteAsync(entitySchema.LogicalName, context, cancellationToken)
+                                    .ConfigureAwait(false);
+                            }
+                            catch (Exception ex) when (ex is not OperationCanceledException)
+                            {
+                                _logger?.LogWarning(ex,
+                                    "Post-import handler {Handler} failed for entity {Entity}",
+                                    handler.GetType().Name, entitySchema.LogicalName);
+                            }
                         }
                     }
                 }
@@ -719,6 +728,23 @@ namespace PPDS.Migration.Import
                     }
                 }
 
+                // Step 2b: Generic state transition collection for entities without handlers
+                if (!_stateTransitionHandlers.Any(h => h.CanHandle(entityName)))
+                {
+                    var sc = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
+                    var stc = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;
+                    if (sc != 0)
+                    {
+                        context.StateTransitions.Add(entityName, record.Id, new StateTransitionData
+                        {
+                            EntityName = entityName,
+                            RecordId = record.Id,
+                            StateCode = sc,
+                            StatusCode = stc
+                        });
+                    }
+                }
+
                 // Step 3: Strip statecode and statuscode from ALL records (AC-05)
                 record.Attributes.Remove("statecode");
                 record.Attributes.Remove("statuscode");
@@ -749,7 +775,7 @@ namespace PPDS.Migration.Import
                     }
                 }
 
-                var prepared = PrepareRecordForImport(transformed, deferredSet, fieldMetadata, idMappings, options);
+                var prepared = PrepareRecordForImport(transformed, deferredSet, fieldMetadata, idMappings, options, effectiveMode);
                 preparedRecords.Add(prepared);
             }
 
@@ -884,19 +910,19 @@ namespace PPDS.Migration.Import
                         case ImportMode.Create:
                             var createRequest = new CreateRequest { Target = record };
                             createRequest.ApplyBypassOptions(options);
-                            var createResponse = (CreateResponse)await client.ExecuteAsync(createRequest).ConfigureAwait(false);
+                            var createResponse = (CreateResponse)await client.ExecuteAsync(createRequest, cancellationToken).ConfigureAwait(false);
                             newId = createResponse.id;
                             break;
                         case ImportMode.Update:
                             var updateRequest = new UpdateRequest { Target = record };
                             updateRequest.ApplyBypassOptions(options);
-                            await client.ExecuteAsync(updateRequest).ConfigureAwait(false);
+                            await client.ExecuteAsync(updateRequest, cancellationToken).ConfigureAwait(false);
                             newId = record.Id;
                             break;
                         default:
                             var upsertRequest = new UpsertRequest { Target = record };
                             upsertRequest.ApplyBypassOptions(options);
-                            var upsertResponse = (UpsertResponse)await client.ExecuteAsync(upsertRequest).ConfigureAwait(false);
+                            var upsertResponse = (UpsertResponse)await client.ExecuteAsync(upsertRequest, cancellationToken).ConfigureAwait(false);
                             newId = upsertResponse.Target?.Id ?? record.Id;
                             break;
                     }
@@ -937,7 +963,8 @@ namespace PPDS.Migration.Import
             HashSet<string> deferredFields,
             IReadOnlyDictionary<string, FieldValidity> fieldMetadata,
             IdMappingCollection idMappings,
-            ImportOptions options)
+            ImportOptions options,
+            ImportMode effectiveMode)
         {
             var prepared = new Entity(record.LogicalName);
             prepared.Id = record.Id; // Keep original ID for mapping
@@ -965,7 +992,7 @@ namespace PPDS.Migration.Import
                 }
 
                 // Skip fields that are not valid for the current operation based on target metadata
-                if (!_schemaValidator.ShouldIncludeField(attr.Key, options.Mode, fieldMetadata, out _))
+                if (!_schemaValidator.ShouldIncludeField(attr.Key, effectiveMode, fieldMetadata, out _))
                 {
                     continue;
                 }

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -716,20 +716,19 @@ namespace PPDS.Migration.Import
                 if (shouldSkip) continue;
 
                 // Step 2: Collect state transitions (before stripping statecode/statuscode)
-                foreach (var handler in _stateTransitionHandlers)
+                // Use first matching handler only — each entity has at most one handler by design.
+                var stateHandler = _stateTransitionHandlers.FirstOrDefault(h => h.CanHandle(entityName));
+                if (stateHandler != null)
                 {
-                    if (handler.CanHandle(entityName))
+                    var transition = stateHandler.GetTransition(record, context);
+                    if (transition != null)
                     {
-                        var transition = handler.GetTransition(record, context);
-                        if (transition != null)
-                        {
-                            context.StateTransitions.Add(entityName, record.Id, transition);
-                        }
+                        context.StateTransitions.Add(entityName, record.Id, transition);
                     }
                 }
 
                 // Step 2b: Generic state transition collection for entities without handlers
-                if (!_stateTransitionHandlers.Any(h => h.CanHandle(entityName)))
+                if (stateHandler == null)
                 {
                     var sc = record.GetAttributeValue<OptionSetValue>("statecode")?.Value ?? 0;
                     var stc = record.GetAttributeValue<OptionSetValue>("statuscode")?.Value ?? -1;

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -15,6 +15,7 @@ using PPDS.Dataverse.Security;
 using PPDS.Migration.Analysis;
 using PPDS.Migration.DependencyInjection;
 using PPDS.Migration.Formats;
+using PPDS.Migration.Import.Handlers;
 using PPDS.Migration.Models;
 using PPDS.Migration.Progress;
 
@@ -35,6 +36,11 @@ namespace PPDS.Migration.Import
         private readonly DeferredFieldProcessor _deferredFieldProcessor;
         private readonly RelationshipProcessor _relationshipProcessor;
         private readonly BulkOperationProber _prober;
+        private readonly IReadOnlyList<IRecordFilter> _recordFilters;
+        private readonly IReadOnlyList<IRecordTransformer> _recordTransformers;
+        private readonly IReadOnlyList<IStateTransitionHandler> _stateTransitionHandlers;
+        private readonly IReadOnlyList<IPostImportHandler> _postImportHandlers;
+        private readonly StateTransitionProcessor? _stateTransitionProcessor;
         private readonly ImportOptions _defaultOptions;
         private readonly IPluginStepManager? _pluginStepManager;
         private readonly ILogger<TieredImporter>? _logger;
@@ -62,6 +68,10 @@ namespace PPDS.Migration.Import
             _deferredFieldProcessor = deferredFieldProcessor ?? throw new ArgumentNullException(nameof(deferredFieldProcessor));
             _relationshipProcessor = relationshipProcessor ?? throw new ArgumentNullException(nameof(relationshipProcessor));
             _prober = prober ?? throw new ArgumentNullException(nameof(prober));
+            _recordFilters = Array.Empty<IRecordFilter>();
+            _recordTransformers = Array.Empty<IRecordTransformer>();
+            _stateTransitionHandlers = Array.Empty<IStateTransitionHandler>();
+            _postImportHandlers = Array.Empty<IPostImportHandler>();
             _defaultOptions = new ImportOptions();
         }
 
@@ -78,12 +88,22 @@ namespace PPDS.Migration.Import
             DeferredFieldProcessor deferredFieldProcessor,
             RelationshipProcessor relationshipProcessor,
             BulkOperationProber prober,
+            IEnumerable<IRecordFilter>? recordFilters = null,
+            IEnumerable<IRecordTransformer>? recordTransformers = null,
+            IEnumerable<IStateTransitionHandler>? stateTransitionHandlers = null,
+            IEnumerable<IPostImportHandler>? postImportHandlers = null,
+            StateTransitionProcessor? stateTransitionProcessor = null,
             IOptions<MigrationOptions>? migrationOptions = null,
             IPluginStepManager? pluginStepManager = null,
             ILogger<TieredImporter>? logger = null)
             : this(connectionPool, bulkExecutor, dataReader, graphBuilder, planBuilder,
                    schemaValidator, deferredFieldProcessor, relationshipProcessor, prober)
         {
+            _recordFilters = recordFilters?.ToList() ?? (IReadOnlyList<IRecordFilter>)Array.Empty<IRecordFilter>();
+            _recordTransformers = recordTransformers?.ToList() ?? (IReadOnlyList<IRecordTransformer>)Array.Empty<IRecordTransformer>();
+            _stateTransitionHandlers = stateTransitionHandlers?.ToList() ?? (IReadOnlyList<IStateTransitionHandler>)Array.Empty<IStateTransitionHandler>();
+            _postImportHandlers = postImportHandlers?.ToList() ?? (IReadOnlyList<IPostImportHandler>)Array.Empty<IPostImportHandler>();
+            _stateTransitionProcessor = stateTransitionProcessor;
             _defaultOptions = migrationOptions?.Value.Import ?? new ImportOptions();
             _pluginStepManager = pluginStepManager;
             _logger = logger;
@@ -166,21 +186,47 @@ namespace PPDS.Migration.Import
                     .ConfigureAwait(false);
                 var phase2Duration = deferredResult.Duration;
 
-                // Phase 3: Process M2M relationships
+                // Phase 3: Process state transitions
+                PhaseResult stateTransitionResult;
+                if (_stateTransitionProcessor != null)
+                {
+                    context.OutputManager?.LogProgress("Starting state transitions phase");
+                    stateTransitionResult = await _stateTransitionProcessor.ProcessAsync(context, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    stateTransitionResult = PhaseResult.Skipped();
+                }
+
+                // Run post-import handlers after state transitions
+                foreach (var handler in _postImportHandlers)
+                {
+                    foreach (var entitySchema in data.Schema.Entities)
+                    {
+                        if (handler.CanHandle(entitySchema.LogicalName))
+                        {
+                            await handler.ExecuteAsync(entitySchema.LogicalName, context, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                }
+
+                // Phase 4: Process M2M relationships
                 context.OutputManager?.LogProgress("Starting M2M relationships phase");
                 var relationshipResult = await _relationshipProcessor.ProcessAsync(context, cancellationToken)
                     .ConfigureAwait(false);
-                var phase3Duration = relationshipResult.Duration;
+                var phase4Duration = relationshipResult.Duration;
 
                 stopwatch.Stop();
 
-                _logger?.LogInformation("Import complete: {Records} imported, {Deferred} deferred, {M2M} relationships in {Duration}",
-                    totalImported, deferredResult.SuccessCount, relationshipResult.SuccessCount, stopwatch.Elapsed);
+                _logger?.LogInformation("Import complete: {Records} imported, {Deferred} deferred, {Transitions} transitions, {M2M} relationships in {Duration}",
+                    totalImported, deferredResult.SuccessCount, stateTransitionResult.SuccessCount, relationshipResult.SuccessCount, stopwatch.Elapsed);
 
                 return BuildImportResult(
                     plan, entityResults, errors, warnings,
                     totalImported, data.TotalRecordCount, deferredResult, relationshipResult,
-                    stopwatch.Elapsed, phase1Duration, phase2Duration, phase3Duration,
+                    stopwatch.Elapsed, phase1Duration, phase2Duration, phase4Duration,
                     options, progress);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -391,6 +437,18 @@ namespace PPDS.Migration.Import
                             return;
                         }
 
+                        // Check per-entity import mode override (AC-37, AC-38)
+                        var entitySchema = context.Data.Schema.Entities
+                            .FirstOrDefault(e => e.LogicalName.Equals(entityName, StringComparison.OrdinalIgnoreCase));
+                        if (entitySchema?.ImportMode == ImportMode.Skip)
+                        {
+                            _logger?.LogInformation("Skipping entity {Entity} (ImportMode=Skip)", entityName);
+                            return;
+                        }
+
+                        // Determine effective import mode for this entity
+                        var effectiveMode = entitySchema?.ImportMode ?? context.Options.Mode;
+
                         context.Plan.DeferredFields.TryGetValue(entityName, out var deferredFields);
                         var entityFieldMetadata = context.TargetFieldMetadata.GetFieldsForEntity(entityName);
 
@@ -400,9 +458,8 @@ namespace PPDS.Migration.Import
                             tier.TierNumber,
                             deferredFields,
                             entityFieldMetadata,
-                            context.IdMappings,
-                            context.Options,
-                            context.Progress,
+                            context,
+                            effectiveMode,
                             warnings,
                             ct).ConfigureAwait(false);
 
@@ -597,9 +654,8 @@ namespace PPDS.Migration.Import
             int tierNumber,
             IReadOnlyList<string>? deferredFields,
             IReadOnlyDictionary<string, FieldValidity> fieldMetadata,
-            IdMappingCollection idMappings,
-            ImportOptions options,
-            IProgressReporter? progress,
+            ImportContext context,
+            ImportMode effectiveMode,
             IWarningCollector warnings,
             CancellationToken cancellationToken)
         {
@@ -608,13 +664,92 @@ namespace PPDS.Migration.Import
                 ? new HashSet<string>(deferredFields, StringComparer.OrdinalIgnoreCase)
                 : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            var options = context.Options;
+            var idMappings = context.IdMappings;
+            var progress = context.Progress;
+
             _logger?.LogDebug("Importing {Count} records for {Entity}", records.Count, entityName);
 
-            // Prepare records: remap lookups, null deferred fields, and filter based on operation validity
+            // Compute elapsed time for date shifting
+            var elapsed = context.Data.ExportedAt != default
+                ? DateTime.UtcNow - context.Data.ExportedAt
+                : TimeSpan.Zero;
+
+            // Look up field schemas for date mode
+            var entitySchema = context.Data.Schema.Entities
+                .FirstOrDefault(e => e.LogicalName.Equals(entityName, StringComparison.OrdinalIgnoreCase));
+            var dateFieldModes = new Dictionary<string, DateMode>(StringComparer.OrdinalIgnoreCase);
+            if (entitySchema != null)
+            {
+                foreach (var field in entitySchema.Fields)
+                {
+                    if (field.DateMode != DateMode.Absolute)
+                    {
+                        dateFieldModes[field.LogicalName] = field.DateMode;
+                    }
+                }
+            }
+
+            // Prepare records: apply handlers, remap lookups, null deferred fields, filter
             var preparedRecords = new List<Entity>();
             foreach (var record in records)
             {
-                var prepared = PrepareRecordForImport(record, deferredSet, fieldMetadata, idMappings, options);
+                // Step 1: Apply record filters
+                var shouldSkip = false;
+                foreach (var filter in _recordFilters)
+                {
+                    if (filter.CanHandle(entityName) && filter.ShouldSkip(record, context))
+                    {
+                        shouldSkip = true;
+                        break;
+                    }
+                }
+                if (shouldSkip) continue;
+
+                // Step 2: Collect state transitions (before stripping statecode/statuscode)
+                foreach (var handler in _stateTransitionHandlers)
+                {
+                    if (handler.CanHandle(entityName))
+                    {
+                        var transition = handler.GetTransition(record, context);
+                        if (transition != null)
+                        {
+                            context.StateTransitions.Add(entityName, record.Id, transition);
+                        }
+                    }
+                }
+
+                // Step 3: Strip statecode and statuscode from ALL records (AC-05)
+                record.Attributes.Remove("statecode");
+                record.Attributes.Remove("statuscode");
+
+                // Step 4: Apply record transformers
+                var transformed = record;
+                foreach (var transformer in _recordTransformers)
+                {
+                    if (transformer.CanHandle(entityName))
+                    {
+                        transformed = transformer.Transform(transformed, context);
+                    }
+                }
+
+                // Step 5: Apply date shifting for non-absolute DateMode fields
+                if (elapsed != TimeSpan.Zero && dateFieldModes.Count > 0)
+                {
+                    foreach (var (fieldName, mode) in dateFieldModes)
+                    {
+                        if (transformed.Contains(fieldName) && transformed[fieldName] is DateTime dtValue)
+                        {
+                            var shifted = DateShifter.Shift(dtValue, mode, elapsed);
+                            if (shifted.HasValue)
+                            {
+                                transformed[fieldName] = shifted.Value;
+                            }
+                        }
+                    }
+                }
+
+                var prepared = PrepareRecordForImport(transformed, deferredSet, fieldMetadata, idMappings, options);
                 preparedRecords.Add(prepared);
             }
 
@@ -651,7 +786,7 @@ namespace PPDS.Migration.Import
                 // Track if we fell back to individual operations (for warning emission)
                 var wasKnownBulkNotSupported = _prober.IsKnownBulkNotSupported(entityName);
 
-                var operationType = options.Mode switch
+                var operationType = effectiveMode switch
                 {
                     ImportMode.Create => BulkOperationType.Create,
                     ImportMode.Update => BulkOperationType.Update,
@@ -663,7 +798,7 @@ namespace PPDS.Migration.Import
                     preparedRecords,
                     operationType,
                     bulkOptions,
-                    async (_, recs) => await ExecuteIndividualOperationsAsync(entityName, recs.ToList(), options, cancellationToken).ConfigureAwait(false),
+                    async (_, recs) => await ExecuteIndividualOperationsAsync(entityName, recs.ToList(), effectiveMode, options, cancellationToken).ConfigureAwait(false),
                     progressAdapter,
                     cancellationToken).ConfigureAwait(false);
 
@@ -685,7 +820,7 @@ namespace PPDS.Migration.Import
             else
             {
                 // UseBulkApis is false - use individual operations directly
-                bulkResult = await ExecuteIndividualOperationsAsync(entityName, preparedRecords, options, cancellationToken).ConfigureAwait(false);
+                bulkResult = await ExecuteIndividualOperationsAsync(entityName, preparedRecords, effectiveMode, options, cancellationToken).ConfigureAwait(false);
             }
 
             // Track ID mappings - for bulk operations, IDs are preserved from Entity.Id
@@ -727,6 +862,7 @@ namespace PPDS.Migration.Import
         private async Task<BulkOperationResult> ExecuteIndividualOperationsAsync(
             string entityName,
             List<Entity> records,
+            ImportMode effectiveMode,
             ImportOptions options,
             CancellationToken cancellationToken)
         {
@@ -743,7 +879,7 @@ namespace PPDS.Migration.Import
                 try
                 {
                     Guid newId;
-                    switch (options.Mode)
+                    switch (effectiveMode)
                     {
                         case ImportMode.Create:
                             var createRequest = new CreateRequest { Target = record };

--- a/src/PPDS.Migration/Models/DateMode.cs
+++ b/src/PPDS.Migration/Models/DateMode.cs
@@ -1,0 +1,20 @@
+namespace PPDS.Migration.Models
+{
+    /// <summary>
+    /// Determines how date/time fields are adjusted during import.
+    /// </summary>
+    public enum DateMode
+    {
+        /// <summary>Import the original date/time value unchanged.</summary>
+        Absolute,
+
+        /// <summary>Shift by whole weeks (round elapsed to nearest 7-day period).</summary>
+        Relative,
+
+        /// <summary>Shift by whole days (round elapsed to nearest day).</summary>
+        RelativeDaily,
+
+        /// <summary>Shift by the exact elapsed time.</summary>
+        RelativeExact
+    }
+}

--- a/src/PPDS.Migration/Models/EntitySchema.cs
+++ b/src/PPDS.Migration/Models/EntitySchema.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PPDS.Migration.Import;
 
 namespace PPDS.Migration.Models
 {
@@ -47,6 +48,12 @@ namespace PPDS.Migration.Models
         /// Gets or sets the relationship definitions.
         /// </summary>
         public IReadOnlyList<RelationshipSchema> Relationships { get; set; } = Array.Empty<RelationshipSchema>();
+
+        /// <summary>
+        /// Gets or sets the per-entity import mode override.
+        /// When null, the global <see cref="ImportOptions.Mode"/> is used.
+        /// </summary>
+        public ImportMode? ImportMode { get; set; }
 
         /// <summary>
         /// Gets or sets the FetchXML filter for export (optional).

--- a/src/PPDS.Migration/Models/FieldSchema.cs
+++ b/src/PPDS.Migration/Models/FieldSchema.cs
@@ -65,6 +65,11 @@ namespace PPDS.Migration.Models
         public int? Precision { get; set; }
 
         /// <summary>
+        /// Gets or sets the date shifting mode for date/time fields.
+        /// </summary>
+        public DateMode DateMode { get; set; } = DateMode.Absolute;
+
+        /// <summary>
         /// Gets whether this field is a lookup type.
         /// </summary>
         public bool IsLookup => Type.Equals("entityreference", StringComparison.OrdinalIgnoreCase) ||

--- a/src/PPDS.Migration/Progress/MigrationPhase.cs
+++ b/src/PPDS.Migration/Progress/MigrationPhase.cs
@@ -17,6 +17,9 @@ namespace PPDS.Migration.Progress
         /// <summary>Processing deferred lookup fields.</summary>
         ProcessingDeferredFields,
 
+        /// <summary>Processing state/status transitions on imported records.</summary>
+        ProcessingStateTransitions,
+
         /// <summary>Processing many-to-many relationships.</summary>
         ProcessingRelationships,
 

--- a/tests/PPDS.Cli.Tests/Tui/Screens/ExecutionPlanPreviewDialogStateTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Screens/ExecutionPlanPreviewDialogStateTests.cs
@@ -1,0 +1,51 @@
+using PPDS.Cli.Tui.Testing.States;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Tui.Screens;
+
+[Trait("Category", "TuiUnit")]
+public sealed class ExecutionPlanPreviewDialogStateTests
+{
+    [Fact]
+    public void CapturesPlanSummary()
+    {
+        var state = new ExecutionPlanPreviewDialogState(
+            TierCount: 3,
+            EntityCount: 8,
+            DeferredFieldCount: 2,
+            StateTransitionCount: 5,
+            ManyToManyRelationshipCount: 1,
+            IsApproved: false);
+
+        Assert.Equal(3, state.TierCount);
+        Assert.Equal(8, state.EntityCount);
+        Assert.Equal(2, state.DeferredFieldCount);
+        Assert.Equal(5, state.StateTransitionCount);
+        Assert.Equal(1, state.ManyToManyRelationshipCount);
+        Assert.False(state.IsApproved);
+    }
+
+    [Fact]
+    public void CapturesApprovedState()
+    {
+        var state = new ExecutionPlanPreviewDialogState(
+            TierCount: 1,
+            EntityCount: 2,
+            DeferredFieldCount: 0,
+            StateTransitionCount: 0,
+            ManyToManyRelationshipCount: 0,
+            IsApproved: true);
+
+        Assert.True(state.IsApproved);
+        Assert.Equal(1, state.TierCount);
+    }
+
+    [Fact]
+    public void RecordEquality()
+    {
+        var state1 = new ExecutionPlanPreviewDialogState(3, 8, 2, 5, 1, false);
+        var state2 = new ExecutionPlanPreviewDialogState(3, 8, 2, 5, 1, false);
+
+        Assert.Equal(state1, state2);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Tui/Screens/MigrationScreenStateTests.cs
+++ b/tests/PPDS.Cli.Tests/Tui/Screens/MigrationScreenStateTests.cs
@@ -1,0 +1,127 @@
+using PPDS.Cli.Tui.Testing.States;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Tui.Screens;
+
+[Trait("Category", "TuiUnit")]
+public sealed class MigrationScreenStateTests
+{
+    [Fact]
+    public void CapturesExportModeDefaults()
+    {
+        var state = new MigrationScreenState(
+            Mode: "Export",
+            OperationState: "Idle",
+            SchemaPath: null,
+            OutputPath: null,
+            DataPath: null,
+            CurrentPhase: null,
+            CurrentEntity: null,
+            RecordCount: 0,
+            SuccessCount: 0,
+            FailureCount: 0,
+            WarningCount: 0,
+            SkipCount: 0,
+            RecordsPerSecond: null,
+            EstimatedRemaining: null,
+            Elapsed: null,
+            ErrorMessage: null,
+            IsLoading: false,
+            StatusMessage: null);
+
+        Assert.Equal("Export", state.Mode);
+        Assert.Equal("Idle", state.OperationState);
+        Assert.False(state.IsLoading);
+        Assert.Equal(0, state.RecordCount);
+    }
+
+    [Fact]
+    public void CapturesImportModeRunningState()
+    {
+        var state = new MigrationScreenState(
+            Mode: "Import",
+            OperationState: "Running",
+            SchemaPath: null,
+            OutputPath: null,
+            DataPath: "/path/to/data.zip",
+            CurrentPhase: "Importing records...",
+            CurrentEntity: "account",
+            RecordCount: 150,
+            SuccessCount: 145,
+            FailureCount: 5,
+            WarningCount: 2,
+            SkipCount: 0,
+            RecordsPerSecond: 42.5,
+            EstimatedRemaining: "1m 30s",
+            Elapsed: "2m 15s",
+            ErrorMessage: null,
+            IsLoading: true,
+            StatusMessage: "Import in progress...");
+
+        Assert.Equal("Import", state.Mode);
+        Assert.Equal("Running", state.OperationState);
+        Assert.True(state.IsLoading);
+        Assert.Equal(150, state.RecordCount);
+        Assert.Equal(145, state.SuccessCount);
+        Assert.Equal(5, state.FailureCount);
+        Assert.Equal(42.5, state.RecordsPerSecond);
+        Assert.Equal("/path/to/data.zip", state.DataPath);
+    }
+
+    [Fact]
+    public void CapturesCompletedState()
+    {
+        var state = new MigrationScreenState(
+            Mode: "Export",
+            OperationState: "Completed",
+            SchemaPath: "/schema.xml",
+            OutputPath: "/output.zip",
+            DataPath: null,
+            CurrentPhase: "Complete",
+            CurrentEntity: null,
+            RecordCount: 500,
+            SuccessCount: 500,
+            FailureCount: 0,
+            WarningCount: 0,
+            SkipCount: 0,
+            RecordsPerSecond: 100.0,
+            EstimatedRemaining: null,
+            Elapsed: "5s",
+            ErrorMessage: null,
+            IsLoading: false,
+            StatusMessage: "Export completed successfully in 5s.");
+
+        Assert.Equal("Completed", state.OperationState);
+        Assert.False(state.IsLoading);
+        Assert.Equal(500, state.SuccessCount);
+        Assert.Null(state.ErrorMessage);
+    }
+
+    [Fact]
+    public void CapturesFailedState()
+    {
+        var state = new MigrationScreenState(
+            Mode: "Import",
+            OperationState: "Failed",
+            SchemaPath: null,
+            OutputPath: null,
+            DataPath: "/data.zip",
+            CurrentPhase: "Error",
+            CurrentEntity: null,
+            RecordCount: 50,
+            SuccessCount: 45,
+            FailureCount: 5,
+            WarningCount: 0,
+            SkipCount: 0,
+            RecordsPerSecond: null,
+            EstimatedRemaining: null,
+            Elapsed: "10s",
+            ErrorMessage: "Connection lost",
+            IsLoading: false,
+            StatusMessage: "Import failed: Connection lost");
+
+        Assert.Equal("Failed", state.OperationState);
+        Assert.Equal("Connection lost", state.ErrorMessage);
+        Assert.False(state.IsLoading);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/DateShifterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/DateShifterTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using PPDS.Migration.Import;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class DateShifterTests
+{
+    private static readonly DateTime BaseDate = new(2025, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void AbsolutePreservesOriginalDate()
+    {
+        // AC-29: Absolute mode returns the original value unchanged
+        var elapsed = TimeSpan.FromDays(30);
+
+        var result = DateShifter.Shift(BaseDate, DateMode.Absolute, elapsed);
+
+        result.Should().Be(BaseDate);
+    }
+
+    [Fact]
+    public void RelativeShiftsByWeeks()
+    {
+        // AC-30: Relative mode rounds elapsed to nearest 7-day period
+        // 10 days rounds to 1 week (7 days)
+        var elapsed = TimeSpan.FromDays(10);
+
+        var result = DateShifter.Shift(BaseDate, DateMode.Relative, elapsed);
+
+        result.Should().Be(BaseDate.AddDays(7));
+    }
+
+    [Fact]
+    public void RelativeDailyShiftsByDays()
+    {
+        // AC-31: RelativeDaily mode rounds elapsed to nearest whole day
+        // 2.5 days rounds to 2 days (Math.Round with banker's rounding: 2.5 -> 2)
+        var elapsed = TimeSpan.FromDays(2.5);
+
+        var result = DateShifter.Shift(BaseDate, DateMode.RelativeDaily, elapsed);
+
+        result.Should().Be(BaseDate.AddDays(2));
+    }
+
+    [Fact]
+    public void RelativeExactShiftsByExactTime()
+    {
+        // AC-32: RelativeExact mode shifts by the exact elapsed time
+        var elapsed = TimeSpan.FromHours(36.5);
+
+        var result = DateShifter.Shift(BaseDate, DateMode.RelativeExact, elapsed);
+
+        result.Should().Be(BaseDate.Add(elapsed));
+    }
+
+    [Fact]
+    public void NullValueReturnsNull()
+    {
+        var result = DateShifter.Shift(null, DateMode.Relative, TimeSpan.FromDays(10));
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/EntityReferenceMapperTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/EntityReferenceMapperTests.cs
@@ -59,7 +59,7 @@ public class EntityReferenceMapperTests
     {
         var sourceId = Guid.NewGuid();
 
-        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RetrieveResponse());
 
         var sut = CreateSut();
@@ -74,12 +74,12 @@ public class EntityReferenceMapperTests
         var sourceId = Guid.NewGuid();
         var targetId = Guid.NewGuid();
 
-        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Record not found"));
 
         var results = new EntityCollection();
         results.Entities.Add(new Entity("transactioncurrency", targetId));
-        _client.Setup(c => c.RetrieveMultipleAsync(It.IsAny<QueryExpression>()))
+        _client.Setup(c => c.RetrieveMultipleAsync(It.IsAny<QueryExpression>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(results);
 
         var sut = CreateSut();
@@ -93,7 +93,7 @@ public class EntityReferenceMapperTests
     {
         var sourceId = Guid.NewGuid();
 
-        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RetrieveResponse());
 
         var sut = CreateSut();

--- a/tests/PPDS.Migration.Tests/Import/EntityReferenceMapperTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/EntityReferenceMapperTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Import;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class EntityReferenceMapperTests
+{
+    private readonly Mock<IDataverseConnectionPool> _pool;
+    private readonly Mock<IPooledClient> _client;
+    private readonly IdMappingCollection _idMappings;
+    private readonly ImportOptions _options;
+
+    public EntityReferenceMapperTests()
+    {
+        _pool = new Mock<IDataverseConnectionPool>();
+        _client = new Mock<IPooledClient>();
+        _idMappings = new IdMappingCollection();
+        _options = new ImportOptions { ResolveExternalLookups = true, SkipUnresolvedLookups = true };
+
+        _pool.Setup(p => p.GetClientAsync(
+                It.IsAny<Dataverse.Client.DataverseClientOptions?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+    }
+
+    private EntityReferenceMapper CreateSut() =>
+        new(_idMappings, _pool.Object, _options);
+
+    [Fact]
+    public async Task ResolvesFromIdMappingFirst()
+    {
+        var sourceId = Guid.NewGuid();
+        var mappedId = Guid.NewGuid();
+        _idMappings.AddMapping("account", sourceId, mappedId);
+
+        var sut = CreateSut();
+        var result = await sut.ResolveAsync("account", sourceId, CancellationToken.None);
+
+        result.Should().Be(mappedId);
+        _pool.Verify(
+            p => p.GetClientAsync(It.IsAny<Dataverse.Client.DataverseClientOptions?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FallsBackToDirectIdCheck()
+    {
+        var sourceId = Guid.NewGuid();
+
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+            .ReturnsAsync(new RetrieveResponse());
+
+        var sut = CreateSut();
+        var result = await sut.ResolveAsync("account", sourceId, CancellationToken.None);
+
+        result.Should().Be(sourceId);
+    }
+
+    [Fact]
+    public async Task FallsBackToNameBasedQuery()
+    {
+        var sourceId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+            .ThrowsAsync(new Exception("Record not found"));
+
+        var results = new EntityCollection();
+        results.Entities.Add(new Entity("transactioncurrency", targetId));
+        _client.Setup(c => c.RetrieveMultipleAsync(It.IsAny<QueryExpression>()))
+            .ReturnsAsync(results);
+
+        var sut = CreateSut();
+        var result = await sut.ResolveWithNameAsync("transactioncurrency", sourceId, "USD", CancellationToken.None);
+
+        result.Should().Be(targetId);
+    }
+
+    [Fact]
+    public async Task CachesResolvedLookups()
+    {
+        var sourceId = Guid.NewGuid();
+
+        _client.Setup(c => c.ExecuteAsync(It.Is<OrganizationRequest>(r => r is RetrieveRequest)))
+            .ReturnsAsync(new RetrieveResponse());
+
+        var sut = CreateSut();
+        var result1 = await sut.ResolveAsync("account", sourceId, CancellationToken.None);
+        var result2 = await sut.ResolveAsync("account", sourceId, CancellationToken.None);
+
+        result1.Should().Be(sourceId);
+        result2.Should().Be(sourceId);
+        _pool.Verify(
+            p => p.GetClientAsync(It.IsAny<Dataverse.Client.DataverseClientOptions?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void MatchesCurrencyByIsoCode()
+    {
+        var matchField = EntityReferenceMapper.GetMatchField("transactioncurrency");
+        matchField.Should().Be("isocurrencycode");
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/FileColumnTransferHelperTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/FileColumnTransferHelperTests.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Import;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class FileColumnTransferHelperTests
+{
+    private const int FourMB = 4_194_304;
+
+    private readonly Mock<IDataverseConnectionPool> _pool;
+    private readonly Mock<IPooledClient> _client;
+    private readonly FileColumnTransferHelper _sut;
+
+    public FileColumnTransferHelperTests()
+    {
+        _pool = new Mock<IDataverseConnectionPool>();
+        _client = new Mock<IPooledClient>();
+
+        _pool.Setup(p => p.GetClientAsync(
+                It.IsAny<Dataverse.Client.DataverseClientOptions?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+
+        _sut = new FileColumnTransferHelper(_pool.Object);
+    }
+
+    #region UploadAsync - chunked upload (AC-35)
+
+    [Fact]
+    public async Task UploadsInFourMegabyteChunks()
+    {
+        // Arrange: 10MB data -> expect 3 UploadBlock calls (4MB + 4MB + 2MB)
+        var tenMB = 10 * 1024 * 1024; // 10,485,760 bytes
+        var data = new byte[tenMB];
+        new Random(42).NextBytes(data);
+
+        var recordId = Guid.NewGuid();
+        const string continuationToken = "test-continuation-token";
+
+        // Mock InitializeFileBlocksUpload
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "InitializeFileBlocksUpload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var response = new OrganizationResponse();
+                response["FileContinuationToken"] = continuationToken;
+                return response;
+            });
+
+        // Track UploadBlock calls
+        var uploadCalls = new List<(byte[] BlockData, string BlockId)>();
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "UploadBlock"),
+                It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                var blockData = (byte[])req["BlockData"];
+                var blockId = (string)req["BlockId"];
+                var copy = new byte[blockData.Length];
+                Array.Copy(blockData, copy, blockData.Length);
+                uploadCalls.Add((copy, blockId));
+            })
+            .ReturnsAsync(new OrganizationResponse());
+
+        // Mock CommitFileBlocksUpload
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "CommitFileBlocksUpload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrganizationResponse());
+
+        // Act
+        await _sut.UploadAsync("account", recordId, "myfilecolumn",
+            data, "report.pdf", "application/pdf", CancellationToken.None);
+
+        // Assert: exactly 3 UploadBlock calls
+        uploadCalls.Should().HaveCount(3);
+
+        // First chunk: 4MB
+        uploadCalls[0].BlockData.Should().HaveCount(FourMB);
+        // Second chunk: 4MB
+        uploadCalls[1].BlockData.Should().HaveCount(FourMB);
+        // Third chunk: remainder (10MB - 8MB = 2,097,152 bytes)
+        uploadCalls[2].BlockData.Should().HaveCount(tenMB - 2 * FourMB);
+
+        // Verify init was called with correct parameters
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r =>
+                r.RequestName == "InitializeFileBlocksUpload"
+                && ((EntityReference)r["Target"]).LogicalName == "account"
+                && ((EntityReference)r["Target"]).Id == recordId
+                && (string)r["FileAttributeName"] == "myfilecolumn"
+                && (string)r["FileName"] == "report.pdf"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify commit was called with correct parameters
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r =>
+                r.RequestName == "CommitFileBlocksUpload"
+                && (string)r["FileName"] == "report.pdf"
+                && (string)r["MimeType"] == "application/pdf"
+                && (string)r["FileContinuationToken"] == continuationToken
+                && ((string[])r["BlockIds"]).Length == 3),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify the uploaded data matches the original
+        var reassembled = uploadCalls.SelectMany(c => c.BlockData).ToArray();
+        reassembled.Should().Equal(data);
+    }
+
+    #endregion
+
+    #region DownloadAsync - chunked download
+
+    [Fact]
+    public async Task DownloadReturnsCompleteData()
+    {
+        // Arrange: simulate a 6MB file downloaded in 2 chunks (4MB + 2MB)
+        var totalSize = 6 * 1024 * 1024L; // 6,291,456 bytes
+        var fullData = new byte[totalSize];
+        new Random(99).NextBytes(fullData);
+
+        var chunk1 = new byte[FourMB];
+        Array.Copy(fullData, 0, chunk1, 0, FourMB);
+        var chunk2 = new byte[totalSize - FourMB];
+        Array.Copy(fullData, FourMB, chunk2, 0, (int)(totalSize - FourMB));
+
+        var recordId = Guid.NewGuid();
+        const string continuationToken = "download-token";
+
+        // Mock InitializeFileBlocksDownload
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "InitializeFileBlocksDownload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var response = new OrganizationResponse();
+                response["FileContinuationToken"] = continuationToken;
+                response["FileSizeInBytes"] = totalSize;
+                return response;
+            });
+
+        // Mock DownloadBlock - return appropriate chunk based on offset
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r =>
+                    r.RequestName == "DownloadBlock"
+                    && (long)r["Offset"] == 0L),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var response = new OrganizationResponse();
+                response["Data"] = chunk1;
+                return response;
+            });
+
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r =>
+                    r.RequestName == "DownloadBlock"
+                    && (long)r["Offset"] == (long)FourMB),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var response = new OrganizationResponse();
+                response["Data"] = chunk2;
+                return response;
+            });
+
+        // Act
+        var result = await _sut.DownloadAsync("account", recordId, "myfilecolumn",
+            CancellationToken.None);
+
+        // Assert: concatenated result matches original data
+        result.Should().Equal(fullData);
+        result.Should().HaveCount((int)totalSize);
+
+        // Verify init was called correctly
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r =>
+                r.RequestName == "InitializeFileBlocksDownload"
+                && ((EntityReference)r["Target"]).LogicalName == "account"
+                && ((EntityReference)r["Target"]).Id == recordId
+                && (string)r["FileAttributeName"] == "myfilecolumn"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify two download block requests
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r => r.RequestName == "DownloadBlock"),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    #endregion
+
+    #region UploadAsync - small file single chunk
+
+    [Fact]
+    public async Task SmallFileUploadsInSingleChunk()
+    {
+        // Arrange: 1MB data -> expect single UploadBlock call
+        var oneMB = 1 * 1024 * 1024;
+        var data = new byte[oneMB];
+        new Random(7).NextBytes(data);
+
+        var recordId = Guid.NewGuid();
+        const string continuationToken = "small-file-token";
+
+        // Mock InitializeFileBlocksUpload
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "InitializeFileBlocksUpload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var response = new OrganizationResponse();
+                response["FileContinuationToken"] = continuationToken;
+                return response;
+            });
+
+        // Mock UploadBlock
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "UploadBlock"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrganizationResponse());
+
+        // Mock CommitFileBlocksUpload
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "CommitFileBlocksUpload"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrganizationResponse());
+
+        // Act
+        await _sut.UploadAsync("contact", recordId, "attachmentfield",
+            data, "small.txt", "text/plain", CancellationToken.None);
+
+        // Assert: exactly 1 UploadBlock call
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r => r.RequestName == "UploadBlock"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify the single block contains the full data
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r =>
+                r.RequestName == "UploadBlock"
+                && ((byte[])r["BlockData"]).Length == oneMB),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify commit was called with single block ID
+        _client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r =>
+                r.RequestName == "CommitFileBlocksUpload"
+                && ((string[])r["BlockIds"]).Length == 1),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Constructor
+
+    [Fact]
+    public void Constructor_ThrowsArgumentNullException_WhenConnectionPoolIsNull()
+    {
+        var act = () => new FileColumnTransferHelper(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("connectionPool");
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/ActivityPointerHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/ActivityPointerHandlerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class ActivityPointerHandlerTests
+{
+    private readonly ActivityPointerHandler _handler = new();
+
+    private static ImportContext CreateContext() =>
+        new(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+
+    [Fact]
+    public void CanHandleReturnsTrueForActivityPointer()
+    {
+        _handler.CanHandle("activitypointer").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandleReturnsFalseForEmail()
+    {
+        _handler.CanHandle("email").Should().BeFalse();
+    }
+
+    [Fact]
+    public void SkipsBaseTypeRecords()
+    {
+        // AC-19: Always skip activitypointer base type
+        var record = new Entity("activitypointer") { Id = Guid.NewGuid() };
+        var context = CreateContext();
+
+        _handler.ShouldSkip(record, context).Should().BeTrue();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/BusinessUnitHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/BusinessUnitHandlerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class BusinessUnitHandlerTests
+{
+    private readonly BusinessUnitHandler _handler = new();
+
+    private static ImportContext CreateContext(Guid? targetRootBuId = null)
+    {
+        var context = new ImportContext(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+        context.TargetRootBusinessUnitId = targetRootBuId;
+        return context;
+    }
+
+    [Fact]
+    public void CanHandle_ReturnsTrueForBusinessUnit()
+    {
+        _handler.CanHandle("businessunit").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_ReturnsFalseForOtherEntity()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MapsRootBusinessUnit()
+    {
+        // AC-18: Root BU (no parentbusinessunitid) gets ID remapped to target root BU
+        var sourceRootId = Guid.NewGuid();
+        var targetRootId = Guid.NewGuid();
+        var record = new Entity("businessunit") { Id = sourceRootId };
+        record["businessunitid"] = sourceRootId;
+        record["name"] = "Root BU";
+        var context = CreateContext(targetRootId);
+
+        var result = _handler.Transform(record, context);
+
+        result.Id.Should().Be(targetRootId);
+        result.GetAttributeValue<Guid>("businessunitid").Should().Be(targetRootId);
+    }
+
+    [Fact]
+    public void DoesNotMapChildBusinessUnit()
+    {
+        // Child BU (has parentbusinessunitid) is not remapped
+        var childId = Guid.NewGuid();
+        var targetRootId = Guid.NewGuid();
+        var record = new Entity("businessunit") { Id = childId };
+        record["businessunitid"] = childId;
+        record["name"] = "Child BU";
+        record["parentbusinessunitid"] = new EntityReference("businessunit", Guid.NewGuid());
+        var context = CreateContext(targetRootId);
+
+        var result = _handler.Transform(record, context);
+
+        result.Id.Should().Be(childId);
+        result.GetAttributeValue<Guid>("businessunitid").Should().Be(childId);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/DuplicateRuleHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/DuplicateRuleHandlerTests.cs
@@ -94,7 +94,7 @@ public class DuplicateRuleHandlerTests
 
         // Set up mock pooled client
         var mockClient = new Mock<IPooledClient>();
-        mockClient.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+        mockClient.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OrganizationResponse());
         mockClient.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
 
@@ -108,13 +108,15 @@ public class DuplicateRuleHandlerTests
         mockClient.Verify(
             c => c.ExecuteAsync(It.Is<OrganizationRequest>(r =>
                 r.RequestName == "PublishDuplicateRule" &&
-                (Guid)r["DuplicateRuleId"] == targetId1)),
+                (Guid)r["DuplicateRuleId"] == targetId1),
+                It.IsAny<CancellationToken>()),
             Times.Once);
 
         mockClient.Verify(
             c => c.ExecuteAsync(It.Is<OrganizationRequest>(r =>
                 r.RequestName == "PublishDuplicateRule" &&
-                (Guid)r["DuplicateRuleId"] == targetId2)),
+                (Guid)r["DuplicateRuleId"] == targetId2),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/PPDS.Migration.Tests/Import/Handlers/DuplicateRuleHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/DuplicateRuleHandlerTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using Moq;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class DuplicateRuleHandlerTests
+{
+    private readonly Mock<IDataverseConnectionPool> _connectionPool;
+    private readonly DuplicateRuleHandler _handler;
+    private readonly ImportContext _context;
+
+    public DuplicateRuleHandlerTests()
+    {
+        _connectionPool = new Mock<IDataverseConnectionPool>();
+        _handler = new DuplicateRuleHandler(_connectionPool.Object);
+        _context = new ImportContext(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+    }
+
+    [Fact]
+    public void CanHandle_DuplicateRule_ReturnsTrue()
+    {
+        _handler.CanHandle("duplicaterule").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void RemapsEntityTypeCodes()
+    {
+        // Source environment: ETC 1 = "account"
+        // Target environment: "account" = ETC 2
+        _context.SourceEntityTypeCodes = new Dictionary<int, string>
+        {
+            [1] = "account",
+            [10] = "contact"
+        };
+        _context.TargetEntityTypeCodes = new Dictionary<string, int>
+        {
+            ["account"] = 2,
+            ["contact"] = 20
+        };
+
+        var record = new Entity("duplicaterule") { Id = Guid.NewGuid() };
+        record["baseentitytypecode"] = 1;
+        record["matchingentitytypecode"] = 10;
+        record["name"] = "Test Rule";
+
+        var result = _handler.Transform(record, _context);
+
+        result.GetAttributeValue<int>("baseentitytypecode").Should().Be(2);
+        result.GetAttributeValue<int>("matchingentitytypecode").Should().Be(20);
+        result.GetAttributeValue<string>("name").Should().Be("Test Rule");
+    }
+
+    [Fact]
+    public void Transform_NoTargetEtcMapping_LeavesFieldUnchanged()
+    {
+        // No ETC mappings configured
+        var record = new Entity("duplicaterule") { Id = Guid.NewGuid() };
+        record["baseentitytypecode"] = 1;
+
+        var result = _handler.Transform(record, _context);
+
+        result.GetAttributeValue<int>("baseentitytypecode").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PublishesRulesPostImport()
+    {
+        // Set up ID mappings for two imported duplicate rules
+        var sourceId1 = Guid.NewGuid();
+        var targetId1 = Guid.NewGuid();
+        var sourceId2 = Guid.NewGuid();
+        var targetId2 = Guid.NewGuid();
+
+        _context.IdMappings.AddMapping("duplicaterule", sourceId1, targetId1);
+        _context.IdMappings.AddMapping("duplicaterule", sourceId2, targetId2);
+
+        // Set up mock pooled client
+        var mockClient = new Mock<IPooledClient>();
+        mockClient.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+            .ReturnsAsync(new OrganizationResponse());
+        mockClient.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        _connectionPool.Setup(p => p.GetClientAsync(null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockClient.Object);
+
+        // Act
+        await _handler.ExecuteAsync("duplicaterule", _context, CancellationToken.None);
+
+        // Verify PublishDuplicateRule was called for each rule
+        mockClient.Verify(
+            c => c.ExecuteAsync(It.Is<OrganizationRequest>(r =>
+                r.RequestName == "PublishDuplicateRule" &&
+                (Guid)r["DuplicateRuleId"] == targetId1)),
+            Times.Once);
+
+        mockClient.Verify(
+            c => c.ExecuteAsync(It.Is<OrganizationRequest>(r =>
+                r.RequestName == "PublishDuplicateRule" &&
+                (Guid)r["DuplicateRuleId"] == targetId2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoMappings_DoesNotCallPool()
+    {
+        // No mappings added — should not attempt to get a client
+        await _handler.ExecuteAsync("duplicaterule", _context, CancellationToken.None);
+
+        _connectionPool.Verify(
+            p => p.GetClientAsync(It.IsAny<Dataverse.Client.DataverseClientOptions?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
@@ -75,15 +75,13 @@ public class IncidentHandlerTests
         result.MessageData.Should().ContainKey("IncidentResolution");
         result.MessageData.Should().ContainKey("Status");
 
-        var resolution = result.MessageData!["IncidentResolution"] as Entity;
-        resolution.Should().NotBeNull();
-        resolution!.LogicalName.Should().Be("incidentresolution");
+        var resolution = (Entity)result.MessageData!["IncidentResolution"];
+        resolution.LogicalName.Should().Be("incidentresolution");
         resolution.GetAttributeValue<EntityReference>("incidentid").Id.Should().Be(record.Id);
         resolution.GetAttributeValue<string>("subject").Should().Be("Resolved (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(5);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(5);
     }
 
     [Fact]
@@ -100,8 +98,7 @@ public class IncidentHandlerTests
         result.StateCode.Should().Be(2);
         result.StatusCode.Should().Be(6);
 
-        var resolution = result.MessageData!["IncidentResolution"] as Entity;
-        resolution.Should().NotBeNull();
-        resolution!.GetAttributeValue<string>("subject").Should().Be("Canceled (migrated)");
+        var resolution = (Entity)result.MessageData!["IncidentResolution"];
+        resolution.GetAttributeValue<string>("subject").Should().Be("Canceled (migrated)");
     }
 }

--- a/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class IncidentHandlerTests
+{
+    private readonly IncidentHandler _handler = new();
+
+    private static ImportContext CreateContext() =>
+        new(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+
+    [Fact]
+    public void CanHandle_Incident_ReturnsTrue()
+    {
+        _handler.CanHandle("incident").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripsStateStatusFromRecord()
+    {
+        var record = new Entity("incident") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(5);
+        record["title"] = "Test Case";
+
+        var result = _handler.Transform(record, CreateContext());
+
+        result.Attributes.Should().NotContainKey("statecode");
+        result.Attributes.Should().NotContainKey("statuscode");
+        result.Attributes.Should().ContainKey("title");
+    }
+
+    [Fact]
+    public void ReturnsNullForActiveIncident()
+    {
+        var record = new Entity("incident") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitsCloseIncidentForResolvedState()
+    {
+        var record = new Entity("incident") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(5);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("CloseIncident");
+        result.EntityName.Should().Be("incident");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(1);
+        result.StatusCode.Should().Be(5);
+        result.MessageData.Should().ContainKey("IncidentResolution");
+        result.MessageData.Should().ContainKey("Status");
+
+        var resolution = result.MessageData!["IncidentResolution"] as Entity;
+        resolution.Should().NotBeNull();
+        resolution!.LogicalName.Should().Be("incidentresolution");
+        resolution.GetAttributeValue<EntityReference>("incidentid").Id.Should().Be(record.Id);
+        resolution.GetAttributeValue<string>("subject").Should().Be("Resolved (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void EmitsCloseIncidentForCanceledState()
+    {
+        var record = new Entity("incident") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(6);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("CloseIncident");
+        result.StateCode.Should().Be(2);
+        result.StatusCode.Should().Be(6);
+
+        var resolution = result.MessageData!["IncidentResolution"] as Entity;
+        resolution.Should().NotBeNull();
+        resolution!.GetAttributeValue<string>("subject").Should().Be("Canceled (migrated)");
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/IncidentHandlerTests.cs
@@ -33,18 +33,16 @@ public class IncidentHandlerTests
     }
 
     [Fact]
-    public void StripsStateStatusFromRecord()
+    public void TransformIsPassThrough()
     {
+        // statecode/statuscode stripping is handled by TieredImporter before Transform is called
         var record = new Entity("incident") { Id = Guid.NewGuid() };
-        record["statecode"] = new OptionSetValue(1);
-        record["statuscode"] = new OptionSetValue(5);
         record["title"] = "Test Case";
 
         var result = _handler.Transform(record, CreateContext());
 
-        result.Attributes.Should().NotContainKey("statecode");
-        result.Attributes.Should().NotContainKey("statuscode");
         result.Attributes.Should().ContainKey("title");
+        result.Should().BeSameAs(record);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
@@ -81,18 +81,16 @@ public class LeadHandlerTests
         result.MessageData.Should().ContainKey("CreateOpportunity");
         result.MessageData.Should().ContainKey("Status");
 
-        var leadRef = result.MessageData!["LeadId"] as EntityReference;
-        leadRef.Should().NotBeNull();
-        leadRef!.Id.Should().Be(record.Id);
+        var leadRef = (EntityReference)result.MessageData!["LeadId"];
+        leadRef.Id.Should().Be(record.Id);
         leadRef.LogicalName.Should().Be("lead");
 
         result.MessageData["CreateAccount"].Should().Be(false);
         result.MessageData["CreateContact"].Should().Be(false);
         result.MessageData["CreateOpportunity"].Should().Be(false);
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(3);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(3);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class LeadHandlerTests
+{
+    private readonly LeadHandler _handler = new();
+    private readonly ImportContext _context;
+
+    public LeadHandlerTests()
+    {
+        _context = new ImportContext(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+    }
+
+    [Fact]
+    public void CanHandle_Lead_ReturnsTrue()
+    {
+        _handler.CanHandle("lead").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripsStateStatusFromRecord()
+    {
+        var record = new Entity("lead") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(3);
+        record["subject"] = "Test Lead";
+
+        var result = _handler.Transform(record, _context);
+
+        result.Attributes.Should().NotContainKey("statecode");
+        result.Attributes.Should().NotContainKey("statuscode");
+        result.Attributes.Should().ContainKey("subject");
+    }
+
+    [Fact]
+    public void ReturnsNullForOpenLead()
+    {
+        var record = new Entity("lead") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitsQualifyWithSuppressedSideEffects()
+    {
+        var record = new Entity("lead") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(3);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("QualifyLead");
+        result.EntityName.Should().Be("lead");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(1);
+        result.StatusCode.Should().Be(3);
+        result.MessageData.Should().ContainKey("LeadId");
+        result.MessageData.Should().ContainKey("CreateAccount");
+        result.MessageData.Should().ContainKey("CreateContact");
+        result.MessageData.Should().ContainKey("CreateOpportunity");
+        result.MessageData.Should().ContainKey("Status");
+
+        var leadRef = result.MessageData!["LeadId"] as EntityReference;
+        leadRef.Should().NotBeNull();
+        leadRef!.Id.Should().Be(record.Id);
+        leadRef.LogicalName.Should().Be("lead");
+
+        result.MessageData["CreateAccount"].Should().Be(false);
+        result.MessageData["CreateContact"].Should().Be(false);
+        result.MessageData["CreateOpportunity"].Should().Be(false);
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void UsesSetStateForDisqualified()
+    {
+        var record = new Entity("lead") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(5);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().BeNull();
+        result.EntityName.Should().Be("lead");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(2);
+        result.StatusCode.Should().Be(5);
+        result.MessageData.Should().BeNull();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/LeadHandlerTests.cs
@@ -36,18 +36,16 @@ public class LeadHandlerTests
     }
 
     [Fact]
-    public void StripsStateStatusFromRecord()
+    public void TransformIsPassThrough()
     {
+        // statecode/statuscode stripping is handled by TieredImporter before Transform is called
         var record = new Entity("lead") { Id = Guid.NewGuid() };
-        record["statecode"] = new OptionSetValue(1);
-        record["statuscode"] = new OptionSetValue(3);
         record["subject"] = "Test Lead";
 
         var result = _handler.Transform(record, _context);
 
-        result.Attributes.Should().NotContainKey("statecode");
-        result.Attributes.Should().NotContainKey("statuscode");
         result.Attributes.Should().ContainKey("subject");
+        result.Should().BeSameAs(record);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
@@ -33,18 +33,16 @@ public class OpportunityHandlerTests
     }
 
     [Fact]
-    public void StripsStateStatusFromRecord()
+    public void TransformIsPassThrough()
     {
+        // statecode/statuscode stripping is handled by TieredImporter before Transform is called
         var record = new Entity("opportunity") { Id = Guid.NewGuid() };
-        record["statecode"] = new OptionSetValue(1);
-        record["statuscode"] = new OptionSetValue(3);
         record["name"] = "Test Opp";
 
         var result = _handler.Transform(record, CreateContext());
 
-        result.Attributes.Should().NotContainKey("statecode");
-        result.Attributes.Should().NotContainKey("statuscode");
         result.Attributes.Should().ContainKey("name");
+        result.Should().BeSameAs(record);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class OpportunityHandlerTests
+{
+    private readonly OpportunityHandler _handler = new();
+
+    private static ImportContext CreateContext() =>
+        new(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+
+    [Fact]
+    public void CanHandle_Opportunity_ReturnsTrue()
+    {
+        _handler.CanHandle("opportunity").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripsStateStatusFromRecord()
+    {
+        var record = new Entity("opportunity") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(3);
+        record["name"] = "Test Opp";
+
+        var result = _handler.Transform(record, CreateContext());
+
+        result.Attributes.Should().NotContainKey("statecode");
+        result.Attributes.Should().NotContainKey("statuscode");
+        result.Attributes.Should().ContainKey("name");
+    }
+
+    [Fact]
+    public void ReturnsNullForActiveOpportunity()
+    {
+        var record = new Entity("opportunity") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitsWinOpportunityForStateCodeOne()
+    {
+        var record = new Entity("opportunity") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(3);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("WinOpportunity");
+        result.EntityName.Should().Be("opportunity");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(1);
+        result.StatusCode.Should().Be(3);
+        result.MessageData.Should().ContainKey("OpportunityClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["OpportunityClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("opportunityclose");
+        closeEntity.GetAttributeValue<EntityReference>("opportunityid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Won (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void EmitsLoseOpportunityForStateCodeTwo()
+    {
+        var record = new Entity("opportunity") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(4);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("LoseOpportunity");
+        result.EntityName.Should().Be("opportunity");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(2);
+        result.StatusCode.Should().Be(4);
+        result.MessageData.Should().ContainKey("OpportunityClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["OpportunityClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("opportunityclose");
+        closeEntity.GetAttributeValue<EntityReference>("opportunityid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Lost (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(4);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/OpportunityHandlerTests.cs
@@ -75,15 +75,13 @@ public class OpportunityHandlerTests
         result.MessageData.Should().ContainKey("OpportunityClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["OpportunityClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("opportunityclose");
+        var closeEntity = (Entity)result.MessageData!["OpportunityClose"];
+        closeEntity.LogicalName.Should().Be("opportunityclose");
         closeEntity.GetAttributeValue<EntityReference>("opportunityid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Won (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(3);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(3);
     }
 
     [Fact]
@@ -104,14 +102,12 @@ public class OpportunityHandlerTests
         result.MessageData.Should().ContainKey("OpportunityClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["OpportunityClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("opportunityclose");
+        var closeEntity = (Entity)result.MessageData!["OpportunityClose"];
+        closeEntity.LogicalName.Should().Be("opportunityclose");
         closeEntity.GetAttributeValue<EntityReference>("opportunityid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Lost (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(4);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(4);
     }
 }

--- a/tests/PPDS.Migration.Tests/Import/Handlers/ProductHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/ProductHandlerTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class ProductHandlerTests
+{
+    private readonly ProductHandler _handler = new();
+    private readonly ImportContext _context;
+
+    public ProductHandlerTests()
+    {
+        _context = new ImportContext(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+    }
+
+    [Fact]
+    public void CanHandle_Product_ReturnsTrue()
+    {
+        _handler.CanHandle("product").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void CascadesSkipToChildren()
+    {
+        // Track parent product as failed
+        var parentId = Guid.NewGuid();
+        _handler.TrackFailure(parentId);
+
+        // Create child product referencing failed parent
+        var childRecord = new Entity("product") { Id = Guid.NewGuid() };
+        childRecord["parentproductid"] = new EntityReference("product", parentId);
+
+        var result = _handler.ShouldSkip(childRecord, _context);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReportsRootCauseInSkipReason()
+    {
+        // Track parent product as failed
+        var parentId = Guid.NewGuid();
+        _handler.TrackFailure(parentId);
+
+        // Create child product referencing failed parent
+        var childId = Guid.NewGuid();
+        var childRecord = new Entity("product") { Id = childId };
+        childRecord["parentproductid"] = new EntityReference("product", parentId);
+
+        // Skip the child — this should also track the child as failed
+        _handler.ShouldSkip(childRecord, _context);
+
+        // Create grandchild product referencing the (now-failed) child
+        var grandchildRecord = new Entity("product") { Id = Guid.NewGuid() };
+        grandchildRecord["parentproductid"] = new EntityReference("product", childId);
+
+        // Grandchild should also be skipped (cascading failure)
+        var grandchildResult = _handler.ShouldSkip(grandchildRecord, _context);
+
+        grandchildResult.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotSkipProductWithHealthyParent()
+    {
+        // Parent is NOT tracked as failed
+        var healthyParentId = Guid.NewGuid();
+
+        var childRecord = new Entity("product") { Id = Guid.NewGuid() };
+        childRecord["parentproductid"] = new EntityReference("product", healthyParentId);
+
+        var result = _handler.ShouldSkip(childRecord, _context);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DoesNotSkipProductWithNoParent()
+    {
+        var record = new Entity("product") { Id = Guid.NewGuid() };
+
+        var result = _handler.ShouldSkip(record, _context);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ReturnsNullForDraftProduct()
+    {
+        var record = new Entity("product") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(0);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReturnsSetStateForNonDraftProduct()
+    {
+        var record = new Entity("product") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().BeNull(); // null means SetStateRequest
+        result.EntityName.Should().Be("product");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(1);
+        result.StatusCode.Should().Be(1);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
@@ -33,18 +33,16 @@ public class QuoteHandlerTests
     }
 
     [Fact]
-    public void StripsStateStatusFromRecord()
+    public void TransformIsPassThrough()
     {
+        // statecode/statuscode stripping is handled by TieredImporter before Transform is called
         var record = new Entity("quote") { Id = Guid.NewGuid() };
-        record["statecode"] = new OptionSetValue(2);
-        record["statuscode"] = new OptionSetValue(3);
         record["name"] = "Test Quote";
 
         var result = _handler.Transform(record, CreateContext());
 
-        result.Attributes.Should().NotContainKey("statecode");
-        result.Attributes.Should().NotContainKey("statuscode");
         result.Attributes.Should().ContainKey("name");
+        result.Should().BeSameAs(record);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
@@ -87,15 +87,13 @@ public class QuoteHandlerTests
         result.MessageData.Should().ContainKey("QuoteClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["QuoteClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("quoteclose");
+        var closeEntity = (Entity)result.MessageData!["QuoteClose"];
+        closeEntity.LogicalName.Should().Be("quoteclose");
         closeEntity.GetAttributeValue<EntityReference>("quoteid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Won (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(4);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(4);
     }
 
     [Fact]
@@ -116,14 +114,12 @@ public class QuoteHandlerTests
         result.MessageData.Should().ContainKey("QuoteClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["QuoteClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("quoteclose");
+        var closeEntity = (Entity)result.MessageData!["QuoteClose"];
+        closeEntity.LogicalName.Should().Be("quoteclose");
         closeEntity.GetAttributeValue<EntityReference>("quoteid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Closed (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(7);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(7);
     }
 }

--- a/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/QuoteHandlerTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class QuoteHandlerTests
+{
+    private readonly QuoteHandler _handler = new();
+
+    private static ImportContext CreateContext() =>
+        new(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+
+    [Fact]
+    public void CanHandle_Quote_ReturnsTrue()
+    {
+        _handler.CanHandle("quote").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripsStateStatusFromRecord()
+    {
+        var record = new Entity("quote") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(3);
+        record["name"] = "Test Quote";
+
+        var result = _handler.Transform(record, CreateContext());
+
+        result.Attributes.Should().NotContainKey("statecode");
+        result.Attributes.Should().NotContainKey("statuscode");
+        result.Attributes.Should().ContainKey("name");
+    }
+
+    [Fact]
+    public void ReturnsNullForDraftQuote()
+    {
+        var record = new Entity("quote") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReturnsNullForActiveQuote()
+    {
+        var record = new Entity("quote") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(2);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitsWinQuoteForStateCodeTwo()
+    {
+        var record = new Entity("quote") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(4);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("WinQuote");
+        result.EntityName.Should().Be("quote");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(2);
+        result.StatusCode.Should().Be(4);
+        result.MessageData.Should().ContainKey("QuoteClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["QuoteClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("quoteclose");
+        closeEntity.GetAttributeValue<EntityReference>("quoteid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Won (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void EmitsCloseQuoteForStateCodeThree()
+    {
+        var record = new Entity("quote") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(3);
+        record["statuscode"] = new OptionSetValue(7);
+
+        var result = _handler.GetTransition(record, CreateContext());
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("CloseQuote");
+        result.EntityName.Should().Be("quote");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(3);
+        result.StatusCode.Should().Be(7);
+        result.MessageData.Should().ContainKey("QuoteClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["QuoteClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("quoteclose");
+        closeEntity.GetAttributeValue<EntityReference>("quoteid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Closed (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(7);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
@@ -36,18 +36,16 @@ public class SalesOrderHandlerTests
     }
 
     [Fact]
-    public void StripsStateStatusFromRecord()
+    public void TransformIsPassThrough()
     {
+        // statecode/statuscode stripping is handled by TieredImporter before Transform is called
         var record = new Entity("salesorder") { Id = Guid.NewGuid() };
-        record["statecode"] = new OptionSetValue(2);
-        record["statuscode"] = new OptionSetValue(100001);
         record["name"] = "Test Order";
 
         var result = _handler.Transform(record, _context);
 
-        result.Attributes.Should().NotContainKey("statecode");
-        result.Attributes.Should().NotContainKey("statuscode");
         result.Attributes.Should().ContainKey("name");
+        result.Should().BeSameAs(record);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
@@ -78,15 +78,13 @@ public class SalesOrderHandlerTests
         result.MessageData.Should().ContainKey("OrderClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["OrderClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("orderclose");
+        var closeEntity = (Entity)result.MessageData!["OrderClose"];
+        closeEntity.LogicalName.Should().Be("orderclose");
         closeEntity.GetAttributeValue<EntityReference>("salesorderid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Fulfilled (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(100001);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(100001);
     }
 
     [Fact]
@@ -107,15 +105,13 @@ public class SalesOrderHandlerTests
         result.MessageData.Should().ContainKey("OrderClose");
         result.MessageData.Should().ContainKey("Status");
 
-        var closeEntity = result.MessageData!["OrderClose"] as Entity;
-        closeEntity.Should().NotBeNull();
-        closeEntity!.LogicalName.Should().Be("orderclose");
+        var closeEntity = (Entity)result.MessageData!["OrderClose"];
+        closeEntity.LogicalName.Should().Be("orderclose");
         closeEntity.GetAttributeValue<EntityReference>("salesorderid").Id.Should().Be(record.Id);
         closeEntity.GetAttributeValue<string>("subject").Should().Be("Canceled (migrated)");
 
-        var status = result.MessageData["Status"] as OptionSetValue;
-        status.Should().NotBeNull();
-        status!.Value.Should().Be(100002);
+        var status = (OptionSetValue)result.MessageData["Status"];
+        status.Value.Should().Be(100002);
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/SalesOrderHandlerTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class SalesOrderHandlerTests
+{
+    private readonly SalesOrderHandler _handler = new();
+    private readonly ImportContext _context;
+
+    public SalesOrderHandlerTests()
+    {
+        _context = new ImportContext(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+    }
+
+    [Fact]
+    public void CanHandle_SalesOrder_ReturnsTrue()
+    {
+        _handler.CanHandle("salesorder").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_OtherEntity_ReturnsFalse()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void StripsStateStatusFromRecord()
+    {
+        var record = new Entity("salesorder") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(100001);
+        record["name"] = "Test Order";
+
+        var result = _handler.Transform(record, _context);
+
+        result.Attributes.Should().NotContainKey("statecode");
+        result.Attributes.Should().NotContainKey("statuscode");
+        result.Attributes.Should().ContainKey("name");
+    }
+
+    [Fact]
+    public void ReturnsNullForActiveOrder()
+    {
+        var record = new Entity("salesorder") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(0);
+        record["statuscode"] = new OptionSetValue(1);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmitsFulfillForStateCodeThree()
+    {
+        var record = new Entity("salesorder") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(3);
+        record["statuscode"] = new OptionSetValue(100001);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("FulfillSalesOrder");
+        result.EntityName.Should().Be("salesorder");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(3);
+        result.StatusCode.Should().Be(100001);
+        result.MessageData.Should().ContainKey("OrderClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["OrderClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("orderclose");
+        closeEntity.GetAttributeValue<EntityReference>("salesorderid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Fulfilled (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(100001);
+    }
+
+    [Fact]
+    public void EmitsCancelForStateCodeTwo()
+    {
+        var record = new Entity("salesorder") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(2);
+        record["statuscode"] = new OptionSetValue(100002);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().NotBeNull();
+        result!.SdkMessage.Should().Be("CancelSalesOrder");
+        result.EntityName.Should().Be("salesorder");
+        result.RecordId.Should().Be(record.Id);
+        result.StateCode.Should().Be(2);
+        result.StatusCode.Should().Be(100002);
+        result.MessageData.Should().ContainKey("OrderClose");
+        result.MessageData.Should().ContainKey("Status");
+
+        var closeEntity = result.MessageData!["OrderClose"] as Entity;
+        closeEntity.Should().NotBeNull();
+        closeEntity!.LogicalName.Should().Be("orderclose");
+        closeEntity.GetAttributeValue<EntityReference>("salesorderid").Id.Should().Be(record.Id);
+        closeEntity.GetAttributeValue<string>("subject").Should().Be("Canceled (migrated)");
+
+        var status = result.MessageData["Status"] as OptionSetValue;
+        status.Should().NotBeNull();
+        status!.Value.Should().Be(100002);
+    }
+
+    [Fact]
+    public void ReturnsNullForSubmittedOrder()
+    {
+        var record = new Entity("salesorder") { Id = Guid.NewGuid() };
+        record["statecode"] = new OptionSetValue(1);
+        record["statuscode"] = new OptionSetValue(2);
+
+        var result = _handler.GetTransition(record, _context);
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/Handlers/SystemUserHandlerTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/Handlers/SystemUserHandlerTests.cs
@@ -1,0 +1,91 @@
+using System;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Import;
+using PPDS.Migration.Import.Handlers;
+using PPDS.Migration.Models;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import.Handlers;
+
+[Trait("Category", "Unit")]
+public class SystemUserHandlerTests
+{
+    private readonly SystemUserHandler _handler = new();
+
+    private static ImportContext CreateContext() =>
+        new(
+            new MigrationData(),
+            new ExecutionPlan(),
+            new ImportOptions(),
+            new IdMappingCollection(),
+            new FieldMetadataCollection(new Dictionary<string, Dictionary<string, FieldValidity>>()));
+
+    [Fact]
+    public void CanHandle_ReturnsTrueForSystemUser()
+    {
+        _handler.CanHandle("systemuser").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_IsCaseInsensitive()
+    {
+        _handler.CanHandle("SystemUser").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanHandle_ReturnsFalseForOtherEntity()
+    {
+        _handler.CanHandle("account").Should().BeFalse();
+    }
+
+    [Fact]
+    public void SkipsSystemUser()
+    {
+        // AC-17: Skip SYSTEM user by fullname
+        var record = new Entity("systemuser") { Id = Guid.NewGuid() };
+        record["fullname"] = "SYSTEM";
+        var context = CreateContext();
+
+        _handler.ShouldSkip(record, context).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SkipsIntegrationUser()
+    {
+        // AC-17: Skip INTEGRATION user by fullname
+        var record = new Entity("systemuser") { Id = Guid.NewGuid() };
+        record["fullname"] = "INTEGRATION";
+        var context = CreateContext();
+
+        _handler.ShouldSkip(record, context).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SkipsSupportAndIntegrationUsers()
+    {
+        // AC-17: Skip support users (accessmode=3) and integration users (accessmode=5)
+        var context = CreateContext();
+
+        var supportUser = new Entity("systemuser") { Id = Guid.NewGuid() };
+        supportUser["fullname"] = "Some Support User";
+        supportUser["accessmode"] = new OptionSetValue(3);
+        _handler.ShouldSkip(supportUser, context).Should().BeTrue();
+
+        var integrationAccessUser = new Entity("systemuser") { Id = Guid.NewGuid() };
+        integrationAccessUser["fullname"] = "Some Integration User";
+        integrationAccessUser["accessmode"] = new OptionSetValue(5);
+        _handler.ShouldSkip(integrationAccessUser, context).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DoesNotSkipRegularUsers()
+    {
+        var record = new Entity("systemuser") { Id = Guid.NewGuid() };
+        record["fullname"] = "John Doe";
+        record["accessmode"] = new OptionSetValue(0);
+        var context = CreateContext();
+
+        _handler.ShouldSkip(record, context).Should().BeFalse();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/StateTransitionCollectionTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/StateTransitionCollectionTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using PPDS.Migration.Import;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class StateTransitionCollectionTests
+{
+    [Fact]
+    public void AddAndRetrieveTransitions()
+    {
+        var collection = new StateTransitionCollection();
+        var id = Guid.NewGuid();
+        var data = new StateTransitionData
+        {
+            EntityName = "account",
+            RecordId = id,
+            StateCode = 1,
+            StatusCode = 2
+        };
+
+        collection.Add("account", id, data);
+
+        var transitions = collection.GetTransitions("account");
+        transitions.Should().ContainSingle();
+        transitions[0].RecordId.Should().Be(id);
+        transitions[0].StateCode.Should().Be(1);
+        transitions[0].StatusCode.Should().Be(2);
+    }
+
+    [Fact]
+    public void GetEntityNamesReturnsDistinctNames()
+    {
+        var collection = new StateTransitionCollection();
+        collection.Add("account", Guid.NewGuid(), new StateTransitionData { EntityName = "account", StateCode = 1, StatusCode = 1 });
+        collection.Add("contact", Guid.NewGuid(), new StateTransitionData { EntityName = "contact", StateCode = 1, StatusCode = 1 });
+        collection.Add("account", Guid.NewGuid(), new StateTransitionData { EntityName = "account", StateCode = 0, StatusCode = 1 });
+
+        var names = collection.GetEntityNames().ToList();
+
+        names.Should().HaveCount(2);
+        names.Should().Contain("account");
+        names.Should().Contain("contact");
+    }
+
+    [Fact]
+    public void CountReturnsTotal()
+    {
+        var collection = new StateTransitionCollection();
+        collection.Add("account", Guid.NewGuid(), new StateTransitionData { EntityName = "account", StateCode = 1, StatusCode = 1 });
+        collection.Add("contact", Guid.NewGuid(), new StateTransitionData { EntityName = "contact", StateCode = 1, StatusCode = 1 });
+        collection.Add("account", Guid.NewGuid(), new StateTransitionData { EntityName = "account", StateCode = 0, StatusCode = 1 });
+
+        collection.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ThreadSafeAdditions()
+    {
+        var collection = new StateTransitionCollection();
+        const int itemsPerThread = 100;
+        const int threadCount = 10;
+
+        var tasks = Enumerable.Range(0, threadCount).Select(t =>
+            Task.Run(() =>
+            {
+                for (var i = 0; i < itemsPerThread; i++)
+                {
+                    var entity = $"entity{t % 3}"; // 3 distinct entity names
+                    collection.Add(entity, Guid.NewGuid(), new StateTransitionData
+                    {
+                        EntityName = entity,
+                        StateCode = 1,
+                        StatusCode = 1
+                    });
+                }
+            })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        collection.Count.Should().Be(threadCount * itemsPerThread);
+    }
+
+    [Fact]
+    public void GetTransitions_UnknownEntity_ReturnsEmptyList()
+    {
+        var collection = new StateTransitionCollection();
+
+        var transitions = collection.GetTransitions("nonexistent");
+
+        transitions.Should().BeEmpty();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
+using Microsoft.Xrm.Sdk.Messages;
 using Moq;
 using PPDS.Dataverse.Pooling;
 using PPDS.Migration.Import;
@@ -54,10 +55,9 @@ public class StateTransitionProcessorTests
         SetupRetrieveStatecode(recordId, 0);
 
         OrganizationRequest? capturedRequest = null;
-        _pool.Setup(p => p.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
-                It.IsAny<CancellationToken>()))
-            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")))
+            .Callback<OrganizationRequest>((req) => capturedRequest = req)
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -94,10 +94,9 @@ public class StateTransitionProcessorTests
 
         result.Success.Should().BeTrue();
         result.SuccessCount.Should().Be(1);
-        _pool.Verify(
-            p => p.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
-                It.IsAny<CancellationToken>()),
+        _client.Verify(
+            c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")),
             Times.Never);
     }
 
@@ -127,10 +126,9 @@ public class StateTransitionProcessorTests
         SetupRetrieveStatecode(recordId, 0);
 
         OrganizationRequest? capturedRequest = null;
-        _pool.Setup(p => p.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "WinOpportunity"),
-                It.IsAny<CancellationToken>()))
-            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "WinOpportunity")))
+            .Callback<OrganizationRequest>((req) => capturedRequest = req)
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -162,9 +160,8 @@ public class StateTransitionProcessorTests
         SetupRetrieveStatecode(id2, 0);
         SetupRetrieveStatecode(id3, 0);
 
-        _pool.Setup(p => p.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
-                It.IsAny<CancellationToken>()))
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")))
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -193,8 +190,8 @@ public class StateTransitionProcessorTests
                 It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
-        _pool.Verify(
-            p => p.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()),
+        _client.Verify(
+            c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()),
             Times.Never);
     }
 
@@ -204,13 +201,12 @@ public class StateTransitionProcessorTests
     {
         var entity = new Entity { Id = recordId };
         entity["statecode"] = new OptionSetValue(statecodeValue);
+        var response = new RetrieveResponse();
+        response["Entity"] = entity;
 
-        _client.Setup(c => c.RetrieveAsync(
-                It.IsAny<string>(),
-                recordId,
-                It.IsAny<ColumnSet>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(entity);
+        _client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "Retrieve")))
+            .ReturnsAsync(response);
     }
 
     private static ImportContext CreateContext()

--- a/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
@@ -52,7 +52,7 @@ public class StateTransitionProcessorTests
         });
 
         // Record is currently active (statecode=0)
-        SetupRetrieveStatecode(recordId, 0);
+        SetupRetrieveState(recordId, stateCode: 0);
 
         OrganizationRequest? capturedRequest = null;
         _client.Setup(c => c.ExecuteAsync(
@@ -74,9 +74,9 @@ public class StateTransitionProcessorTests
     }
 
     [Fact]
-    public async Task SkipsAlreadyClosedRecords()
+    public async Task SkipsAlreadyInTargetStateRecords()
     {
-        // AC-16: record already has non-zero statecode, skip transition
+        // AC-16: record already matches desired statecode and statuscode, skip transition
         var recordId = Guid.NewGuid();
         var context = CreateContext();
         context.StateTransitions.Add("incident", recordId, new StateTransitionData
@@ -88,8 +88,8 @@ public class StateTransitionProcessorTests
             SdkMessage = null
         });
 
-        // Record already has non-zero statecode (closed)
-        SetupRetrieveStatecode(recordId, 1);
+        // Record already has the target statecode and statuscode
+        SetupRetrieveState(recordId, stateCode: 1, statusCode: 5);
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
 
@@ -125,7 +125,7 @@ public class StateTransitionProcessorTests
             }
         });
 
-        SetupRetrieveStatecode(recordId, 0);
+        SetupRetrieveState(recordId, stateCode: 0);
 
         OrganizationRequest? capturedRequest = null;
         _client.Setup(c => c.ExecuteAsync(
@@ -159,9 +159,9 @@ public class StateTransitionProcessorTests
         context.StateTransitions.Add("account", id3, new StateTransitionData
         { EntityName = "account", RecordId = id3, StateCode = 1, StatusCode = 2 });
 
-        SetupRetrieveStatecode(id1, 0);
-        SetupRetrieveStatecode(id2, 0);
-        SetupRetrieveStatecode(id3, 0);
+        SetupRetrieveState(id1, stateCode: 0);
+        SetupRetrieveState(id2, stateCode: 0);
+        SetupRetrieveState(id3, stateCode: 0);
 
         _client.Setup(c => c.ExecuteAsync(
                 It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
@@ -201,10 +201,11 @@ public class StateTransitionProcessorTests
 
     #region Helpers
 
-    private void SetupRetrieveStatecode(Guid recordId, int statecodeValue)
+    private void SetupRetrieveState(Guid recordId, int stateCode, int statusCode = 1)
     {
         var entity = new Entity { Id = recordId };
-        entity["statecode"] = new OptionSetValue(statecodeValue);
+        entity["statecode"] = new OptionSetValue(stateCode);
+        entity["statuscode"] = new OptionSetValue(statusCode);
         var response = new RetrieveResponse();
         response["Entity"] = entity;
 

--- a/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
@@ -56,8 +56,9 @@ public class StateTransitionProcessorTests
 
         OrganizationRequest? capturedRequest = null;
         _client.Setup(c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")))
-            .Callback<OrganizationRequest>((req) => capturedRequest = req)
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -96,7 +97,8 @@ public class StateTransitionProcessorTests
         result.SuccessCount.Should().Be(1);
         _client.Verify(
             c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")),
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -127,8 +129,9 @@ public class StateTransitionProcessorTests
 
         OrganizationRequest? capturedRequest = null;
         _client.Setup(c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "WinOpportunity")))
-            .Callback<OrganizationRequest>((req) => capturedRequest = req)
+                It.Is<OrganizationRequest>(r => r.RequestName == "WinOpportunity"),
+                It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -161,7 +164,8 @@ public class StateTransitionProcessorTests
         SetupRetrieveStatecode(id3, 0);
 
         _client.Setup(c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "SetState")))
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OrganizationResponse());
 
         var result = await _sut.ProcessAsync(context, CancellationToken.None);
@@ -191,7 +195,7 @@ public class StateTransitionProcessorTests
                 It.IsAny<CancellationToken>()),
             Times.Never);
         _client.Verify(
-            c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()),
+            c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -205,7 +209,8 @@ public class StateTransitionProcessorTests
         response["Entity"] = entity;
 
         _client.Setup(c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r.RequestName == "Retrieve")))
+                It.Is<RetrieveRequest>(r => r.Target.Id == recordId),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
     }
 

--- a/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/StateTransitionProcessorTests.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Moq;
+using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Import;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class StateTransitionProcessorTests
+{
+    private readonly Mock<IDataverseConnectionPool> _pool;
+    private readonly Mock<IPooledClient> _client;
+    private readonly StateTransitionProcessor _sut;
+
+    public StateTransitionProcessorTests()
+    {
+        _pool = new Mock<IDataverseConnectionPool>();
+        _client = new Mock<IPooledClient>();
+
+        _pool.Setup(p => p.GetClientAsync(
+                It.IsAny<Dataverse.Client.DataverseClientOptions?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+
+        _sut = new StateTransitionProcessor(_pool.Object);
+    }
+
+    [Fact]
+    public async Task AppliesSetStateForNonDefaultState()
+    {
+        // AC-06: transition statecode=1, record currently at statecode=0
+        var recordId = Guid.NewGuid();
+        var context = CreateContext();
+        context.StateTransitions.Add("incident", recordId, new StateTransitionData
+        {
+            EntityName = "incident",
+            RecordId = recordId,
+            StateCode = 1,
+            StatusCode = 5,
+            SdkMessage = null
+        });
+
+        // Record is currently active (statecode=0)
+        SetupRetrieveStatecode(recordId, 0);
+
+        OrganizationRequest? capturedRequest = null;
+        _pool.Setup(p => p.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new OrganizationResponse());
+
+        var result = await _sut.ProcessAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.SuccessCount.Should().Be(1);
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.RequestName.Should().Be("SetState");
+        var state = (OptionSetValue)capturedRequest["State"];
+        state.Value.Should().Be(1);
+        var status = (OptionSetValue)capturedRequest["Status"];
+        status.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task SkipsAlreadyClosedRecords()
+    {
+        // AC-16: record already has non-zero statecode, skip transition
+        var recordId = Guid.NewGuid();
+        var context = CreateContext();
+        context.StateTransitions.Add("incident", recordId, new StateTransitionData
+        {
+            EntityName = "incident",
+            RecordId = recordId,
+            StateCode = 1,
+            StatusCode = 5,
+            SdkMessage = null
+        });
+
+        // Record already has non-zero statecode (closed)
+        SetupRetrieveStatecode(recordId, 1);
+
+        var result = await _sut.ProcessAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.SuccessCount.Should().Be(1);
+        _pool.Verify(
+            p => p.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecutesSdkMessageWhenSpecified()
+    {
+        var recordId = Guid.NewGuid();
+        var closeEntity = new Entity("opportunityclose");
+        closeEntity["opportunityid"] = new EntityReference("opportunity", recordId);
+        closeEntity["subject"] = "Won (migrated)";
+
+        var context = CreateContext();
+        context.StateTransitions.Add("opportunity", recordId, new StateTransitionData
+        {
+            EntityName = "opportunity",
+            RecordId = recordId,
+            StateCode = 1,
+            StatusCode = 3,
+            SdkMessage = "WinOpportunity",
+            MessageData = new Dictionary<string, object>
+            {
+                ["OpportunityClose"] = closeEntity,
+                ["Status"] = new OptionSetValue(3)
+            }
+        });
+
+        SetupRetrieveStatecode(recordId, 0);
+
+        OrganizationRequest? capturedRequest = null;
+        _pool.Setup(p => p.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "WinOpportunity"),
+                It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new OrganizationResponse());
+
+        var result = await _sut.ProcessAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.SuccessCount.Should().Be(1);
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.RequestName.Should().Be("WinOpportunity");
+        capturedRequest["OpportunityClose"].Should().Be(closeEntity);
+        ((OptionSetValue)capturedRequest["Status"]).Value.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ReturnsCorrectPhaseResult()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var id3 = Guid.NewGuid();
+
+        var context = CreateContext();
+        context.StateTransitions.Add("incident", id1, new StateTransitionData
+        { EntityName = "incident", RecordId = id1, StateCode = 1, StatusCode = 5 });
+        context.StateTransitions.Add("incident", id2, new StateTransitionData
+        { EntityName = "incident", RecordId = id2, StateCode = 1, StatusCode = 5 });
+        context.StateTransitions.Add("account", id3, new StateTransitionData
+        { EntityName = "account", RecordId = id3, StateCode = 1, StatusCode = 2 });
+
+        SetupRetrieveStatecode(id1, 0);
+        SetupRetrieveStatecode(id2, 0);
+        SetupRetrieveStatecode(id3, 0);
+
+        _pool.Setup(p => p.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r.RequestName == "SetState"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrganizationResponse());
+
+        var result = await _sut.ProcessAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.RecordsProcessed.Should().Be(3);
+        result.SuccessCount.Should().Be(3);
+        result.FailureCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SkipsWhenNoTransitions()
+    {
+        var context = CreateContext();
+
+        var result = await _sut.ProcessAsync(context, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.RecordsProcessed.Should().Be(0);
+        result.SuccessCount.Should().Be(0);
+        result.FailureCount.Should().Be(0);
+
+        _pool.Verify(
+            p => p.GetClientAsync(
+                It.IsAny<Dataverse.Client.DataverseClientOptions?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _pool.Verify(
+            p => p.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    #region Helpers
+
+    private void SetupRetrieveStatecode(Guid recordId, int statecodeValue)
+    {
+        var entity = new Entity { Id = recordId };
+        entity["statecode"] = new OptionSetValue(statecodeValue);
+
+        _client.Setup(c => c.RetrieveAsync(
+                It.IsAny<string>(),
+                recordId,
+                It.IsAny<ColumnSet>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+    }
+
+    private static ImportContext CreateContext()
+    {
+        var data = new MigrationData();
+        var plan = new ExecutionPlan();
+        var options = new ImportOptions { ContinueOnError = true };
+        var fieldMetadata = new FieldMetadataCollection(
+            new Dictionary<string, Dictionary<string, FieldValidity>>());
+
+        return new ImportContext(data, plan, options, new IdMappingCollection(), fieldMetadata);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
@@ -1007,7 +1007,7 @@ public class TieredImporterTests
         // Set up the pooled client for individual fallback operations
         var mockPooledClient = new Mock<IPooledClient>();
         mockPooledClient
-            .Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+            .Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UpsertResponse
             {
                 Results = { ["Target"] = new EntityReference("team", Guid.NewGuid()) }
@@ -1336,7 +1336,7 @@ public class TieredImporterTests
         // Set up pooled client for individual operations
         var mockPooledClient = new Mock<IPooledClient>();
         mockPooledClient
-            .Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>()))
+            .Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UpsertResponse
             {
                 Results = { ["Target"] = new EntityReference("account", records[0].Id) }


### PR DESCRIPTION
## Summary

Implements full CMT (Configuration Migration Tool) parity for the PPDS migration engine. Adds entity-specific handlers, state transition processing, external lookup resolution, date shifting, file column import support, per-entity import modes, and a TUI MigrationScreen.

- **Handler framework:** 4 focused interfaces (IRecordFilter, IRecordTransformer, IStateTransitionHandler, IPostImportHandler) with 10 entity-specific handlers
- **State transitions:** Phase 3 processing with specialized SDK messages for 8 state machine entities (opportunity, incident, quote, salesorder, lead, etc.)
- **Components:** DateShifter (4 modes), EntityReferenceMapper (cascading resolution), FileColumnTransferHelper (4MB chunked upload), StateTransitionProcessor
- **CLI:** New import flags (--resolve-lookups, --skip-unresolved-lookups, --impersonate-owners)
- **TUI:** MigrationScreen with Export/Import modes, configuration, progress, keyboard hints
- **DI:** Singleton forwarding for multi-interface handlers ensuring shared state
- **Quality:** 2 rounds of impartial review + 2 QA rounds. All constitution violations (R2, D2) resolved.

Closes #30, #31, #32, #33, #34, #35, #37, #665, #666, #667

## Test plan

- [x] 425 migration unit tests pass across net8.0/net9.0/net10.0
- [x] All 10 entity handler test suites pass
- [x] StateTransitionProcessor tests (SetState, SDK messages, target state check)
- [x] DateShifter tests (absolute, relative, relativeDaily, relativeExact)
- [x] EntityReferenceMapper tests (ID mapping, direct ID, name-based, caching)
- [x] CLI verification: help flags, missing --data error, nonexistent file error
- [x] TUI verification: menu integration, screen render, hotkeys, tab focus, placeholders
- [x] TUI snapshot tests (12 pass, 4 snapshots match)
- [x] Full solution: 0 build errors, 0 test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)