### PR TITLE
fix: cleanup dead code, consolidate triage, wire CallerId impersonation

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -32,6 +32,14 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from triage_common import (
+    build_triage_prompt,
+    format_reply_body,
+    get_repo_slug as _get_repo_slug,
+    parse_triage_stage_log,
+    post_replies as _post_replies_common,
+)
+
 STAGES = [
     "worktree",
     "implement",
@@ -815,17 +823,8 @@ def ensure_retro_summary_updated(worktree_path, logger, repo_root):
 
 
 def get_repo_slug(worktree_path):
-    """Get owner/repo from git remote. Returns 'owner/repo' or None."""
-    try:
-        result = subprocess.run(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
-            cwd=worktree_path, capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
-    return None
+    """Get owner/repo from gh CLI. Returns 'owner/repo' or None."""
+    return _get_repo_slug(worktree_path)
 
 
 def poll_gemini(worktree_path, pr_number, logger, min_wait=90, max_wait=300):
@@ -889,22 +888,7 @@ def poll_gemini(worktree_path, pr_number, logger, min_wait=90, max_wait=300):
 
 def run_triage(worktree_path, pr_number, comments, logger, dry_run=False):
     """Invoke gemini-triage agent to fix/dismiss comments. Returns list or None."""
-    state = read_state(worktree_path)
-    spec_path = state.get("spec", "")
-
-    prompt = (
-        f"Triage these Gemini review comments on PR #{pr_number}.\n\n"
-        f"Spec (read for design rationale): {spec_path}\n\n"
-        f"Comments:\n{json.dumps(comments, indent=2)}\n\n"
-        "For each comment:\n"
-        "1. Read the referenced file at the specified line\n"
-        "2. Evaluate: is this a valid finding?\n"
-        "3. If valid: fix the code and commit\n"
-        "4. If invalid: compose a brief dismissal rationale\n\n"
-        "After all comments, push fixes and output this JSON:\n"
-        '[{"id": <id>, "action": "fixed"|"dismissed", '
-        '"description": "...", "commit": "<sha>"|null}]'
-    )
+    prompt = build_triage_prompt(worktree_path, pr_number, comments)
 
     exit_code, logger_out = run_claude(
         worktree_path, prompt, logger, "pr-triage",
@@ -915,51 +899,23 @@ def run_triage(worktree_path, pr_number, comments, logger, dry_run=False):
         return None
 
     # Parse structured output from the human-readable stage log
-    stage_log_dir = os.path.join(worktree_path, ".workflow", "stages")
-    stage_log_path = os.path.join(stage_log_dir, "pr-triage.log")
-    try:
-        with open(stage_log_path, "r", errors="replace") as f:
-            content = f.read()
-        # Find JSON array using raw_decode (handles trailing text correctly)
-        last_bracket = content.rfind("[")
-        if last_bracket != -1:
-            decoder = json.JSONDecoder()
-            obj, _ = decoder.raw_decode(content[last_bracket:])
-            if isinstance(obj, list):
-                return obj
-    except (OSError, json.JSONDecodeError, ValueError):
-        pass
-    return None
+    stage_log_path = os.path.join(
+        worktree_path, ".workflow", "stages", "pr-triage.log")
+    return parse_triage_stage_log(stage_log_path)
 
 
 def post_replies(worktree_path, pr_number, triage_results, logger):
     """Post threaded replies to Gemini comments from triage results."""
-    repo = get_repo_slug(worktree_path)
-    if not repo:
-        return
-
-    for item in triage_results:
-        comment_id = item.get("id")
-        action = item.get("action", "unknown")
-        description = item.get("description", "")
-        commit_sha = item.get("commit")
-
-        if action == "fixed" and commit_sha:
-            body = f"Fixed in {commit_sha} — {description}"
-        elif action == "dismissed":
-            body = f"Not applicable — {description}"
+    def _log_fn(event, **kwargs):
+        # Map triage_common log events to pipeline's log(logger, step, event) format
+        if event == "POSTED":
+            log(logger, "pr", "REPLY_POSTED", **kwargs)
+        elif event == "FAILED":
+            log(logger, "pr", "REPLY_FAILED", **kwargs)
         else:
-            body = description or "Reviewed."
+            log(logger, "pr", event, **kwargs)
 
-        try:
-            subprocess.run(
-                ["gh", "api", f"repos/{repo}/pulls/{pr_number}/comments",
-                 "-F", f"in_reply_to={comment_id}", "-f", f"body={body}"],
-                cwd=worktree_path, capture_output=True, text=True, timeout=15,
-            )
-            log(logger, "pr", "REPLY_POSTED", comment_id=comment_id, action=action)
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            log(logger, "pr", "REPLY_FAILED", comment_id=comment_id)
+    _post_replies_common(worktree_path, pr_number, triage_results, _log_fn)
 
 
 def run_pr_stage(worktree_path, logger, dry_run=False):

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -34,7 +34,6 @@ from pathlib import Path
 
 from triage_common import (
     build_triage_prompt,
-    format_reply_body,
     get_repo_slug as _get_repo_slug,
     parse_triage_stage_log,
     post_replies as _post_replies_common,

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -25,6 +25,13 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from triage_common import (
+    build_triage_prompt,
+    get_repo_slug as _get_repo_slug,
+    parse_triage_jsonl,
+    post_replies as _post_replies_common,
+)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -149,19 +156,7 @@ def cleanup_pid(worktree):
 
 def get_repo_slug(worktree):
     """Get owner/repo from gh CLI. Returns 'owner/repo' or None."""
-    if SHAKEDOWN:
-        return "test-owner/test-repo"
-    try:
-        result = subprocess.run(
-            ["gh", "repo", "view", "--json", "nameWithOwner",
-             "--jq", ".nameWithOwner"],
-            cwd=worktree, capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
-    return None
+    return _get_repo_slug(worktree, shakedown=bool(SHAKEDOWN))
 
 
 def poll_ci(worktree, pr_number, logger):
@@ -299,29 +294,7 @@ def run_triage(worktree, pr_number, comments, logger):
         logger.log("triage", "SHAKEDOWN_SKIPPED")
         return []
 
-    # Read spec from workflow state for context
-    state_path = os.path.join(worktree, ".workflow", "state.json")
-    spec_path = ""
-    try:
-        with open(state_path, "r") as f:
-            state = json.load(f)
-        spec_path = state.get("spec", "")
-    except (json.JSONDecodeError, OSError):
-        pass
-
-    prompt = (
-        f"Triage these Gemini review comments on PR #{pr_number}.\n\n"
-        f"Spec (read for design rationale): {spec_path}\n\n"
-        f"Comments:\n{json.dumps(comments, indent=2)}\n\n"
-        "For each comment:\n"
-        "1. Read the referenced file at the specified line\n"
-        "2. Evaluate: is this a valid finding?\n"
-        "3. If valid: fix the code and commit\n"
-        "4. If invalid: compose a brief dismissal rationale\n\n"
-        "After all comments, push fixes and output this JSON:\n"
-        '[{"id": <id>, "action": "fixed"|"dismissed", '
-        '"description": "...", "commit": "<sha>"|null}]'
-    )
+    prompt = build_triage_prompt(worktree, pr_number, comments)
 
     full_prompt = (
         "You are running in headless mode via the pr-monitor background process. "
@@ -391,52 +364,11 @@ def run_triage(worktree, pr_number, comments, logger):
         return None
 
     # Extract triage results from JSONL output
-    return _parse_triage_output(stage_jsonl_path, logger)
-
-
-def _parse_triage_output(jsonl_path, logger):
-    """Parse structured triage JSON from stage JSONL output."""
-    # First extract text from JSONL events
-    text_parts = []
-    try:
-        with open(jsonl_path, "r", errors="replace") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if event.get("type") == "result":
-                    result_text = event.get("result", "")
-                    if result_text:
-                        text_parts.append(result_text)
-                elif event.get("type") == "assistant":
-                    content = event.get("message", {}).get("content", [])
-                    for block in content:
-                        if block.get("type") == "text":
-                            text = block.get("text", "")
-                            if text:
-                                text_parts.append(text)
-    except OSError:
-        return None
-
-    combined = "\n".join(text_parts)
-    # Find JSON array using raw_decode
-    last_bracket = combined.rfind("[")
-    if last_bracket != -1:
-        try:
-            decoder = json.JSONDecoder()
-            obj, _ = decoder.raw_decode(combined[last_bracket:])
-            if isinstance(obj, list):
-                return obj
-        except (json.JSONDecodeError, ValueError):
-            pass
-
-    logger.log("triage", "PARSE_FAILED",
-               reason="No JSON array found in triage output")
-    return None
+    results = parse_triage_jsonl(stage_jsonl_path)
+    if results is None:
+        logger.log("triage", "PARSE_FAILED",
+                   reason="No JSON array found in triage output")
+    return results
 
 
 def mark_pr_ready(worktree, pr_number, logger):
@@ -463,44 +395,13 @@ def mark_pr_ready(worktree, pr_number, logger):
 
 def post_replies(worktree, pr_number, triage_results, logger):
     """Post threaded replies to Gemini review comments from triage results."""
-    if SHAKEDOWN:
-        logger.log("replies", "SHAKEDOWN_SKIPPED")
-        return
+    def _log_fn(event, **kwargs):
+        logger.log("replies", event, **kwargs)
 
-    repo = get_repo_slug(worktree)
-    if not repo:
-        logger.log("replies", "ERROR", reason="Cannot determine repo slug")
-        return
-
-    for item in triage_results:
-        comment_id = item.get("id")
-        if not comment_id:
-            logger.log("replies", "SKIPPED", reason="missing comment id")
-            continue
-        action = item.get("action", "unknown")
-        description = item.get("description", "")
-        commit_sha = item.get("commit")
-
-        if action == "fixed" and commit_sha:
-            body = f"Fixed in {commit_sha} — {description}"
-        elif action == "dismissed":
-            body = f"Not applicable — {description}"
-        else:
-            body = description or "Reviewed."
-
-        try:
-            result = subprocess.run(
-                ["gh", "api", f"repos/{repo}/pulls/{pr_number}/comments",
-                 "-F", f"in_reply_to={comment_id}", "-f", f"body={body}"],
-                cwd=worktree, capture_output=True, text=True, timeout=15,
-            )
-            if result.returncode != 0:
-                logger.log("replies", "FAILED", comment_id=comment_id,
-                           error=result.stderr.strip()[:100])
-            else:
-                logger.log("replies", "POSTED", comment_id=comment_id, action=action)
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            logger.log("replies", "FAILED", comment_id=comment_id)
+    _post_replies_common(
+        worktree, pr_number, triage_results, _log_fn,
+        shakedown=bool(SHAKEDOWN),
+    )
 
 
 def run_retro(worktree, logger):

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -1,0 +1,174 @@
+"""Shared triage logic for pipeline.py and pr_monitor.py.
+
+Extracted to satisfy Constitution A2 (single code path) — both callers
+delegate to these pure-ish functions instead of duplicating logic.
+"""
+import json
+import os
+import subprocess
+
+
+def get_repo_slug(worktree, shakedown=False):
+    """Get owner/repo from gh CLI. Returns 'owner/repo' or None."""
+    if shakedown:
+        return "test-owner/test-repo"
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner",
+             "--jq", ".nameWithOwner"],
+            cwd=worktree, capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+def build_triage_prompt(worktree, pr_number, comments):
+    """Build the triage prompt. Pure function -- no I/O except reading state.json."""
+    state_path = os.path.join(worktree, ".workflow", "state.json")
+    spec_path = ""
+    try:
+        with open(state_path, "r") as f:
+            state = json.load(f)
+        spec_path = state.get("spec", "")
+    except (json.JSONDecodeError, OSError):
+        pass
+
+    return (
+        f"Triage these Gemini review comments on PR #{pr_number}.\n\n"
+        f"Spec (read for design rationale): {spec_path}\n\n"
+        f"Comments:\n{json.dumps(comments, indent=2)}\n\n"
+        "For each comment:\n"
+        "1. Read the referenced file at the specified line\n"
+        "2. Evaluate: is this a valid finding?\n"
+        "3. If valid: fix the code and commit\n"
+        "4. If invalid: compose a brief dismissal rationale\n\n"
+        "After all comments, push fixes and output this JSON:\n"
+        '[{"id": <id>, "action": "fixed"|"dismissed", '
+        '"description": "...", "commit": "<sha>"|null}]'
+    )
+
+
+def parse_triage_json(content):
+    """Find and parse triage JSON array from raw text content.
+
+    Works for both direct stage log content (pipeline) and
+    pre-extracted text (pr_monitor). Returns list or None.
+    """
+    last_bracket = content.rfind("[")
+    if last_bracket != -1:
+        try:
+            decoder = json.JSONDecoder()
+            obj, _ = decoder.raw_decode(content[last_bracket:])
+            if isinstance(obj, list):
+                return obj
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
+def parse_triage_jsonl(jsonl_path):
+    """Parse triage results from JSONL stream output (pr_monitor style).
+
+    Extracts text from 'result' and 'assistant' events, then finds
+    the JSON array. Returns list or None.
+    """
+    text_parts = []
+    try:
+        with open(jsonl_path, "r", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("type") == "result":
+                    result_text = event.get("result", "")
+                    if result_text:
+                        text_parts.append(result_text)
+                elif event.get("type") == "assistant":
+                    content = event.get("message", {}).get("content", [])
+                    for block in content:
+                        if block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text:
+                                text_parts.append(text)
+    except OSError:
+        return None
+
+    return parse_triage_json("\n".join(text_parts))
+
+
+def parse_triage_stage_log(stage_log_path):
+    """Parse triage results from a stage log file (pipeline style).
+
+    Reads the file and finds the JSON array via raw_decode.
+    Returns list or None.
+    """
+    try:
+        with open(stage_log_path, "r", errors="replace") as f:
+            content = f.read()
+    except OSError:
+        return None
+    return parse_triage_json(content)
+
+
+def format_reply_body(item):
+    """Format a single triage result into a reply body string."""
+    action = item.get("action", "unknown")
+    description = item.get("description", "")
+    commit_sha = item.get("commit")
+
+    if action == "fixed" and commit_sha:
+        return f"Fixed in {commit_sha} \u2014 {description}"
+    elif action == "dismissed":
+        return f"Not applicable \u2014 {description}"
+    else:
+        return description or "Reviewed."
+
+
+def post_replies(worktree, pr_number, triage_results, log_fn, shakedown=False):
+    """Post threaded replies to Gemini comments.
+
+    Args:
+        worktree: path to the git worktree
+        pr_number: PR number (int or str)
+        triage_results: list of triage result dicts
+        log_fn: callable(event, **kwargs) for logging
+        shakedown: if True, skip actual posting
+    """
+    if shakedown:
+        log_fn("SHAKEDOWN_SKIPPED")
+        return
+
+    repo = get_repo_slug(worktree, shakedown=shakedown)
+    if not repo:
+        log_fn("ERROR", reason="Cannot determine repo slug")
+        return
+
+    for item in triage_results:
+        comment_id = item.get("id")
+        if not comment_id:
+            log_fn("SKIPPED", reason="missing comment id")
+            continue
+
+        body = format_reply_body(item)
+        action = item.get("action", "unknown")
+
+        try:
+            result = subprocess.run(
+                ["gh", "api", f"repos/{repo}/pulls/{pr_number}/comments",
+                 "-F", f"in_reply_to={comment_id}", "-f", f"body={body}"],
+                cwd=worktree, capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode != 0:
+                log_fn("FAILED", comment_id=comment_id,
+                       error=result.stderr.strip()[:100])
+            else:
+                log_fn("POSTED", comment_id=comment_id, action=action)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            log_fn("FAILED", comment_id=comment_id)

--- a/scripts/verify_workflow_checks.py
+++ b/scripts/verify_workflow_checks.py
@@ -2,8 +2,6 @@
 import json
 import os
 import re
-import subprocess
-import sys
 
 
 def check_skill_frontmatter(skill_path: str) -> list[str]:
@@ -150,48 +148,5 @@ def check_retro_store_schema(store_path: str) -> list[str]:
             f"{store_path}: schema_version is {data.get('schema_version')}, expected 1 — "
             "rebuild the store"
         )
-
-    return errors
-
-
-def check_behavioral_tests(repo_root: str) -> list[str]:
-    """Check 8 (behavioral): Run verify-workflow.py scenario tests.
-
-    Returns list of error messages (empty = pass).
-    """
-    script_path = os.path.join(repo_root, "scripts", "verify-workflow.py")
-    if not os.path.isfile(script_path):
-        return [f"Behavioral test script not found: {script_path}"]
-
-    try:
-        result = subprocess.run(
-            [sys.executable, script_path],
-            capture_output=True, text=True, timeout=60,
-            cwd=repo_root,
-        )
-    except subprocess.TimeoutExpired:
-        return ["Behavioral tests timed out (>60s)"]
-    except FileNotFoundError:
-        return [f"Cannot execute: {script_path}"]
-
-    # Parse JSON output from stdout
-    try:
-        report = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return [f"Behavioral tests produced invalid JSON: {result.stdout[:200]}"]
-
-    errors = []
-    summary = report.get("summary", {})
-    failed = summary.get("failed", 0)
-
-    if failed > 0:
-        # Report each failed scenario
-        for name, scenario in report.get("scenarios", {}).items():
-            if scenario.get("status") == "fail":
-                detail = scenario.get("detail", "no detail")
-                errors.append(f"Behavioral test '{name}' failed: {detail}")
-
-    if result.returncode != 0 and not errors:
-        errors.append(f"Behavioral tests exited with code {result.returncode}")
 
     return errors

--- a/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/DeleteCommand.cs
@@ -411,8 +411,8 @@ public static class DeleteCommand
                 entity,
                 idsToDelete,
                 options,
-                progress,
-                cancellationToken);
+                progress: progress,
+                cancellationToken: cancellationToken);
 
             if (!globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Commands/Data/TruncateCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/TruncateCommand.cs
@@ -383,8 +383,8 @@ public static class TruncateCommand
                 entity,
                 ids,
                 options,
-                batchProgress,
-                cancellationToken);
+                progress: batchProgress,
+                cancellationToken: cancellationToken);
 
             totalDeleted += result.SuccessCount;
             totalFailed += result.FailureCount;

--- a/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/UpdateCommand.cs
@@ -460,8 +460,8 @@ public static class UpdateCommand
                 entity,
                 entitiesToUpdate,
                 options,
-                progress,
-                cancellationToken);
+                progress: progress,
+                cancellationToken: cancellationToken);
 
             if (!globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
+++ b/src/PPDS.Cli/CsvLoader/CsvDataLoader.cs
@@ -346,8 +346,8 @@ public sealed class CsvDataLoader
                 BypassPowerAutomateFlows = options.BypassFlows,
                 ContinueOnError = options.ContinueOnError
             },
-            progress,
-            cancellationToken);
+            progress: progress,
+            cancellationToken: cancellationToken);
 
         // 8. Map bulk operation errors
         foreach (var bulkError in bulkResult.Errors)

