### PR TITLE
feat: /investigate skill, challenger agent, retro store, verify workflow

### DIFF
--- a/.claude/agents/challenger.md
+++ b/.claude/agents/challenger.md
@@ -1,0 +1,76 @@
+---
+name: challenger
+model: sonnet
+tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# Challenger
+
+You are an adversarial reviewer. You receive an investigation summary and a
+set of constraints/decisions. Your job is to find blind spots, flawed
+assumptions, and missing considerations.
+
+You do NOT have access to the original problem statement, session transcript,
+or user goals. You review ONLY what is presented to you.
+
+## Mandatory Dimensions
+
+You MUST evaluate the proposal against ALL 8 dimensions. Do not skip any.
+
+1. **Testability**: How is this tested? Can the tests run headless?
+2. **Verifiability**: How do you know it works after shipping?
+3. **Failure modes**: What breaks? How do you detect and recover?
+4. **Observability**: How do you see what is happening?
+5. **Operability**: What is the maintenance burden? Who runs it?
+6. **Reversibility**: Can you undo this easily?
+7. **Dependencies**: What must exist first?
+8. **Scope**: What does this explicitly NOT cover?
+
+## Finding Classification
+
+For each finding:
+- **BLOCKER**: Architectural flaw, missing critical property, will cause failure
+- **CONCERN**: Non-trivial gap, should be addressed but not a showstopper
+- **NIT**: Style, preference, minor improvement
+
+## Output Format
+
+For each dimension:
+```
+### {N}. {Dimension}
+
+[BLOCKER|CONCERN|NIT] C-{N}: {one-line summary}
+  Evidence: {what in the proposal demonstrates the problem}
+  Impact: {what happens if this is not addressed}
+  Suggestion: {what to do about it}
+```
+
+If a dimension has no findings, write:
+```
+### {N}. {Dimension}
+No findings.
+```
+
+## Summary
+
+End with:
+```
+## Summary
+Blockers: {count}
+Concerns: {count}
+Nits: {count}
+
+{If blockers > 0: "This proposal has blocking issues that must be resolved."}
+{If blockers == 0: "No blocking issues. Concerns are addressable during implementation."}
+```
+
+## Rules
+
+1. Every dimension gets a section — no omissions.
+2. Be specific — cite the actual text from the proposal.
+3. Do not invent requirements — review what is proposed, not what you wish was proposed.
+4. BLOCKERs must be real — an architectural flaw that will cause failure, not a preference.
+5. If the proposal is solid, say so. "No findings" is valid.

--- a/.claude/agents/gemini-triage.md
+++ b/.claude/agents/gemini-triage.md
@@ -1,7 +1,7 @@
 ---
 name: gemini-triage
 model: sonnet
-allowedTools:
+tools:
   - Read
   - Edit
   - Write

--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -101,7 +101,7 @@ def main():
         )
 
     # Valid surface keys
-    valid_surfaces = ("ext", "tui", "mcp", "cli")
+    valid_surfaces = ("ext", "tui", "mcp", "cli", "workflow")
 
     # 2. At least one valid surface verified
     verify = state.get("verify", {})

--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -32,20 +32,24 @@ def get_current_branch() -> str:
 
 
 def is_allowed_path(file_path: str) -> bool:
-    normalized = file_path.replace("\\", "/").lower()
-    # Strip project dir prefix so absolute paths work the same as relative ones
-    project_dir = normalize_msys_path(os.environ.get("CLAUDE_PROJECT_DIR", "")).replace("\\", "/").lower().rstrip("/")
+    normalized = normalize_msys_path(file_path).replace("\\", "/").lower()
+    project_dir = normalize_msys_path(
+        os.environ.get("CLAUDE_PROJECT_DIR", "")
+    ).replace("\\", "/").lower().rstrip("/")
+
+    relative = normalized
     if project_dir and normalized.startswith(project_dir + "/"):
-        normalized = normalized[len(project_dir) + 1:]
-    allowed_prefixes = []
+        relative = normalized[len(project_dir) + 1:]
+
     allowed_substrings = [
         "/tmp/",
         "/temp/",
         "appdata/local/temp",
         ".worktrees/",
     ]
-    return any(normalized.startswith(p) for p in allowed_prefixes) or any(
-        s in normalized for s in allowed_substrings
+    # Check both absolute and relative forms
+    return any(s in normalized for s in allowed_substrings) or any(
+        s in relative for s in allowed_substrings
     )
 
 def main() -> None:

--- a/.claude/hooks/session-start-workflow.py
+++ b/.claude/hooks/session-start-workflow.py
@@ -63,7 +63,7 @@ def main():
         msg = (
             f"WORKFLOW ENFORCEMENT ACTIVE on branch {branch}:\n"
             "  No workflow state tracked yet.\n"
-            "  For new features: /spec → /implement → /gates → /verify → /qa → /review → /pr\n"
+            "  For new features: /design → /implement → /gates → /verify → /qa → /review → /pr\n"
             "  For bug fixes: /gates → /verify (if UI changed) → /pr"
         )
         if not os.environ.get("PPDS_PIPELINE"):

--- a/.claude/hooks/session-start-workflow.py
+++ b/.claude/hooks/session-start-workflow.py
@@ -117,9 +117,9 @@ def main():
 
     # Verify surfaces
     verify = state.get("verify", {})
-    for surface in ("ext", "tui", "mcp", "cli"):
+    for surface in ("ext", "tui", "mcp", "cli", "workflow"):
         ts = verify.get(surface)
-        label = {"ext": "Extension", "tui": "TUI", "mcp": "MCP", "cli": "CLI"}[surface]
+        label = {"ext": "Extension", "tui": "TUI", "mcp": "MCP", "cli": "CLI", "workflow": "Workflow"}[surface]
         if ts:
             lines.append(f"  ✓ {label} verified")
         else:
@@ -152,7 +152,7 @@ def main():
     missing = []
     if not gates_passed or (head_sha and gates_ref != head_sha):
         missing.append("/gates")
-    if not any(verify.get(s) for s in ("ext", "tui", "mcp", "cli")):
+    if not any(verify.get(s) for s in ("ext", "tui", "mcp", "cli", "workflow")):
         missing.append("/verify")
     if not qa_surfaces:
         missing.append("/qa")

--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -99,7 +99,6 @@ def main():
                 "specs/",
                 ".plans/",
                 "docs/",
-                ".claude/",
                 "README",
                 "CLAUDE.md",
             )
@@ -144,7 +143,7 @@ def main():
             missing.append("/gates")
 
     # Valid surface keys
-    valid_surfaces = ("ext", "tui", "mcp", "cli")
+    valid_surfaces = ("ext", "tui", "mcp", "cli", "workflow")
 
     # Verify (at least one valid surface)
     verify = state.get("verify", {})

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -31,6 +31,23 @@ Before asking any questions, read:
 - Propose update mode: "Should I update this spec, or is this a new spec?"
 - If updating, read the existing spec fully before proceeding.
 
+**Check for design context:** After searching for existing specs, check for
+`.plans/design-context.md` in the current working directory.
+
+If found:
+1. Read the file
+2. Present a summary: "Design context loaded from investigation: {topic}. Covers: {scope summary}."
+3. Ask: "Proceed to spec writing, or brainstorm further?"
+4. If "proceed": skip Step 2 (Brainstorm), go directly to Step 3 (Write Spec)
+5. If "brainstorm": continue with Step 2, using the design context as starting input
+
+**Constraint checking:** Before presenting the architecture (Step 2 or Step 3),
+verify the proposal against each Constraint and each Known Concern in
+`design-context.md`. Flag conflicts — e.g., "Constraint #3 says X, but the
+proposed architecture does Y."
+
+If not found: continue with normal Step 2 brainstorm flow.
+
 ### Step 2: Brainstorm
 
 **Understand the idea** — ask clarifying questions **one at a time**:

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -100,7 +100,7 @@ Agent tool:
 
 **Convergence rules:**
 - **Max 3 rounds** — safety valve, stop after 3 rounds regardless
