### PR TITLE
feat(migration): add filter feedback during data export (#501)

### DIFF
--- a/specs/migration.md
+++ b/specs/migration.md
@@ -474,6 +474,10 @@ The `MigrationScreen` provides an interactive Terminal.Gui interface for configu
 | AC-46 | GUID partitions cover full space without gaps or overlaps | `GuidPartitionerTests.PartitionsCoverFullGuidSpace` | ✅ |
 | AC-47 | Each partition runs on its own pooled connection independently | `ParallelExporterPartitionTests.UsesPartitioningAboveThreshold` | ✅ |
 | AC-48 | Progress aggregates across all partitions for a single entity | `ParallelExporterPartitionTests.ProgressAggregatesAcrossPartitions` | ✅ |
+| AC-49 | Export progress reports include `FilterApplied` flag per entity | `ProgressEventArgsTests.FilterApplied_DefaultsFalse` | ✅ |
+| AC-50 | Export progress shows "(filtered)" suffix when entity has FetchXmlFilter | `ConsoleProgressReporterTests.Report_ExportWithFilter_ShowsFilteredSuffix` | ✅ |
+| AC-51 | Export logs filter description on first progress report for filtered entity | `ConsoleProgressReporterTests.Report_ExportWithFilter_ShowsFilterDescription` | ✅ |
+| AC-52 | Empty `<filter>` element in schema produces warning via progress message | `ParallelExporterFilterFeedbackTests.SummarizeFilter_EmptyFilter_ReturnsNoConditionsMessage` | ✅ |
 
 ### Edge Cases
 

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -293,7 +293,7 @@ namespace PPDS.Migration.Export
             {
                 _logger?.LogDebug("Exporting entity {Entity} (sequential)", entitySchema.LogicalName);
 
-                var hasFilter = !string.IsNullOrEmpty(entitySchema.FetchXmlFilter);
+                var hasFilter = !string.IsNullOrWhiteSpace(entitySchema.FetchXmlFilter);
                 var filterDescription = hasFilter ? SummarizeFilter(entitySchema.FetchXmlFilter!) : null;
 
                 await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -393,7 +393,7 @@ namespace PPDS.Migration.Export
                 _logger?.LogInformation("Exporting entity {Entity} with {Partitions} partitions (page-level parallelism)",
                     entitySchema.LogicalName, partitionCount);
 
-                var hasFilter = !string.IsNullOrEmpty(entitySchema.FetchXmlFilter);
+                var hasFilter = !string.IsNullOrWhiteSpace(entitySchema.FetchXmlFilter);
                 var filterDescription = hasFilter ? SummarizeFilter(entitySchema.FetchXmlFilter!) : null;
 
                 var partitions = GuidPartitioner.CreatePartitions(partitionCount);
@@ -922,8 +922,9 @@ namespace PPDS.Migration.Export
 
                 return summary;
             }
-            catch
+            catch (Exception)
             {
+                // Best-effort summary — malformed XML should not break export
                 return "(filter)";
             }
         }

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -257,6 +257,17 @@ namespace PPDS.Migration.Export
             long recordCount,
             CancellationToken cancellationToken)
         {
+            // Warn when schema has a <filter> element but it parsed to empty content
+            if (entitySchema.FetchXmlFilter != null && string.IsNullOrWhiteSpace(entitySchema.FetchXmlFilter))
+            {
+                progress.Report(new ProgressEventArgs
+                {
+                    Phase = MigrationPhase.Exporting,
+                    Entity = entitySchema.LogicalName,
+                    Message = $"Warning: {entitySchema.LogicalName} has a <filter> element in the schema but it is empty — all records will be exported (no filter applied). Check the schema for a malformed filter."
+                });
+            }
+
             var partitionCount = DeterminePartitionCount(recordCount, options);
 
             if (partitionCount > 1)
@@ -281,6 +292,9 @@ namespace PPDS.Migration.Export
             try
             {
                 _logger?.LogDebug("Exporting entity {Entity} (sequential)", entitySchema.LogicalName);
+
+                var hasFilter = !string.IsNullOrEmpty(entitySchema.FetchXmlFilter);
+                var filterDescription = hasFilter ? SummarizeFilter(entitySchema.FetchXmlFilter!) : null;
 
                 await using var client = await _connectionPool.GetClientAsync(null, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -312,7 +326,9 @@ namespace PPDS.Migration.Export
                             Entity = entitySchema.LogicalName,
                             Current = records.Count,
                             Total = records.Count, // We don't know total upfront
-                            RecordsPerSecond = rps
+                            RecordsPerSecond = rps,
+                            FilterApplied = hasFilter,
+                            FilterDescription = filterDescription
                         });
 
                         lastReportedCount = records.Count;
@@ -377,6 +393,9 @@ namespace PPDS.Migration.Export
                 _logger?.LogInformation("Exporting entity {Entity} with {Partitions} partitions (page-level parallelism)",
                     entitySchema.LogicalName, partitionCount);
 
+                var hasFilter = !string.IsNullOrEmpty(entitySchema.FetchXmlFilter);
+                var filterDescription = hasFilter ? SummarizeFilter(entitySchema.FetchXmlFilter!) : null;
+
                 var partitions = GuidPartitioner.CreatePartitions(partitionCount);
                 var fetchXml = BuildFetchXml(entitySchema, options.PageSize);
 
@@ -409,7 +428,9 @@ namespace PPDS.Migration.Export
                             Entity = entitySchema.LogicalName,
                             Current = (int)currentTotal,
                             Total = (int)(recordCount > 0 ? Math.Max(recordCount, currentTotal) : currentTotal),
-                            RecordsPerSecond = rps
+                            RecordsPerSecond = rps,
+                            FilterApplied = hasFilter,
+                            FilterDescription = filterDescription
                         });
                     }).ConfigureAwait(false);
 