--- a/src/PPDS.Dataverse/BulkOperations/BulkOperationExecutor.cs
+++ b/src/PPDS.Dataverse/BulkOperations/BulkOperationExecutor.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.DependencyInjection;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Progress;
@@ -118,6 +119,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default)
         {
@@ -152,7 +154,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Sequential execution for single batch or when parallelism unavailable
                 result = await ExecuteBatchesSequentiallyAsync(
                     batches,
-                    (batch, ct) => ExecuteCreateMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteCreateMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -162,7 +164,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Pool-managed parallel execution - pool semaphore limits concurrency
                 result = await ExecuteBatchesParallelAsync(
                     batches,
-                    (batch, ct) => ExecuteCreateMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteCreateMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -183,6 +185,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default)
         {
@@ -217,7 +220,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Sequential execution for single batch or when parallelism unavailable
                 result = await ExecuteBatchesSequentiallyAsync(
                     batches,
-                    (batch, ct) => ExecuteUpdateMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteUpdateMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -227,7 +230,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Pool-managed parallel execution - pool semaphore limits concurrency
                 result = await ExecuteBatchesParallelAsync(
                     batches,
-                    (batch, ct) => ExecuteUpdateMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteUpdateMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -248,6 +251,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default)
         {
@@ -282,7 +286,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Sequential execution for single batch or when parallelism unavailable
                 result = await ExecuteBatchesSequentiallyAsync(
                     batches,
-                    (batch, ct) => ExecuteUpsertMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteUpsertMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -292,7 +296,7 @@ namespace PPDS.Dataverse.BulkOperations
                 // Pool-managed parallel execution - pool semaphore limits concurrency
                 result = await ExecuteBatchesParallelAsync(
                     batches,
-                    (batch, ct) => ExecuteUpsertMultipleBatchAsync(entityLogicalName, batch, options, ct),
+                    (batch, ct) => ExecuteUpsertMultipleBatchAsync(entityLogicalName, batch, options, clientOptions, ct),
                     tracker,
                     progress,
                     cancellationToken);
@@ -313,6 +317,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Guid> ids,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default)
         {
@@ -332,8 +337,8 @@ namespace PPDS.Dataverse.BulkOperations
 
             // Select the appropriate batch execution function based on table type
             Func<List<Guid>, CancellationToken, Task<BulkOperationResult>> executeBatch = options.ElasticTable
-                ? (batch, ct) => ExecuteElasticDeleteBatchAsync(entityLogicalName, batch, options, ct)
-                : (batch, ct) => ExecuteStandardDeleteBatchAsync(entityLogicalName, batch, options, ct);
+                ? (batch, ct) => ExecuteElasticDeleteBatchAsync(entityLogicalName, batch, options, clientOptions, ct)
+                : (batch, ct) => ExecuteStandardDeleteBatchAsync(entityLogicalName, batch, options, clientOptions, ct);
 
             // Determine parallelism: user override or pool's DOP-based recommendation
             var parallelism = options.MaxParallelBatches ?? _connectionPool.GetTotalRecommendedParallelism();
@@ -371,17 +376,18 @@ namespace PPDS.Dataverse.BulkOperations
         /// <summary>
         /// Gets a connection from the pool with retry logic for pool exhaustion.
         /// </summary>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A pooled client.</returns>
         /// <exception cref="PoolExhaustedException">Thrown when the pool remains exhausted after all retries.</exception>
-        private async Task<IPooledClient> GetClientWithRetryAsync(CancellationToken cancellationToken)
+        private async Task<IPooledClient> GetClientWithRetryAsync(DataverseClientOptions? clientOptions, CancellationToken cancellationToken)
         {
             // Attempts are 1-indexed for clearer logging
             for (int attempt = 1; attempt <= MaxPoolExhaustionRetries; attempt++)
             {
                 try
                 {
-                    return await _connectionPool.GetClientAsync(cancellationToken: cancellationToken);
+                    return await _connectionPool.GetClientAsync(options: clientOptions, cancellationToken: cancellationToken);
                 }
                 catch (PoolExhaustedException) when (attempt < MaxPoolExhaustionRetries)
                 {
@@ -698,6 +704,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<T> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             Func<IPooledClient, List<T>, CancellationToken, Task<BulkOperationResult>> executeBatch,
             CancellationToken cancellationToken)
         {
@@ -714,7 +721,7 @@ namespace PPDS.Dataverse.BulkOperations
 
                 try
                 {
-                    client = await GetClientWithRetryAsync(cancellationToken);
+                    client = await GetClientWithRetryAsync(clientOptions, cancellationToken);
                     connectionName = client.ConnectionName;
 
                     // PRE-FLIGHT GUARD: Don't execute if connection is known to be throttled.
@@ -745,7 +752,7 @@ namespace PPDS.Dataverse.BulkOperations
                         await client.DisposeAsync();
                         client = null;
 
-                        client = await GetClientWithRetryAsync(cancellationToken);
+                        client = await GetClientWithRetryAsync(clientOptions, cancellationToken);
                         connectionName = client.ConnectionName;
                     }
 
@@ -960,6 +967,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<Entity> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             return ExecuteBatchWithThrottleHandlingAsync(
@@ -967,6 +975,7 @@ namespace PPDS.Dataverse.BulkOperations
                 entityLogicalName,
                 batch,
                 options,
+                clientOptions,
                 (client, b, ct) => ExecuteCreateMultipleCoreAsync(client, entityLogicalName, b, options, ct),
                 cancellationToken);
         }
@@ -1020,6 +1029,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<Entity> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             return ExecuteBatchWithThrottleHandlingAsync(
@@ -1027,6 +1037,7 @@ namespace PPDS.Dataverse.BulkOperations
                 entityLogicalName,
                 batch,
                 options,
+                clientOptions,
                 (client, b, ct) => ExecuteUpdateMultipleCoreAsync(client, entityLogicalName, b, options, ct),
                 cancellationToken);
         }
@@ -1079,6 +1090,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<Entity> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             return ExecuteBatchWithThrottleHandlingAsync(
@@ -1086,6 +1098,7 @@ namespace PPDS.Dataverse.BulkOperations
                 entityLogicalName,
                 batch,
                 options,
+                clientOptions,
                 (client, b, ct) => ExecuteUpsertMultipleCoreAsync(client, entityLogicalName, b, options, ct),
                 cancellationToken);
         }
@@ -1160,6 +1173,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<Guid> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             return ExecuteBatchWithThrottleHandlingAsync(
@@ -1167,6 +1181,7 @@ namespace PPDS.Dataverse.BulkOperations
                 entityLogicalName,
                 batch,
                 options,
+                clientOptions,
                 (client, b, ct) => ExecuteElasticDeleteCoreAsync(client, entityLogicalName, b, options, ct),
                 cancellationToken);
         }
@@ -1222,6 +1237,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             List<Guid> batch,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             return ExecuteBatchWithThrottleHandlingAsync(
@@ -1229,6 +1245,7 @@ namespace PPDS.Dataverse.BulkOperations
                 entityLogicalName,
                 batch,
                 options,
+                clientOptions,
                 (client, b, ct) => ExecuteStandardDeleteCoreAsync(client, entityLogicalName, b, options, ct),
                 cancellationToken);
         }

--- a/src/PPDS.Dataverse/BulkOperations/BulkOperationExecutor.cs
+++ b/src/PPDS.Dataverse/BulkOperations/BulkOperationExecutor.cs
@@ -129,7 +129,7 @@ namespace PPDS.Dataverse.BulkOperations
             // Get connection info for logging only - release immediately to avoid holding pool slot
             int recommended;
             {
-                await using var infoClient = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken);
+                await using var infoClient = await _connectionPool.GetClientAsync(options: clientOptions, cancellationToken: cancellationToken);
                 recommended = infoClient.RecommendedDegreesOfParallelism;
             }
 
@@ -195,7 +195,7 @@ namespace PPDS.Dataverse.BulkOperations
             // Get connection info for logging only - release immediately to avoid holding pool slot
             int recommended;
             {
-                await using var infoClient = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken);
+                await using var infoClient = await _connectionPool.GetClientAsync(options: clientOptions, cancellationToken: cancellationToken);
                 recommended = infoClient.RecommendedDegreesOfParallelism;
             }
 
@@ -261,7 +261,7 @@ namespace PPDS.Dataverse.BulkOperations
             // Get connection info for logging only - release immediately to avoid holding pool slot
             int recommended;
             {
-                await using var infoClient = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken);
+                await using var infoClient = await _connectionPool.GetClientAsync(options: clientOptions, cancellationToken: cancellationToken);
                 recommended = infoClient.RecommendedDegreesOfParallelism;
             }
 
@@ -327,7 +327,7 @@ namespace PPDS.Dataverse.BulkOperations
             // Get connection info for logging only - release immediately to avoid holding pool slot
             int recommended;
             {
-                await using var infoClient = await _connectionPool.GetClientAsync(cancellationToken: cancellationToken);
+                await using var infoClient = await _connectionPool.GetClientAsync(options: clientOptions, cancellationToken: cancellationToken);
                 recommended = infoClient.RecommendedDegreesOfParallelism;
             }
 

--- a/src/PPDS.Dataverse/BulkOperations/IBulkOperationExecutor.cs
+++ b/src/PPDS.Dataverse/BulkOperations/IBulkOperationExecutor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Progress;
 
 namespace PPDS.Dataverse.BulkOperations
@@ -19,6 +20,7 @@ namespace PPDS.Dataverse.BulkOperations
         /// <param name="entityLogicalName">The entity logical name.</param>
         /// <param name="entities">The entities to create.</param>
         /// <param name="options">Bulk operation options.</param>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="progress">Optional progress reporter for tracking operation progress.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The result of the operation.</returns>
@@ -26,6 +28,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default);
 