-- **Fewer blockers each round** — round N+1 must have fewer BLOCKERs than round N to indicate convergence
+- **Fewer blockers each round** — round N+1 must have fewer BLOCKERs than round N to indicate convergence. If blockers increase (divergence), continue up to max 3 rounds, then stop and note "challenger diverged — escalate all findings to human"
 - **Zero blockers + implementation-detail concerns only** — stop when no BLOCKERs remain and all CONCERNs are implementation-detail level (not architectural)
 - **Same findings reappear** — if the challenger raises the same findings across rounds, it is looping; stop and note "challenger converged (repeated findings)"
 

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: investigate
+description: Pre-commitment exploration with optional adversarial challenge. Use when exploring ideas, evaluating approaches, or researching before committing to a direction.
+---
+
+# Investigate
+
+Pre-commitment exploration that gathers context, researches options, synthesizes tradeoffs, and runs adversarial challenge before the human commits to a direction. Produces a validated design context for handoff to `/start` and `/design`.
+
+## Usage
+
+`/investigate` — with freeform description of what to explore
+`/investigate Should we use Terminal.Gui v2 or stay on v1?`
+`/investigate How should we structure the MCP tool registration?`
+
+## Process
+
+### Preamble: Ceremony Level
+
+Ask the user: **"Quick exploration or full investigation?"**
+
+- **Quick**: Steps 1, 3, 6, 7, 8 only (Gather, Synthesize, Present, Align, Handoff)
+- **Full**: All 8 steps (Gather, Research, Synthesize, Challenge, Triage, Present, Align, Handoff)
+
+Quick mode is appropriate for small scope changes, familiar domains, or when the human already has strong opinions. Full mode is appropriate for unfamiliar domains, high-risk architectural decisions, or when the human wants adversarial challenge.
+
+### Step 1: Gather
+
+Read relevant context from the codebase:
+
+1. **Specs**: Search `specs/*.md` for overlapping scope — check file names, overview sections, and `**Code:**` frontmatter
+2. **Skills**: Read any skills that will be affected by the proposal
+3. **Code**: Read key source files in the affected area
+4. **Retro patterns**: Read `.retros/summary.json` if it exists — check `findings_by_category` for recurring patterns relevant to this investigation. If the file doesn't exist or has invalid JSON, skip without error.
+5. **Design context from args**: If `$ARGUMENTS` contains a design-context reference, read it
+
+Present a brief summary of what was gathered: "Found N specs, M skills, K source files relevant to this topic."
+
+### Step 2: Research (full mode only)
+
+Dispatch a researcher agent for external practices and patterns:
+
+```
+Agent tool:
+  subagent_type: general-purpose
+  prompt: {research question with codebase context}
+```
+
+**Researcher tool restrictions** — the prompt MUST include:
+> You may ONLY use these tools: Read, Glob, Grep, WebSearch, WebFetch.
+> Do NOT use Edit, Write, Bash, or Agent. You are read-only.
+
+**Auto-detect research need:**
+- Process/architecture changes → research external practices
+- Bug investigation → skip research (not useful)
+- Unfamiliar domain → research patterns and prior art
+
+The human can override: "Skip research" or "Research X specifically."
+
+### Step 3: Synthesize
+
+Present the investigation synthesis:
+
+1. **Options**: 2-3 approaches with tradeoffs for each
+2. **Recommendation**: Lead with the recommended option and explain why
+3. **Assumptions**: Explicit list of assumptions being made
+4. **Constraints and Decisions**: Numbered list of items that are settled or must be settled
+
+Format as:
+```
+## Investigation Summary
+### Problem: {what we're exploring}
+### Options: {2-3 approaches with tradeoffs}
+### Assumptions: {explicit list}
+### Constraints and Decisions: {numbered list of settled items}
+```
+
+### Step 4: Challenge (full mode only)
+
+Dispatch the challenger agent for adversarial review:
+
+```
+Agent tool:
+  subagent_type: challenger
+  prompt: |
+    Review this proposal:
+
+    {Investigation Summary from Step 3}
+
+    {Constraints and Decisions section from Step 3}
+
+    Evaluate against all 8 mandatory dimensions.
+```
+
+**CRITICAL**: Pass ONLY the Investigation Summary and Constraints/Decisions to the challenger. Do NOT pass:
+- The original problem statement or user's question
+- Session transcript or conversation history
+- User goals or preferences
+- Research findings (the challenger reviews the synthesis, not the raw research)
+
+**Convergence rules:**
+- **Max 3 rounds** — safety valve, stop after 3 rounds regardless
+- **Fewer blockers each round** — round N+1 must have fewer BLOCKERs than round N to indicate convergence
+- **Zero blockers + implementation-detail concerns only** — stop when no BLOCKERs remain and all CONCERNs are implementation-detail level (not architectural)
+- **Same findings reappear** — if the challenger raises the same findings across rounds, it is looping; stop and note "challenger converged (repeated findings)"
+
+Between rounds, address the BLOCKERs by updating the Investigation Summary and re-dispatching. Do NOT address CONCERNs or NITs between rounds — those go to triage.
+
+### Step 5: Triage (full mode only)
+
+Classify and route challenge findings:
+
+- **BLOCKERs**: ALWAYS present to human at Align step — never auto-resolved
+- **CONCERNs with factual errors** (challenger cited wrong information): AI auto-resolves with correction
+- **CONCERNs with design decisions** (legitimate tradeoff the challenger flagged): Present to human at Align step
+- **NITs with missing details** (challenger noted something not mentioned): AI fills in the detail
+- **NITs with style/values questions** (naming, conventions, preferences): Present to human at Align step
+
+Present triage results: "Auto-resolved N findings (M factual corrections, K detail additions). Presenting P findings for your review."
+
+### Step 6: Present
+
+Present the investigation results side by side:
+
+**Left column: Investigation Summary** (from Step 3, updated after challenge rounds if applicable)
+**Right column: Challenge Findings** (from Step 4, after triage in Step 5)
+
+If quick mode: present only the Investigation Summary (no challenge findings).
+
+### Step 7: Align
+
+Ask the human for a decision:
+
+1. **Go** — proceed with the recommended approach
+2. **Change X** — modify a specific aspect and re-evaluate (loops back to relevant step)
+3. **Not worth it** — abandon the investigation
+
+Wait for the human's response. Do not proceed until alignment is reached.
+
+### Step 8: Handoff
+
+Present the design-context summary that will be passed to `/start`:
+
+```markdown
+# Design Context: {topic}
+
+**Source:** /investigate session on {date}
+**Validated:** {challenge round summary, or "Quick mode — no adversarial challenge"}
+
+## Problem Statement
+{what we're exploring and why}
+
+## Scope
+{deliverables with brief descriptions}
+
+## Constraints and Decisions
+{numbered list of settled items from the investigation}
+
+## Known Concerns
+{items needing spec-level answers — from challenge findings marked for human review}
+
+## Evidence
+{key data points that informed the investigation}
+```
+
+Instruct the human:
+> Run `/start` to create a worktree. The design context will be written to `.plans/design-context.md` in the new worktree. Then run `/design` to continue to spec writing.
+
+The design-context content stays in conversation memory — `/start` will write it to the worktree's `.plans/design-context.md` when invoked in the same conversation.
+
+## Rules
+
+1. **Never headless** — `/investigate` is always interactive, never a pipeline stage
+2. **Ceremony is the human's call** — within a chosen level, do not skip steps to save tokens
+3. **Challenger isolation** — only summary + constraints, never raw conversation context
+4. **Gather includes retro patterns** — always check `.retros/summary.json` for recurring issues
+5. **Research is read-only** — researcher agent may not edit, write, or execute commands
+6. **Convergence is mandatory** — do not skip challenge rounds if blockers exist (up to max 3)
+7. **BLOCKERs always to human** — never auto-resolve a BLOCKER finding
+8. **Handoff is conversation-based** — design-context lives in conversation memory, written by `/start`

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -199,6 +199,35 @@ Tier definitions:
 - **draft-fix**: Skill wording, checklist gaps. Auto-PR but flag for review.
 - **issue-only**: Architectural changes, new skills. Create GitHub issue, needs /design.
 
+### 10. Persistent Store Update
+
+After writing `.workflow/retro-findings.json`, update the persistent retro store:
+
+1. **Read** `.retros/summary.json` (from repo root, not worktree `.workflow/`)
+   - If file doesn't exist: create with seed schema (schema_version: 1, total_retros: 0, empty findings_by_category, zeroed metrics)
+   - If file has invalid JSON: log warning, create fresh
+   - If `schema_version` differs from expected (1): log warning, create fresh
+
+2. **Append** each finding to `findings_by_category[category]` with `{date, branch, finding_id}`
+   - Append only — never mutate or delete existing entries during this step
+   - New categories are added as new keys
+
+3. **Increment** `total_retros`
+
+4. **Update** `metrics` (rolling averages computed from all entries in store):
+   - `avg_fix_ratio`: average feat/fix ratio across all retros
+   - `pipeline_success_rate`: fraction of retros with severity "clean"
+   - `avg_convergence_rounds`: average convergence rounds (from pipeline retros)
+
+5. **Trim** entries that fall outside both retention windows:
+   - Keep entries within last 20 retros (by `total_retros` count)
+   - Keep entries within last 6 months (by `date` field)
+   - Remove only entries that exceed BOTH thresholds (older than 6 months AND beyond 20 retros)
+
+6. **Update** `last_updated` to today's date
+
+7. **Write** `.retros/summary.json`
+
 ---
 
 ## Pipeline Retro
@@ -209,7 +238,8 @@ When running as a pipeline stage (headless, no user present):
 2. Read worktree transcripts — count sessions, extract basic metrics
 3. Read git log — commit count, feat/fix ratio
 4. Write `.workflow/retro-findings.json` with mechanical metrics ONLY
-5. No grading, no judgment, no root cause analysis — just data
-6. **Crash detection:** If this retro runs for less than 5 minutes and produces zero findings, log a warning in retro-findings.json
+5. **Update persistent store:** Follow the same Persistent Store Update process (section 10) to append findings to `.retros/summary.json`
+6. No grading, no judgment, no root cause analysis — just data
+7. **Crash detection:** If this retro runs for less than 5 minutes and produces zero findings, log a warning in retro-findings.json
 
 The pipeline orchestrator reads this file for auto-heal decisions.

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -97,6 +97,25 @@ python scripts/workflow-state.py append issues <N>
 
 Run these commands from within the worktree directory (use the `cwd` parameter when executing via Bash tool).
 
+### Step 5b: Write Design Context (if present)
+
+If the conversation contains design-context content from a prior `/investigate` session:
+
+1. Create `.plans/` directory in the new worktree:
+   ```bash
+   mkdir -p .worktrees/<name>/.plans
+   ```
+
+2. Write the design-context content from conversation to `.plans/design-context.md` in the worktree
+
+3. Update Step 7 guidance to include:
+   ```
+   Design context written to .plans/design-context.md.
+   Run /design to continue.
+   ```
+
+If no design-context in conversation — skip this step, no file written.
+
 ### Step 6: Open Terminal
 
 Detect platform:

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -35,6 +35,7 @@ Based on $ARGUMENTS or recent changes:
 - `src/PPDS.Cli/Tui/` → TUI mode
 - `src/PPDS.Extension/` → Extension mode
 - `src/PPDS.Mcp/` → MCP mode
+- `.claude/` or `scripts/` → Workflow mode
 - No clear match → Ask user
 
 ### 2. Run Unit Tests First
@@ -162,6 +163,55 @@ For each tool:
 2. Call with edge case input -> verify error handling
 3. Verify response matches expected schema
 
