### PR TITLE
feat(migration): code quality improvements (#460, #459, #455, #453)

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 from triage_common import (
     build_triage_prompt,
+    format_reply_body,
     get_repo_slug as _get_repo_slug,
     parse_triage_stage_log,
     post_replies as _post_replies_common,

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -34,7 +34,6 @@ from pathlib import Path
 
 from triage_common import (
     build_triage_prompt,
-    format_reply_body,
     get_repo_slug as _get_repo_slug,
     parse_triage_stage_log,
     post_replies as _post_replies_common,

--- a/src/PPDS.Migration/Constants/EntityNames.cs
+++ b/src/PPDS.Migration/Constants/EntityNames.cs
@@ -1,0 +1,26 @@
+namespace PPDS.Migration.Constants
+{
+    /// <summary>
+    /// Dataverse entity logical names used in migration operations.
+    /// </summary>
+    public static class EntityNames
+    {
+        /// <summary>The logical name of the systemuser entity.</summary>
+        public const string SystemUser = "systemuser";
+
+        /// <summary>The logical name of the team entity.</summary>
+        public const string Team = "team";
+
+        /// <summary>The logical name of the businessunit entity.</summary>
+        public const string BusinessUnit = "businessunit";
+    }
+
+    /// <summary>
+    /// Dataverse attribute logical names used in migration operations.
+    /// </summary>
+    public static class AttributeNames
+    {
+        /// <summary>The logical name of the isdefault attribute.</summary>
+        public const string IsDefault = "isdefault";
+    }
+}

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -75,7 +75,9 @@ namespace PPDS.Migration.Export
             IProgressReporter? progress = null,
             CancellationToken cancellationToken = default)
         {
-            progress?.Report(new ProgressEventArgs
+            progress ??= IProgressReporter.Silent;
+
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = "Parsing schema..."
@@ -97,6 +99,7 @@ namespace PPDS.Migration.Export
             if (schema == null) throw new ArgumentNullException(nameof(schema));
             if (string.IsNullOrEmpty(outputPath)) throw new ArgumentNullException(nameof(outputPath));
 
+            progress ??= IProgressReporter.Silent;
             options ??= _defaultOptions;
             var stopwatch = Stopwatch.StartNew();
             var entityResults = new ConcurrentBag<EntityExportResult>();
@@ -106,7 +109,7 @@ namespace PPDS.Migration.Export
             _logger?.LogInformation("Starting parallel export of {Count} entities with parallelism {Parallelism}",
                 schema.Entities.Count, options.DegreeOfParallelism);
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Exporting,
                 Message = $"Exporting {schema.Entities.Count} entities..."
@@ -143,7 +146,7 @@ namespace PPDS.Migration.Export
                     }).ConfigureAwait(false);
 
                 // Export M2M relationships
-                progress?.Report(new ProgressEventArgs
+                progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Exporting,
                     Message = "Exporting M2M relationships..."
@@ -153,7 +156,7 @@ namespace PPDS.Migration.Export
                     schema, entityData, options, progress, errors, cancellationToken).ConfigureAwait(false);
 
                 // Write to output file
-                progress?.Report(new ProgressEventArgs
+                progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Exporting,
                     Message = "Writing output file..."
@@ -187,7 +190,7 @@ namespace PPDS.Migration.Export
                     Errors = errors.ToArray()
                 };
 
-                progress?.Complete(new MigrationResult
+                progress.Complete(new MigrationResult
                 {
                     Success = result.Success,
                     RecordsProcessed = result.RecordsExported,
@@ -204,7 +207,7 @@ namespace PPDS.Migration.Export
                 _logger?.LogError(ex, "Export failed");
 
                 var safeMessage = ConnectionStringRedactor.RedactExceptionMessage(ex.Message);
-                progress?.Error(ex, "Export failed");
+                progress.Error(ex, "Export failed");
 
                 return new ExportResult
                 {
@@ -226,7 +229,7 @@ namespace PPDS.Migration.Export
         private async Task<EntityExportResultWithData> ExportEntityAsync(
             EntitySchema entitySchema,
             ExportOptions options,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             CancellationToken cancellationToken)
         {
             var entityStopwatch = Stopwatch.StartNew();
@@ -260,7 +263,7 @@ namespace PPDS.Migration.Export
                             ? records.Count / entityStopwatch.Elapsed.TotalSeconds
                             : 0;
 
-                        progress?.Report(new ProgressEventArgs
+                        progress.Report(new ProgressEventArgs
                         {
                             Phase = MigrationPhase.Exporting,
                             Entity = entitySchema.LogicalName,
@@ -318,7 +321,7 @@ namespace PPDS.Migration.Export
             MigrationSchema schema,
             ConcurrentDictionary<string, IReadOnlyList<Entity>> entityData,
             ExportOptions options,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             ConcurrentBag<MigrationError> errors,
             CancellationToken cancellationToken)
         {
@@ -347,7 +350,7 @@ namespace PPDS.Migration.Export
                 {
                     // Report message-only (no Entity) to avoid 0/0 display
                     // Entity progress is reported inside ExportM2MRelationshipAsync with actual counts
-                    progress?.Report(new ProgressEventArgs
+                    progress.Report(new ProgressEventArgs
                     {
                         Phase = MigrationPhase.Exporting,
                         Message = $"Exporting {entitySchema.LogicalName} M2M {rel.Name}..."
@@ -388,7 +391,7 @@ namespace PPDS.Migration.Export
             RelationshipSchema rel,
             HashSet<Guid> exportedSourceIds,
             ExportOptions options,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             CancellationToken cancellationToken)
         {
             await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -431,7 +434,7 @@ namespace PPDS.Migration.Export
                 // Report progress at intervals
                 if (associations.Count - lastReportedCount >= options.ProgressInterval || !response.MoreRecords)
                 {
-                    progress?.Report(new ProgressEventArgs
+                    progress.Report(new ProgressEventArgs
                     {
                         Phase = MigrationPhase.Exporting,
                         Entity = entitySchema.LogicalName,

--- a/src/PPDS.Migration/Formats/CmtDataReader.cs
+++ b/src/PPDS.Migration/Formats/CmtDataReader.cs
@@ -73,7 +73,9 @@ namespace PPDS.Migration.Formats
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            progress?.Report(new ProgressEventArgs
+            progress ??= IProgressReporter.Silent;
+
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = "Opening data archive..."
@@ -124,7 +126,7 @@ namespace PPDS.Migration.Formats
         private async Task<(IReadOnlyDictionary<string, IReadOnlyList<Entity>>, IReadOnlyDictionary<string, IReadOnlyList<ManyToManyRelationshipData>>)> ParseDataXmlAsync(
             Stream stream,
             MigrationSchema schema,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             CancellationToken cancellationToken)
         {
 #if NET8_0_OR_GREATER

--- a/src/PPDS.Migration/Formats/CmtDataWriter.cs
+++ b/src/PPDS.Migration/Formats/CmtDataWriter.cs
@@ -59,6 +59,8 @@ namespace PPDS.Migration.Formats
             if (data == null) throw new ArgumentNullException(nameof(data));
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
+            progress ??= IProgressReporter.Silent;
+
             using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
 
             // Write [Content_Types].xml (required by CMT)
@@ -69,7 +71,7 @@ namespace PPDS.Migration.Formats
             }
 
             // Write data.xml
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Exporting,
                 Message = "Writing data.xml..."
@@ -82,7 +84,7 @@ namespace PPDS.Migration.Formats
             }
 
             // Write schema
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Exporting,
                 Message = "Writing data_schema.xml..."
@@ -123,7 +125,7 @@ namespace PPDS.Migration.Formats
             await writer.FlushAsync().ConfigureAwait(false);
         }
 
-        private async Task WriteDataXmlAsync(MigrationData data, Stream stream, IProgressReporter? progress, CancellationToken cancellationToken)
+        private async Task WriteDataXmlAsync(MigrationData data, Stream stream, IProgressReporter progress, CancellationToken cancellationToken)
         {
             var settings = new XmlWriterSettings
             {

--- a/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
+++ b/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
@@ -108,7 +108,7 @@ namespace PPDS.Migration.Import
                     updates.Count, entityName, fieldList);
 
                 // Report initial progress
-                context.Progress?.Report(new ProgressEventArgs
+                context.Progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.ProcessingDeferredFields,
                     Entity = entityName,
@@ -160,7 +160,7 @@ namespace PPDS.Migration.Import
             // Create progress adapter
             var progressAdapter = new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
             {
-                context.Progress?.Report(new ProgressEventArgs
+                context.Progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.ProcessingDeferredFields,
                     Entity = entityName,
@@ -233,7 +233,7 @@ namespace PPDS.Migration.Import
                 // Report progress periodically (every 100 records)
                 if ((i + 1) % 100 == 0 || i == updates.Count - 1)
                 {
-                    context.Progress?.Report(new ProgressEventArgs
+                    context.Progress.Report(new ProgressEventArgs
                     {
                         Phase = MigrationPhase.ProcessingDeferredFields,
                         Entity = entityName,

--- a/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
+++ b/src/PPDS.Migration/Import/DeferredFieldProcessor.cs
@@ -158,18 +158,15 @@ namespace PPDS.Migration.Import
             };
 
             // Create progress adapter
-            var progressAdapter = new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
+            var progressAdapter = ProgressAdapterFactory.Create(context.Progress, snapshot => new ProgressEventArgs
             {
-                context.Progress.Report(new ProgressEventArgs
-                {
-                    Phase = MigrationPhase.ProcessingDeferredFields,
-                    Entity = entityName,
-                    Field = fieldList,
-                    Current = (int)snapshot.Processed,
-                    Total = updates.Count,
-                    SuccessCount = (int)snapshot.Succeeded,
-                    Message = $"Updating deferred fields: {fieldList}"
-                });
+                Phase = MigrationPhase.ProcessingDeferredFields,
+                Entity = entityName,
+                Field = fieldList,
+                Current = (int)snapshot.Processed,
+                Total = updates.Count,
+                SuccessCount = (int)snapshot.Succeeded,
+                Message = $"Updating deferred fields: {fieldList}"
             });
 
             var result = await _prober.ExecuteWithProbeAsync(

--- a/src/PPDS.Migration/Import/EntityReferenceMapper.cs
+++ b/src/PPDS.Migration/Import/EntityReferenceMapper.cs
@@ -10,6 +10,7 @@ using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using PPDS.Dataverse.Pooling;
+using PPDS.Migration.Constants;
 using PPDS.Migration.Models;
 
 namespace PPDS.Migration.Import
@@ -28,7 +29,7 @@ namespace PPDS.Migration.Import
         private static readonly Dictionary<string, string> MatchFieldOverrides = new(StringComparer.OrdinalIgnoreCase)
         {
             ["transactioncurrency"] = "isocurrencycode",
-            ["businessunit"] = "name",
+            [EntityNames.BusinessUnit] = "name",
             ["role"] = "name",
             ["uom"] = "name",
             ["uomschedule"] = "name"

--- a/src/PPDS.Migration/Import/Handlers/BusinessUnitHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/BusinessUnitHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Constants;
 
 namespace PPDS.Migration.Import.Handlers
 {
@@ -11,7 +12,7 @@ namespace PPDS.Migration.Import.Handlers
     {
         /// <inheritdoc />
         public bool CanHandle(string entityLogicalName)
-            => entityLogicalName.Equals("businessunit", StringComparison.OrdinalIgnoreCase);
+            => entityLogicalName.Equals(EntityNames.BusinessUnit, StringComparison.OrdinalIgnoreCase);
 
         /// <inheritdoc />
         public Entity Transform(Entity record, ImportContext context)

--- a/src/PPDS.Migration/Import/Handlers/SystemUserHandler.cs
+++ b/src/PPDS.Migration/Import/Handlers/SystemUserHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Constants;
 
 namespace PPDS.Migration.Import.Handlers
 {
@@ -10,7 +11,7 @@ namespace PPDS.Migration.Import.Handlers
     {
         /// <inheritdoc />
         public bool CanHandle(string entityLogicalName)
-            => entityLogicalName.Equals("systemuser", StringComparison.OrdinalIgnoreCase);
+            => entityLogicalName.Equals(EntityNames.SystemUser, StringComparison.OrdinalIgnoreCase);
 
         /// <inheritdoc />
         public bool ShouldSkip(Entity record, ImportContext context)

--- a/src/PPDS.Migration/Import/ImportContext.cs
+++ b/src/PPDS.Migration/Import/ImportContext.cs
@@ -33,7 +33,7 @@ namespace PPDS.Migration.Import
             Options = options ?? throw new ArgumentNullException(nameof(options));
             IdMappings = idMappings ?? throw new ArgumentNullException(nameof(idMappings));
             TargetFieldMetadata = targetFieldMetadata ?? throw new ArgumentNullException(nameof(targetFieldMetadata));
-            Progress = progress;
+            Progress = progress ?? IProgressReporter.Silent;
         }
 
         /// <summary>
@@ -65,9 +65,9 @@ namespace PPDS.Migration.Import
         public FieldMetadataCollection TargetFieldMetadata { get; }
 
         /// <summary>
-        /// Gets the optional progress reporter.
+        /// Gets the progress reporter (never null; defaults to <see cref="IProgressReporter.Silent"/>).
         /// </summary>
-        public IProgressReporter? Progress { get; }
+        public IProgressReporter Progress { get; }
 
         /// <summary>
         /// Gets or sets the target environment's root business unit ID.

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -194,7 +194,7 @@ namespace PPDS.Migration.Import
                         // Report progress (throttled to reduce log verbosity)
                         if (ShouldReportProgress(current, totalTargetAssociations))
                         {
-                            context.Progress?.Report(new ProgressEventArgs
+                            context.Progress.Report(new ProgressEventArgs
                             {
                                 Phase = MigrationPhase.ProcessingRelationships,
                                 Entity = entityName,
@@ -223,7 +223,7 @@ namespace PPDS.Migration.Import
                             // Report progress (throttled to reduce log verbosity)
                             if (ShouldReportProgress(current, totalTargetAssociations))
                             {
-                                context.Progress?.Report(new ProgressEventArgs
+                                context.Progress.Report(new ProgressEventArgs
                                 {
                                     Phase = MigrationPhase.ProcessingRelationships,
                                     Entity = entityName,
@@ -263,7 +263,7 @@ namespace PPDS.Migration.Import
             // Report final completion (parallel counting may not hit exact total)
             if (totalTargetAssociations > 0)
             {
-                context.Progress?.Report(new ProgressEventArgs
+                context.Progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.ProcessingRelationships,
                     Entity = "M2M",

--- a/src/PPDS.Migration/Import/SchemaMismatchException.cs
+++ b/src/PPDS.Migration/Import/SchemaMismatchException.cs
@@ -27,7 +27,7 @@ namespace PPDS.Migration.Import
         public SchemaMismatchException(string message, Dictionary<string, List<string>> missingColumns)
             : base(message)
         {
-            MissingColumns = missingColumns;
+            MissingColumns = missingColumns ?? new Dictionary<string, List<string>>();
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace PPDS.Migration.Import
         public SchemaMismatchException(string message, Dictionary<string, List<string>> missingColumns, Exception innerException)
             : base(message, innerException)
         {
-            MissingColumns = missingColumns;
+            MissingColumns = missingColumns ?? new Dictionary<string, List<string>>();
         }
     }
 }

--- a/src/PPDS.Migration/Import/SchemaMismatchException.cs
+++ b/src/PPDS.Migration/Import/SchemaMismatchException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PPDS.Migration.Import
 {
@@ -16,7 +17,7 @@ namespace PPDS.Migration.Import
         /// <summary>
         /// Gets the total count of missing columns across all entities.
         /// </summary>
-        public int TotalMissingCount { get; }
+        public int TotalMissingCount => MissingColumns.Values.Sum(list => list.Count);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SchemaMismatchException"/> class.
@@ -27,11 +28,6 @@ namespace PPDS.Migration.Import
             : base(message)
         {
             MissingColumns = missingColumns;
-            TotalMissingCount = 0;
-            foreach (var columns in missingColumns.Values)
-            {
-                TotalMissingCount += columns.Count;
-            }
         }
 
         /// <summary>
@@ -44,11 +40,6 @@ namespace PPDS.Migration.Import
             : base(message, innerException)
         {
             MissingColumns = missingColumns;
-            TotalMissingCount = 0;
-            foreach (var columns in missingColumns.Values)
-            {
-                TotalMissingCount += columns.Count;
-            }
         }
     }
 }

--- a/src/PPDS.Migration/Import/SchemaValidator.cs
+++ b/src/PPDS.Migration/Import/SchemaValidator.cs
@@ -40,9 +40,11 @@ namespace PPDS.Migration.Import
             IProgressReporter? progress,
             CancellationToken cancellationToken)
         {
+            progress ??= IProgressReporter.Silent;
+
             var result = new Dictionary<string, Dictionary<string, FieldValidity>>(StringComparer.OrdinalIgnoreCase);
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = "Loading target environment field metadata..."

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -14,6 +14,7 @@ using PPDS.Dataverse.Client;
 using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Security;
 using PPDS.Migration.Analysis;
+using PPDS.Migration.Constants;
 using PPDS.Migration.DependencyInjection;
 using PPDS.Migration.Formats;
 using PPDS.Migration.Import.Handlers;
@@ -1170,10 +1171,10 @@ namespace PPDS.Migration.Import
 
             // Force team.isdefault to false to prevent conflicts with existing default teams
             // This matches CMT behavior - default teams should not be imported as defaults
-            if (record.LogicalName.Equals("team", StringComparison.OrdinalIgnoreCase) &&
-                prepared.Contains("isdefault"))
+            if (record.LogicalName.Equals(EntityNames.Team, StringComparison.OrdinalIgnoreCase) &&
+                prepared.Contains(AttributeNames.IsDefault))
             {
-                prepared["isdefault"] = false;
+                prepared[AttributeNames.IsDefault] = false;
             }
 
             return prepared;
@@ -1212,7 +1213,7 @@ namespace PPDS.Migration.Import
                 if (options.UserMappings.UseCurrentUserAsDefault && options.CurrentUserId.HasValue)
                 {
                     _logger?.LogDebug("User {UserId} not found in mappings, using current user fallback", er.Id);
-                    return new EntityReference("systemuser", options.CurrentUserId.Value);
+                    return new EntityReference(EntityNames.SystemUser, options.CurrentUserId.Value);
                 }
 
                 // User mapping exists but no mapping found and no fallback available
@@ -1231,8 +1232,8 @@ namespace PPDS.Migration.Import
 
         private static bool IsUserReference(string entityLogicalName)
         {
-            return entityLogicalName.Equals("systemuser", StringComparison.OrdinalIgnoreCase) ||
-                   entityLogicalName.Equals("team", StringComparison.OrdinalIgnoreCase);
+            return entityLogicalName.Equals(EntityNames.SystemUser, StringComparison.OrdinalIgnoreCase) ||
+                   entityLogicalName.Equals(EntityNames.Team, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -811,20 +811,17 @@ namespace PPDS.Migration.Import
             var ownerMapping = ownerMappingList?.ToArray();
 
             // Create progress adapter that bridges BulkOperationExecutor progress to IProgressReporter
-            var progressAdapter = new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
+            var progressAdapter = ProgressAdapterFactory.Create(progress, snapshot => new ProgressEventArgs
             {
-                progress.Report(new ProgressEventArgs
-                {
-                    Phase = MigrationPhase.Importing,
-                    Entity = entityName,
-                    TierNumber = tierNumber,
-                    Current = (int)snapshot.Processed,
-                    Total = (int)snapshot.Total,
-                    SuccessCount = (int)snapshot.Succeeded,
-                    FailureCount = (int)snapshot.Failed,
-                    RecordsPerSecond = snapshot.RatePerSecond,
-                    EstimatedRemaining = snapshot.EstimatedRemaining
-                });
+                Phase = MigrationPhase.Importing,
+                Entity = entityName,
+                TierNumber = tierNumber,
+                Current = (int)snapshot.Processed,
+                Total = (int)snapshot.Total,
+                SuccessCount = (int)snapshot.Succeeded,
+                FailureCount = (int)snapshot.Failed,
+                RecordsPerSecond = snapshot.RatePerSecond,
+                EstimatedRemaining = snapshot.EstimatedRemaining
             });
 
             // Pass ALL records to BulkOperationExecutor - it handles batching dynamically

--- a/src/PPDS.Migration/Import/TieredImporter.cs
+++ b/src/PPDS.Migration/Import/TieredImporter.cs
@@ -118,7 +118,9 @@ namespace PPDS.Migration.Import
             IProgressReporter? progress = null,
             CancellationToken cancellationToken = default)
         {
-            progress?.Report(new ProgressEventArgs
+            progress ??= IProgressReporter.Silent;
+
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = "Reading data archive..."
@@ -126,7 +128,7 @@ namespace PPDS.Migration.Import
 
             var data = await _dataReader.ReadAsync(dataPath, progress, cancellationToken).ConfigureAwait(false);
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = "Building dependency graph..."
@@ -149,6 +151,7 @@ namespace PPDS.Migration.Import
             if (data == null) throw new ArgumentNullException(nameof(data));
             if (plan == null) throw new ArgumentNullException(nameof(plan));
 
+            progress ??= IProgressReporter.Silent;
             options ??= _defaultOptions;
 
             if (options.ImpersonateOwners && options.UserMappings == null)
@@ -269,7 +272,7 @@ namespace PPDS.Migration.Import
         private async Task<FieldMetadataCollection> ValidateSchemaAndHandleMissingColumnsAsync(
             MigrationData data,
             ImportOptions options,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             IWarningCollector warnings,
             CancellationToken cancellationToken)
         {
@@ -288,7 +291,7 @@ namespace PPDS.Migration.Import
                 _logger?.LogError("Schema mismatch detected: {Count} columns missing in target",
                     mismatchResult.TotalMissingCount);
 
-                progress?.Report(new ProgressEventArgs
+                progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Analyzing,
                     Message = $"Schema mismatch: {mismatchResult.TotalMissingCount} column(s) not found in target"
@@ -317,7 +320,7 @@ namespace PPDS.Migration.Import
                 });
             }
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = $"Warning: Skipping {mismatchResult.TotalMissingCount} column(s) not found in target"
@@ -332,7 +335,7 @@ namespace PPDS.Migration.Import
         private async Task<IReadOnlyList<Guid>> DisablePluginsForImportAsync(
             MigrationData data,
             ImportOptions options,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             CancellationToken cancellationToken)
         {
             if (!options.RespectDisablePluginsSetting || _pluginStepManager == null)
@@ -350,7 +353,7 @@ namespace PPDS.Migration.Import
                 return Array.Empty<Guid>();
             }
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = $"Disabling plugins for {entitiesToDisablePlugins.Count} entities..."
@@ -375,7 +378,7 @@ namespace PPDS.Migration.Import
         /// </summary>
         private async Task EnablePluginsAfterImportAsync(
             IReadOnlyList<Guid> disabledPluginSteps,
-            IProgressReporter? progress,
+            IProgressReporter progress,
             IWarningCollector warnings)
         {
             if (disabledPluginSteps.Count == 0 || _pluginStepManager == null)
@@ -383,7 +386,7 @@ namespace PPDS.Migration.Import
                 return;
             }
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Complete,
                 Message = $"Re-enabling {disabledPluginSteps.Count} plugin steps..."
@@ -431,7 +434,7 @@ namespace PPDS.Migration.Import
 
                 context.OutputManager?.LogTierStart(tier.TierNumber, tier.Entities.ToArray());
 
-                context.Progress?.Report(new ProgressEventArgs
+                context.Progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Importing,
                     TierNumber = tier.TierNumber,
@@ -519,7 +522,7 @@ namespace PPDS.Migration.Import
                     ? $"Tier {tier.TierNumber} completed: {tier.Entities.Count} entities, {tierRecordsSuccess:N0} records ({tierRecordsFailed:N0} failed) in {tierDuration:mm\\:ss} @ {tierRps:F0} rec/s"
                     : $"Tier {tier.TierNumber} completed: {tier.Entities.Count} entities, {tierRecordsSuccess:N0} records in {tierDuration:mm\\:ss} @ {tierRps:F0} rec/s";
 
-                context.Progress?.Report(new ProgressEventArgs
+                context.Progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Importing,
                     TierNumber = tier.TierNumber,
@@ -553,7 +556,7 @@ namespace PPDS.Migration.Import
             TimeSpan phase2Duration,
             TimeSpan phase3Duration,
             ImportOptions options,
-            IProgressReporter? progress)
+            IProgressReporter progress)
         {
             var result = new ImportResult
             {
@@ -600,7 +603,7 @@ namespace PPDS.Migration.Import
             var totalUpdated = hasUpdated ? (int?)updatedAgg : null;
             var totalFailureCount = recordFailureCount + relationshipResult.FailureCount;
 
-            progress?.Complete(new MigrationResult
+            progress.Complete(new MigrationResult
             {
                 Success = result.Success,
                 SourceRecordCount = sourceRecordCount,
@@ -632,10 +635,10 @@ namespace PPDS.Migration.Import
             TimeSpan duration,
             Exception ex,
             ImportOptions options,
-            IProgressReporter? progress)
+            IProgressReporter progress)
         {
             var safeMessage = ConnectionStringRedactor.RedactExceptionMessage(ex.Message);
-            progress?.Error(ex, "Import failed");
+            progress.Error(ex, "Import failed");
 
             var exceptionError = new MigrationError
             {
@@ -808,23 +811,21 @@ namespace PPDS.Migration.Import
             var ownerMapping = ownerMappingList?.ToArray();
 
             // Create progress adapter that bridges BulkOperationExecutor progress to IProgressReporter
-            var progressAdapter = progress != null
-                ? new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
+            var progressAdapter = new Progress<Dataverse.Progress.ProgressSnapshot>(snapshot =>
+            {
+                progress.Report(new ProgressEventArgs
                 {
-                    progress.Report(new ProgressEventArgs
-                    {
-                        Phase = MigrationPhase.Importing,
-                        Entity = entityName,
-                        TierNumber = tierNumber,
-                        Current = (int)snapshot.Processed,
-                        Total = (int)snapshot.Total,
-                        SuccessCount = (int)snapshot.Succeeded,
-                        FailureCount = (int)snapshot.Failed,
-                        RecordsPerSecond = snapshot.RatePerSecond,
-                        EstimatedRemaining = snapshot.EstimatedRemaining
-                    });
-                })
-                : null;
+                    Phase = MigrationPhase.Importing,
+                    Entity = entityName,
+                    TierNumber = tierNumber,
+                    Current = (int)snapshot.Processed,
+                    Total = (int)snapshot.Total,
+                    SuccessCount = (int)snapshot.Succeeded,
+                    FailureCount = (int)snapshot.Failed,
+                    RecordsPerSecond = snapshot.RatePerSecond,
+                    EstimatedRemaining = snapshot.EstimatedRemaining
+                });
+            });
 
             // Pass ALL records to BulkOperationExecutor - it handles batching dynamically
             var bulkOptions = new BulkOperationOptions

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using PPDS.Migration.Constants;
 
 namespace PPDS.Migration.Progress
 {
@@ -370,13 +371,13 @@ namespace PPDS.Migration.Progress
                 return string.Empty;
 
             // systemuser/team does not exist - common cross-environment issue
-            if (message.Contains("systemuser", StringComparison.OrdinalIgnoreCase) &&
+            if (message.Contains(EntityNames.SystemUser, StringComparison.OrdinalIgnoreCase) &&
                 message.Contains("Does Not Exist", StringComparison.OrdinalIgnoreCase))
             {
                 return "MISSING_USER";
             }
 
-            if (message.Contains("team", StringComparison.OrdinalIgnoreCase) &&
+            if (message.Contains(EntityNames.Team, StringComparison.OrdinalIgnoreCase) &&
                 message.Contains("Does Not Exist", StringComparison.OrdinalIgnoreCase))
             {
                 return "MISSING_TEAM";

--- a/src/PPDS.Migration/Progress/ErrorReportWriter.cs
+++ b/src/PPDS.Migration/Progress/ErrorReportWriter.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using PPDS.Migration.Constants;
 using PPDS.Migration.Import;
 
 namespace PPDS.Migration.Progress
@@ -179,13 +180,13 @@ namespace PPDS.Migration.Progress
             }
 
             // systemuser/team does not exist - common cross-environment issue
-            if (message.Contains("systemuser", StringComparison.OrdinalIgnoreCase) &&
+            if (message.Contains(EntityNames.SystemUser, StringComparison.OrdinalIgnoreCase) &&
                 message.Contains("Does Not Exist", StringComparison.OrdinalIgnoreCase))
             {
                 return "MISSING_USER";
             }
 
-            if (message.Contains("team", StringComparison.OrdinalIgnoreCase) &&
+            if (message.Contains(EntityNames.Team, StringComparison.OrdinalIgnoreCase) &&
                 message.Contains("Does Not Exist", StringComparison.OrdinalIgnoreCase))
             {
                 return "MISSING_TEAM";

--- a/src/PPDS.Migration/Progress/IProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/IProgressReporter.cs
@@ -37,5 +37,20 @@ namespace PPDS.Migration.Progress
         /// Use this between phases (e.g., between export and import in a copy operation).
         /// </summary>
         void Reset();
+
+        /// <summary>
+        /// A no-op reporter that silently discards all progress reports.
+        /// Use as a null object: <c>reporter ?? IProgressReporter.Silent</c>.
+        /// </summary>
+        static IProgressReporter Silent { get; } = new SilentProgressReporter();
+
+        private sealed class SilentProgressReporter : IProgressReporter
+        {
+            public string OperationName { get; set; } = string.Empty;
+            public void Report(ProgressEventArgs args) { }
+            public void Complete(MigrationResult result) { }
+            public void Error(Exception exception, string? context = null) { }
+            public void Reset() { }
+        }
     }
 }

--- a/src/PPDS.Migration/Progress/ProgressAdapterFactory.cs
+++ b/src/PPDS.Migration/Progress/ProgressAdapterFactory.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace PPDS.Migration.Progress
+{
+    /// <summary>
+    /// Creates <see cref="IProgress{T}"/> adapters that bridge
+    /// <see cref="Dataverse.Progress.ProgressSnapshot"/> to <see cref="IProgressReporter"/>.
+    /// </summary>
+    public static class ProgressAdapterFactory
+    {
+        /// <summary>
+        /// Creates an <see cref="IProgress{ProgressSnapshot}"/> that maps each snapshot
+        /// to a <see cref="ProgressEventArgs"/> via the supplied <paramref name="mapper"/>
+        /// and forwards it to the <paramref name="reporter"/>.
+        /// </summary>
+        /// <param name="reporter">The progress reporter to forward to.</param>
+        /// <param name="mapper">
+        /// A function that converts a <see cref="Dataverse.Progress.ProgressSnapshot"/>
+        /// into a <see cref="ProgressEventArgs"/>.
+        /// </param>
+        /// <returns>An <see cref="IProgress{ProgressSnapshot}"/> adapter.</returns>
+        public static IProgress<Dataverse.Progress.ProgressSnapshot> Create(
+            IProgressReporter reporter,
+            Func<Dataverse.Progress.ProgressSnapshot, ProgressEventArgs> mapper)
+        {
+            if (reporter == null) throw new ArgumentNullException(nameof(reporter));
+            if (mapper == null) throw new ArgumentNullException(nameof(mapper));
+
+            return new SynchronousProgress(reporter, mapper);
+        }
+
+        /// <summary>
+        /// Synchronous <see cref="IProgress{T}"/> that invokes the mapper and reporter
+        /// inline on the calling thread. Unlike <see cref="Progress{T}"/>, this does not
+        /// post to a <see cref="System.Threading.SynchronizationContext"/>.
+        /// </summary>
+        private sealed class SynchronousProgress : IProgress<Dataverse.Progress.ProgressSnapshot>
+        {
+            private readonly IProgressReporter _reporter;
+            private readonly Func<Dataverse.Progress.ProgressSnapshot, ProgressEventArgs> _mapper;
+
+            public SynchronousProgress(
+                IProgressReporter reporter,
+                Func<Dataverse.Progress.ProgressSnapshot, ProgressEventArgs> mapper)
+            {
+                _reporter = reporter;
+                _mapper = mapper;
+            }
+
+            public void Report(Dataverse.Progress.ProgressSnapshot value)
+            {
+                _reporter.Report(_mapper(value));
+            }
+        }
+    }
+}

--- a/src/PPDS.Migration/Schema/DataverseSchemaGenerator.cs
+++ b/src/PPDS.Migration/Schema/DataverseSchemaGenerator.cs
@@ -78,12 +78,13 @@ namespace PPDS.Migration.Schema
             IProgressReporter? progress = null,
             CancellationToken cancellationToken = default)
         {
+            progress ??= IProgressReporter.Silent;
             options ??= new SchemaGeneratorOptions();
             var entityNames = entityLogicalNames.ToList();
 
             _logger?.LogInformation("Generating schema for {Count} entities", entityNames.Count);
 
-            progress?.Report(new ProgressEventArgs
+            progress.Report(new ProgressEventArgs
             {
                 Phase = MigrationPhase.Analyzing,
                 Message = $"Generating schema for {entityNames.Count} entities..."
@@ -99,7 +100,7 @@ namespace PPDS.Migration.Schema
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                progress?.Report(new ProgressEventArgs
+                progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Analyzing,
                     Entity = entityName,

--- a/tests/PPDS.Migration.Tests/Constants/EntityNamesTests.cs
+++ b/tests/PPDS.Migration.Tests/Constants/EntityNamesTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using PPDS.Migration.Constants;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Constants;
+
+[Trait("Category", "Unit")]
+public class EntityNamesTests
+{
+    [Fact]
+    public void SystemUser_HasCorrectDataverseLogicalName()
+    {
+        EntityNames.SystemUser.Should().Be("systemuser");
+    }
+
+    [Fact]
+    public void Team_HasCorrectDataverseLogicalName()
+    {
+        EntityNames.Team.Should().Be("team");
+    }
+
+    [Fact]
+    public void BusinessUnit_HasCorrectDataverseLogicalName()
+    {
+        EntityNames.BusinessUnit.Should().Be("businessunit");
+    }
+}
+
+[Trait("Category", "Unit")]
+public class AttributeNamesTests
+{
+    [Fact]
+    public void IsDefault_HasCorrectDataverseLogicalName()
+    {
+        AttributeNames.IsDefault.Should().Be("isdefault");
+    }
+}

--- a/tests/PPDS.Migration.Tests/Import/SchemaMismatchExceptionTests.cs
+++ b/tests/PPDS.Migration.Tests/Import/SchemaMismatchExceptionTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using PPDS.Migration.Import;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Import;
+
+[Trait("Category", "Unit")]
+public class SchemaMismatchExceptionTests
+{
+    [Fact]
+    public void TotalMissingCount_ReturnsSumAcrossAllEntities()
+    {
+        // Arrange
+        var missingColumns = new Dictionary<string, List<string>>
+        {
+            ["account"] = new List<string> { "custom_field1", "custom_field2" },
+            ["contact"] = new List<string> { "custom_field3" }
+        };
+
+        // Act
+        var exception = new SchemaMismatchException("Schema mismatch", missingColumns);
+
+        // Assert
+        exception.TotalMissingCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void TotalMissingCount_ReturnsZero_WhenDictionaryIsEmpty()
+    {
+        // Arrange
+        var missingColumns = new Dictionary<string, List<string>>();
+
+        // Act
+        var exception = new SchemaMismatchException("Schema mismatch", missingColumns);
+
+        // Assert
+        exception.TotalMissingCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void MissingColumns_IsSetCorrectly()
+    {
+        // Arrange
+        var missingColumns = new Dictionary<string, List<string>>
+        {
+            ["account"] = new List<string> { "custom_field1" }
+        };
+
+        // Act
+        var exception = new SchemaMismatchException("Schema mismatch", missingColumns);
+
+        // Assert
+        exception.MissingColumns.Should().ContainKey("account");
+        exception.MissingColumns["account"].Should().ContainSingle().Which.Should().Be("custom_field1");
+    }
+
+    [Fact]
+    public void TotalMissingCount_ReturnsSumAcrossAllEntities_WhenConstructedWithInnerException()
+    {
+        // Arrange
+        var missingColumns = new Dictionary<string, List<string>>
+        {
+            ["account"] = new List<string> { "field_a", "field_b" },
+            ["lead"] = new List<string> { "field_c" }
+        };
+        var inner = new InvalidOperationException("inner");
+
+        // Act
+        var exception = new SchemaMismatchException("Schema mismatch", missingColumns, inner);
+
+        // Assert
+        exception.TotalMissingCount.Should().Be(3);
+        exception.InnerException.Should().BeSameAs(inner);
+    }
+}

--- a/tests/PPDS.Migration.Tests/Progress/ProgressAdapterFactoryTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ProgressAdapterFactoryTests.cs
@@ -1,0 +1,193 @@
+using System;
+using FluentAssertions;
+using PPDS.Dataverse.Progress;
+using PPDS.Migration.Progress;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Progress;
+
+[Trait("Category", "Unit")]
+public class ProgressAdapterFactoryTests
+{
+    [Fact]
+    public void Create_ThrowsOnNullReporter()
+    {
+        var act = () => ProgressAdapterFactory.Create(null!, _ => new ProgressEventArgs());
+
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("reporter");
+    }
+
+    [Fact]
+    public void Create_ThrowsOnNullMapper()
+    {
+        var act = () => ProgressAdapterFactory.Create(
+            IProgressReporter.Silent,
+            null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("mapper");
+    }
+
+    [Fact]
+    public void Create_ReturnsNonNullAdapter()
+    {
+        var adapter = ProgressAdapterFactory.Create(
+            IProgressReporter.Silent,
+            _ => new ProgressEventArgs());
+
+        adapter.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Report_ForwardsSnapshotToReporter()
+    {
+        // Arrange
+        var recorder = new RecordingProgressReporter();
+        var adapter = ProgressAdapterFactory.Create(recorder, snapshot => new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Importing,
+            Entity = "account",
+            Current = (int)snapshot.Processed,
+            Total = (int)snapshot.Total,
+            SuccessCount = (int)snapshot.Succeeded,
+            FailureCount = (int)snapshot.Failed,
+            RecordsPerSecond = snapshot.RatePerSecond,
+            EstimatedRemaining = snapshot.EstimatedRemaining
+        });
+
+        var snapshot = new ProgressSnapshot
+        {
+            Succeeded = 75,
+            Failed = 5,
+            Total = 200,
+            OverallRatePerSecond = 42.5,
+            EstimatedRemaining = TimeSpan.FromSeconds(10)
+        };
+
+        // Act
+        adapter.Report(snapshot);
+
+        // Assert
+        recorder.Reports.Should().ContainSingle();
+        var args = recorder.Reports[0];
+        args.Phase.Should().Be(MigrationPhase.Importing);
+        args.Entity.Should().Be("account");
+        args.Current.Should().Be(80); // Processed = Succeeded + Failed
+        args.Total.Should().Be(200);
+        args.SuccessCount.Should().Be(75);
+        args.FailureCount.Should().Be(5);
+        args.RecordsPerSecond.Should().Be(42.5);
+        args.EstimatedRemaining.Should().Be(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void Report_MapsImportingPhaseWithTierNumber()
+    {
+        // Arrange
+        var recorder = new RecordingProgressReporter();
+        var adapter = ProgressAdapterFactory.Create(recorder, snapshot => new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Importing,
+            Entity = "contact",
+            TierNumber = 3,
+            Current = (int)snapshot.Processed,
+            Total = (int)snapshot.Total,
+            SuccessCount = (int)snapshot.Succeeded,
+            FailureCount = (int)snapshot.Failed,
+            RecordsPerSecond = snapshot.RatePerSecond,
+            EstimatedRemaining = snapshot.EstimatedRemaining
+        });
+
+        // Act
+        adapter.Report(new ProgressSnapshot
+        {
+            Succeeded = 10,
+            Total = 50,
+            OverallRatePerSecond = 5.0,
+            EstimatedRemaining = TimeSpan.FromSeconds(8)
+        });
+
+        // Assert
+        recorder.Reports.Should().ContainSingle();
+        var args = recorder.Reports[0];
+        args.TierNumber.Should().Be(3);
+        args.Entity.Should().Be("contact");
+    }
+
+    [Fact]
+    public void Report_MapsDeferredFieldsPhase()
+    {
+        // Arrange
+        var recorder = new RecordingProgressReporter();
+        var fieldList = "parentid, managerid";
+        var adapter = ProgressAdapterFactory.Create(recorder, snapshot => new ProgressEventArgs
+        {
+            Phase = MigrationPhase.ProcessingDeferredFields,
+            Entity = "account",
+            Field = fieldList,
+            Current = (int)snapshot.Processed,
+            Total = 100,
+            SuccessCount = (int)snapshot.Succeeded,
+            Message = $"Updating deferred fields: {fieldList}"
+        });
+
+        // Act
+        adapter.Report(new ProgressSnapshot
+        {
+            Succeeded = 30,
+            Total = 100,
+            OverallRatePerSecond = 15.0,
+            EstimatedRemaining = TimeSpan.FromSeconds(4)
+        });
+
+        // Assert
+        recorder.Reports.Should().ContainSingle();
+        var args = recorder.Reports[0];
+        args.Phase.Should().Be(MigrationPhase.ProcessingDeferredFields);
+        args.Field.Should().Be("parentid, managerid");
+        args.Message.Should().Be("Updating deferred fields: parentid, managerid");
+        args.Current.Should().Be(30);
+        args.Total.Should().Be(100);
+        args.SuccessCount.Should().Be(30);
+    }
+
+    [Fact]
+    public void Report_MultipleReportsAreAllForwarded()
+    {
+        // Arrange
+        var recorder = new RecordingProgressReporter();
+        var adapter = ProgressAdapterFactory.Create(recorder, snapshot => new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Importing,
+            Current = (int)snapshot.Processed,
+            Total = (int)snapshot.Total
+        });
+
+        // Act
+        adapter.Report(new ProgressSnapshot { Succeeded = 10, Total = 100 });
+        adapter.Report(new ProgressSnapshot { Succeeded = 50, Total = 100 });
+        adapter.Report(new ProgressSnapshot { Succeeded = 100, Total = 100 });
+
+        // Assert
+        recorder.Reports.Should().HaveCount(3);
+        recorder.Reports[0].Current.Should().Be(10);
+        recorder.Reports[1].Current.Should().Be(50);
+        recorder.Reports[2].Current.Should().Be(100);
+    }
+
+    /// <summary>
+    /// A simple recording implementation of <see cref="IProgressReporter"/>
+    /// that stores all reported events for assertion.
+    /// </summary>
+    private sealed class RecordingProgressReporter : IProgressReporter
+    {
+        public string OperationName { get; set; } = string.Empty;
+        public System.Collections.Generic.List<ProgressEventArgs> Reports { get; } = new();
+
+        public void Report(ProgressEventArgs args) => Reports.Add(args);
+        public void Complete(MigrationResult result) { }
+        public void Error(Exception exception, string? context = null) { }
+        public void Reset() { }
+    }
+}

--- a/tests/PPDS.Migration.Tests/Progress/SilentProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/SilentProgressReporterTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using PPDS.Migration.Progress;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Progress;
+
+[Trait("Category", "Unit")]
+public class SilentProgressReporterTests
+{
+    [Fact]
+    public void Silent_IsNotNull()
+    {
+        IProgressReporter.Silent.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Silent_ReturnsSameInstance()
+    {
+        var first = IProgressReporter.Silent;
+        var second = IProgressReporter.Silent;
+
+        first.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void Report_DoesNotThrow()
+    {
+        var silent = IProgressReporter.Silent;
+
+        var act = () => silent.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Importing,
+            Entity = "account",
+            Current = 50,
+            Total = 100,
+            Message = "test"
+        });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Complete_DoesNotThrow()
+    {
+        var silent = IProgressReporter.Silent;
+
+        var act = () => silent.Complete(new MigrationResult
+        {
+            Success = true,
+            RecordsProcessed = 100,
+            SuccessCount = 100
+        });
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Error_DoesNotThrow()
+    {
+        var silent = IProgressReporter.Silent;
+
+        var act = () => silent.Error(new InvalidOperationException("test error"), "test context");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Error_WithNullContext_DoesNotThrow()
+    {
+        var silent = IProgressReporter.Silent;
+
+        var act = () => silent.Error(new InvalidOperationException("test error"));
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Reset_DoesNotThrow()
+    {
+        var silent = IProgressReporter.Silent;
+
+        var act = () => silent.Reset();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void OperationName_CanBeSetAndRead()
+    {
+        var silent = IProgressReporter.Silent;
+
+        silent.OperationName = "Export";
+
+        silent.OperationName.Should().Be("Export");
+    }
+
+    [Fact]
+    public void OperationName_DefaultsToEmptyString()
+    {
+        // Get a fresh reference — shared singleton, so reset to verify default behavior
+        var silent = IProgressReporter.Silent;
+        silent.OperationName = string.Empty;
+
+        silent.OperationName.Should().BeEmpty();
+    }
+}

--- a/tests/PPDS.Migration.Tests/Progress/SilentProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/SilentProgressReporterTests.cs
@@ -88,19 +88,34 @@ public class SilentProgressReporterTests
     public void OperationName_CanBeSetAndRead()
     {
         var silent = IProgressReporter.Silent;
+        var original = silent.OperationName;
 
-        silent.OperationName = "Export";
-
-        silent.OperationName.Should().Be("Export");
+        try
+        {
+            silent.OperationName = "Export";
+            silent.OperationName.Should().Be("Export");
+        }
+        finally
+        {
+            silent.OperationName = original;
+        }
     }
 
     [Fact]
-    public void OperationName_DefaultsToEmptyString()
+    public void OperationName_CanBeSetToEmpty()
     {
-        // Get a fresh reference — shared singleton, so reset to verify default behavior
         var silent = IProgressReporter.Silent;
-        silent.OperationName = string.Empty;
+        var original = silent.OperationName;
 
-        silent.OperationName.Should().BeEmpty();
+        try
+        {
+            silent.OperationName = "SomeValue";
+            silent.OperationName = string.Empty;
+            silent.OperationName.Should().BeEmpty();
+        }
+        finally
+        {
+            silent.OperationName = original;
+        }
     }
 }

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -3,8 +3,6 @@ import json
 import os
 import sys
 
-import pytest
-
 # Add scripts dir to path so we can import triage_common
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -3,6 +3,8 @@ import json
 import os
 import sys
 
+import pytest
+
 # Add scripts dir to path so we can import triage_common
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))


### PR DESCRIPTION
## Summary
- Make `SchemaMismatchException.TotalMissingCount` a computed property so it always reflects current dictionary state (#460)
- Replace 12+ magic entity/attribute name strings with `EntityNames` and `AttributeNames` constants (#459)
- Add `IProgressReporter.Silent` null object, eliminating 28+ null-conditional `progress?.Report` calls across 8 files (#455)
- Extract `ProgressAdapterFactory` to deduplicate `Progress<ProgressSnapshot>` adapter creation in TieredImporter and DeferredFieldProcessor (#453)

Closes #460
Closes #459
Closes #455
Closes #453

## Test Plan
- [x] SchemaMismatchExceptionTests — lazy TotalMissingCount correct for multiple entities, empty dict, inner exception ctor
- [x] EntityNamesTests — constant values match Dataverse logical names
- [x] SilentProgressReporterTests — all methods no-op, singleton identity, OperationName get/set with cleanup
- [x] ProgressAdapterFactoryTests — null guards, forwarding, tier mapping, deferred-fields mapping, multi-report

## Verification
- [x] /gates passed (0 errors, 0 warnings, 189 migration tests across 3 TFMs)
- [x] /review completed (1 critical finding fixed — singleton test pollution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)