@@ -35,6 +38,7 @@ namespace PPDS.Dataverse.BulkOperations
         /// <param name="entityLogicalName">The entity logical name.</param>
         /// <param name="entities">The entities to update.</param>
         /// <param name="options">Bulk operation options.</param>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="progress">Optional progress reporter for tracking operation progress.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The result of the operation.</returns>
@@ -42,6 +46,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default);
 
@@ -51,6 +56,7 @@ namespace PPDS.Dataverse.BulkOperations
         /// <param name="entityLogicalName">The entity logical name.</param>
         /// <param name="entities">The entities to upsert.</param>
         /// <param name="options">Bulk operation options.</param>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="progress">Optional progress reporter for tracking operation progress.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The result of the operation.</returns>
@@ -58,6 +64,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Entity> entities,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default);
 
@@ -67,6 +74,7 @@ namespace PPDS.Dataverse.BulkOperations
         /// <param name="entityLogicalName">The entity logical name.</param>
         /// <param name="ids">The IDs of the records to delete.</param>
         /// <param name="options">Bulk operation options.</param>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="progress">Optional progress reporter for tracking operation progress.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The result of the operation.</returns>
@@ -74,6 +82,7 @@ namespace PPDS.Dataverse.BulkOperations
             string entityLogicalName,
             IEnumerable<Guid> ids,
             BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
             IProgress<ProgressSnapshot>? progress = null,
             CancellationToken cancellationToken = default);
     }