@@ -870,6 +891,41 @@ namespace PPDS.Migration.Export
             }
 
             return fetch.ToString(SaveOptions.DisableFormatting);
+        }
+
+        /// <summary>
+        /// Summarizes a FetchXML filter into a human-readable description.
+        /// Extracts attribute/operator/value from condition elements.
+        /// </summary>
+        public static string SummarizeFilter(string fetchXmlFilter)
+        {
+            try
+            {
+                var doc = XDocument.Parse($"<root>{fetchXmlFilter}</root>");
+                var conditions = doc.Descendants("condition").ToList();
+
+                if (conditions.Count == 0)
+                    return "(filter — no conditions)";
+
+                var parts = conditions.Select(c =>
+                {
+                    var attr = c.Attribute("attribute")?.Value ?? "?";
+                    var op = c.Attribute("operator")?.Value ?? "?";
+                    var val = c.Attribute("value")?.Value;
+                    return val != null ? $"{attr} {op} '{val}'" : $"{attr} {op}";
+                }).ToList();
+
+                // Cap at 3 conditions to keep output concise
+                var summary = parts.Count <= 3
+                    ? string.Join(" AND ", parts)
+                    : string.Join(" AND ", parts.Take(3)) + $" (+{parts.Count - 3} more)";
+
+                return summary;
+            }
+            catch
+            {
+                return "(filter)";
+            }
         }
 
         private string AddPaging(string fetchXml, int pageNumber, string? pagingCookie)

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -257,9 +257,23 @@ namespace PPDS.Migration.Export
             long recordCount,
             CancellationToken cancellationToken)
         {
-            // Warn when schema has a <filter> element but it parsed to empty content
-            if (entitySchema.FetchXmlFilter != null && string.IsNullOrWhiteSpace(entitySchema.FetchXmlFilter))
+            // Warn when schema has a <filter> element but it contains no conditions
+            if (!string.IsNullOrWhiteSpace(entitySchema.FetchXmlFilter))
             {
+                var summary = SummarizeFilter(entitySchema.FetchXmlFilter);
+                if (summary == NoConditionsSummary)
+                {
+                    progress.Report(new ProgressEventArgs
+                    {
+                        Phase = MigrationPhase.Exporting,
+                        Entity = entitySchema.LogicalName,
+                        Message = $"Warning: {entitySchema.LogicalName} has a <filter> element in the schema but it contains no conditions — all records will be exported. Check the schema for a malformed filter."
+                    });
+                }
+            }
+            else if (entitySchema.FetchXmlFilter != null)
+            {
+                // FetchXmlFilter is empty/whitespace — <filter> element existed but was empty
                 progress.Report(new ProgressEventArgs
                 {
                     Phase = MigrationPhase.Exporting,
@@ -893,9 +907,12 @@ namespace PPDS.Migration.Export
             return fetch.ToString(SaveOptions.DisableFormatting);
         }
 
+        internal const string NoConditionsSummary = "(filter — no conditions)";
+
         /// <summary>
         /// Summarizes a FetchXML filter into a human-readable description.
         /// Extracts attribute/operator/value from condition elements.
+        /// Uses neutral separator since filters may mix AND/OR logic.
         /// </summary>
         public static string SummarizeFilter(string fetchXmlFilter)
         {
@@ -905,20 +922,29 @@ namespace PPDS.Migration.Export
                 var conditions = doc.Descendants("condition").ToList();
 
                 if (conditions.Count == 0)
-                    return "(filter — no conditions)";
+                    return NoConditionsSummary;
 
                 var parts = conditions.Select(c =>
                 {
                     var attr = c.Attribute("attribute")?.Value ?? "?";
                     var op = c.Attribute("operator")?.Value ?? "?";
                     var val = c.Attribute("value")?.Value;
+
+                    // Check for child <value> elements (used by 'in', 'not-in' operators)
+                    if (val == null)
+                    {
+                        var childValues = c.Elements("value").Select(v => v.Value).ToList();
+                        if (childValues.Count == 1) val = childValues[0];
+                        else if (childValues.Count > 1) val = string.Join(",", childValues);
+                    }
+
                     return val != null ? $"{attr} {op} '{val}'" : $"{attr} {op}";
                 }).ToList();
 
                 // Cap at 3 conditions to keep output concise
                 var summary = parts.Count <= 3
-                    ? string.Join(" AND ", parts)
-                    : string.Join(" AND ", parts.Take(3)) + $" (+{parts.Count - 3} more)";
+                    ? string.Join(", ", parts)
+                    : string.Join(", ", parts.Take(3)) + $" (+{parts.Count - 3} more)";
 
                 return summary;
             }

--- a/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
+++ b/src/PPDS.Migration/Progress/ConsoleProgressReporter.cs
@@ -80,13 +80,22 @@ namespace PPDS.Migration.Progress
                         var rps = args.RecordsPerSecond.HasValue ? $" @ {args.RecordsPerSecond:F1} rec/s" : "";
                         var pct = args.Total > 0 ? $" ({args.PercentComplete:F0}%)" : "";
                         var eta = args.EstimatedRemaining.HasValue ? $" | ETA: {FormatEta(args.EstimatedRemaining.Value)}" : "";
+                        var filterInfo = args.FilterApplied ? " (filtered)" : "";
 
                         // Show success/failure breakdown if there are failures
                         var failureInfo = args.FailureCount > 0
                             ? $" [{args.SuccessCount} ok, {args.FailureCount} failed]"
                             : "";
 
-                        Console.Error.WriteLine($"{prefix} [{phase}] {args.Entity}{relInfo}{tierInfo}: {args.Current:N0}/{args.Total:N0}{pct}{rps}{eta}{failureInfo}");
+                        Console.Error.WriteLine($"{prefix} [{phase}] {args.Entity}{relInfo}{tierInfo}{filterInfo}: {args.Current:N0}/{args.Total:N0}{pct}{rps}{eta}{failureInfo}");
+
+                        // Show filter description on first progress report for this entity
+                        if (isNewEntity && args.FilterApplied && !string.IsNullOrEmpty(args.FilterDescription))
+                        {
+                            Console.ForegroundColor = ConsoleColor.DarkGray;
+                            Console.Error.WriteLine($"        filter: {args.FilterDescription}");
+                            Console.ResetColor();
+                        }
 
                         // Show sample errors for real-time visibility
                         if (args.FailureCount > 0 && args.ErrorSamples?.Count > 0)

--- a/src/PPDS.Migration/Progress/ProgressEventArgs.cs
+++ b/src/PPDS.Migration/Progress/ProgressEventArgs.cs
@@ -95,6 +95,16 @@ namespace PPDS.Migration.Progress
         public IReadOnlyList<MigrationError>? ErrorSamples { get; set; }
 
         /// <summary>
+        /// Gets or sets whether a FetchXML filter is applied for this entity export.
+        /// </summary>
+        public bool FilterApplied { get; set; }
+
+        /// <summary>
+        /// Gets or sets the filter description (summarized FetchXML filter conditions).
+        /// </summary>
+        public string? FilterDescription { get; set; }
+
+        /// <summary>
         /// Gets or sets a descriptive message.
         /// </summary>
         public string? Message { get; set; }

--- a/tests/PPDS.Migration.Tests/Export/ParallelExporterFilterFeedbackTests.cs
+++ b/tests/PPDS.Migration.Tests/Export/ParallelExporterFilterFeedbackTests.cs
@@ -26,7 +26,7 @@ public class ParallelExporterFilterFeedbackTests
 
         var result = ParallelExporter.SummarizeFilter(filter);
 
-        result.Should().Be("country eq 'US' AND statecode eq '0'");
+        result.Should().Be("country eq 'US', statecode eq '0'");
     }
 
     [Fact]
@@ -77,6 +77,16 @@ public class ParallelExporterFilterFeedbackTests
 
         result.Should().Contain("x eq '1'");
         result.Should().Contain("y eq '2'");
+    }
+
+    [Fact]
+    public void SummarizeFilter_InOperatorWithChildValues_ExtractsValues()
+    {
+        var filter = "<filter><condition attribute='statecode' operator='in'><value>0</value><value>1</value></condition></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("statecode in '0,1'");
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Export/ParallelExporterFilterFeedbackTests.cs
+++ b/tests/PPDS.Migration.Tests/Export/ParallelExporterFilterFeedbackTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using PPDS.Migration.Export;
+using Xunit;
+
+namespace PPDS.Migration.Tests.Export;
+
+[Trait("Category", "Unit")]
+public class ParallelExporterFilterFeedbackTests
+{
+    #region SummarizeFilter
+
+    [Fact]
+    public void SummarizeFilter_SingleCondition_ReturnsAttributeOperatorValue()
+    {
+        var filter = "<filter><condition attribute='statecode' operator='eq' value='0'/></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("statecode eq '0'");
+    }
+
+    [Fact]
+    public void SummarizeFilter_MultipleConditions_JoinsWithAnd()
+    {
+        var filter = "<filter><condition attribute='country' operator='eq' value='US'/><condition attribute='statecode' operator='eq' value='0'/></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("country eq 'US' AND statecode eq '0'");
+    }
+
+    [Fact]
+    public void SummarizeFilter_ConditionWithoutValue_OmitsValue()
+    {
+        var filter = "<filter><condition attribute='name' operator='not-null'/></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("name not-null");
+    }
+
+    [Fact]
+    public void SummarizeFilter_MoreThanThreeConditions_TruncatesWithCount()
+    {
+        var filter = "<filter>" +
+            "<condition attribute='a' operator='eq' value='1'/>" +
+            "<condition attribute='b' operator='eq' value='2'/>" +
+            "<condition attribute='c' operator='eq' value='3'/>" +
+            "<condition attribute='d' operator='eq' value='4'/>" +
+            "</filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Contain("a eq '1'");
+        result.Should().Contain("b eq '2'");
+        result.Should().Contain("c eq '3'");
+        result.Should().Contain("(+1 more)");
+        result.Should().NotContain("d eq '4'");
+    }
+
+    [Fact]
+    public void SummarizeFilter_EmptyFilter_ReturnsNoConditionsMessage()
+    {
+        var filter = "<filter></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("(filter — no conditions)");
+    }
+
+    [Fact]
+    public void SummarizeFilter_NestedFilter_ExtractsConditions()
+    {
+        var filter = "<filter type='and'><filter type='or'><condition attribute='x' operator='eq' value='1'/><condition attribute='y' operator='eq' value='2'/></filter></filter>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Contain("x eq '1'");
+        result.Should().Contain("y eq '2'");
+    }
+
+    [Fact]
+    public void SummarizeFilter_MalformedXml_ReturnsFallback()
+    {
+        var filter = "not valid xml <<>>";
+
+        var result = ParallelExporter.SummarizeFilter(filter);
+
+        result.Should().Be("(filter)");
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
@@ -303,6 +303,101 @@ public class ConsoleProgressReporterTests : IDisposable
 
     #endregion
 
+    #region Report() — Export Filter Feedback (#501)
+
+    [Fact]
+    public void Report_ExportWithFilter_ShowsFilteredSuffix()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Export" };
+
+        reporter.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Exporting,
+            Entity = "customeraddress",
+            Current = 100,
+            Total = 100,
+            FilterApplied = true,
+            FilterDescription = "country eq 'US'"
+        });
+
+        var output = GetOutput();
+        output.Should().Contain("[Export] customeraddress (filtered):");
+    }
+
+    [Fact]
+    public void Report_ExportWithFilter_ShowsFilterDescription()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Export" };
+
+        reporter.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Exporting,
+            Entity = "customeraddress",
+            Current = 100,
+            Total = 100,
+            FilterApplied = true,
+            FilterDescription = "country eq 'US' AND statecode eq '0'"
+        });
+
+        var output = GetOutput();
+        output.Should().Contain("filter: country eq 'US' AND statecode eq '0'");
+    }
+
+    [Fact]
+    public void Report_ExportWithoutFilter_NoFilteredSuffix()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Export" };
+
+        reporter.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Exporting,
+            Entity = "account",
+            Current = 50,
+            Total = 100,
+            FilterApplied = false
+        });
+
+        var output = GetOutput();
+        output.Should().Contain("[Export] account:");
+        output.Should().NotContain("(filtered)");
+        output.Should().NotContain("filter:");
+    }
+
+    [Fact]
+    public void Report_ExportFilterDescription_ShownOnlyOnFirstReport()
+    {
+        var reporter = new ConsoleProgressReporter { OperationName = "Export" };
+
+        // First report for entity — should show filter description
+        reporter.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Exporting,
+            Entity = "customeraddress",
+            Current = 100,
+            Total = 200,
+            FilterApplied = true,
+            FilterDescription = "country eq 'US'"
+        });
+
+        // Second report for same entity — should NOT show filter description again
+        reporter.Report(new ProgressEventArgs
+        {
+            Phase = MigrationPhase.Exporting,
+            Entity = "customeraddress",
+            Current = 200,
+            Total = 200,
+            FilterApplied = true,
+            FilterDescription = "country eq 'US'"
+        });
+
+        var output = GetOutput();
+        // Filter description should appear exactly once
+        var filterLines = output.Split('\n').Count(l => l.Contains("filter: country eq 'US'"));
+        filterLines.Should().Be(1);
+    }
+
+    #endregion
+
     #region Complete() — Basic Output
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ConsoleProgressReporterTests.cs
@@ -336,11 +336,11 @@ public class ConsoleProgressReporterTests : IDisposable
             Current = 100,
             Total = 100,
             FilterApplied = true,