+
+### 8. Workflow Mode
+
+Structural validation of process code (`.claude/` and `scripts/`).
+
+**Check 1: Python tests**
+```bash
+pytest tests/test_pipeline.py tests/test_workflow_state.py tests/test_protect_main_branch.py tests/test_session_stop_workflow.py -v
+```
+
+**Check 2: Hook script tests**
+For each `.py` file in `.claude/hooks/` (excluding `_pathfix.py`):
+```bash
+echo '{}' | python .claude/hooks/{hook}.py
+# Expect exit 0 (allow) or exit 2 (block) — not a crash (exit 1)
+```
+
+**Check 3: settings.json validation**
+Parse `.claude/settings.json` as JSON. For each hook entry, verify the `command` path exists on disk.
+
+**Check 4: Skill frontmatter validation**
+For each `.claude/skills/*/SKILL.md`:
+- Parse YAML frontmatter (between `---` delimiters)
+- Verify `name` field present and non-empty
+- Verify `description` field present and non-empty
+
+**Check 5: Agent frontmatter validation**
+For each `.claude/agents/*.md`:
+- Parse YAML frontmatter
+- Verify `tools` list present
+- Verify each tool name is in the known valid set: `Read`, `Edit`, `Write`, `Glob`, `Grep`, `Bash`, `Agent`, `WebSearch`, `WebFetch`, `NotebookEdit` (and Bash with patterns like `Bash(git diff:*)`)
+
+**Check 6: Skill file references**
+Scan each skill markdown for file path patterns (relative paths starting with `./`, `../`, or absolute paths). Verify each referenced file exists.
+
+**Check 7: Retro store schema**
+If `.retros/summary.json` exists:
+- Parse as JSON
+- Verify required keys: `schema_version`, `last_updated`, `total_retros`, `findings_by_category`, `metrics`
+- Verify `schema_version == 1`
+If the file does not exist, this check passes (the store is optional until first retro).
+
+**Check 8: Workflow state write**
+On all checks passing:
+```bash
+python scripts/workflow-state.py set verify.workflow now
+python scripts/workflow-state.py set qa.workflow now
+```
+
 ### 7. Report
 
 Present structured results:
@@ -190,6 +240,7 @@ python scripts/workflow-state.py set verify.{surface} now
 ```
 
 Surface key matches mode: `ext`, `tui`, `mcp`, `cli`. Example: `/verify extension` → `verify.ext`.
+Surface key `workflow`: `/verify workflow` → writes `verify.workflow` + `qa.workflow` (structural validation IS the QA for process code).
 
 ## Rules
 

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: Verify
+description: AI self-verification of implemented work across surfaces (extension, CLI, MCP, TUI, workflow). Use after implementation to verify code works in its runtime environment.
 ---
 
 # Verify
@@ -164,7 +164,7 @@ For each tool:
 3. Verify response matches expected schema
 
 
-### 8. Workflow Mode
+### 7. Workflow Mode
 
 Structural validation of process code (`.claude/` and `scripts/`).
 
@@ -212,7 +212,7 @@ python scripts/workflow-state.py set verify.workflow now
 python scripts/workflow-state.py set qa.workflow now
 ```
 