--- a/src/PPDS.Migration/Import/BulkOperationProber.cs
+++ b/src/PPDS.Migration/Import/BulkOperationProber.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xrm.Sdk;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Progress;
 
 namespace PPDS.Migration.Import
@@ -66,6 +67,7 @@ namespace PPDS.Migration.Import
         /// <param name="records">The records to process.</param>
         /// <param name="operationType">The type of bulk operation.</param>
         /// <param name="options">Bulk operation options.</param>
+        /// <param name="clientOptions">Optional per-request connection options (e.g., CallerId for impersonation).</param>
         /// <param name="fallbackExecutor">Executor for individual operations when bulk isn't supported.</param>
         /// <param name="progress">Optional progress reporter.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
@@ -75,6 +77,7 @@ namespace PPDS.Migration.Import
             IReadOnlyList<Entity> records,
             BulkOperationType operationType,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             Func<string, IReadOnlyList<Entity>, Task<BulkOperationResult>> fallbackExecutor,
             IProgress<ProgressSnapshot>? progress,
             CancellationToken cancellationToken)
@@ -99,7 +102,7 @@ namespace PPDS.Migration.Import
             // Probe with first record
             var probeRecord = records.Take(1).ToList();
             var probeResult = await ExecuteBulkOperationAsync(
-                entityName, probeRecord, operationType, options, null, cancellationToken).ConfigureAwait(false);
+                entityName, probeRecord, operationType, options, clientOptions, null, cancellationToken).ConfigureAwait(false);
 
             if (IsBulkNotSupportedFailure(probeResult, 1))
             {
@@ -116,7 +119,7 @@ namespace PPDS.Migration.Import
             {
                 var remainingRecords = records.Skip(1).ToList();
                 var remainingResult = await ExecuteBulkOperationAsync(
-                    entityName, remainingRecords, operationType, options, progress, cancellationToken).ConfigureAwait(false);
+                    entityName, remainingRecords, operationType, options, clientOptions, progress, cancellationToken).ConfigureAwait(false);
 
                 // Merge probe result with remaining result
                 return MergeBulkResults(probeResult, remainingResult);
@@ -143,17 +146,18 @@ namespace PPDS.Migration.Import
             IReadOnlyList<Entity> records,
             BulkOperationType operationType,
             BulkOperationOptions options,
+            DataverseClientOptions? clientOptions,
             IProgress<ProgressSnapshot>? progress,
             CancellationToken cancellationToken)
         {
             return operationType switch
             {
                 BulkOperationType.Create => await _bulkExecutor.CreateMultipleAsync(
-                    entityName, records, options, progress, cancellationToken).ConfigureAwait(false),
+                    entityName, records, options, clientOptions, progress, cancellationToken).ConfigureAwait(false),
                 BulkOperationType.Update => await _bulkExecutor.UpdateMultipleAsync(
-                    entityName, records, options, progress, cancellationToken).ConfigureAwait(false),
+                    entityName, records, options, clientOptions, progress, cancellationToken).ConfigureAwait(false),
                 BulkOperationType.Upsert => await _bulkExecutor.UpsertMultipleAsync(
-                    entityName, records, options, progress, cancellationToken).ConfigureAwait(false),
+                    entityName, records, options, clientOptions, progress, cancellationToken).ConfigureAwait(false),
                 _ => throw new ArgumentOutOfRangeException(nameof(operationType), operationType, "Unknown bulk operation type")
             };
         }

--- a/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
+++ b/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
@@ -177,6 +177,7 @@ namespace PPDS.Migration.Import
                 updates,
                 BulkOperationType.Update,
                 bulkOptions,
+                null, // clientOptions
                 async (_, recs) => await ExecuteIndividualUpdatesAsync(entityName, recs.ToList(), fieldList, context, cancellationToken).ConfigureAwait(false),
                 progressAdapter,
                 cancellationToken).ConfigureAwait(false);

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -1032,7 +1032,7 @@ namespace PPDS.Migration.Import
             }
 
             var mappedOwnerCount = groups.Count(g => g.Key != Guid.Empty);
-            var unmappedCount = groups.ContainsKey(Guid.Empty) ? groups[Guid.Empty].Count : 0;
+            var unmappedCount = groups.TryGetValue(Guid.Empty, out var unmappedGroup) ? unmappedGroup.Count : 0;
 
             _logger?.LogInformation(
                 "Impersonation grouping for {Entity}: {Groups} owner groups ({Owners} distinct owners, {Unmapped} unmapped)",

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -823,6 +823,7 @@ namespace PPDS.Migration.Import
                     preparedRecords,
                     operationType,
                     bulkOptions,
+                    null, // clientOptions — Phase 3b will wire impersonation here
                     async (_, recs) => await ExecuteIndividualOperationsAsync(entityName, recs.ToList(), effectiveMode, options, cancellationToken).ConfigureAwait(false),
                     progressAdapter,
                     cancellationToken).ConfigureAwait(false);

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -710,6 +710,7 @@ namespace PPDS.Migration.Import
 
             // Prepare records: apply handlers, remap lookups, null deferred fields, filter
             var preparedRecords = new List<Entity>();
+            List<Guid?>? ownerMappingList = options.ImpersonateOwners ? new List<Guid?>() : null;
             foreach (var record in records)
             {
                 // Step 1: Apply record filters
@@ -783,27 +784,27 @@ namespace PPDS.Migration.Import
                     }
                 }
 
+                // Extract owner mapping BEFORE PrepareRecordForImport may strip ownerid
+                // Built alongside preparedRecords to keep indices aligned after filtering
+                if (ownerMappingList != null)
+                {
+                    Guid? mappedOwner = null;
+                    if (record.Contains("ownerid") && record["ownerid"] is EntityReference ownerRef)
+                    {
+                        if (options.UserMappings!.TryGetMappedUserId(ownerRef.Id, out var mappedId))
+                        {
+                            mappedOwner = mappedId;
+                        }
+                    }
+                    ownerMappingList.Add(mappedOwner);
+                }
+
                 var prepared = PrepareRecordForImport(transformed, deferredSet, fieldMetadata, idMappings, options, effectiveMode);
                 preparedRecords.Add(prepared);
             }
 
