### PR TITLE
fix(pipeline): 5 reliability bugs (#721 #720 #719 #717 #711)

### DIFF
--- a/.claude/hooks/notify.py
+++ b/.claude/hooks/notify.py
@@ -55,6 +55,9 @@ def show_toast(title, msg, url):
 
 
 def main():
+    if os.environ.get("PPDS_PIPELINE"):
+        sys.exit(0)
+
     parser = argparse.ArgumentParser(description="Desktop toast notification")
     parser.add_argument("--title", default="PR Ready")
     parser.add_argument("--msg", default="Click to open pull request")

--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -53,6 +53,9 @@ def is_allowed_path(file_path: str) -> bool:
     )
 
 def main() -> None:
+    if os.environ.get("PPDS_PIPELINE"):
+        sys.exit(0)
+
     branch = get_current_branch()
     if branch != "main":
         sys.exit(0)

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -19,7 +19,7 @@ Run `/status` to check current workflow state.
 
 ## Process
 
-### 1. Rebase on Main
+### 1. Rebase on Main and Push
 
 ```bash
 git fetch origin main
@@ -27,6 +27,19 @@ git rebase origin/main
 ```
 
 If conflicts exist, present them to the user — do NOT auto-resolve.
+
+After successful rebase, verify and push:
+
+```bash
+# Verify rebase succeeded — origin/main must be an ancestor of HEAD
+git merge-base --is-ancestor origin/main HEAD
+
+# Push rebased branch (force-with-lease is safe — only overwrites our own commits)
+git push --force-with-lease origin HEAD
+```
+
+If `merge-base` fails, the rebase didn't apply correctly — investigate before proceeding.
+If push is rejected, fetch and retry the rebase.
 
 ### 2. Check for Linked Issues
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -606,7 +606,7 @@ def process_retro_findings(worktree_path, logger, repo_root):
         try:
             title = f"retro: {desc[:70]}"
             existing = subprocess.run(
-                ["gh", "issue", "list", "--search", f"in:title {title}",
+                ["gh", "issue", "list", "--search", f'"{title}" in:title',
                  "--state", "open", "--json", "number", "--jq", "length"],
                 cwd=repo_root, capture_output=True, text=True, timeout=15,
                 env=gh_env,
@@ -1322,7 +1322,7 @@ def main():
                     )
                     if commit.returncode == 0:
                         log(logger, stage, "AUTO_COMMIT", reason="stranded files committed")
-                    else:
+                    elif "nothing to commit" not in (commit.stdout + commit.stderr):
                         log(logger, stage, "AUTO_COMMIT_FAILED", reason=commit.stderr.strip()[:200])
 
             # Track stage duration with exit code and last output line

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -588,6 +588,9 @@ def process_retro_findings(worktree_path, logger, repo_root):
         auto_fix=len(auto_fixes), draft_fix=len(draft_fixes), issue_only=len(issues),
     )
 
+    gh_env = os.environ.copy()
+    gh_env["MSYS_NO_PATHCONV"] = "1"
+
     for finding in issues:
         desc = finding.get("description", "No description")
         fix = finding.get("fix_description", "")
@@ -601,9 +604,21 @@ def process_retro_findings(worktree_path, logger, repo_root):
         body += "\n\n---\n*Filed automatically by pipeline retro.*"
 
         try:
+            title = f"retro: {desc[:70]}"
+            existing = subprocess.run(
+                ["gh", "issue", "list", "--search", f"in:title {title}",
+                 "--state", "open", "--json", "number", "--jq", "length"],
+                cwd=repo_root, capture_output=True, text=True, timeout=15,
+                env=gh_env,
+            )
+            if existing.returncode == 0 and existing.stdout.strip() not in ("", "0"):
+                log(logger, "retro", "ISSUE_EXISTS", finding=finding_id)
+                continue
+
             subprocess.run(
-                ["gh", "issue", "create", "--title", f"retro: {desc[:70]}", "--body", body],
+                ["gh", "issue", "create", "--title", title, "--body", body],
                 cwd=repo_root, capture_output=True, text=True, timeout=30, check=True,
+                env=gh_env,
             )
             log(logger, "retro", "ISSUE_CREATED", finding=finding_id)
         except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
@@ -1291,6 +1306,24 @@ def main():
                     log(logger, "retro", "FAILED_NON_BLOCKING")
                 else:
                     process_retro_findings(worktree_path, logger, repo_root)
+
+            # Auto-commit stranded files between stages (#717)
+            if worktree_path and stage not in ("worktree", "retro", "pr"):
+                dirty = subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    cwd=worktree_path, capture_output=True, text=True, timeout=10,
+                )
+                if dirty.returncode == 0 and dirty.stdout.strip():
+                    subprocess.run(["git", "add", "-u"], cwd=worktree_path,
+                                   capture_output=True, text=True, timeout=10)
+                    commit = subprocess.run(
+                        ["git", "commit", "-m", f"chore({stage}): auto-commit stage changes"],
+                        cwd=worktree_path, capture_output=True, text=True, timeout=30,
+                    )
+                    if commit.returncode == 0:
+                        log(logger, stage, "AUTO_COMMIT", reason="stranded files committed")
+                    else:
+                        log(logger, stage, "AUTO_COMMIT_FAILED", reason=commit.stderr.strip()[:200])
 
             # Track stage duration with exit code and last output line
             stage_dur = f"{int(time.time() - stage_start_time)}s"


### PR DESCRIPTION
## Summary

- Fix MSYS path conversion corrupting `gh issue create` titles with forward slashes (#721)
- Add dedup check before creating retro issues to prevent duplicates across pipeline retries (#720)
- Add `git push --force-with-lease` after rebase in `/pr` skill to prevent stale PRs (#719)
- Auto-commit stranded files between pipeline stages using `git add -u` with result checking (#717)
- Add `PPDS_PIPELINE` early-exit to `protect-main-branch.py` and `notify.py` hooks (#711)

Closes #721
Closes #720
Closes #719
Closes #717
Closes #711

## Test Plan

- [x] Python syntax verification (ast.parse) for all changed .py files
- [x] `python scripts/pipeline.py --help` — imports and CLI parse clean
- [x] 70/70 Python tests pass (test_pipeline, test_protect_main_branch, test_session_stop_workflow)
- [x] All 10 hook scripts accept `{}` stdin without crashing
- [x] Skill and agent frontmatter validation passes
- [x] Workflow verification passes (all 8 checks)

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] /qa completed (surfaces: workflow)
- [x] /review completed (findings: 8 — fixed 4 critical/important, dismissed 2 as safe, noted 2 suggestions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)