-            FilterDescription = "country eq 'US' AND statecode eq '0'"
+            FilterDescription = "country eq 'US', statecode eq '0'"
         });
 
         var output = GetOutput();
-        output.Should().Contain("filter: country eq 'US' AND statecode eq '0'");
+        output.Should().Contain("filter: country eq 'US', statecode eq '0'");
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Progress/ProgressEventArgsTests.cs
+++ b/tests/PPDS.Migration.Tests/Progress/ProgressEventArgsTests.cs
@@ -99,4 +99,26 @@ public class ProgressEventArgsTests
 
         args.PercentComplete.Should().Be(100);
     }
+
+    [Fact]
+    public void FilterApplied_DefaultsFalse()
+    {
+        var args = new ProgressEventArgs();
+
+        args.FilterApplied.Should().BeFalse();
+        args.FilterDescription.Should().BeNull();
+    }
+
+    [Fact]
+    public void FilterApplied_CanBeSetAndRetrieved()
+    {
+        var args = new ProgressEventArgs
+        {
+            FilterApplied = true,
+            FilterDescription = "statecode eq '0'"
+        };
+
+        args.FilterApplied.Should().BeTrue();
+        args.FilterDescription.Should().Be("statecode eq '0'");
+    }
 }


### PR DESCRIPTION
## Summary
- Add `FilterApplied` and `FilterDescription` properties to `ProgressEventArgs` so all progress consumers can see filter status per entity
- Show `(filtered)` suffix in export progress lines and log filter condition summary on first report per entity
- Warn when schema has an empty `<filter>` element (malformed filter that silently exports all records)

Closes #501

## Test Plan
- [x] `ProgressEventArgsTests.FilterApplied_DefaultsFalse` — defaults to false
- [x] `ProgressEventArgsTests.FilterApplied_CanBeSetAndRetrieved` — round-trip
- [x] `ConsoleProgressReporterTests.Report_ExportWithFilter_ShowsFilteredSuffix` — "(filtered)" appears
- [x] `ConsoleProgressReporterTests.Report_ExportWithFilter_ShowsFilterDescription` — condition text shown
- [x] `ConsoleProgressReporterTests.Report_ExportWithoutFilter_NoFilteredSuffix` — no "(filtered)" when unfiltered
- [x] `ConsoleProgressReporterTests.Report_ExportFilterDescription_ShownOnlyOnFirstReport` — no duplicate descriptions
- [x] `ParallelExporterFilterFeedbackTests` — 7 tests covering SummarizeFilter edge cases

## Verification
- [x] /gates passed
- [x] /review completed (findings: 2, both fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)