-            // Build owner mapping for impersonation grouping
-            // Use original records (before prep) since PrepareRecordForImport may strip ownerid
-            Guid?[]? ownerMapping = null;
-            if (options.ImpersonateOwners)
-            {
-                ownerMapping = new Guid?[records.Count];
-                for (int i = 0; i < records.Count; i++)
-                {
-                    if (records[i].Contains("ownerid") && records[i]["ownerid"] is EntityReference ownerRef)
-                    {
-                        if (options.UserMappings!.TryGetMappedUserId(ownerRef.Id, out var mappedId))
-                        {
-                            ownerMapping[i] = mappedId;
-                        }
-                    }
-                }
-            }
+            // Convert to array for ExecuteWithOwnerGroupingAsync
+            var ownerMapping = ownerMappingList?.ToArray();
 
             // Create progress adapter that bridges BulkOperationExecutor progress to IProgressReporter
             var progressAdapter = progress != null

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Security;
 using PPDS.Migration.Analysis;
@@ -148,6 +149,14 @@ namespace PPDS.Migration.Import
             if (plan == null) throw new ArgumentNullException(nameof(plan));
 
             options ??= _defaultOptions;
+
+            if (options.ImpersonateOwners && options.UserMappings == null)
+            {
+                throw new InvalidOperationException(
+                    "ImpersonateOwners requires UserMappings to be configured. " +
+                    "Provide a user mapping file with source-to-target user ID mappings.");
+            }
+
             var stopwatch = Stopwatch.StartNew();
             var idMappings = new IdMappingCollection();
             var entityResults = new ConcurrentBag<EntityImportResult>();
@@ -778,6 +787,24 @@ namespace PPDS.Migration.Import
                 preparedRecords.Add(prepared);
             }
 
+            // Build owner mapping for impersonation grouping
+            // Use original records (before prep) since PrepareRecordForImport may strip ownerid
+            Guid?[]? ownerMapping = null;
+            if (options.ImpersonateOwners)
+            {
+                ownerMapping = new Guid?[records.Count];
+                for (int i = 0; i < records.Count; i++)
+                {
+                    if (records[i].Contains("ownerid") && records[i]["ownerid"] is EntityReference ownerRef)
+                    {
+                        if (options.UserMappings!.TryGetMappedUserId(ownerRef.Id, out var mappedId))
+                        {
+                            ownerMapping[i] = mappedId;
+                        }
+                    }
+                }
+            }
+
             // Create progress adapter that bridges BulkOperationExecutor progress to IProgressReporter
             var progressAdapter = progress != null
                 ? new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
@@ -818,15 +845,25 @@ namespace PPDS.Migration.Import
                     _ => BulkOperationType.Upsert
                 };
 
-                bulkResult = await _prober.ExecuteWithProbeAsync(
-                    entityName,
-                    preparedRecords,
-                    operationType,
-                    bulkOptions,
-                    null, // clientOptions — Phase 3b will wire impersonation here
-                    async (_, recs) => await ExecuteIndividualOperationsAsync(entityName, recs.ToList(), effectiveMode, options, cancellationToken).ConfigureAwait(false),
-                    progressAdapter,
-                    cancellationToken).ConfigureAwait(false);
+                if (options.ImpersonateOwners && ownerMapping != null)
+                {
+                    // Group records by mapped owner for impersonation
+                    bulkResult = await ExecuteWithOwnerGroupingAsync(
+                        entityName, preparedRecords, ownerMapping, operationType, bulkOptions,
+                        effectiveMode, options, progressAdapter, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    bulkResult = await _prober.ExecuteWithProbeAsync(
+                        entityName,
+                        preparedRecords,
+                        operationType,
+                        bulkOptions,
+                        null,
+                        async (_, recs) => await ExecuteIndividualOperationsAsync(entityName, recs.ToList(), effectiveMode, options, null, cancellationToken).ConfigureAwait(false),
+                        progressAdapter,
+                        cancellationToken).ConfigureAwait(false);
+                }
 
                 // Emit warning if bulk fallback occurred during this call (not previously known)
                 if (!wasKnownBulkNotSupported && _prober.IsKnownBulkNotSupported(entityName))
@@ -845,8 +882,17 @@ namespace PPDS.Migration.Import
             }
             else
             {
-                // UseBulkApis is false - use individual operations directly
-                bulkResult = await ExecuteIndividualOperationsAsync(entityName, preparedRecords, effectiveMode, options, cancellationToken).ConfigureAwait(false);
+                if (options.ImpersonateOwners && ownerMapping != null)
+                {
+                    bulkResult = await ExecuteWithOwnerGroupingAsync(
+                        entityName, preparedRecords, ownerMapping, BulkOperationType.Upsert, bulkOptions,
+                        effectiveMode, options, null, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    // UseBulkApis is false - use individual operations directly
+                    bulkResult = await ExecuteIndividualOperationsAsync(entityName, preparedRecords, effectiveMode, options, null, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             // Track ID mappings - for bulk operations, IDs are preserved from Entity.Id
@@ -890,6 +936,7 @@ namespace PPDS.Migration.Import
             List<Entity> records,
             ImportMode effectiveMode,
             ImportOptions options,
+            DataverseClientOptions? clientOptions,
             CancellationToken cancellationToken)
         {
             var createdIds = new List<Guid>();
@@ -897,7 +944,7 @@ namespace PPDS.Migration.Import
             var successCount = 0;
             var failureCount = 0;
 
-            await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await using var client = await _connectionPool.GetClientAsync(clientOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             for (var i = 0; i < records.Count; i++)
             {
@@ -955,6 +1002,113 @@ namespace PPDS.Migration.Import
                 CreatedIds = createdIds,
                 Errors = errors,
                 Duration = TimeSpan.Zero
+            };
+        }
+
+        private async Task<BulkOperationResult> ExecuteWithOwnerGroupingAsync(
+            string entityName,
+            List<Entity> preparedRecords,
+            Guid?[] ownerMapping,
+            BulkOperationType operationType,
+            BulkOperationOptions bulkOptions,
+            ImportMode effectiveMode,
+            ImportOptions options,
+            IProgress<Dataverse.Progress.ProgressSnapshot>? progress,
+            CancellationToken cancellationToken)
+        {
+            // Group record indices by mapped owner
+            // Use Guid.Empty as sentinel for unmapped records (no impersonation)
+            var groups = new Dictionary<Guid, List<int>>();
+            for (int i = 0; i < preparedRecords.Count; i++)
+            {
+                var owner = ownerMapping[i] ?? Guid.Empty;
+                if (!groups.TryGetValue(owner, out var indices))
+                {
+                    indices = new List<int>();
+                    groups[owner] = indices;
+                }
+                indices.Add(i);
+            }
+
+            var mappedOwnerCount = groups.Count(g => g.Key != Guid.Empty);
+            var unmappedCount = groups.ContainsKey(Guid.Empty) ? groups[Guid.Empty].Count : 0;
+
+            _logger?.LogInformation(
+                "Impersonation grouping for {Entity}: {Groups} owner groups ({Owners} distinct owners, {Unmapped} unmapped)",
+                entityName, groups.Count,
+                mappedOwnerCount,
+                unmappedCount);
+
+            // Execute each owner group
+            var allErrors = new List<BulkOperationError>();
+            var totalSuccess = 0;
+            var totalFailure = 0;
+            int? totalCreated = null;
+            int? totalUpdated = null;
+
+            foreach (var (ownerId, indices) in groups)
+            {
+                var groupRecords = indices.Select(i => preparedRecords[i]).ToList();
+                var clientOptions = ownerId != Guid.Empty
+                    ? new DataverseClientOptions { CallerId = ownerId }
+                    : null;
+
+                BulkOperationResult groupResult;
+                if (options.UseBulkApis)
+                {
+                    groupResult = await _prober.ExecuteWithProbeAsync(
+                        entityName,
+                        groupRecords,
+                        operationType,
+                        bulkOptions,
+                        clientOptions,
+                        async (_, recs) => await ExecuteIndividualOperationsAsync(
+                            entityName, recs.ToList(), effectiveMode, options, clientOptions, cancellationToken).ConfigureAwait(false),
+                        progress,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    groupResult = await ExecuteIndividualOperationsAsync(
+                        entityName, groupRecords, effectiveMode, options, clientOptions, cancellationToken).ConfigureAwait(false);
+                }
+
+                totalSuccess += groupResult.SuccessCount;
+                totalFailure += groupResult.FailureCount;
+
+                // Remap error indices back to original positions
+                foreach (var error in groupResult.Errors)
+                {
+                    allErrors.Add(new BulkOperationError
+                    {
+                        Index = error.Index < indices.Count ? indices[error.Index] : error.Index,
+                        RecordId = error.RecordId,
+                        ErrorCode = error.ErrorCode,
+                        Message = error.Message,
+                        FieldName = error.FieldName,
+                        FieldValueDescription = error.FieldValueDescription,
+                        Diagnostics = error.Diagnostics
+                    });
+                }
+
+                if (groupResult.CreatedCount.HasValue)
+                {
+                    totalCreated = (totalCreated ?? 0) + groupResult.CreatedCount.Value;
+                }
+                if (groupResult.UpdatedCount.HasValue)
+                {
+                    totalUpdated = (totalUpdated ?? 0) + groupResult.UpdatedCount.Value;
+                }
+            }
+
+            return new BulkOperationResult
+            {
+                SuccessCount = totalSuccess,
+                FailureCount = totalFailure,
+                Errors = allErrors,
+                Duration = TimeSpan.Zero,
+                CreatedCount = totalCreated,
+                UpdatedCount = totalUpdated
             };
         }
 

--- a/tests/PPDS.Dataverse.IntegrationTests/BulkOperations/BatchingBehaviorTests.cs
+++ b/tests/PPDS.Dataverse.IntegrationTests/BulkOperations/BatchingBehaviorTests.cs
@@ -88,7 +88,7 @@ public class BatchingBehaviorTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.CreateMultipleAsync(EntityName, entities, options, progress);
+        await Executor.CreateMultipleAsync(EntityName, entities, options, progress: progress);
 
         // Assert - Should have 3 batches: 10, 10, 5
         progress.Reports.Should().HaveCount(3);
@@ -111,7 +111,7 @@ public class BatchingBehaviorTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.UpdateMultipleAsync(EntityName, updateEntities, options, progress);
+        await Executor.UpdateMultipleAsync(EntityName, updateEntities, options, progress: progress);
 
         // Assert - Should have 3 batches: 10, 10, 5
         progress.Reports.Should().HaveCount(3);
@@ -131,7 +131,7 @@ public class BatchingBehaviorTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.DeleteMultipleAsync(EntityName, createResult.CreatedIds!.ToList(), options, progress);
+        await Executor.DeleteMultipleAsync(EntityName, createResult.CreatedIds!.ToList(), options, progress: progress);
 
         // Assert - Should have 3 batches: 10, 10, 5
         progress.Reports.Should().HaveCount(3);
@@ -151,7 +151,7 @@ public class BatchingBehaviorTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.CreateMultipleAsync(EntityName, entities, options, progress);
+        await Executor.CreateMultipleAsync(EntityName, entities, options, progress: progress);
 
         // Assert
         progress.LastReport!.Total.Should().Be(100);

--- a/tests/PPDS.Dataverse.IntegrationTests/BulkOperations/ElasticTableTests.cs
+++ b/tests/PPDS.Dataverse.IntegrationTests/BulkOperations/ElasticTableTests.cs
@@ -91,7 +91,7 @@ public class ElasticTableTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.DeleteMultipleAsync(EntityName, idsToDelete, options, progress);
+        await Executor.DeleteMultipleAsync(EntityName, idsToDelete, options, progress: progress);
 
         // Assert
         progress.Reports.Should().NotBeEmpty();
@@ -226,7 +226,7 @@ public class ElasticTableTests : BulkOperationExecutorTestsBase
         var progress = CreateProgressReporter();
 
         // Act
-        await Executor.CreateMultipleAsync(EntityName, entities, options, progress);
+        await Executor.CreateMultipleAsync(EntityName, entities, options, progress: progress);
 
         // Assert
         progress.Reports.Should().HaveCount(3); // 3 batches of 10

--- a/tests/PPDS.Migration.Tests/Import/BulkOperationProberTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/BulkOperationProberTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Xrm.Sdk;
 using Moq;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Progress;
 using PPDS.Migration.Import;
 using Xunit;
@@ -40,6 +41,7 @@ public class BulkOperationProberTests
             null!,
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, _) => Task.FromResult(new BulkOperationResult()),
             null,
             CancellationToken.None);
@@ -58,6 +60,7 @@ public class BulkOperationProberTests
             Array.Empty<Entity>(),
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, _) => Task.FromResult(new BulkOperationResult()),
             null,
             CancellationToken.None);
@@ -97,6 +100,7 @@ public class BulkOperationProberTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(probeResult)
@@ -110,6 +114,7 @@ public class BulkOperationProberTests
             records,
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, _) =>
             {
                 fallbackCalled = true;
@@ -154,6 +159,7 @@ public class BulkOperationProberTests
                 "team",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(probeResult);
@@ -171,6 +177,7 @@ public class BulkOperationProberTests
             records,
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, recs) =>
             {
                 // Fallback receives ALL records (including the probe record)
@@ -211,6 +218,7 @@ public class BulkOperationProberTests
             records,
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, _) =>
             {
                 fallbackCalled = true;
@@ -226,6 +234,7 @@ public class BulkOperationProberTests
             It.IsAny<string>(),
             It.IsAny<IEnumerable<Entity>>(),
             It.IsAny<BulkOperationOptions>(),
+            It.IsAny<DataverseClientOptions>(),
             It.IsAny<IProgress<ProgressSnapshot>>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -250,6 +259,7 @@ public class BulkOperationProberTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(probeResult);
@@ -260,6 +270,7 @@ public class BulkOperationProberTests
             records,
             BulkOperationType.Upsert,
             new BulkOperationOptions(),
+            null, // clientOptions
             (_, _) => Task.FromResult(new BulkOperationResult()),
             null,
             CancellationToken.None);

