### PR TITLE
feat(workflow): CLAUDE.md workflow section + PR gate surface detection fixes

### DIFF
--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -35,6 +35,8 @@ _SURFACE_RULES = [
     ("src/PPDS.Migration/", "cli"),
     (".claude/", "workflow"),
     ("scripts/", "workflow"),
+    ("specs/", "workflow"),
+    ("docs/", "workflow"),
     ("CLAUDE.md", "workflow"),
 ]
 

--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -35,6 +35,7 @@ _SURFACE_RULES = [
     ("src/PPDS.Migration/", "cli"),
     (".claude/", "workflow"),
     ("scripts/", "workflow"),
+    ("CLAUDE.md", "workflow"),
 ]
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,49 @@ Odd/even minor convention: odd minor = pre-release, even minor = stable. See `.p
 
 TUI-first multi-interface platform. All business logic in Application Services, never in UI code.
 
+## Workflow (REQUIRED SEQUENCE)
+
+### New feature or non-trivial change
+1. /design (brainstorm → spec → plan → review)
+2. /implement (or /implement <plan-path>)
+3. /gates — STOP on failure, fix before proceeding
+4. /verify for EVERY affected surface — you MUST use the product:
+   - Extension changed → /ext-verify (screenshots required)
+   - TUI changed → /tui-verify (PTY interaction required)
+   - MCP changed → /mcp-verify (tool invocation required)
+   - CLI changed → /cli-verify (run the command)
+5. /qa for at least one affected surface (blind verification)
+6. /review → /converge until 0 critical, 0 important
+7. /pr (rebase, create PR, monitor CI + reviews)
+
+### Bug fix or small change
+1. /gates before committing
+2. If UI/output changed → /verify for affected surface
+3. /pr when ready
+
+### Docs change
+1. Edit docs and commit
+2. /pr when ready
+
+### Enforcement
+Steps 3-6 are enforced by hooks. The PR gate hook will block `gh pr create`
+if these steps are incomplete. Run `/status` to check current workflow state.
+
+### STOP conditions
+- DO NOT skip steps 3-6 because "tests pass." Tests are necessary, not sufficient.
+- DO NOT declare work complete without visual verification of affected surfaces.
+
+### Autonomy scope
+"Don't ask, just do it" applies to: committing after tasks, running gates,
+running verification, running QA, running review, triaging external review
+comments (fix valid ones, dismiss invalid ones with rationale).
+"Don't ask, just do it" does NOT apply to: skipping any workflow step,
+filing/closing issues, creating PRs without passing gates.
+
+After external review: respond to EACH comment individually on the PR with
+the action taken (fixed in <commit>, or dismissed with rationale). Include
+a summary of all comments and actions in the PR status report.
+
 ## Git Hooks
 
 Pre-commit hook (`scripts/hooks/`) runs:

--- a/specs/workflow-enforcement.md
+++ b/specs/workflow-enforcement.md
@@ -3,7 +3,7 @@
 **Status:** Draft (v8.0 — commit-aware exit validation, PR-as-source-of-truth triage, CodeQL automation, Gemini retry)
 **Version:** 8.0
 **Last Updated:** 2026-03-30
-**Code:** [.claude/](../.claude/) | [scripts/pipeline.py](../scripts/pipeline.py) | [scripts/pr_monitor.py](../scripts/pr_monitor.py) | [.claude/hooks/](../.claude/hooks/) | [.claude/skills/](../.claude/skills/)
+**Code:** [.claude/](../.claude/) | [scripts/pipeline.py](../scripts/pipeline.py) | [scripts/pr_monitor.py](../scripts/pr_monitor.py) | [.claude/hooks/](../.claude/hooks/) | [.claude/skills/](../.claude/skills/) | [CLAUDE.md](../CLAUDE.md)
 **Surfaces:** N/A
 
 ---

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2591,6 +2591,21 @@ class TestPrGateWorkflowOnlyNoQa:
             "Workflow-only diff should have empty non_workflow set — QA is skipped"
         )
 
+    def test_specs_docs_claudemd_are_workflow_surfaces(self):
+        """AC-133/AC-134: specs/, docs/, and CLAUDE.md map to 'workflow' surface."""
+        pr_gate = _load_pr_gate("pr_gate_134_new_paths")
+
+        mock_result = unittest.mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "specs/workflow-enforcement.md\ndocs/BACKLOG.md\nCLAUDE.md"
+
+        with unittest.mock.patch("subprocess.run", return_value=mock_result):
+            surfaces = pr_gate.detect_affected_surfaces("/fake/project")
+
+        assert surfaces == {"workflow"}, (
+            f"Expected only 'workflow' for specs/docs/CLAUDE.md changes, got {surfaces}"
+        )
+
     def test_mixed_surfaces_require_qa_in_hook(self, tmp_path):
         """AC-134 negative: Non-workflow surfaces DO require QA.
 


### PR DESCRIPTION
## Summary

- Add the `## Workflow (REQUIRED SEQUENCE)` section to CLAUDE.md, prescribing the three workflow paths (new feature, bug fix, docs), enforcement rules, STOP conditions, and autonomy scope
- Fix PR gate surface detection: add `specs/`, `docs/`, and `CLAUDE.md` to `_SURFACE_RULES` so these paths map to the `workflow` surface (AC-133, AC-134)
- Add test for new surface rules (`specs/`, `docs/`, `CLAUDE.md` → workflow)
- Add `CLAUDE.md` to workflow-enforcement spec `Code:` frontmatter (SL4 compliance)

## Test plan

- [x] 195 Python workflow tests pass (194 existing + 1 new)
- [x] 9/9 behavioral scenarios pass (verify-workflow.py)
- [x] `dotnet build PPDS.sln` — 0 errors, 0 warnings
- [x] `/verify workflow` — all 9 structural checks pass
- [x] `/review` — 0 critical, 0 important (after fixes), 1 suggestion (acknowledged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)