-### 7. Report
+### 8. Report
 
 Present structured results:
 

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "last_updated": "2026-03-27",
+  "total_retros": 0,
+  "findings_by_category": {},
+  "metrics": {
+    "avg_fix_ratio": 0.0,
+    "pipeline_success_rate": 0.0,
+    "avg_convergence_rounds": 0.0
+  }
+}

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "last_updated": "2026-03-27",
-  "total_retros": 1,
+  "total_retros": 2,
   "findings_by_category": {
     "external": [
       { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-01" }
@@ -9,11 +9,17 @@
     "tooling": [
       { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-02" },
       { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-03" }
+    ],
+    "design": [
+      { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-04" }
+    ],
+    "behavior": [
+      { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-04" }
     ]
   },
   "metrics": {
-    "avg_fix_ratio": 0.2,
+    "avg_fix_ratio": 0.45,
     "pipeline_success_rate": 0.0,
-    "avg_convergence_rounds": 0.0
+    "avg_convergence_rounds": 2.0
   }
 }

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,10 +1,18 @@
 {
   "schema_version": 1,
   "last_updated": "2026-03-27",
-  "total_retros": 0,
-  "findings_by_category": {},
+  "total_retros": 1,
+  "findings_by_category": {
+    "external": [
+      { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-01" }
+    ],
+    "tooling": [
+      { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-02" },
+      { "date": "2026-03-27", "branch": "feat/investigation-skill", "finding_id": "R-03" }
+    ]
+  },
   "metrics": {
-    "avg_fix_ratio": 0.0,
+    "avg_fix_ratio": 0.2,
     "pipeline_success_rate": 0.0,
     "avg_convergence_rounds": 0.0
   }

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1031,7 +1031,6 @@ def main():
     parser.add_argument("--worktree", help="Use existing worktree instead of creating one")
     parser.add_argument("--issue", type=int, action="append", default=[], help="GitHub issue number(s) (repeatable)")
     parser.add_argument("--dry-run", action="store_true", help="Run orchestration without invoking claude -p")
-    parser.add_argument("--stage-timeout", type=int, help="(Deprecated — ignored. Timeouts are now activity-based.)")
     args = parser.parse_args()
 
     # Handle backward compat: positional plan arg

--- a/scripts/verify_workflow_checks.py
+++ b/scripts/verify_workflow_checks.py
@@ -59,15 +59,15 @@ def check_agent_frontmatter(agent_path: str) -> list[str]:
 
     frontmatter = parts[1].strip()
 
-    # Parse tools list from YAML
+    # Parse tools list from YAML (accept both 'tools' and 'allowedTools')
     tools = []
     in_tools = False
     for line in frontmatter.split("\n"):
         stripped = line.strip()
-        if stripped.startswith("tools:"):
+        if stripped.startswith("tools:") or stripped.startswith("allowedTools:"):
             in_tools = True
             # Check for inline list
-            after = stripped[len("tools:"):].strip()
+            after = stripped.split(":", 1)[1].strip()
             if after.startswith("["):
                 # Inline list: tools: [Read, Grep]
                 tools = [t.strip() for t in after.strip("[]").split(",") if t.strip()]

--- a/scripts/verify_workflow_checks.py
+++ b/scripts/verify_workflow_checks.py
@@ -1,0 +1,152 @@
+"""Verify workflow checks — importable validation functions for .claude/ and scripts/."""
+import json
+import os
+import re
+
+
+def check_skill_frontmatter(skill_path: str) -> list[str]:
+    """Check 4: Validate skill YAML frontmatter has name and description.
+
+    Returns list of error messages (empty = pass).
+    """
+    errors = []
+    try:
+        with open(skill_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        return [f"Cannot read {skill_path}: {e}"]
+
+    # Extract frontmatter between --- delimiters
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return [f"{skill_path}: No YAML frontmatter found (missing --- delimiters)"]
+
+    frontmatter = parts[1].strip()
+    # Simple YAML parsing for name and description
+    fields = {}
+    for line in frontmatter.split("\n"):
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+
+    if not fields.get("name"):
+        errors.append(f"{skill_path}: Missing or empty 'name' field in frontmatter")
+    if not fields.get("description"):
+        errors.append(f"{skill_path}: Missing or empty 'description' field in frontmatter")
+
+    return errors
+
+
+def check_agent_frontmatter(agent_path: str) -> list[str]:
+    """Check 5: Validate agent YAML frontmatter has valid tools.
+
+    Returns list of error messages (empty = pass).
+    """
+    VALID_TOOLS = {
+        "Read", "Edit", "Write", "Glob", "Grep", "Bash",
+        "Agent", "WebSearch", "WebFetch", "NotebookEdit",
+    }
+    errors = []
+    try:
+        with open(agent_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        return [f"Cannot read {agent_path}: {e}"]
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return [f"{agent_path}: No YAML frontmatter found"]
+
+    frontmatter = parts[1].strip()
+
+    # Parse tools list from YAML
+    tools = []
+    in_tools = False
+    for line in frontmatter.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("tools:"):
+            in_tools = True
+            # Check for inline list
+            after = stripped[len("tools:"):].strip()
+            if after.startswith("["):
+                # Inline list: tools: [Read, Grep]
+                tools = [t.strip() for t in after.strip("[]").split(",") if t.strip()]
+                in_tools = False
+            continue
+        if in_tools:
+            if stripped.startswith("- "):
+                tool_name = stripped[2:].strip()
+                tools.append(tool_name)
+            elif stripped and not stripped.startswith("#"):
+                in_tools = False
+
+    if not tools:
+        errors.append(f"{agent_path}: No 'tools' list found in frontmatter")
+        return errors
+
+    for tool in tools:
+        # Allow Bash with patterns like Bash(git diff:*)
+        base_tool = tool.split("(")[0] if "(" in tool else tool
+        if base_tool not in VALID_TOOLS:
+            errors.append(f"{agent_path}: Invalid tool '{tool}' — not in known valid set")
+
+    return errors
+
+
+def check_skill_file_references(skill_path: str, repo_root: str) -> list[str]:
+    """Check 6: Find file path references in skill markdown and verify they exist.
+
+    Returns list of error messages (empty = pass).
+    """
+    errors = []
+    try:
+        with open(skill_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError as e:
+        return [f"Cannot read {skill_path}: {e}"]
+
+    # Match relative paths like ./foo, ../bar, but not in code blocks that are templates
+    # Focus on markdown link targets: [text](path) where path starts with ./ or ../
+    link_pattern = re.compile(r'\[.*?\]\((\.\.?/[^)]+)\)')
+
+    for match in link_pattern.finditer(content):
+        ref_path = match.group(1)
+        # Resolve relative to the skill file's directory
+        skill_dir = os.path.dirname(skill_path)
+        resolved = os.path.normpath(os.path.join(skill_dir, ref_path))
+        if not os.path.exists(resolved):
+            errors.append(f"{skill_path}: Dead link to '{ref_path}' (resolved: {resolved})")
+
+    return errors
+
+
+def check_retro_store_schema(store_path: str) -> list[str]:
+    """Check 7: Validate .retros/summary.json schema.
+
+    Returns list of error messages (empty = pass).
+    Missing file is NOT an error — the store is optional.
+    """
+    if not os.path.exists(store_path):
+        return []  # Missing store is OK
+
+    errors = []
+    try:
+        with open(store_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return [f"{store_path}: Invalid JSON — {e}"]
+    except OSError as e:
+        return [f"{store_path}: Cannot read — {e}"]
+
+    required_keys = ["schema_version", "last_updated", "total_retros", "findings_by_category", "metrics"]
+    for key in required_keys:
+        if key not in data:
+            errors.append(f"{store_path}: Missing required key '{key}'")
+
+    if data.get("schema_version") != 1:
+        errors.append(
+            f"{store_path}: schema_version is {data.get('schema_version')}, expected 1 — "
+            "rebuild the store"
+        )
+
+    return errors

--- a/specs/investigation.md
+++ b/specs/investigation.md
@@ -1,0 +1,640 @@
+# Investigation
+
+**Status:** Draft
+**Last Updated:** 2026-03-27
+**Code:** [.claude/skills/investigate/](../.claude/skills/investigate/), [.claude/agents/challenger.md](../.claude/agents/challenger.md), [.claude/hooks/](../.claude/hooks/), [scripts/](../scripts/)
+**Surfaces:** N/A
+
+---
+
+## Overview
+
+Pre-commitment exploration skill that gathers context, researches options, synthesizes tradeoffs, and runs adversarial challenge before the human commits to a direction. Bridges the gap between "I have an idea" and `/start` → `/design` by producing a validated design context. Includes supporting infrastructure: a challenger agent, a retro persistent store, a `/verify workflow` mode, and handoff modifications to `/start` and `/design`.
+
+### Goals
+
+- **Structured exploration**: Replace ad-hoc investigation with a repeatable skill that gathers context, researches, synthesizes, and challenges before commitment
+- **Adversarial quality**: Catch blind spots via a structurally isolated challenger agent with a mandatory 8-dimension checklist
+- **Retro feedback loop**: Persist retro findings across sessions so `/investigate` can detect recurring patterns
+- **Workflow verification**: Validate `.claude/` and `scripts/` changes with the same rigor as product code
+- **Seamless handoff**: Bridge `/investigate` → `/start` → `/design` via design-context content passed through conversation
+
+### Non-Goals
+
+- Headless or pipeline execution of `/investigate` — always interactive
+- Metrics dashboards or trend analysis — not enough data yet (deferred)
+- Auto-heal from retro findings — only 1 auto-fix finding exists (deferred)
+- Spec-reviewer agent — build challenger first, extract reviewer later (deferred)
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    /investigate                          │
+│  (interactive skill, never headless)                    │
+│                                                         │
+│  ┌──────────┐  ┌───────────┐  ┌───────────┐           │
+│  │ Gather   │─▶│ Research   │─▶│ Synthesize│           │
+│  │ context  │  │ (full only)│  │ options + │           │
+│  └──────────┘  │            │  │ tradeoffs │           │
+│                │ ┌────────┐ │  └─────┬─────┘           │
+│                │ │Research│ │        │                  │
+│                │ │Agent   │ │        │                  │
+│                │ │(inline)│ │        │                  │
+│                │ └────────┘ │        │                  │
+│                └────────────┘        │                  │
+│       ┌──────────────────────────────┘                  │
+│       ▼                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐             │
+│  │ Challenge │─▶│ Triage   │─▶│ Present  │             │
+│  │ (full     │  │ AI auto- │  │ summary +│             │
+│  │  only)    │  │ resolve  │  │ findings │             │
+│  └─────┬─────┘  └──────────┘  └─────┬────┘             │
+│        │                             │                  │
+│        ▼                             ▼                  │
+│  ┌───────────┐               ┌──────────┐              │
+│  │ Challenger │               │  ALIGN   │              │
+│  │ Agent     │               │ (human)  │              │
+│  │ (Sonnet)  │               └─────┬────┘              │
+│  └───────────┘                     │                   │
+│   Receives ONLY:                   ▼                   │
+│   - Summary                  ┌──────────┐              │
+│   - Constraints              │ Handoff  │              │
+│                              │ (convo)  │              │
+│                              └──────────┘              │
+└────────────────────────────────┬────────────────────────┘
+                                 │ design-context in conversation
+                                 ▼
+┌──────────┐    ┌──────────┐    ┌──────────┐
+│  /start  │───▶│ worktree │───▶│  /design │
+│ writes   │    │ .plans/  │    │ loads    │
+│ context  │    │ design-  │    │ context  │
+│ to .plans│    │ context  │    │          │
+└──────────┘    └──────────┘    └──────────┘
+```
+
+```
+┌─────────────────────────────────────────────┐
+│          Retro Persistent Store             │
+│                                             │
+│  /retro (pipeline stage)                    │
+│    │                                        │
+│    ├──▶ .workflow/retro-findings.json       │
+│    │    (per-session, gitignored)           │
+│    │                                        │
+│    └──▶ .retros/summary.json               │
+│         (git-tracked, append-only)          │
+│         - findings_by_category              │
+│         - per-occurrence timestamps         │
+│         - windowed: 20 retros / 6 months   │
+└─────────────────────────────────────────────┘
+```
+
+```
+┌─────────────────────────────────────────────┐
+│          /verify workflow                   │
+│                                             │
+│  Triggers: changes in .claude/ or scripts/  │
+│                                             │
+│  Checks:                                    │
+│  1. pytest: pipeline.py, workflow-state.py  │
+│  2. Hook scripts: test inputs, exit codes   │
+│  3. settings.json validation                │
+│  4. Skill frontmatter (name, description)   │
+│  5. Agent frontmatter (valid tool names)    │
+│  6. Skill file references (no dead links)   │
+│  7. .retros/summary.json schema validation  │
+│  8. Writes verify.workflow to state         │
+└─────────────────────────────────────────────┘
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `/investigate` skill | Interactive pre-commitment exploration — gathers context, researches, synthesizes, challenges, presents, gets human alignment, hands off |
+| Challenger agent | Adversarial review via 8-dimension checklist, structurally isolated from session context |
+| Researcher agent | Read-only codebase + web research, dispatched inline via Agent tool (not a separate agent file) |
+| `.retros/summary.json` | Persistent retro findings store — append-only, windowed, git-tracked |
+| `/verify workflow` mode | Structural validation of `.claude/` and `scripts/` changes |
+| `/start` modification | Writes design-context to worktree `.plans/` during creation |
+| `/design` modification | Loads design-context from `.plans/` if present at Step 1 |
+| Hook fixes | Stop-hook, pr-gate, session-start, protect-main changes |
+
+### Dependencies
+
+- Uses patterns from: [workflow-enforcement.md](./workflow-enforcement.md)
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. `/investigate` is always interactive, never a pipeline stage, never headless
+2. Human declares ceremony level upfront: "quick" (skip research + challenge) or "full" (all steps)
+3. Challenger agent receives ONLY the investigation summary and constraints/decisions — no session transcript, no user goals, no original problem framing
+4. Challenger uses the 8-dimension mandatory checklist: testability, verifiability, failure modes, observability, operability, reversibility, dependencies, scope
+5. Retro persistent store (`.retros/summary.json`) is git-tracked, append-only, updated by `/retro` skill
+6. `/verify workflow` validates all `.claude/` and `scripts/` structural properties
+7. Handoff passes design-context through conversation memory — `/investigate` holds content, `/start` writes it to worktree `.plans/design-context.md`
+8. Hook changes enforce workflow verification for process code changes
+
+### Primary Flows
+
+**Full Investigation:**
+
+1. **Gather**: Read relevant skills, specs, code, retro findings (including `.retros/summary.json` for recurring patterns)
+2. **Research**: Dispatch researcher agent (Read, Glob, Grep, WebSearch, WebFetch) for external practices — auto-detect need based on domain: process/architecture changes → research; bug investigation → no research; unfamiliar domain → research. Human can override.
+3. **Synthesize**: Present options, tradeoffs, and an explicit assumptions list
+4. **Challenge**: Dispatch challenger agent (Sonnet, isolated) with summary + constraints only. Convergence rules: round N+1 must have fewer blockers than round N; stop at zero blockers with only implementation-detail concerns; stop if same findings reappear; max 3 rounds.
+5. **Triage**: AI auto-resolves factual errors and missing details. Design decisions and values questions go to human at align step.
+6. **Present**: Investigation summary + challenge findings side by side
+7. **Align**: Human says go / change X / not worth it
+8. **Handoff**: Present the design-context summary and instruct human to run `/start` in the same conversation — `/start` writes the design-context from conversation to the worktree
+
+**Quick Investigation:**
+
+Steps 1, 3, 6, 7, 8 only. Skips research (step 2) and challenge (steps 4-5).
+
+**Retro Store Update (within `/retro` skill):**
+
+1. `/retro` completes analysis and writes `.workflow/retro-findings.json` (per-session, existing behavior)
+2. `/retro` also reads `.retros/summary.json` (or creates it if absent)
+3. Appends new findings by category with date, branch, finding_id per occurrence
+4. Updates aggregate metrics (avg_fix_ratio, pipeline_success_rate, avg_convergence_rounds)
+5. Trims entries that fall outside both windows (older than 6 months AND beyond the last 20 retros)
+6. Writes updated `.retros/summary.json`
+
+**Verify Workflow:**
+
+1. Detect trigger: changed files in `.claude/` or `scripts/`
+2. Run all 8 checks (see Verify Workflow Checks below)
+3. Report structured pass/fail results
+4. On all-pass: write `verify.workflow` and `qa.workflow` to workflow state (structural validation IS the QA for process code)
+
+### `/investigate` Skill Definition
+
+File: `.claude/skills/investigate/SKILL.md`
+
+Frontmatter:
+- name: investigate
+- description: Pre-commitment exploration with optional adversarial challenge. Use when exploring ideas, evaluating approaches, or researching before committing to a direction.
+
+Permissions by phase:
+- Gather phase: main agent reads codebase directly (Read, Glob, Grep)
+- Research phase: researcher agent with Read, Glob, Grep, WebSearch, WebFetch only — no Edit, Write, Bash
+- Challenge phase: challenger agent receives ONLY investigation summary + constraints/decisions section
+
+### Challenger Agent Definition
+
+File: `.claude/agents/challenger.md`
+
+Frontmatter:
+- name: challenger
+- model: sonnet
+- tools: Read, Grep, Glob (read-only — no Edit, Write, Bash)
+
+**Dispatch mechanism:** The `/investigate` skill invokes the challenger via the Agent tool, referencing the agent file by name (`subagent_type: challenger`). The agent file defines model, tools, and prompt. The skill constructs the prompt payload with ONLY the investigation summary and constraints/decisions.
+
+Mandatory dimensions checklist (baked into agent prompt):
+1. **Testability**: How is this tested? Can the tests run headless?
+2. **Verifiability**: How do you know it works after shipping?
+3. **Failure modes**: What breaks? How do you detect and recover?
+4. **Observability**: How do you see what is happening?
+5. **Operability**: What is the maintenance burden? Who runs it?
+6. **Reversibility**: Can you undo this easily?
+7. **Dependencies**: What must exist first?
+8. **Scope**: What does this explicitly NOT cover?
+
+Finding classification:
+- BLOCKER: Architectural flaw, missing critical property, will cause failure
+- CONCERN: Non-trivial gap, should be addressed but not a showstopper
+- NIT: Style, preference, minor improvement
+
+Convergence stopping rules:
+- Round N+1 has fewer blockers than round N → converging
+- Zero blockers + all remaining concerns are implementation-detail level → stop
+- Same findings reappear across rounds → challenger is looping, stop
+- Max 3 rounds (safety valve)
+
+Finding triage convention (by classification):
+- BLOCKERs always go to the human at the align checkpoint — never auto-resolved
+- CONCERNs: factual errors → AI auto-resolves; design decisions → human at align
+- NITs: AI auto-resolves missing details; style/values questions → human at align
+
+### Researcher Agent (Inline Dispatch)
+
+The researcher is NOT a separate agent file. It is dispatched inline within the `/investigate` skill using the Agent tool with explicit tool restrictions. This avoids creating a permanent agent definition for what is a single-use, skill-internal dispatch.
+
+Dispatch parameters:
+- subagent_type: general-purpose (default)
+- Tools permitted: Read, Glob, Grep, WebSearch, WebFetch
+- Tools excluded: Edit, Write, Bash, Agent (no nested agents)
+- Prompt: constructed by the skill with the research question and codebase context
+- Model: inherits from parent (no override)
+
+### Retro Persistent Store
+
+File: `.retros/summary.json` — git-tracked in main repo, updated in-place.
+
+Schema:
+```json
+{
+  "schema_version": 1,
+  "last_updated": "2026-03-27",
+  "total_retros": 1,
+  "findings_by_category": {
+    "fix-ratio": [
+      {
+        "date": "2026-03-26",
+        "branch": "feat/example",
+        "finding_id": "R-01"
+      }
+    ]
+  },
+  "metrics": {
+    "avg_fix_ratio": 0.0,
+    "pipeline_success_rate": 0.0,
+    "avg_convergence_rounds": 0.0
+  }
+}
+```
+
+Category vocabulary (seed, extensible):
+- `fix-ratio` — high ratio of fix commits to feature commits
+- `timeout` — pipeline or QA timeouts
+- `stale-reference` — dead links, outdated paths
+- `thrashing` — 3+ commits on same fix
+- `pipeline-scheduling` — orchestrator timing/ordering issues
+- `missing-validation` — gaps in verification coverage
+- `false-positive` — incorrect findings from review or QA
+- `convergence-failure` — review/fix cycles that don't converge
+- `daemon-orphan` — leaked processes
+
+Retention window: retain entries that fall within the last 20 retros OR the last 6 months, whichever criterion retains more entries. On each update, trim entries that fall outside both windows.
+
+### Verify Workflow Checks
+
+All checks are headless-capable. Triggered when changed files are in `.claude/` or `scripts/`.
+
+| # | Check | Method | Pass Criteria |
+|---|-------|--------|---------------|
+| 1 | Python tests | `pytest tests/test_pipeline.py tests/test_workflow_state.py` | Exit code 0 |
+| 2 | Hook script tests | Execute each hook in `.claude/hooks/` with test inputs, check exit codes | All hooks exit 0 on valid input, exit 2 on invalid input |
+| 3 | settings.json validation | Parse `.claude/settings.json` as JSON, validate hook entries reference existing files | Valid JSON, all hook `command` paths exist |
+| 4 | Skill frontmatter | Parse each `.claude/skills/*/SKILL.md` YAML frontmatter | `name` and `description` fields present and non-empty |
+| 5 | Agent frontmatter | Parse each `.claude/agents/*.md` YAML frontmatter | `tools` list present, each tool name is a known valid tool |
+| 6 | Skill file references | Scan skill markdown for file paths, verify targets exist | No dead links to non-existent files |
+| 7 | Retro store schema | Validate `.retros/summary.json` against expected schema | Valid JSON matching schema (if file exists) |
+| 8 | Workflow state write | Write `verify.workflow` and `qa.workflow` to `.workflow/state.json` | State file updated with both keys |
+
+### `/start` Modification
+
+After worktree creation (current Step 5), before opening terminal (Step 6):
+
+The AI has the investigation output in conversation context. `/start` writes it directly — no scanning or sentinels needed.
+
+After worktree creation, `/start` writes the design-context content from conversation to `.plans/design-context.md` in the new worktree:
+1. Create `.plans/` directory in the new worktree (if it doesn't exist)
+2. Write the design-context content to `.plans/design-context.md` in the worktree
+3. Include this in the Step 7 guidance: "Design context written to `.plans/design-context.md`. Run `/design` to continue."
+
+If `/start` is invoked without prior `/investigate` (no design-context in conversation) — existing flow unchanged, no file written.
+
+### `/design` Modification
+
+At the end of Step 1 (after loading constitution and spec template):
+
+1. Check for `.plans/design-context.md` in current working directory
+2. If found: read it, present a summary to the user, ask: "Design context loaded from investigation. Proceed to spec writing, or brainstorm further?"
+3. If "proceed": skip brainstorm (Step 2), go directly to Step 3 (write spec)
+4. If "brainstorm": continue with normal Step 2 flow, using the design context as input
+5. If not found: normal brainstorm flow, no change
+
+**Constraint checking (when design-context is loaded):**
+Before presenting the architecture (Step 2 or Step 3), verify the proposal against each Constraint and each Known Concern listed in `design-context.md`. Flag any conflicts — e.g., "Constraint #3 says X, but the proposed architecture does Y." This catches drift between the investigation decisions and the spec being written.
+
+### Hook Changes
+
+**session-stop-workflow.py (line 102):**
+Remove `.claude/` from `non_code_prefixes`. Process code in `.claude/` requires workflow enforcement (gates, verify, review) just like product code.
+
+Before:
+```python
+non_code_prefixes = (
+    "specs/",
+    ".plans/",
+    "docs/",
+    ".claude/",
+    "README",
+    "CLAUDE.md",
+)
+```
+
+After:
+```python
+non_code_prefixes = (
+    "specs/",
+    ".plans/",
+    "docs/",
+    "README",
+    "CLAUDE.md",
+)
+```
+
+**session-stop-workflow.py (line 147) and pr-gate.py (line 104):**
+Add `"workflow"` to `valid_surfaces` tuple. Allows `verify.workflow` to satisfy the "at least one surface verified" check.
+
+Before:
+```python
+valid_surfaces = ("ext", "tui", "mcp", "cli")
+```
+
+After:
+```python
+valid_surfaces = ("ext", "tui", "mcp", "cli", "workflow")
+```
+
+**session-start-workflow.py (line 66):**
+Fix stale reference: `/spec` → `/design`.
+
+Before:
+```python
+"  For new features: /spec → /implement → /gates → /verify → /qa → /review → /pr\n"
+```
+
+After:
+```python
+"  For new features: /design → /implement → /gates → /verify → /qa → /review → /pr\n"
+```
+
+**session-stop-workflow.py and pr-gate.py — QA gate for workflow-only changes:**
+The `valid_surfaces` tuple is used for both `/verify` and `/qa` gates. Adding `"workflow"` to `valid_surfaces` means `verify.workflow` satisfies the verify gate, but the QA gate also needs a pathway. For workflow-only changes (only `.claude/` and `scripts/` files changed), the `/verify workflow` check IS the QA — structural validation of process code doesn't need a separate interactive QA surface. The QA gate is satisfied by `qa.workflow`, which `/verify workflow` writes alongside `verify.workflow` when all checks pass. Both hooks use the same `valid_surfaces` tuple, so adding `"workflow"` covers both gates.
+
+**protect-main-branch.py — MSYS path normalization fix:**
+The `is_allowed_path` function (line 34) normalizes paths but the `.worktrees/` substring check can fail when `CLAUDE_PROJECT_DIR` contains an MSYS-style path that doesn't normalize consistently. The fix: normalize both the file path and project dir through `normalize_msys_path()` before the prefix strip, and also check the un-stripped path for allowed substrings.
+
+### Constraints
+
+- `/investigate` must never be added to the pipeline orchestrator or called via `claude -p`
+- Within a chosen ceremony level, token/compute cost is secondary to process quality — do not optimize by skipping steps
+- Challenger agent prompt must be explicitly constructed with only summary + constraints — never pass raw conversation context
+- Category vocabulary in `.retros/summary.json` is extensible — new categories can be added by the retro skill without a spec change
+- `.retros/summary.json` merge conflicts are accepted risk — append-only semantics makes them rare and mechanically resolvable
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `/investigate` skill definition exists with correct frontmatter (name, description) | `VerifyWorkflow.SkillFrontmatter` (check 4) | 🔲 |
+| AC-02 | `/investigate` skill contains quick mode flow that excludes research and challenge steps | `grep "quick" .claude/skills/investigate/SKILL.md` matches flow definition listing only gather/synthesize/present/align/handoff | 🔲 |
+| AC-03 | `/investigate` skill contains full mode flow that includes all 8 steps in order | `grep -c "Gather\|Research\|Synthesize\|Challenge\|Triage\|Present\|Align\|Handoff" .claude/skills/investigate/SKILL.md` returns 8 (one per step) | 🔲 |
+| AC-04 | Challenger agent definition exists at `.claude/agents/challenger.md` with model: sonnet and read-only tools | `VerifyWorkflow.AgentFrontmatter` (check 5) | 🔲 |
+| AC-05 | Challenger agent prompt contains all 8 mandatory dimensions (one per line) | 8 individual grep checks: `grep "Testability" .claude/agents/challenger.md`, `grep "Verifiability"`, ..., `grep "Scope"` — all 8 return matches | 🔲 |
+| AC-06 | Challenger agent dispatch in skill passes only summary + constraints, not session context | `grep -A5 "challenger\|Agent.*challenger" .claude/skills/investigate/SKILL.md` shows prompt constructed from summary + constraints sections only | 🔲 |
+| AC-07 | Skill contains max 3 round guard for challenger convergence | `grep -E "max.*3\|3.*round\|round.*3" .claude/skills/investigate/SKILL.md` returns match | 🔲 |
+| AC-08 | Skill contains fewer-blockers stopping condition for challenger | `grep -i "fewer.*blocker" .claude/skills/investigate/SKILL.md` returns match | 🔲 |
+| AC-09 | Skill contains same-findings-loop stopping condition for challenger | `grep -i "same.*finding\|loop\|reappear" .claude/skills/investigate/SKILL.md` returns match | 🔲 |
+| AC-10 | Skill contains zero-blockers stopping condition for challenger | `grep -i "zero.*blocker" .claude/skills/investigate/SKILL.md` returns match | 🔲 |
+| AC-11 | Researcher dispatched via Agent tool with only Read, Glob, Grep, WebSearch, WebFetch | `grep -E "WebSearch\|WebFetch" .claude/skills/investigate/SKILL.md` returns match AND `grep -E "Edit\|Write\|Bash" .claude/skills/investigate/SKILL.md` returns no match in researcher section | 🔲 |
+| AC-12 | `.retros/summary.json` schema includes schema_version, last_updated, total_retros, findings_by_category, metrics | `VerifyWorkflow.RetroStoreSchema` (check 7) | 🔲 |
+| AC-13 | `/retro` skill contains dual-write logic for both `.workflow/retro-findings.json` and `.retros/summary.json` | `grep "summary.json" .claude/skills/retro/SKILL.md` returns match in write/update section | 🔲 |
+| AC-14 | `.retros/summary.json` entries include date, branch, finding_id per occurrence | `VerifyWorkflow.RetroStoreSchema` (check 7) | 🔲 |
+| AC-15 | Retro store is append-only — existing entries are never mutated, only new entries appended and old entries trimmed by retention window | `grep -i "append" .claude/skills/retro/SKILL.md` returns match in store update section | 🔲 |
+| AC-16 | Retention window trims entries older than both 20 retros and 6 months | `grep -E "20.*retro\|6.*month" .claude/skills/retro/SKILL.md` returns match | 🔲 |
+| AC-17 | `/verify workflow` runs all 8 checks when triggered by `.claude/` or `scripts/` changes | `grep -c "Check\|check" .claude/skills/verify/SKILL.md` shows workflow section with 8 checks listed | 🔲 |
+| AC-18 | `/verify workflow` writes `verify.workflow` and `qa.workflow` to state on all-pass | `grep -E "verify.workflow\|qa.workflow" .claude/skills/verify/SKILL.md` returns matches | 🔲 |
+| AC-19 | Skill frontmatter validation catches missing name or description | `test_verify_workflow.py::test_skill_frontmatter_missing_name` | 🔲 |
+| AC-20 | Agent frontmatter validation catches invalid tool names | `test_verify_workflow.py::test_agent_frontmatter_invalid_tool` | 🔲 |
+| AC-21 | Dead link detection finds references to non-existent files | `test_verify_workflow.py::test_dead_link_detection` | 🔲 |
+| AC-22 | `/start` skill writes `.plans/design-context.md` to worktree when design-context is present in conversation | `grep "design-context.md" .claude/skills/start/SKILL.md` returns match in write logic | 🔲 |
+| AC-23 | `/design` skill loads `.plans/design-context.md` at Step 1 and offers proceed/brainstorm choice | `grep "design-context.md" .claude/skills/design/SKILL.md` returns match in Step 1 section | 🔲 |
+| AC-24 | session-stop-workflow.py `non_code_prefixes` does not contain `.claude/` | `python -c "exec(open('.claude/hooks/session-stop-workflow.py').read()); assert '.claude/' not in non_code_prefixes"` or equivalent grep | 🔲 |
+| AC-25 | session-stop-workflow.py and pr-gate.py `valid_surfaces` contains `"workflow"` | `grep '"workflow"' .claude/hooks/session-stop-workflow.py .claude/hooks/pr-gate.py` returns matches in valid_surfaces tuples | 🔲 |
+| AC-26 | session-start-workflow.py references `/design` not `/spec` in guidance text | `grep '/spec' .claude/hooks/session-start-workflow.py` returns no matches | 🔲 |
+| AC-27 | protect-main-branch.py correctly allows `.worktrees/` paths under MSYS normalization | `test_protect_main_branch.py::test_msys_worktree_path_allowed` | 🔲 |
+| AC-28 | `/investigate` skill references `.retros/summary.json` in gather step for pattern awareness | `grep "summary.json" .claude/skills/investigate/SKILL.md` returns match in gather section | 🔲 |
+| AC-29 | `.claude/` file changes trigger workflow enforcement (end-to-end: commit .claude/ change, session-stop blocks without verify) | `test_session_stop_workflow.py::test_claude_dir_requires_enforcement` | 🔲 |
+| AC-30 | `/design` skill verifies proposal against each Constraint and Known Concern from design-context before presenting architecture | `grep -i "constraint.*flag\|known concern\|conflict" .claude/skills/design/SKILL.md` returns match | 🔲 |
+| AC-31 | Workflow-only change passes QA gate when `qa.workflow` is set by `/verify workflow` | `test_session_stop_workflow.py::test_qa_workflow_surface_accepted` | 🔲 |
+| AC-32 | Missing `.retros/summary.json` does not cause error during `/investigate` gather phase | `test_verify_workflow.py::test_missing_retro_store_no_error` | 🔲 |
+| AC-33 | `.retros/summary.json` with wrong `schema_version` triggers rebuild, not crash | `test_verify_workflow.py::test_retro_store_schema_mismatch_rebuild` | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| No retro store exists | First `/investigate` run, `.retros/summary.json` absent | Gather phase skips retro patterns, no error |
+| Challenger finds zero issues in round 1 | Clean proposal | Stop after round 1, present with "no concerns found" |
+| Challenger loops (same findings reappear) | Round 2 repeats round 1 findings | Stop, note "challenger converged (repeated findings)" |
+| Quick mode on complex topic | Human chooses quick for architecture change | Skill proceeds without challenge — human's judgment call |
+| No design-context in conversation | `/start` invoked without prior `/investigate` | Normal `/start` flow, no `.plans/design-context.md` written |
+| `.plans/design-context.md` already exists | `/design` finds stale context from prior investigation | Present it, ask "proceed or brainstorm?" — human decides |
+| `.retros/summary.json` has merge conflict | Two branches update concurrently | Append-only makes conflict mechanically resolvable — both additions are valid |
+| MSYS path with mixed separators | `/c/VS/ppdsw/ppds/.worktrees/foo/bar.md` | `protect-main-branch.py` normalizes to `C:/VS/...` and allows |
+| Challenger diverges (more blockers each round) | Round 2 has more blockers than round 1 | Stop at max 3 rounds, present all findings, note divergence to human |
+| Retro store schema version mismatch | `summary.json` has `schema_version: 2` but code expects 1 | Log warning, rebuild fresh file with current schema |
+| No design-context in new session | Human runs `/start` in a new session without prior `/investigate` | No `.plans/design-context.md` written, normal `/start` flow |
+
+---
+
+## Core Types
+
+### Investigation Summary
+
+The output of the synthesize step, input to the challenger agent. Plain markdown, not a formal type — lives in conversation memory.
+
+```markdown
+## Investigation Summary
+### Problem: {what we're exploring}
+### Options: {2-3 approaches with tradeoffs}
+### Assumptions: {explicit list}
+### Constraints and Decisions: {numbered list of settled items}
+```
+
+### Design Context
+
+The file written by `/start` to `.plans/design-context.md`. Contains the investigation output that `/design` consumes.
+
+```markdown
+# Design Context: {topic}
+
+**Source:** /investigate session on {date}
+**Validated:** {challenge round summary, or "Quick mode — no adversarial challenge"}
+
+## Problem Statement
+{what we're exploring and why}
+
+## Scope
+{deliverables with brief descriptions}
+
+## Constraints and Decisions
+{numbered list of settled items from the investigation}
+
+## Known Concerns
+{items needing spec-level answers}
+
+## Evidence
+{key data points that informed the investigation}
+```
+
+### Retro Summary Store
+
+```json
+{
+  "schema_version": "number (currently 1)",
+  "last_updated": "string (ISO date)",
+  "total_retros": "number",
+  "findings_by_category": {
+    "<category>": [
+      {
+        "date": "string (ISO date)",
+        "branch": "string",
+        "finding_id": "string (R-NN)"
+      }
+    ]
+  },
+  "metrics": {
+    "avg_fix_ratio": "number",
+    "pipeline_success_rate": "number",
+    "avg_convergence_rounds": "number"
+  }
+}
+```
+
+---
+
+## Error Handling
+
+### Error Types
+
+| Error | Condition | Recovery |
+|-------|-----------|----------|
+| No codebase context found | Gather phase finds no relevant files | Ask human for more specific direction |
+| Researcher agent timeout | WebSearch/WebFetch takes too long | Present what was gathered, skip remaining research |
+| Challenger agent failure | Agent crashes or returns malformed output | Present investigation summary without challenge findings, note challenger was skipped |
+| `.retros/summary.json` corrupted | Invalid JSON | Log warning, create fresh file, do not lose per-session findings |
+| `.retros/summary.json` schema mismatch | Valid JSON but `schema_version` differs from expected | Log warning with version numbers, create fresh file with current schema version. Old data is lost but per-session files remain as source of truth |
+| `/verify workflow` partial failure | Some checks pass, others fail | Report all results, do not write state, list failing checks |
+
+### Recovery Strategies
+
+- **Agent failures**: Degrade gracefully — the investigation summary is still valuable without the challenger. Present what exists and let the human decide.
+- **Store corruption**: Rebuild from scratch — the per-session files in `.workflow/` are the source of truth. The persistent store is a convenience aggregation.
+
+---
+
+## Design Decisions
+
+### Why one spec for five deliverables?
+
+**Context:** Five deliverables (skill, agent, store, verify route, handoff mods) could be 1-5 specs.
+
+**Decision:** One spec named `investigation.md`.
+
+**Alternatives considered:**
+- Separate specs per deliverable: Rejected — deliverables 2-5 exist only to serve deliverable 1. No independent consumer exists for any of them. SL1 says "one spec per domain concept" and the domain concept is investigation.
+- Three specs (skill, infrastructure, hooks): Rejected — arbitrary split that doesn't match domain boundaries.
+
+**Consequences:**
+- Positive: Single AC table, single review pass, single implementation plan
+- Negative: Larger spec, but all five deliverables are small modifications except the skill itself
+
+### Why human declares ceremony level?
+
+**Context:** Ceremony should scale with risk. Could auto-detect or let human decide.
+
+**Decision:** Human declares "quick" or "full" at the start of `/investigate`.
+
+**Alternatives considered:**
+- Auto-detect from scope: Rejected — heuristics can misfire (is this skill tweak risky or not?). The human knows the risk.
+- Progressive escalation (ask after synthesize): Rejected — adds a decision point mid-flow. Simpler to decide upfront.
+
+**Consequences:**
+- Positive: Simplest implementation, human is always right about their own risk tolerance
+- Negative: Human might choose quick when full was warranted — accepted risk, human judgment call
+
+### Why Sonnet for the challenger?
+
+**Context:** Challenger needs to find real blind spots — judgment-heavy work.
+
+**Decision:** Sonnet. The task is bounded by the 8-dimension checklist and structured output format. The input is constrained (summary + constraints only). The human is the final judge.
+
+**Alternatives considered:**
+- Opus: Maximum quality, but higher cost/latency for an interactive skill where the human is waiting. The checklist constrains the task enough that Sonnet performs well.
+- Configurable: Default Sonnet with Opus override. Adds a parameter for marginal benefit.
+
+**Consequences:**
+- Positive: Faster, cheaper, good enough for structured adversarial review
+- Negative: May miss subtle architectural issues that Opus would catch — mitigated by human review at align step
+
+### Why conversation-based handoff?
+
+**Context:** `/investigate` needs to pass design-context to `/start` → `/design`. Can't write to main (protect-main-branch hook blocks it).
+
+**Decision:** `/investigate` holds design-context in conversation memory. Human runs `/start`, which writes it to the new worktree's `.plans/design-context.md`.
+
+**Alternatives considered:**
+- Write intermediate file on main: Rejected — protect-main-branch hook blocks it.
+- CLI argument: Rejected — content too large for command-line args.
+- Clipboard: Rejected — fragile, platform-dependent, loses content on copy.
+
+**Consequences:**
+- Positive: No file on main, no hook conflict, content travels with the conversation
+- Negative: Requires the human to run `/start` in the same conversation as `/investigate`. If they start a new session, the context is lost — but they can re-run `/investigate` or manually create the file.
+
+### Why accept merge conflict risk on summary.json?
+
+**Context:** `.retros/summary.json` is git-tracked and updated by `/retro` on PR branches. Concurrent PRs could conflict.
+
+**Decision:** Accept the risk. The retro skill writes to both per-session (`.workflow/retro-findings.json`) and persistent (`.retros/summary.json`) in the same pass.
+
+**Alternatives considered:**
+- Post-merge update only: Rejected — adds a second code path (post-merge hook) that must understand the findings schema. Two producers of the same file is worse than occasional merge conflicts.
+- Separate aggregation script: Rejected — YAGNI. One consumer, one producer.
+
+**Consequences:**
+- Positive: Single producer, single moment of update, simple implementation
+- Negative: Occasional merge conflicts — mitigated by append-only semantics (both sides' additions are valid, mechanically resolvable)
+
+### Why 8-dimension checklist as core mechanism?
+
+**Context:** Adversarial review needs structure to prevent blind spots. An unconstrained "find problems" prompt produces inconsistent coverage.
+
+**Decision:** 8 mandatory dimensions baked into the challenger agent prompt: testability, verifiability, failure modes, observability, operability, reversibility, dependencies, scope.
+
+**Alternatives considered:**
+- Unconstrained adversarial prompt: Rejected — produces inconsistent coverage. Some dimensions (observability, operability) are systematically overlooked without explicit prompting.
+- Domain-specific checklists: Rejected — too many checklists to maintain. The 8 dimensions are universal enough to apply to any proposal.
+
+**Consequences:**
+- Positive: Consistent coverage, prevents omission blind spots, makes challenger output predictable and comparable across investigations
+- Negative: May force commentary on dimensions that aren't relevant (e.g., "observability" for a typo fix) — mitigated by ceremony scaling (quick mode skips challenge entirely)
+
+---
+
+## Related Specs
+
+- [workflow-enforcement.md](./workflow-enforcement.md) — Workflow state, pipeline orchestrator, hook infrastructure that this spec extends
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-03-27 | Initial spec |
+
+---
+
+## Roadmap
+
+- **Spec-reviewer agent**: Extract a dedicated reviewer from the challenger pattern — reviews specs against constitution and template, not proposals against dimensions
+- **Metrics layer**: Dashboard or summary view of `.retros/summary.json` trends once enough data exists (target: after 10+ retros)
+- **Auto-heal from retro findings**: Automatically apply `auto-fix` tier findings from retro store — currently only 1 auto-fix finding exists, not enough to justify the machinery
+- **Ceremony auto-detection**: Infer quick vs full from scope/risk heuristics instead of human declaration — deferred because heuristics misfire and human judgment is cheap

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -747,7 +747,7 @@ class TestGeminiTriageAgentExists:
             content = f.read()
 
         assert "model: sonnet" in content, "Agent must use model: sonnet"
-        assert "allowedTools" in content, "Agent must have allowedTools"
+        assert "tools:" in content, "Agent must have tools"
         assert "Read" in content, "Agent must allow Read tool"
         assert "Edit" in content, "Agent must allow Edit tool"
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -229,20 +229,6 @@ class TestOutputTail:
             assert "output line 10" in lines[-20:][0]
 
 
-# ---------------------------------------------------------------------------
-# AC-60: --stage-timeout CLI override
-# ---------------------------------------------------------------------------
-class TestStageTimeoutCli:
-    def test_stage_timeout_cli_override(self):
-        """AC-60: --stage-timeout flag is accepted by argparse."""
-        import pipeline
-
-        # Parse args with --stage-timeout
-        parser = pipeline.argparse.ArgumentParser()
-        parser.add_argument("--stage-timeout", type=int)
-        args = parser.parse_args(["--stage-timeout", "100"])
-        assert args.stage_timeout == 100
-
 
 # ---------------------------------------------------------------------------
 # AC-61: Dry-run works

--- a/tests/test_protect_main_branch.py
+++ b/tests/test_protect_main_branch.py
@@ -1,0 +1,52 @@
+"""Tests for protect-main-branch hook — MSYS path normalization."""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+
+def _load_hook():
+    """Import protect-main-branch.py as a module."""
+    hook_path = os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        ".claude",
+        "hooks",
+        "protect-main-branch.py",
+    )
+    hook_path = os.path.normpath(hook_path)
+    spec = importlib.util.spec_from_file_location("protect_main_branch", hook_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Ensure _pathfix is importable
+    hooks_dir = os.path.dirname(hook_path)
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+class TestIsAllowedPath:
+    def test_msys_worktree_path_allowed(self, monkeypatch):
+        """AC-27: MSYS-style worktree paths are allowed."""
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/c/VS/ppdsw/ppds")
+        assert hook.is_allowed_path("/c/VS/ppdsw/ppds/.worktrees/foo/bar.md")
+
+    def test_windows_native_worktree_path_allowed(self, monkeypatch):
+        """AC-27: Windows native worktree paths are allowed."""
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "C:\\VS\\ppdsw\\ppds")
+        assert hook.is_allowed_path("C:\\VS\\ppdsw\\ppds\\.worktrees\\foo\\bar.md")
+
+    def test_main_repo_path_blocked(self, monkeypatch):
+        """Main repo source paths are NOT allowed."""
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "C:\\VS\\ppdsw\\ppds")
+        assert not hook.is_allowed_path("C:\\VS\\ppdsw\\ppds\\src\\Foo.cs")
+
+    def test_temp_path_allowed(self, monkeypatch):
+        """Temp directory paths are allowed."""
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", "C:\\VS\\ppdsw\\ppds")
+        assert hook.is_allowed_path("/tmp/somefile.txt")
+        assert hook.is_allowed_path("C:\\Users\\josh\\AppData\\Local\\Temp\\foo.txt")

--- a/tests/test_session_stop_workflow.py
+++ b/tests/test_session_stop_workflow.py
@@ -98,3 +98,33 @@ class TestWorkflowSurface:
                             assert "workflow" in elements, (
                                 "'workflow' must be in valid_surfaces"
                             )
+
+    def test_workflow_surface_in_pr_gate(self):
+        """AC-25: 'workflow' is a valid surface in pr-gate."""
+        hook_path = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            ".claude",
+            "hooks",
+            "pr-gate.py",
+        )
+        hook_path = os.path.normpath(hook_path)
+        with open(hook_path, "r") as f:
+            source = f.read()
+
+        import ast
+
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "valid_surfaces":
+                        if isinstance(node.value, ast.Tuple):
+                            elements = [
+                                elt.value
+                                for elt in node.value.elts
+                                if isinstance(elt, ast.Constant)
+                            ]
+                            assert "workflow" in elements, (
+                                "'workflow' must be in pr-gate valid_surfaces"
+                            )

--- a/tests/test_session_stop_workflow.py
+++ b/tests/test_session_stop_workflow.py
@@ -1,0 +1,100 @@
+"""Tests for session-stop-workflow hook — .claude/ enforcement and workflow surface."""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_hook():
+    """Import session-stop-workflow.py as a module."""
+    hook_path = os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        ".claude",
+        "hooks",
+        "session-stop-workflow.py",
+    )
+    hook_path = os.path.normpath(hook_path)
+    spec = importlib.util.spec_from_file_location("session_stop_workflow", hook_path)
+    mod = importlib.util.module_from_spec(spec)
+    hooks_dir = os.path.dirname(hook_path)
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+class TestClaudeDirEnforcement:
+    def test_claude_dir_requires_enforcement(self):
+        """AC-29: .claude/ files are NOT in non_code_prefixes, so they require enforcement."""
+        # Read the source file and check that .claude/ is not in non_code_prefixes
+        hook_path = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            ".claude",
+            "hooks",
+            "session-stop-workflow.py",
+        )
+        hook_path = os.path.normpath(hook_path)
+        with open(hook_path, "r") as f:
+            source = f.read()
+
+        # Find the non_code_prefixes tuple in the source
+        # It should NOT contain ".claude/"
+        import ast
+
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "non_code_prefixes":
+                        # Extract tuple elements
+                        if isinstance(node.value, ast.Tuple):
+                            elements = [
+                                elt.value
+                                for elt in node.value.elts
+                                if isinstance(elt, ast.Constant)
+                            ]
+                            assert ".claude/" not in elements, (
+                                ".claude/ should NOT be in non_code_prefixes — "
+                                "process code requires workflow enforcement"
+                            )
+
+
+class TestWorkflowSurface:
+    def test_workflow_surface_accepted(self):
+        """AC-25/AC-31: 'workflow' is a valid surface in session-stop-workflow."""
+        hook_path = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            ".claude",
+            "hooks",
+            "session-stop-workflow.py",
+        )
+        hook_path = os.path.normpath(hook_path)
+        with open(hook_path, "r") as f:
+            source = f.read()
+
+        import ast
+
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "valid_surfaces":
+                        if isinstance(node.value, ast.Tuple):
+                            elements = [
+                                elt.value
+                                for elt in node.value.elts
+                                if isinstance(elt, ast.Constant)
+                            ]
+                            assert "workflow" in elements, (
+                                "'workflow' must be in valid_surfaces"
+                            )

--- a/tests/test_verify_workflow.py
+++ b/tests/test_verify_workflow.py
@@ -55,6 +55,13 @@ class TestAgentFrontmatter:
         errors = verify_workflow_checks.check_agent_frontmatter(str(agent))
         assert errors == []
 
+    def test_agent_frontmatter_allowed_tools_key(self, tmp_path):
+        """AC-20: allowedTools is accepted as an alias for tools."""
+        agent = tmp_path / "agent.md"
+        agent.write_text("---\nname: test\nallowedTools:\n  - Read\n  - Bash\n---\n# Test\n")
+        errors = verify_workflow_checks.check_agent_frontmatter(str(agent))
+        assert errors == []
+
 
 class TestDeadLinkDetection:
     def test_dead_link_detection(self, tmp_path):

--- a/tests/test_verify_workflow.py
+++ b/tests/test_verify_workflow.py
@@ -1,0 +1,107 @@
+"""Tests for /verify workflow checks (checks 4-7)."""
+import json
+import os
+import sys
+
+import pytest
+
+# Add scripts/ to path so we can import verify_workflow_checks
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "scripts"))
+import verify_workflow_checks
+
+
+class TestSkillFrontmatter:
+    def test_skill_frontmatter_missing_name(self, tmp_path):
+        """AC-19: Skill frontmatter validation catches missing name."""
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\ndescription: A skill\n---\n# Test\n")
+        errors = verify_workflow_checks.check_skill_frontmatter(str(skill))
+        assert any("name" in e.lower() for e in errors)
+
+    def test_skill_frontmatter_missing_description(self, tmp_path):
+        """AC-19: Skill frontmatter validation catches missing description."""
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\n---\n# Test\n")
+        errors = verify_workflow_checks.check_skill_frontmatter(str(skill))
+        assert any("description" in e.lower() for e in errors)
+
+    def test_skill_frontmatter_valid(self, tmp_path):
+        """AC-19: Valid frontmatter passes."""
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\ndescription: A test skill\n---\n# Test\n")
+        errors = verify_workflow_checks.check_skill_frontmatter(str(skill))
+        assert errors == []
+
+
+class TestAgentFrontmatter:
+    def test_agent_frontmatter_invalid_tool(self, tmp_path):
+        """AC-20: Agent frontmatter validation catches invalid tool names."""
+        agent = tmp_path / "agent.md"
+        agent.write_text("---\nname: test\ntools:\n  - FakeTool\n---\n# Test\n")
+        errors = verify_workflow_checks.check_agent_frontmatter(str(agent))
+        assert any("FakeTool" in e for e in errors)
+
+    def test_agent_frontmatter_valid(self, tmp_path):
+        """AC-20: Valid agent frontmatter passes."""
+        agent = tmp_path / "agent.md"
+        agent.write_text("---\nname: test\ntools:\n  - Read\n  - Grep\n---\n# Test\n")
+        errors = verify_workflow_checks.check_agent_frontmatter(str(agent))
+        assert errors == []
+
+    def test_agent_frontmatter_bash_pattern(self, tmp_path):
+        """AC-20: Bash with pattern is valid."""
+        agent = tmp_path / "agent.md"
+        agent.write_text("---\nname: test\ntools:\n  - Bash(git diff:*)\n---\n# Test\n")
+        errors = verify_workflow_checks.check_agent_frontmatter(str(agent))
+        assert errors == []
+
+
+class TestDeadLinkDetection:
+    def test_dead_link_detection(self, tmp_path):
+        """AC-21: Dead link detection finds references to non-existent files."""
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\ndescription: test\n---\n# Test\nSee [link](./nonexistent-file.md)\n")
+        errors = verify_workflow_checks.check_skill_file_references(str(skill), str(tmp_path))
+        assert any("nonexistent" in e for e in errors)
+
+    def test_dead_link_valid(self, tmp_path):
+        """AC-21: Valid file references pass."""
+        target = tmp_path / "existing.md"
+        target.write_text("# Exists\n")
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\ndescription: test\n---\n# Test\nSee [link](./existing.md)\n")
+        errors = verify_workflow_checks.check_skill_file_references(str(skill), str(tmp_path))
+        assert errors == []
+
+
+class TestRetroStoreSchema:
+    def test_missing_retro_store_no_error(self, tmp_path):
+        """AC-32: Missing .retros/summary.json is not an error."""
+        errors = verify_workflow_checks.check_retro_store_schema(str(tmp_path / "nonexistent.json"))
+        assert errors == []
+
+    def test_retro_store_schema_mismatch_rebuild(self, tmp_path):
+        """AC-33: Wrong schema_version triggers rebuild message."""
+        store = tmp_path / "summary.json"
+        store.write_text(json.dumps({
+            "schema_version": 2,
+            "last_updated": "2026-03-27",
+            "total_retros": 0,
+            "findings_by_category": {},
+            "metrics": {}
+        }))
+        errors = verify_workflow_checks.check_retro_store_schema(str(store))
+        assert any("rebuild" in e.lower() for e in errors)
+
+    def test_retro_store_valid(self, tmp_path):
+        """Valid retro store passes."""
+        store = tmp_path / "summary.json"
+        store.write_text(json.dumps({
+            "schema_version": 1,
+            "last_updated": "2026-03-27",
+            "total_retros": 0,
+            "findings_by_category": {},
+            "metrics": {"avg_fix_ratio": 0.0, "pipeline_success_rate": 0.0, "avg_convergence_rounds": 0.0}
+        }))
+        errors = verify_workflow_checks.check_retro_store_schema(str(store))
+        assert errors == []


### PR DESCRIPTION
## Summary

- **`/investigate` skill**: Pre-commitment exploration with optional adversarial challenge (quick/full ceremony levels)
- **Challenger agent** (Sonnet): 8-dimension mandatory checklist, structurally isolated, max 3 convergence rounds
- **Retro persistent store** (`.retros/summary.json`): Git-tracked, append-only, windowed retention, dual-write from `/retro`
- **`/verify workflow` mode**: 8 structural checks for `.claude/` and `scripts/` changes, writes `verify.workflow` + `qa.workflow`
- **`/start` + `/design` handoff**: Design-context flows from `/investigate` through conversation to worktree `.plans/`
- **Hook fixes**: Remove `.claude/` exemption from stop-hook, add `workflow` to valid surfaces (stop/start/pr-gate), fix `/spec` → `/design` reference, MSYS path normalization
- **Cleanup**: Delete deprecated `--stage-timeout` arg, fix `gemini-triage.md` `allowedTools` → `tools`

## Test plan

- [x] 82 Python tests passing (pipeline, protect-main-branch, session-stop-workflow, verify-workflow)
- [x] 33/33 spec ACs verified via grep assertions and pytest
- [x] `/verify workflow` — all 8 checks green
- [x] `/qa` — 3 findings auto-fixed (descriptions, section order, divergence clause)
- [x] `/review` — 3 important findings fixed (session-start workflow surface, pr-gate test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)