--- a/tests/PPDS.Migration.Tests/Import/DeferredFieldProcessorTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/DeferredFieldProcessorTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.Xrm.Sdk;
 using Moq;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Progress;
 using PPDS.Migration.Import;
@@ -74,9 +75,10 @@ public class DeferredFieldProcessorTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, IEnumerable<Entity> entities, BulkOperationOptions _, IProgress<ProgressSnapshot> _, CancellationToken _) =>
+            .ReturnsAsync((string _, IEnumerable<Entity> entities, BulkOperationOptions _, DataverseClientOptions? _, IProgress<ProgressSnapshot> _, CancellationToken _) =>
             {
                 var list = entities.ToList();
                 return new BulkOperationResult
@@ -99,6 +101,7 @@ public class DeferredFieldProcessorTests
             "account",
             It.IsAny<IEnumerable<Entity>>(),
             It.IsAny<BulkOperationOptions>(),
+            It.IsAny<DataverseClientOptions>(),
             It.IsAny<IProgress<ProgressSnapshot>>(),
             It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
@@ -146,9 +149,10 @@ public class DeferredFieldProcessorTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string _, IEnumerable<Entity> entities, BulkOperationOptions _, IProgress<ProgressSnapshot> _, CancellationToken _) =>
+            .ReturnsAsync((string _, IEnumerable<Entity> entities, BulkOperationOptions _, DataverseClientOptions? _, IProgress<ProgressSnapshot> _, CancellationToken _) =>
             {
                 var batch = entities.ToList();
                 allUpdatedEntities.AddRange(batch);
@@ -174,6 +178,7 @@ public class DeferredFieldProcessorTests
             "account",
             It.IsAny<IEnumerable<Entity>>(),
             It.IsAny<BulkOperationOptions>(),
+            It.IsAny<DataverseClientOptions>(),
             It.IsAny<IProgress<ProgressSnapshot>>(),
             It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
@@ -214,6 +219,7 @@ public class DeferredFieldProcessorTests
                 "team",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BulkOperationResult

--- a/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
@@ -1609,8 +1609,6 @@ public class TieredImporterTests
 
         SetupSchemaValidatorNoMismatches();
 
-        var capturedClientOptions = new List<DataverseClientOptions?>();
-
         _bulkExecutor.SetupSequence(x => x.UpsertMultipleAsync(
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),

--- a/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
@@ -747,8 +747,8 @@ public class TieredImporterTests
                 It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
-                (_, entities, _, _, _) => capturedContact = entities.FirstOrDefault())
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, entities, _, _, _, _) => capturedContact = entities.FirstOrDefault())
             .ReturnsAsync(new BulkOperationResult
             {
                 SuccessCount = 1,
@@ -808,8 +808,8 @@ public class TieredImporterTests
                 It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
-                (_, entities, _, _, _) => capturedEntity = entities.FirstOrDefault())
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, entities, _, _, _, _) => capturedEntity = entities.FirstOrDefault())
             .ReturnsAsync(new BulkOperationResult
             {
                 SuccessCount = 1,
@@ -869,8 +869,8 @@ public class TieredImporterTests
                 It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
-                (_, entities, _, _, _) => capturedEntity = entities.FirstOrDefault())
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, entities, _, _, _, _) => capturedEntity = entities.FirstOrDefault())
             .ReturnsAsync(new BulkOperationResult
             {
                 SuccessCount = 1,
@@ -939,8 +939,8 @@ public class TieredImporterTests
                 It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
-                (_, entities, _, _, _) => capturedEntity = entities.FirstOrDefault())
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, entities, _, _, _, _) => capturedEntity = entities.FirstOrDefault())
             .ReturnsAsync(new BulkOperationResult
             {
                 SuccessCount = 1,
@@ -1315,8 +1315,8 @@ public class TieredImporterTests
                 It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
-                (_, entities, _, _, _) => capturedEntity = entities.FirstOrDefault())
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, entities, _, _, _, _) => capturedEntity = entities.FirstOrDefault())
             .ReturnsAsync(new BulkOperationResult
             {
                 SuccessCount = 1,
@@ -1384,6 +1384,274 @@ public class TieredImporterTests
             It.IsAny<DataverseClientOptions>(),
             It.IsAny<IProgress<ProgressSnapshot>>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region ImpersonateOwners
+
+    [Fact]
+    public async Task ImpersonateOwners_WithoutUserMappings_Throws()
+    {
+        // Arrange
+        var records = new List<Entity>
+        {
+            new Entity("account") { Id = Guid.NewGuid(), ["name"] = "Contoso" }
+        };
+
+        var data = CreateMigrationData("account", records);
+        var plan = CreateSingleTierPlan("account");
+
+        var options = new ImportOptions
+        {
+            ImpersonateOwners = true,
+            UserMappings = null,
+            RespectDisablePluginsSetting = false
+        };
+
+        // Act
+        var act = async () => await _sut.ImportAsync(data, plan, options);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ImpersonateOwners requires UserMappings*");
+    }
+
+    [Fact]
+    public async Task ImpersonateOwners_GroupsByOwner()
+    {
+        // Arrange
+        var sourceOwner1 = Guid.NewGuid();
+        var sourceOwner2 = Guid.NewGuid();
+        var targetOwner1 = Guid.NewGuid();
+        var targetOwner2 = Guid.NewGuid();
+
+        var records = new List<Entity>
+        {
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Contoso",
+                ["ownerid"] = new EntityReference("systemuser", sourceOwner1)
+            },
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Fabrikam",
+                ["ownerid"] = new EntityReference("systemuser", sourceOwner2)
+            },
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Northwind",
+                ["ownerid"] = new EntityReference("systemuser", sourceOwner1)
+            }
+        };
+
+        var data = CreateMigrationData("account", records);
+        var plan = CreateSingleTierPlan("account");
+
+        SetupSchemaValidatorNoMismatches();
+
+        // Track which DataverseClientOptions are used per call
+        var capturedClientOptions = new List<DataverseClientOptions?>();
+
+        _bulkExecutor.Setup(x => x.UpsertMultipleAsync(
+                "account",
+                It.IsAny<IEnumerable<Entity>>(),
+                It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
+                It.IsAny<IProgress<ProgressSnapshot>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, _, _, clientOpts, _, _) => capturedClientOptions.Add(clientOpts))
+            .ReturnsAsync((string _, IEnumerable<Entity> entities, BulkOperationOptions _, DataverseClientOptions? _, IProgress<ProgressSnapshot>? _, CancellationToken _) =>
+                new BulkOperationResult
+                {
+                    SuccessCount = entities.Count(),
+                    FailureCount = 0,
+                    Errors = Array.Empty<BulkOperationError>()
+                });
+
+        var userMappings = new UserMappingCollection
+        {
+            Mappings = new Dictionary<Guid, PPDS.Migration.Models.UserMapping>
+            {
+                [sourceOwner1] = new PPDS.Migration.Models.UserMapping
+                {
+                    SourceUserId = sourceOwner1,
+                    TargetUserId = targetOwner1
+                },
+                [sourceOwner2] = new PPDS.Migration.Models.UserMapping
+                {
+                    SourceUserId = sourceOwner2,
+                    TargetUserId = targetOwner2
+                }
+            }
+        };
+
+        var options = new ImportOptions
+        {
+            ImpersonateOwners = true,
+            UserMappings = userMappings,
+            RespectDisablePluginsSetting = false
+        };
+
+        // Act
+        var result = await _sut.ImportAsync(data, plan, options);
+
+        // Assert
+        result.RecordsImported.Should().Be(3);
+        result.Success.Should().BeTrue();
+
+        // Should have called the bulk executor with distinct CallerId values for each owner group.
+        // Each group goes through probing (1 probe + remaining), so we expect multiple calls.
+        // But we can verify that the captured client options contain both target owners.
+        var callerIds = capturedClientOptions
+            .Where(o => o?.CallerId != null)
+            .Select(o => o!.CallerId!.Value)
+            .Distinct()
+            .ToList();
+
+        callerIds.Should().Contain(targetOwner1);
+        callerIds.Should().Contain(targetOwner2);
+    }
+
+    [Fact]
+    public async Task ImpersonateOwners_UnmappedOwner_NoImpersonation()
+    {
+        // Arrange
+        var unmappedOwnerId = Guid.NewGuid();
+
+        var records = new List<Entity>
+        {
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Contoso",
+                ["ownerid"] = new EntityReference("systemuser", unmappedOwnerId)
+            }
+        };
+
+        var data = CreateMigrationData("account", records);
+        var plan = CreateSingleTierPlan("account");
+
+        SetupSchemaValidatorNoMismatches();
+
+        var capturedClientOptions = new List<DataverseClientOptions?>();
+
+        _bulkExecutor.Setup(x => x.UpsertMultipleAsync(
+                "account",
+                It.IsAny<IEnumerable<Entity>>(),
+                It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
+                It.IsAny<IProgress<ProgressSnapshot>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, IEnumerable<Entity>, BulkOperationOptions, DataverseClientOptions?, IProgress<ProgressSnapshot>?, CancellationToken>(
+                (_, _, _, clientOpts, _, _) => capturedClientOptions.Add(clientOpts))
+            .ReturnsAsync(new BulkOperationResult
+            {
+                SuccessCount = 1,
+                FailureCount = 0,
+                Errors = Array.Empty<BulkOperationError>()
+            });
+
+        // UserMappings exists but has no mapping for the owner
+        var userMappings = new UserMappingCollection
+        {
+            Mappings = new Dictionary<Guid, PPDS.Migration.Models.UserMapping>(),
+            DefaultUserId = null,
+            UseCurrentUserAsDefault = false
+        };
+
+        var options = new ImportOptions
+        {
+            ImpersonateOwners = true,
+            UserMappings = userMappings,
+            RespectDisablePluginsSetting = false
+        };
+
+        // Act
+        var result = await _sut.ImportAsync(data, plan, options);
+
+        // Assert
+        result.RecordsImported.Should().Be(1);
+        result.Success.Should().BeTrue();
+
+        // All calls should have null clientOptions (no impersonation for unmapped owners)
+        capturedClientOptions.Should().AllSatisfy(o => o.Should().BeNull());
+    }
+
+    [Fact]
+    public async Task ImpersonateOwners_False_NoGrouping()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+
+        var records = new List<Entity>
+        {
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Contoso",
+                ["ownerid"] = new EntityReference("systemuser", ownerId)
+            },
+            new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["name"] = "Fabrikam",
+                ["ownerid"] = new EntityReference("systemuser", ownerId)
+            }
+        };
+
+        var data = CreateMigrationData("account", records);
+        var plan = CreateSingleTierPlan("account");
+
+        SetupSchemaValidatorNoMismatches();
+
+        var capturedClientOptions = new List<DataverseClientOptions?>();
+
+        _bulkExecutor.SetupSequence(x => x.UpsertMultipleAsync(
+                "account",
+                It.IsAny<IEnumerable<Entity>>(),
+                It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
+                It.IsAny<IProgress<ProgressSnapshot>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BulkOperationResult
+            {
+                SuccessCount = 1,
+                FailureCount = 0,
+                Errors = Array.Empty<BulkOperationError>()
+            })
+            .ReturnsAsync(new BulkOperationResult
+            {
+                SuccessCount = 1,
+                FailureCount = 0,
+                Errors = Array.Empty<BulkOperationError>()
+            });
+
+        var options = new ImportOptions
+        {
+            ImpersonateOwners = false,
+            RespectDisablePluginsSetting = false
+        };
+
+        // Act
+        var result = await _sut.ImportAsync(data, plan, options);
+
+        // Assert
+        result.RecordsImported.Should().Be(2);
+        result.Success.Should().BeTrue();
+
+        // Verify the bulk executor was called with null clientOptions (no impersonation)
+        _bulkExecutor.Verify(x => x.UpsertMultipleAsync(
+            "account",
+            It.IsAny<IEnumerable<Entity>>(),
+            It.IsAny<BulkOperationOptions>(),
+            It.Is<DataverseClientOptions?>(o => o == null),
+            It.IsAny<IProgress<ProgressSnapshot>>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2)); // probe + remaining
     }
 
     #endregion

--- a/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Moq;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Progress;
 using PPDS.Migration.Analysis;
@@ -232,6 +233,7 @@ public class TieredImporterTests
                 entityName,
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(probeResult)
@@ -309,6 +311,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => importOrder.Add("account"))
@@ -324,6 +327,7 @@ public class TieredImporterTests
                 "contact",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => importOrder.Add("contact"))
@@ -406,6 +410,7 @@ public class TieredImporterTests
                     entityName,
                     It.IsAny<IEnumerable<Entity>>(),
                     It.IsAny<BulkOperationOptions>(),
+                    It.IsAny<DataverseClientOptions>(),
                     It.IsAny<IProgress<ProgressSnapshot>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(async () =>
@@ -660,6 +665,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Simulated failure"));
@@ -722,6 +728,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BulkOperationResult
@@ -737,6 +744,7 @@ public class TieredImporterTests
                 "contact",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
@@ -797,6 +805,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
@@ -857,6 +866,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
@@ -926,6 +936,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
@@ -987,6 +998,7 @@ public class TieredImporterTests
                 "team",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BulkOperationResult
@@ -1140,6 +1152,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BulkOperationResult
@@ -1154,6 +1167,7 @@ public class TieredImporterTests
                 "contact",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BulkOperationResult
@@ -1208,6 +1222,7 @@ public class TieredImporterTests
                 "account",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Connection pool exhausted"));
@@ -1297,6 +1312,7 @@ public class TieredImporterTests
                 "team",
                 It.IsAny<IEnumerable<Entity>>(),
                 It.IsAny<BulkOperationOptions>(),
+                It.IsAny<DataverseClientOptions>(),
                 It.IsAny<IProgress<ProgressSnapshot>>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, IEnumerable<Entity>, BulkOperationOptions, IProgress<ProgressSnapshot>?, CancellationToken>(
@@ -1365,6 +1381,7 @@ public class TieredImporterTests
             It.IsAny<string>(),
             It.IsAny<IEnumerable<Entity>>(),
             It.IsAny<BulkOperationOptions>(),
+            It.IsAny<DataverseClientOptions>(),
             It.IsAny<IProgress<ProgressSnapshot>>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/TieredImporterTests.cs
@@ -1418,7 +1418,7 @@ public class TieredImporterTests
     }
 
     [Fact]
-    public async Task ImpersonateOwners_GroupsByOwner()
+    public async Task ImpersonatesViaClonePerOwnerGroup()
     {
         // Arrange
         var sourceOwner1 = Guid.NewGuid();
@@ -1518,7 +1518,7 @@ public class TieredImporterTests
     }
 
     [Fact]
-    public async Task ImpersonateOwners_UnmappedOwner_NoImpersonation()
+    public async Task FallsBackToServicePrincipalForUnmappedOwner()
     {
         // Arrange
         var unmappedOwnerId = Guid.NewGuid();

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -1,0 +1,198 @@
+"""Tests for scripts/triage_common.py shared triage functions."""
+import json
+import os
+import sys
+
+import pytest
+
+# Add scripts dir to path so we can import triage_common
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+
+from triage_common import (
+    build_triage_prompt,
+    format_reply_body,
+    get_repo_slug,
+    parse_triage_json,
+    parse_triage_jsonl,
+    parse_triage_stage_log,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_repo_slug
+# ---------------------------------------------------------------------------
+
+
+class TestGetRepoSlug:
+    def test_shakedown_returns_test_slug(self):
+        result = get_repo_slug("/nonexistent", shakedown=True)
+        assert result == "test-owner/test-repo"
+
+
+# ---------------------------------------------------------------------------
+# build_triage_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTriagePrompt:
+    def test_includes_pr_number_and_comments(self, tmp_path):
+        comments = [{"id": 1, "body": "Fix this"}]
+        prompt = build_triage_prompt(str(tmp_path), 42, comments)
+        assert "PR #42" in prompt
+        assert '"Fix this"' in prompt
+
+    def test_reads_spec_from_state(self, tmp_path):
+        wf = tmp_path / ".workflow"
+        wf.mkdir()
+        (wf / "state.json").write_text(json.dumps({"spec": "specs/my-spec.md"}))
+        prompt = build_triage_prompt(str(tmp_path), 1, [])
+        assert "specs/my-spec.md" in prompt
+
+    def test_missing_state_uses_empty_spec(self, tmp_path):
+        prompt = build_triage_prompt(str(tmp_path), 1, [])
+        assert "Spec (read for design rationale): \n" in prompt
+
+    def test_contains_output_format_instructions(self, tmp_path):
+        prompt = build_triage_prompt(str(tmp_path), 1, [])
+        assert '"action": "fixed"|"dismissed"' in prompt
+
+
+# ---------------------------------------------------------------------------
+# parse_triage_json
+# ---------------------------------------------------------------------------
+
+
+class TestParseTriageJson:
+    def test_finds_json_array(self):
+        text = 'Some preamble\n[{"id": 1, "action": "fixed"}]\ntrailing'
+        result = parse_triage_json(text)
+        assert result == [{"id": 1, "action": "fixed"}]
+
+    def test_returns_none_for_no_bracket(self):
+        assert parse_triage_json("no json here") is None
+
+    def test_returns_none_for_invalid_json(self):
+        assert parse_triage_json("[invalid json") is None
+
+    def test_finds_last_bracket(self):
+        text = 'first [ignore this] then [{"id": 2}]'
+        result = parse_triage_json(text)
+        assert result == [{"id": 2}]
+
+    def test_returns_none_for_non_list(self):
+        # raw_decode on a bracket that starts a non-list should return None
+        # This would actually parse as a list, so test with edge case
+        assert parse_triage_json("[") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_triage_jsonl
+# ---------------------------------------------------------------------------
+
+
+class TestParseTriageJsonl:
+    def test_extracts_from_result_events(self, tmp_path):
+        jsonl = tmp_path / "out.jsonl"
+        lines = [
+            json.dumps({
+                "type": "result",
+                "result": '[{"id": 1, "action": "dismissed", "description": "not relevant"}]',
+            }),
+        ]
+        jsonl.write_text("\n".join(lines))
+        result = parse_triage_jsonl(str(jsonl))
+        assert result == [{"id": 1, "action": "dismissed", "description": "not relevant"}]
+
+    def test_extracts_from_assistant_events(self, tmp_path):
+        jsonl = tmp_path / "out.jsonl"
+        lines = [
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": 'Here is the result:'},
+                        {"type": "text", "text": '[{"id": 3, "action": "fixed", "commit": "abc"}]'},
+                    ],
+                },
+            }),
+        ]
+        jsonl.write_text("\n".join(lines))
+        result = parse_triage_jsonl(str(jsonl))
+        assert result == [{"id": 3, "action": "fixed", "commit": "abc"}]
+
+    def test_returns_none_for_missing_file(self):
+        assert parse_triage_jsonl("/nonexistent/path.jsonl") is None
+
+    def test_skips_invalid_json_lines(self, tmp_path):
+        jsonl = tmp_path / "out.jsonl"
+        content = 'not json\n' + json.dumps({
+            "type": "result",
+            "result": '[{"id": 1, "action": "fixed"}]',
+        })
+        jsonl.write_text(content)
+        result = parse_triage_jsonl(str(jsonl))
+        assert result == [{"id": 1, "action": "fixed"}]
+
+    def test_returns_none_when_no_json_array_in_text(self, tmp_path):
+        jsonl = tmp_path / "out.jsonl"
+        lines = [
+            json.dumps({"type": "result", "result": "no array here"}),
+        ]
+        jsonl.write_text("\n".join(lines))
+        assert parse_triage_jsonl(str(jsonl)) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_triage_stage_log
+# ---------------------------------------------------------------------------
+
+
+class TestParseTriageStageLog:
+    def test_reads_stage_log_file(self, tmp_path):
+        log = tmp_path / "triage.log"
+        log.write_text('stuff\n[{"id": 2, "action": "fixed", "commit": "abc123"}]\n')
+        result = parse_triage_stage_log(str(log))
+        assert result == [{"id": 2, "action": "fixed", "commit": "abc123"}]
+
+    def test_returns_none_for_missing_file(self):
+        assert parse_triage_stage_log("/nonexistent/triage.log") is None
+
+    def test_returns_none_for_no_json(self, tmp_path):
+        log = tmp_path / "triage.log"
+        log.write_text("just some text with no arrays\n")
+        assert parse_triage_stage_log(str(log)) is None
+
+
+# ---------------------------------------------------------------------------
+# format_reply_body
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReplyBody:
+    def test_fixed_with_commit(self):
+        body = format_reply_body({
+            "action": "fixed", "commit": "abc", "description": "done",
+        })
+        assert body == "Fixed in abc \u2014 done"
+
+    def test_dismissed(self):
+        body = format_reply_body({
+            "action": "dismissed", "description": "not relevant",
+        })
+        assert body == "Not applicable \u2014 not relevant"
+
+    def test_unknown_with_description(self):
+        body = format_reply_body({
+            "action": "unknown", "description": "needs review",
+        })
+        assert body == "needs review"
+
+    def test_unknown_no_description(self):
+        assert format_reply_body({}) == "Reviewed."
+
+    def test_fixed_without_commit_uses_description(self):
+        body = format_reply_body({
+            "action": "fixed", "description": "patched",
+        })
+        assert body == "patched"

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -3,8 +3,6 @@ import json
 import os
 import sys
 
-import pytest
-
 # Add scripts dir to path so we can import triage_common
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))


### PR DESCRIPTION
## Summary

- Remove dead `check_behavioral_tests()` function from verify_workflow_checks.py (#744)
- Extract shared triage logic (prompt building, JSON parsing, reply posting) from pipeline.py and pr_monitor.py into triage_common.py (#739)
- Thread `DataverseClientOptions` through `IBulkOperationExecutor` → `BulkOperationExecutor` → `BulkOperationProber` to support per-request connection options (#37)
- Wire `ImpersonateOwners` into the import path: records grouped by mapped owner, each group executed with `CallerId` impersonation via the connection pool (#37)

Closes #744
Closes #739
Closes #37

## Test Plan

- [x] Python: 140 tests pass (triage_common, pipeline, pr_monitor)
- [x] .NET: All unit tests pass across net8.0/net9.0/net10.0
- [x] New impersonation tests: ImpersonatesViaClonePerOwnerGroup, FallsBackToServicePrincipalForUnmappedOwner, ImpersonateOwners_WithoutUserMappings_Throws, ImpersonateOwners_False_NoGrouping
- [x] Owner mapping index alignment verified (built alongside preparedRecords, not from original records)

## Verification
- [x] /gates passed
- [x] /review completed (findings: 8, all fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)