### PR TITLE
feat: audit-capture pipeline (TUI + extension)

### DIFF
--- a/.claude/skills/audit-capture/SKILL.md
+++ b/.claude/skills/audit-capture/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: audit-capture
+description: Run manifest-driven PNG captures of TUI and extension surfaces for design audits. Emits a schema-conformant capture tree for consumption by a Claude design-audit session.
+allowed-tools: Bash(node tools/audit-capture*), Bash(node tools/audit-capture.mjs *), Bash(npm run audit*)
+---
+
+# Audit Capture
+
+Manifest-driven capture of every user-facing PPDS surface. Produces PNGs + `meta.json` + root `manifest.json` under `$AUDIT_OUT/` per [`ppds-design-system/AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md). Output is consumed by a Claude audit session (or human designer) against our design system.
+
+## When to Use
+
+- Before a design-audit round — capture a clean baseline of every surface
+- After UI shakedown / visual fixes land, to refresh the baseline
+- When adding a new TUI screen or extension panel, to verify the manifest entry reaches it
+- **NOT** for regression testing — this is audit input, not a diff tool
+
+## Quick start
+
+```bash
+# One capture run, all surfaces, local output
+export AUDIT_OUT="$TEMP/ppds-audit-$(date +%s)"
+export PPDS_PROFILE=dev                 # optional — unlocks connected captures
+export PPDS_ENV=test-env                 # optional — unlocks connected captures
+node tools/audit-capture.mjs run all
+
+# Single surface
+node tools/audit-capture.mjs run tui
+node tools/audit-capture.mjs run extension
+
+# Dry-run a manifest without capturing
+node tools/audit-capture.mjs validate tui
+
+# List manifest entries
+node tools/audit-capture.mjs list extension
+```
+
+Exit codes: `0` = everything `ok` or `skipped`, `1` = at least one entry errored.
+
+## Required environment
+
+| Var | Required | Purpose |
+|---|---|---|
+| `AUDIT_OUT` | **yes** | Absolute path, **outside** the repo working tree. Runner refuses relative or in-repo paths. |
+| `PPDS_PROFILE` | no | Profile name. Entries with `requires: connected` are `skipped` without it. |
+| `PPDS_ENV` | no | Environment name. Skipped same as above. |
+| `AUDIT_REDACT` | no | `true` (default) masks identifying values in status bars. Set `false` for raw. |
+| `AUDIT_SOURCE_REPO` / `_REF` / `_COMMIT` | no | Overrides the git metadata recorded in `manifest.json`. CI uses these. |
+
+## Output layout
+
+Per [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md):
+
+```
+$AUDIT_OUT/
+├── manifest.json                  ← inventory + state + summary
+├── tui/<entry-id>/*.png
+├── tui/<entry-id>/meta.json
+├── extension/<entry-id>/*.png
+└── extension/<entry-id>/meta.json
+```
+
+`manifest.json` is written **last**, after every entry's directory is flushed. A reader never sees it referencing a file that hasn't been written.
+
+## Manifests (single source of truth)
+
+Adding a new screen or panel means editing one YAML file. No runner changes required.
+
+- TUI: [`tools/audit-manifests/tui.yaml`](../../../tools/audit-manifests/tui.yaml)
+- Extension: [`tools/audit-manifests/extension.yaml`](../../../tools/audit-manifests/extension.yaml)
+
+Each entry has:
+
+```yaml
+- id: kebab-case-id                   # unique within surface
+  title: Human readable title
+  requires: connected                 # or "none" (default)
+  steps:
+    - key: alt+t
+    - wait: { text: "SQL Query", timeout: 5000 }
+    - screenshot: 01-empty            # NN-name, zero-padded
+    - type: "SELECT * FROM account"
+    - key: F5
+    - wait: { text: "rows", timeout: 30000 }
+    - screenshot: 02-results
+  masks:
+    - { row: 28, colStart: 0, colEnd: 120, reason: "status bar" }
+```
+
+Step types: `key`, `type`, `wait`, `screenshot`, `sleep` (all surfaces). Extension adds `command`, `click`, `eval`.
+
+Masks:
+- TUI: cell-grid — `{ row, colStart, colEnd, reason }`
+- Extension: pixel rect — `{ x, y, width, height, reason }`
+
+Every entry must capture at least one screenshot. Entry ids must be kebab-case. Screenshot names must match `NN-name` (e.g. `01-empty`, `02-results`).
+
+## What runs unattended
+
+- **No profile required:** splash, file/help menu, profile picker, command palette. Always captured.
+- **Connected (requires `PPDS_PROFILE` + `PPDS_ENV`):** every data-bearing screen/panel. Without a configured connection they're marked `state: skipped` with a clear `skipReason` — run still exits `0`.
+
+## Typical flow
+
+1. `node tools/audit-capture.mjs validate <surface>` — parses manifest, flags bad steps/ids.
+2. `npm run audit:tui` / `npm run audit:extension` — capture that surface. Runs build first.
+3. Inspect `$AUDIT_OUT/manifest.json` — should show `state: ok` for everything that matched `requires`.
+4. Hand `$AUDIT_OUT/` to the audit consumer (push to `ppds-v1-audit` in CI; local: open PNGs directly).
+
+## Gap protocol
+
+If a manifest entry can't reach its target screen with the available step types:
+
+1. **Stop.** Do not add a `sleep: 10000` to work around a flaky step — that's a silent lie that a designer will later debug.
+2. Fix the navigation. If keys changed, update the entry's `steps`.
+3. If tui-verify / webview-cdp lacks a capability, **stop** and say so — propose an enhancement to those tools, not a workaround here.
+4. Re-run `validate` before `run`.
+
+## Known limitations
+
+- **Font substitution in CI** — if Cascadia Mono is absent, xterm.js falls back to system monospace. Output differs from a Cascadia-installed dev box. Bundling the WOFF2 is a roadmap item.
+- **No light-theme captures** — v1 is dark-only on TUI + extension. Manifest schema reserves `themes` for future.
+- **Single VS Code instance for extension run** — opening many panels in one session can accumulate focus noise. If you see wrong-panel captures, split the manifest into smaller runs.
+
+## Related
+
+- [specs/audit-capture.md](../../../specs/audit-capture.md) — the contract
+- [@tui-verify](../tui-verify/SKILL.md) — underlying PTY harness (invokes `tui-verify render` for TUI captures)
+- [@ext-verify](../ext-verify/SKILL.md) — underlying VS Code harness
+- [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) — output format contract

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "audit-capture-pipeline",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "pngjs": "^7.0.0",
+        "yaml": "^2.6.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,16 @@
 {
   "private": true,
   "description": "PPDS workspace — root proxy scripts for extension and TUI",
+  "dependencies": {
+    "yaml": "^2.6.0",
+    "pngjs": "^7.0.0"
+  },
   "scripts": {
+    "audit:tui": "node tools/audit-capture.mjs run tui",
+    "audit:extension": "node tools/audit-capture.mjs run extension",
+    "audit:all": "node tools/audit-capture.mjs run all",
+    "audit:validate:tui": "node tools/audit-capture.mjs validate tui",
+    "audit:validate:extension": "node tools/audit-capture.mjs validate extension",
     "ext:compile": "npm run compile --prefix src/PPDS.Extension",
     "ext:watch": "npm run watch --prefix src/PPDS.Extension",
     "ext:package": "npm run package --prefix src/PPDS.Extension",

--- a/specs/audit-capture.md
+++ b/specs/audit-capture.md
@@ -1,0 +1,456 @@
+# Audit Capture
+
+**Status:** Draft
+**Last Updated:** 2026-04-18
+**Code:** [tools/audit-capture.mjs](../tools/audit-capture.mjs) | [tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs](../tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs) | [.claude/skills/audit-capture/](../.claude/skills/audit-capture/) | [.claude/audit-manifests/](../.claude/audit-manifests/)
+**Surfaces:** TUI | Extension
+
+---
+
+## Overview
+
+Reusable, low-friction capture pipeline that produces PNG snapshots of every user-facing TUI screen and extension panel, written to a contract-conforming directory tree that design-audit sessions (Claude web UI or human designer) can consume. Manifests are the single source of truth for "what counts as a surface."
+
+The contract is defined by [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) in `ppds-design-system`. This spec describes how PPDS produces artifacts that conform to that contract for the `tui` and `extension` surfaces; `ppds-docs` produces `docs` artifacts under its own spec.
+
+### Goals
+
+- **Uniform capture artifact** — every TUI screen and extension panel emits PNG + `meta.json`, layout per schema
+- **Manifest-driven** — adding a new screen means editing `.claude/audit-manifests/{surface}.yaml`, nothing else
+- **Unattended** — once a profile+env is configured, `audit-capture run <surface>` walks the whole manifest with no prompts
+- **Robust** — a broken entry marks itself `state: error`, the run continues, exit is non-zero
+- **No new render engine for TUI** — reuse Playwright (already a dev dep) + xterm.js rather than adopting `agg` or native canvas libs
+- **CI-ready** — deterministic output (fixed font, DPR, viewport) so the same commit produces byte-stable captures
+
+### Non-Goals
+
+- Capturing the docs site (separate spec, separate repo — `ppds-docs`)
+- Writing the `manifest.json` / `meta.json` schema itself (defined in `ppds-design-system/AUDIT-SCHEMA.md`)
+- Producing design-audit findings (produced downstream by a Claude audit session; findings schema also in `AUDIT-SCHEMA.md`)
+- Visual regression testing (this is audit input, not regression output — different workflow)
+- Running the capture automatically on every commit (Phase 4 GH Action is manual `workflow_dispatch` only)
+- Light-theme extension captures (dark-only in v1; manifest schema reserves a `themes` field for future)
+
+---
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  tools/audit-capture.mjs                                          │
+│  (runner — orchestrates per-surface captures)                     │
+└───┬─────────────────────────────────────────┬──────────────────────┘
+    │                                         │
+    │ shells out to                           │ shells out to
+    ▼                                         ▼
+┌──────────────────────────────┐   ┌──────────────────────────────┐
+│ tests/PPDS.Tui.E2eTests/     │   │ src/PPDS.Extension/          │
+│   tools/tui-verify.mjs        │   │   tools/webview-cdp.mjs      │
+│                              │   │                              │
+│ + NEW `render <file.png>`    │   │ (existing `screenshot`)      │
+│   subcommand                 │   │                              │
+│                              │   │                              │
+│ daemon: tui-test Terminal    │   │ daemon: Playwright Electron  │
+│ + Playwright page holding    │   │ + VS Code                    │
+│   xterm.js for PNG render    │   │                              │
+└──────────────────────────────┘   └──────────────────────────────┘
+
+Inputs:   .claude/audit-manifests/{surface}.yaml
+Outputs:  $AUDIT_OUT/{surface}/{entry-id}/{NN-name}.png
+          $AUDIT_OUT/{surface}/{entry-id}/meta.json
+          $AUDIT_OUT/manifest.json   (written last)
+```
+
+The runner is a thin orchestrator. All the heavy-lifting (PTY, VS Code, rendering) stays in the existing verify tools; the runner only walks manifests and shells out.
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `tools/audit-capture.mjs` | Reads a manifest, drives the appropriate verify tool, writes schema-conformant output. Subcommands: `run`, `validate`, `list`. |
+| `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` | Existing PTY harness. Gains a `render` subcommand that writes a PNG of current terminal state. |
+| Render harness (internal to tui-verify daemon) | Headless Chromium page holding xterm.js. Kept warm across captures. |
+| `.claude/audit-manifests/tui.yaml` | Inventory of TUI screens to capture. Version-controlled. |
+| `.claude/audit-manifests/extension.yaml` | Inventory of extension panels to capture. Version-controlled. |
+| `.claude/skills/audit-capture/SKILL.md` | Skill-authored documentation: usage, env vars, gotchas. |
+| Theme pin | On extension launch, `audit-capture` writes `settings.json` into webview-cdp's profile dir to lock `workbench.colorTheme`. |
+
+### Dependencies
+
+- Depends on: [tui-verify-tool.md](./tui-verify-tool.md) — the PTY harness
+- Depends on: [ext-verify-tool.md](./ext-verify-tool.md) — the VS Code webview harness
+- Contract: [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) on `ppds-design-system` `main`
+
+No new npm dependencies for the runner itself (uses `yaml`, already transitively available, or a tiny parser). For `tui-verify render`: reuses existing `@playwright/test` in `tests/PPDS.Tui.E2eTests/`. Adds `xterm` (the DOM terminal library) as a new dev dep there — tiny (~200 KB), pure JS, no native code. xterm.js is the terminal renderer VS Code itself uses, so it produces faithful output for our users.
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. The runner MUST read manifests in YAML at `.claude/audit-manifests/{surface}.yaml`
+2. The runner MUST write output conforming to `AUDIT-SCHEMA.md` v1: folder layout, `manifest.json`, `meta.json`
+3. The runner MUST refuse to write inside the repo working tree — `$AUDIT_OUT` must be an absolute path outside the repo
+4. The runner MUST write `manifest.json` **after** every entry directory is flushed, so a reader never sees a manifest referencing missing files
+5. The runner MUST continue after an entry errors; final exit code is 0 iff every entry is `state=ok` or `state=skipped`
+6. The runner MUST record redacted values in `meta.json` rather than raw values when `redactEnv: true` is configured (default true)
+7. `tui-verify render <file.png>` MUST produce a PNG of the current terminal state, 120 cols × 30 rows, DPR 2.0, PPDS default palette
+8. `tui-verify render` MUST NOT modify the existing `screenshot` JSON dump command — that command stays as-is for text-based verification
+9. Extension captures MUST pin VS Code's color theme deterministically via a pre-launch `settings.json` write to webview-cdp's profile dir
+10. Manifest entries MUST support `requires: connected` — the runner marks the entry `state=skipped` when `PPDS_PROFILE` or `PPDS_ENV` is unset
+
+### Command Interface
+
+**Runner (`tools/audit-capture.mjs`):**
+
+| Command | Signature | Purpose |
+|---------|-----------|---------|
+| `run` | `run <surface>` | Walk the manifest for `tui` or `extension`, capture every entry, emit `manifest.json`. |
+| `run all` | `run all` | Capture every surface in sequence. Writes one merged `manifest.json`. |
+| `validate` | `validate <surface>` | Parse the manifest, dry-run every entry through the verify tool (no captures written). Exits non-zero on first broken entry. |
+| `list` | `list <surface>` | Print the manifest entry ids and titles. Useful for quick inventory. |
+
+**`tui-verify.mjs` additions:**
+
+| Command | Signature | Purpose |
+|---------|-----------|---------|
+| `render` | `render <file.png>` | Write a PNG of the current terminal state to `<file.png>`. Uses xterm.js in a warm headless Chromium. |
+
+### Environment Variables
+
+| Name | Required | Purpose |
+|------|----------|---------|
+| `AUDIT_OUT` | yes | Absolute path to output directory. Must be outside the repo working tree. Runner creates it if missing. |
+| `PPDS_PROFILE` | no | Profile name for connected captures. Entries with `requires: connected` are skipped when unset. |
+| `PPDS_ENV` | no | Environment name for connected captures. Skipped same as above when unset. |
+| `AUDIT_REDACT` | no | `true` (default) to mask env name + user principal in the TUI status bar and extension sidebar before writing PNG. `false` to keep raw values. |
+| `AUDIT_SOURCE_REPO` | no | Overrides the `source.repo` field in `manifest.json`. Defaults to detecting from `origin` URL. |
+| `AUDIT_SOURCE_REF` | no | Overrides the `source.ref` field. Defaults to current branch ref. |
+| `AUDIT_SOURCE_COMMIT` | no | Overrides the `source.commit` field. Defaults to `HEAD`. |
+
+### Manifest Format
+
+YAML. One manifest per surface. Structure:
+
+```yaml
+# .claude/audit-manifests/tui.yaml
+surface: tui
+entries:
+  - id: sql-query-main
+    title: SQL Query screen — empty state
+    requires: connected           # optional: connected | none (default)
+    steps:
+      - key: alt+t
+      - key: enter
+      - wait: { text: "SQL Query", timeout: 5000 }
+      - screenshot: 01-empty
+      - type: "SELECT TOP 5 name FROM account"
+      - screenshot: 02-query-typed
+      - key: F5
+      - wait: { text: "rows", timeout: 30000 }
+      - screenshot: 03-results
+    masks:
+      - { row: 24, colStart: 0, colEnd: 120, reason: "latency varies per run" }
+```
+
+Supported step types (TUI):
+
+| Step | Shape | Maps to tui-verify command |
+|------|-------|----------------------------|
+| key | `{ key: "alt+t" }` | `key "alt+t"` |
+| type | `{ type: "text" }` | `type "text"` |
+| wait | `{ wait: { text: "...", timeout: 5000 } }` | `wait "..." 5000` |
+| screenshot | `{ screenshot: "01-name" }` | `render $AUDIT_OUT/tui/<id>/01-name.png` |
+| sleep | `{ sleep: 250 }` | `setTimeout(250)` in the runner — only for entries where a deterministic wait isn't possible |
+
+Supported step types (extension):
+
+| Step | Shape | Maps to webview-cdp command |
+|------|-------|------------------------------|
+| command | `{ command: "PPDS: Data Explorer" }` | `command "PPDS: Data Explorer"` |
+| wait | `{ wait: { ext: "power-platform-developer-suite", timeout: 30000 } }` | `wait --ext ... --timeout ...` |
+| click | `{ click: "#execute-btn", ext: "power-platform-developer-suite" }` | `click "#execute-btn" --ext ...` |
+| eval | `{ eval: "monaco.editor.getEditors()[0].setValue('...')" }` | `eval "..."` |
+| key | `{ key: "ctrl+enter" }` | `key "ctrl+enter"` |
+| screenshot | `{ screenshot: "01-loaded" }` | `screenshot $AUDIT_OUT/extension/<id>/01-loaded.png` |
+| sleep | `{ sleep: 500 }` | `setTimeout` — minimal use |
+
+Masks (TUI): `{ row, colStart, colEnd, reason }` — blanks that cell range before PNG write. Coordinates in cell units.
+Masks (extension): `{ x, y, width, height, reason }` — blanks that rect in pixels before PNG write.
+
+### Runner Flow (TUI surface)
+
+1. **Validate env**: `AUDIT_OUT` absolute, outside repo root.
+2. **Parse manifest**: fail fast if malformed; dedupe entry ids.
+3. **Launch tui-verify**: `tui-verify.mjs launch --build` once. Wait for splash.
+4. **For each entry**:
+    - If `requires: connected` and no profile/env: record `state=skipped`, skip.
+    - Navigate to baseline (Esc, Esc, back to splash) — best-effort; fall back to full relaunch on failure.
+    - For each step: translate → `sendToDaemon`. Collect steps in memory for `meta.json`.
+    - On screenshot step: call `render` → writes PNG. After write, apply masks via canvas post-process (load PNG, fill masked rects with `#000`, re-encode).
+    - On any step failure: capture stderr (4 KB cap), mark `state=error`, attempt teardown + relaunch for next entry, continue.
+5. **Close tui-verify** after final entry.
+6. **Write per-entry `meta.json`** with steps echo, masks applied, surfaceSpecific including the `serialize()` dump.
+7. **Emit `manifest.json`** at `$AUDIT_OUT/manifest.json`.
+8. Exit 0 iff every entry is `ok` or `skipped`; else 1.
+
+### Runner Flow (Extension surface)
+
+1. **Validate env**.
+2. **Write theme pin**: ensure `src/PPDS.Extension/tools/.webview-cdp-profile/User/settings.json` contains `{ "workbench.colorTheme": "Default Dark+" }`. Create directories as needed.
+3. **Launch webview-cdp**: `webview-cdp.mjs launch --build` once.
+4. **For each entry** (same error/skip semantics as TUI):
+    - Translate steps. Screenshot steps → `screenshot --page` (full VS Code window) OR `screenshot` (webview-only) depending on entry config.
+    - Apply pixel-rect masks to PNG.
+5. **Close webview-cdp**.
+6. **Emit meta.json + manifest.json**.
+
+### `tui-verify render` — Render Pipeline
+
+1. **On first `render` call** in a daemon lifetime: spawn a Playwright Chromium page navigated to a data-URL HTML shell that loads xterm.js and instantiates a `Terminal({ rows: 30, cols: 120, fontFamily: "Cascadia Mono", fontSize: 16, theme: PPDS_THEME })`. The page stays open for the daemon's lifetime.
+2. **On every `render` call**:
+    - Call tui-test `terminal.serialize()` — returns `{ view, shifts }`.
+    - Convert shifts to an SGR-annotated replay stream (per-cell escape sequences preceding each rendered char, reset at row end). Plain text only (no cursor position moves) because we `term.clear()` + write sequentially row by row.
+    - `page.evaluate((stream) => window.__writeBuffer(stream), replayStream)`.
+    - Screenshot the `.xterm-screen` canvas rect: `page.locator(".xterm-screen").screenshot({ path: outFile })`.
+3. **Theme** is locked in the page shell:
+    - Foreground `#f0f0f0`, background `#1e1e1e`, cursor `#f0f0f0`, 16-color ANSI mapped from PPDS design-system palette (`--c-black` `#1e1e1e`, `--c-cyan` `#00cccc`, etc., sourced from `ppds-design-system/colors_and_type.css`).
+    - Font **bundled** as WOFF2 in the page shell via base64 data URL so the render has zero filesystem-font dependence and is byte-stable in CI.
+
+### Constraints
+
+- `$AUDIT_OUT` must be outside repo working tree. Runner rejects paths under the current git root with exit 1.
+- All errors to stderr; stdout is schema-relevant data or silent.
+- No `shell: true` anywhere (Constitution S2).
+- Secret-carrying values (`clientSecret`, `password`, tokens) never logged (Constitution S3). Env name + user principal redacted by default (pre-PNG write for TUI status bar; post-capture for extension sidebar via pixel mask).
+- Runner is single-process, single-surface-at-a-time. `run all` serializes (TUI then extension) to avoid contention.
+- Render viewport: 120 cols × 30 rows × 16px Cascadia Mono × DPR 2.0 = fixed-size PNG (computed at render time; target ~2304 × 1080).
+- Extension capture: default full-window shot (matches webview-cdp's existing behavior). `meta.json` records `webviewRect` so audit tooling can crop.
+- Manifest `id` values must be kebab-case ASCII and unique within a surface. Runner rejects at parse time.
+
+### Validation Rules
+
+| Input | Rule | Error |
+|-------|------|-------|
+| `AUDIT_OUT` | absolute path, outside repo | "AUDIT_OUT must be an absolute path outside the repo working tree" |
+| manifest path | file exists and parses as YAML | "Manifest not found" / "Manifest parse error: ..." |
+| entry `id` | kebab-case ASCII, unique | "Invalid id: '...' (must be kebab-case)" / "Duplicate id: '...'" |
+| step shape | matches one of the supported shapes | "Unknown step at entries[N].steps[M]: ..." |
+| screenshot `name` | `<NN>-<kebab>` pattern; N is integer, monotonic | "Screenshot name must match NN-name pattern: '...'" |
+| `render <file>` | parent dir exists or can be created | "Cannot write to: ..." |
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `tui-verify render <file.png>` writes a readable PNG containing the current terminal state's visible text | Manual: launch TUI, run `render $TEMP/out.png`, open PNG and verify title bar text is present | 🔲 |
+| AC-02 | `tui-verify render` uses PPDS default palette (cyan accents, dark background) | Manual: render a screen with cyan highlights, visually confirm the palette matches `colors_and_type.css` | 🔲 |
+| AC-03 | `tui-verify render` output is 120 cols × 30 rows at DPR 2.0 (approx 2304×1080 px) | Manual: render; check PNG dimensions via `file out.png` or image inspector | 🔲 |
+| AC-04 | Existing `tui-verify screenshot <file.json>` command still dumps `serialize()` JSON unchanged | Manual: run both commands; diff JSON output against pre-change behavior | 🔲 |
+| AC-05 | `audit-capture run tui` captures every entry in `tui.yaml` without prompts given `AUDIT_OUT` + connected profile | Manual: configure `PPDS_PROFILE`+`PPDS_ENV`, run; every entry should be `ok` or intentionally `skipped` | 🔲 |
+| AC-06 | `audit-capture run extension` does the same for `extension.yaml` | Manual: same as AC-05 for extension surface | 🔲 |
+| AC-07 | `$AUDIT_OUT/manifest.json` conforms to `AUDIT-SCHEMA.md` v1 | Manual: validate with a schema checker (e.g., hand-check fields per the schema doc) | 🔲 |
+| AC-08 | Each entry's `meta.json` conforms to the surface-specific meta schema | Manual: pick one tui + one extension entry, diff against schema | 🔲 |
+| AC-09 | When any entry's step fails, the run continues, that entry is `state=error` with stderr captured, and final exit is non-zero | Manual: deliberately break one entry (bad key); verify the rest complete and exit is 1 | 🔲 |
+| AC-10 | Entries with `requires: connected` are marked `state=skipped` when `PPDS_PROFILE` is unset; run continues; exit is 0 if nothing else errored | Manual: unset env, run; verify skipped entries have `skipReason` | 🔲 |
+| AC-11 | `audit-capture validate <surface>` dry-runs every entry through the verify tool without writing captures, exits non-zero on first broken step | Manual: run against a deliberately broken manifest | 🔲 |
+| AC-12 | Adding a new screen requires only editing `tui.yaml` or `extension.yaml`; no runner changes needed | Manual: add a trivial entry, run; the new entry appears in the output | 🔲 |
+| AC-13 | `.claude/skills/audit-capture/SKILL.md` documents the single-command example and the env vars | Manual: read the skill; verify it includes `AUDIT_OUT`, `PPDS_PROFILE`, `PPDS_ENV`, one-line usage | 🔲 |
+| AC-14 | Runner rejects `AUDIT_OUT` pointing inside the repo working tree | Manual: set `AUDIT_OUT=./out`; run; expect exit 1 + clear error | 🔲 |
+| AC-15 | TUI masks blank the configured cell range in the final PNG | Manual: mask row 24 cols 0-120; render; inspect PNG — status bar region is `#000` | 🔲 |
+| AC-16 | Extension capture pins VS Code theme to `Default Dark+` via `settings.json` in profile dir | Manual: run capture; inspect `.webview-cdp-profile/User/settings.json` contains the theme setting | 🔲 |
+| AC-17 | `manifest.json` is written *after* every entry directory is flushed (manifest never references missing files) | Manual: interrupt mid-run; `manifest.json` should not exist | 🔲 |
+| AC-18 | Manifest entry `id` validation: kebab-case required, uniqueness enforced at parse time | Manual: add duplicate ids; run; expect clear parse error | 🔲 |
+| AC-19 | `audit-capture list <surface>` prints id + title per entry | Manual: run; verify stdout lists entries | 🔲 |
+| AC-20 | Runner detects source repo/ref/commit from git and records in `manifest.json`, overridable via env vars | Manual: run; check `source` block; override with `AUDIT_SOURCE_COMMIT=xyz` and verify | 🔲 |
+
+### Edge Cases
+
+| Scenario | Input | Expected Output |
+|----------|-------|-----------------|
+| Empty manifest | `entries: []` | stdout: "No entries to capture"; `manifest.json` written with empty surface; exit 0 |
+| Manifest missing | No `tui.yaml` | stderr: "Manifest not found: ..."; exit 1 |
+| `$AUDIT_OUT` inside repo | `AUDIT_OUT=./out` | stderr: "AUDIT_OUT must be outside repo working tree"; exit 1 |
+| Render fails mid-run | xterm.js page crashes | Entry marked `error`, daemon recovers by recreating the render page, next entry proceeds |
+| Screenshot name collision | Two `screenshot: 01-empty` in same entry | stderr: "Duplicate screenshot name ... in entry ..."; exit 1 |
+| Profile unset, entry doesn't require | `requires: none` (default) | Entry runs normally — some screens work without a profile |
+| Masks out of bounds | TUI mask row 50 | stderr: "Mask row 50 out of range (0-29)"; exit 1 at parse |
+
+### Test Examples
+
+```bash
+# Capture everything locally
+export AUDIT_OUT=/tmp/ppds-audit-$(date +%s)
+export PPDS_PROFILE=dev
+export PPDS_ENV=test-env
+node tools/audit-capture.mjs run all
+
+# Validate without capturing
+node tools/audit-capture.mjs validate tui
+
+# List entries
+node tools/audit-capture.mjs list extension
+```
+
+---
+
+## Core Types
+
+### Manifest (TypeScript-style)
+
+```ts
+interface Manifest {
+  surface: "tui" | "extension";
+  entries: Entry[];
+}
+
+interface Entry {
+  id: string;                  // kebab-case, unique within surface
+  title: string;
+  requires?: "connected" | "none";  // default "none"
+  steps: Step[];
+  masks?: Mask[];
+}
+
+type Step =
+  | { key: string }
+  | { type: string }
+  | { wait: { text?: string; ext?: string; timeout: number } }
+  | { click: string; ext?: string }
+  | { eval: string }
+  | { command: string }
+  | { screenshot: string }
+  | { sleep: number };
+
+type Mask =
+  | { row: number; colStart: number; colEnd: number; reason: string }  // tui
+  | { x: number; y: number; width: number; height: number; reason: string };  // extension
+```
+
+### Runner Output (per-entry `meta.json`)
+
+Conforms to [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md#metajson--per-capture). See that doc for the canonical schema; this spec only describes what values PPDS populates:
+
+| Field | Value source |
+|-------|--------------|
+| `surfaceSpecific.serialize` (TUI) | Direct output of `terminal.serialize()` at capture time |
+| `surfaceSpecific.font` (TUI) | `"Cascadia Mono"` (bundled WOFF2) |
+| `surfaceSpecific.theme` (TUI) | `"ppds-dark"` — our locked palette |
+| `surfaceSpecific.vscodeTheme` (ext) | Echoes the pinned `workbench.colorTheme` |
+| `surfaceSpecific.panel` (ext) | The command-id the entry invoked, derived from `command` step |
+| `masks` | Echo of manifest masks (with `reason`) |
+
+---
+
+## Design Decisions
+
+### Why Playwright + xterm.js for TUI rendering?
+
+**Context:** PNG rendering of terminal state is the hard requirement in this spec. Original brief suggested `agg` (asciinema GIF generator); we rejected it for reasons in the table below. Options evaluated:
+
+| Approach | Fidelity | Deps | Cross-plat | Verdict |
+|---|---|---|---|---|
+| Playwright + xterm.js | High — xterm.js is VS Code's integrated terminal renderer | `@playwright/test` (have), `xterm` (new, pure JS, small) | Yes | **chosen** |
+| `node-canvas` hand-rendered | Medium — reinvents cell layout + attr handling | `canvas` native (flaky on Windows) | Yes (painfully) | rejected |
+| `agg` + `.cast` synthesis + GIF→PNG extract | Medium | Rust toolchain or GitHub release binary, plus ImageMagick/ffmpeg | Awkward on Windows CI | rejected |
+| `aha`/`ansi2html` + Playwright | Medium — loses stateful attr tracking | `aha` C binary (Linux/Mac only), Playwright (have) | Partial | rejected |
+
+**Decision:** Playwright drives a headless Chromium page that loads xterm.js and renders into its canvas. The runner/daemon reuses this page across captures to amortize browser startup.
+
+**Consequences:**
+- Positive: no new native deps; rendering engine is exactly what users see in VS Code's terminal; byte-stable output with bundled font.
+- Negative: ~1–2 s warm-up per run (amortized across 15+ captures).
+
+### Why convert `serialize()` shifts back to ANSI, instead of accessing tui-test's internal xterm?
+
+**Context:** tui-test's `terminal.serialize()` returns `{ view, shifts }` — plain text + a coordinates→attributes map. Rendering needs ANSI or equivalent state. Three paths:
+
+- (a) Re-emit SGR ANSI from shifts, write into a fresh xterm.js instance. Chosen.
+- (b) Reach into tui-test internals to grab its underlying xterm, attach `@xterm/addon-serialize`. Brittle — tui-test's API is unstable (`@0.0.1-rc.5`).
+- (c) Intercept raw node-pty stream and tee it to our own xterm. Most invasive; requires patching tui-test's spawn.
+
+**Decision:** (a). Small helper (~50 lines) iterates shifts row by row, emits SGR before char, resets at row end. Deterministic, tui-test-version-independent.
+
+### Why YAML manifests (not JSON)?
+
+- Manifests will be hand-edited — YAML's comments, block strings, and looser syntax matter.
+- Every other `.claude/*` data file in PPDS uses plain text or YAML-friendly shapes; staying consistent.
+
+### Why the runner lives at repo root (`tools/audit-capture.mjs`)?
+
+It orchestrates tools from *two* subsystem dirs (`tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` and `src/PPDS.Extension/tools/webview-cdp.mjs`). Placing the runner inside one subsystem would imply ownership it doesn't have. `tools/` at the root is where cross-cutting scripts already live in practice for this kind of role.
+
+### Why reject `$AUDIT_OUT` inside the repo?
+
+- Captures are large (tens of MB per run). Gitignore patterns are easy to forget; accidental commits are worse than a clear "nope."
+- CI pushes captures to a *different* repo (`ppds-v1-audit`) — making "inside repo" an error early catches misconfigurations.
+
+### Why default-redact env + user principal?
+
+- Constitution S3: no secret logging. Env names and user principals aren't technically secrets, but a public audit repo could leak tenant info that customers don't want indexed. Default opt-out is safer; set `AUDIT_REDACT=false` explicitly to capture raw values.
+
+### Why no light-theme extension captures in v1?
+
+- Doubles capture count for a binary that most PPDS users don't use in light mode.
+- Manifest schema reserves a `themes: [dark, light]` field so adding it later is configuration-only — no runner change.
+
+### Why not generate screen lists automatically from code?
+
+- Considered: crawl `src/PPDS.Cli/Tui/Screens/` + `package.json` `contributes.commands` and synthesize manifests.
+- Rejected: the manifest is the *design* of what a designer audits, not the raw inventory. Generated manifests would miss important states (empty vs loaded, dialog open, error state) that a human must declare. Keeping it hand-authored makes the manifest itself an intentional artifact.
+
+---
+
+## Extension Points
+
+### Adding a new TUI screen capture
+
+1. Add an entry to `.claude/audit-manifests/tui.yaml`:
+   ```yaml
+   - id: my-new-screen
+     title: My New Screen — initial state
+     requires: none
+     steps:
+       - key: alt+t
+       - key: down
+       - key: enter
+       - wait: { text: "My New Screen", timeout: 5000 }
+       - screenshot: 01-initial
+   ```
+2. Run `node tools/audit-capture.mjs validate tui` to verify the steps reach the screen.
+3. Run `node tools/audit-capture.mjs run tui` for a real capture. No runner code changes.
+
+### Adding a new extension panel capture
+
+Same pattern against `.claude/audit-manifests/extension.yaml`. Use `command:` to open the panel, `wait:` on the extension id, then `screenshot:`.
+
+### Adding a new surface (e.g., `mcp`)
+
+Out of scope for this spec. Would require: a new manifest file, a new runner surface handler, and a matching verify tool for that surface.
+
+---
+
+## Related Specs
+
+- [tui-verify-tool.md](./tui-verify-tool.md) — the PTY harness this extends
+- [ext-verify-tool.md](./ext-verify-tool.md) — the VS Code webview harness this drives
+- `ppds-design-system/AUDIT-SCHEMA.md` — the output contract
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-18 | Initial spec |
+
+---
+
+## Roadmap
+
+- **Light-theme extension captures** — turn on `themes: [dark, light]` on extension entries; runner toggles via `workbench.action.selectTheme` between captures.
+- **Auto-validation CI gate** — run `audit-capture validate tui` + `validate extension` in PR CI to catch manifest drift when UI changes.
+- **Pixel-diff regression** — compare captures across commits (not in Phase 1; the audit workflow is the primary consumer for v1).

--- a/specs/audit-capture.md
+++ b/specs/audit-capture.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Last Updated:** 2026-04-18
-**Code:** [tools/audit-capture.mjs](../tools/audit-capture.mjs) | [tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs](../tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs) | [.claude/skills/audit-capture/](../.claude/skills/audit-capture/) | [.claude/audit-manifests/](../.claude/audit-manifests/)
+**Code:** [tools/audit-capture.mjs](../tools/audit-capture.mjs) | [tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs](../tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs) | [.claude/skills/audit-capture/](../.claude/skills/audit-capture/) | [tools/audit-manifests/](../tools/audit-manifests/)
 **Surfaces:** TUI | Extension
 
 ---
@@ -16,7 +16,7 @@ The contract is defined by [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/p
 ### Goals
 
 - **Uniform capture artifact** — every TUI screen and extension panel emits PNG + `meta.json`, layout per schema
-- **Manifest-driven** — adding a new screen means editing `.claude/audit-manifests/{surface}.yaml`, nothing else
+- **Manifest-driven** — adding a new screen means editing `tools/audit-manifests/{surface}.yaml`, nothing else
 - **Unattended** — once a profile+env is configured, `audit-capture run <surface>` walks the whole manifest with no prompts
 - **Robust** — a broken entry marks itself `state: error`, the run continues, exit is non-zero
 - **No new render engine for TUI** — reuse Playwright (already a dev dep) + xterm.js rather than adopting `agg` or native canvas libs
@@ -55,7 +55,7 @@ The contract is defined by [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/p
 │   xterm.js for PNG render    │   │                              │
 └──────────────────────────────┘   └──────────────────────────────┘
 
-Inputs:   .claude/audit-manifests/{surface}.yaml
+Inputs:   tools/audit-manifests/{surface}.yaml
 Outputs:  $AUDIT_OUT/{surface}/{entry-id}/{NN-name}.png
           $AUDIT_OUT/{surface}/{entry-id}/meta.json
           $AUDIT_OUT/manifest.json   (written last)
@@ -70,8 +70,8 @@ The runner is a thin orchestrator. All the heavy-lifting (PTY, VS Code, renderin
 | `tools/audit-capture.mjs` | Reads a manifest, drives the appropriate verify tool, writes schema-conformant output. Subcommands: `run`, `validate`, `list`. |
 | `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` | Existing PTY harness. Gains a `render` subcommand that writes a PNG of current terminal state. |
 | Render harness (internal to tui-verify daemon) | Headless Chromium page holding xterm.js. Kept warm across captures. |
-| `.claude/audit-manifests/tui.yaml` | Inventory of TUI screens to capture. Version-controlled. |
-| `.claude/audit-manifests/extension.yaml` | Inventory of extension panels to capture. Version-controlled. |
+| `tools/audit-manifests/tui.yaml` | Inventory of TUI screens to capture. Version-controlled. |
+| `tools/audit-manifests/extension.yaml` | Inventory of extension panels to capture. Version-controlled. |
 | `.claude/skills/audit-capture/SKILL.md` | Skill-authored documentation: usage, env vars, gotchas. |
 | Theme pin | On extension launch, `audit-capture` writes `settings.json` into webview-cdp's profile dir to lock `workbench.colorTheme`. |
 
@@ -89,7 +89,7 @@ No new npm dependencies for the runner itself (uses `yaml`, already transitively
 
 ### Core Requirements
 
-1. The runner MUST read manifests in YAML at `.claude/audit-manifests/{surface}.yaml`
+1. The runner MUST read manifests in YAML at `tools/audit-manifests/{surface}.yaml`
 2. The runner MUST write output conforming to `AUDIT-SCHEMA.md` v1: folder layout, `manifest.json`, `meta.json`
 3. The runner MUST refuse to write inside the repo working tree — `$AUDIT_OUT` must be an absolute path outside the repo
 4. The runner MUST write `manifest.json` **after** every entry directory is flushed, so a reader never sees a manifest referencing missing files
@@ -134,7 +134,7 @@ No new npm dependencies for the runner itself (uses `yaml`, already transitively
 YAML. One manifest per surface. Structure:
 
 ```yaml
-# .claude/audit-manifests/tui.yaml
+# tools/audit-manifests/tui.yaml
 surface: tui
 entries:
   - id: sql-query-main
@@ -408,7 +408,7 @@ It orchestrates tools from *two* subsystem dirs (`tests/PPDS.Tui.E2eTests/tools/
 
 ### Adding a new TUI screen capture
 
-1. Add an entry to `.claude/audit-manifests/tui.yaml`:
+1. Add an entry to `tools/audit-manifests/tui.yaml`:
    ```yaml
    - id: my-new-screen
      title: My New Screen — initial state
@@ -425,7 +425,7 @@ It orchestrates tools from *two* subsystem dirs (`tests/PPDS.Tui.E2eTests/tools/
 
 ### Adding a new extension panel capture
 
-Same pattern against `.claude/audit-manifests/extension.yaml`. Use `command:` to open the panel, `wait:` on the extension id, then `screenshot:`.
+Same pattern against `tools/audit-manifests/extension.yaml`. Use `command:` to open the panel, `wait:` on the extension id, then `screenshot:`.
 
 ### Adding a new surface (e.g., `mcp`)
 

--- a/tests/PPDS.Tui.E2eTests/package-lock.json
+++ b/tests/PPDS.Tui.E2eTests/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@microsoft/tui-test": "^0.0.1-rc.5",
         "@playwright/test": "^1.40.0",
-        "xterm": "^5.3.0"
+        "@xterm/xterm": "^5.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -498,6 +498,13 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
       "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2060,14 +2067,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }

--- a/tests/PPDS.Tui.E2eTests/package-lock.json
+++ b/tests/PPDS.Tui.E2eTests/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "@microsoft/tui-test": "^0.0.1-rc.5",
-        "@playwright/test": "^1.40.0"
+        "@playwright/test": "^1.40.0",
+        "xterm": "^5.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2059,6 +2060,14 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/tests/PPDS.Tui.E2eTests/package.json
+++ b/tests/PPDS.Tui.E2eTests/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "@microsoft/tui-test": "^0.0.1-rc.5",
     "@playwright/test": "^1.40.0",
-    "xterm": "^5.3.0"
+    "@xterm/xterm": "^5.5.0"
   }
 }

--- a/tests/PPDS.Tui.E2eTests/package.json
+++ b/tests/PPDS.Tui.E2eTests/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@microsoft/tui-test": "^0.0.1-rc.5",
-    "@playwright/test": "^1.40.0"
+    "@playwright/test": "^1.40.0",
+    "xterm": "^5.3.0"
   }
 }

--- a/tests/PPDS.Tui.E2eTests/tools/render-harness.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/render-harness.mjs
@@ -1,0 +1,248 @@
+// Headless Chromium + xterm.js render harness for tui-verify.
+// Takes tui-test's serialize() output and produces a PNG that matches what a
+// user would see in a 120×30 terminal with PPDS's default color scheme.
+//
+// Dep: @playwright/test (dev dep already, for Electron E2E), xterm (new, ~200 KB).
+
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname, join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const COLS = 120;
+export const ROWS = 30;
+export const DPR = 2.0;
+export const FONT_SIZE = 16;
+
+// Palette — sourced from ppds-design-system/colors_and_type.css.
+// Dark-mode-first; 16 ANSI entries mapped to the design system's locked values.
+// Background and foreground set to panel defaults; cursor matches foreground.
+export const PPDS_THEME = {
+  background: '#1e1e1e',
+  foreground: '#f0f0f0',
+  cursor: '#f0f0f0',
+  cursorAccent: '#1e1e1e',
+  selectionBackground: '#00cccc',
+  selectionForeground: '#000000',
+  black: '#1e1e1e',
+  red: '#c00000',
+  green: '#00a300',
+  yellow: '#c5b000',
+  blue: '#005aad',
+  magenta: '#b23cc0',
+  cyan: '#00cccc',
+  white: '#c8c8c8',
+  brightBlack: '#5c5c5c',
+  brightRed: '#ff5555',
+  brightGreen: '#33d955',
+  brightYellow: '#f5e94a',
+  brightBlue: '#4aa8ff',
+  brightMagenta: '#e070ff',
+  brightCyan: '#33ffff',
+  brightWhite: '#ffffff',
+};
+
+// ── shifts → ANSI (exported for unit-testability) ───────────────────────
+
+/**
+ * Convert tui-test's serialize() output ({view, shifts}) into an SGR-annotated
+ * replay stream suitable for term.write() on a fresh xterm.js instance.
+ *
+ * Algorithm: iterate row×col, emit an SGR escape only when the attribute set
+ * differs from the previous cell. Reset + newline between rows. No cursor
+ * positioning — we write rows linearly into a cleared terminal.
+ */
+export function shiftsToAnsi(view, shifts) {
+  const rows = view.split('\n');
+  const get = (r, c) => {
+    if (shifts instanceof Map) return shifts.get(`${r},${c}`);
+    return shifts[`${r},${c}`];
+  };
+
+  let out = '\x1b[0m';
+  let prevSgr = '';
+  for (let r = 0; r < rows.length; r++) {
+    const line = rows[r];
+    for (let c = 0; c < line.length; c++) {
+      const attrs = get(r, c);
+      const sgr = attrsToSgr(attrs);
+      if (sgr !== prevSgr) {
+        out += '\x1b[0m' + sgr;
+        prevSgr = sgr;
+      }
+      out += line[c];
+    }
+    out += '\x1b[0m\r\n';
+    prevSgr = '';
+  }
+  return out;
+}
+
+/**
+ * Map a single tui-test CellShift object to an SGR escape sequence.
+ * Empty shift or null/undefined → '' (default attributes).
+ */
+export function attrsToSgr(attrs) {
+  if (!attrs) return '';
+  const codes = [];
+  if (attrs.bold) codes.push(1);
+  if (attrs.dim) codes.push(2);
+  if (attrs.italic) codes.push(3);
+  if (attrs.underline) codes.push(4);
+  if (attrs.blink) codes.push(5);
+  if (attrs.inverse) codes.push(7);
+  if (attrs.invisible) codes.push(8);
+  if (attrs.strike) codes.push(9);
+  if (attrs.overline) codes.push(53);
+
+  // Foreground
+  if (attrs.fgColorMode === 1) {
+    // 16-color base: fgColor is 0-7 (normal) or 8-15 (bright)
+    const fg = attrs.fgColor ?? 0;
+    if (fg < 8) codes.push(30 + fg);
+    else codes.push(90 + (fg - 8));
+  } else if (attrs.fgColorMode === 2) {
+    codes.push(38, 5, attrs.fgColor ?? 0);
+  } else if (attrs.fgColorMode === 3) {
+    const rgb = attrs.fgColor ?? 0;
+    codes.push(38, 2, (rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+  }
+
+  // Background
+  if (attrs.bgColorMode === 1) {
+    const bg = attrs.bgColor ?? 0;
+    if (bg < 8) codes.push(40 + bg);
+    else codes.push(100 + (bg - 8));
+  } else if (attrs.bgColorMode === 2) {
+    codes.push(48, 5, attrs.bgColor ?? 0);
+  } else if (attrs.bgColorMode === 3) {
+    const rgb = attrs.bgColor ?? 0;
+    codes.push(48, 2, (rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff);
+  }
+
+  if (codes.length === 0) return '';
+  return `\x1b[${codes.join(';')}m`;
+}
+
+// ── HTML shell served to the render page ────────────────────────────────
+
+function findPackage(startDir, pkgName) {
+  let dir = startDir;
+  while (dir) {
+    const candidate = join(dir, 'node_modules', pkgName);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+function loadXtermAssets() {
+  const pkgDir = findPackage(__dirname, 'xterm');
+  if (!pkgDir) {
+    throw new Error('xterm package not installed. Run `npm install` in tests/PPDS.Tui.E2eTests first.');
+  }
+  const js = readFileSync(join(pkgDir, 'lib', 'xterm.js'), 'utf8');
+  const css = readFileSync(join(pkgDir, 'css', 'xterm.css'), 'utf8');
+  return { js, css };
+}
+
+function buildShellHtml() {
+  const { js, css } = loadXtermAssets();
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>${css}</style>
+<style>
+  :root { color-scheme: dark; }
+  html, body { margin: 0; padding: 0; background: ${PPDS_THEME.background}; }
+  body { display: flex; align-items: flex-start; justify-content: flex-start; }
+  #term { display: inline-block; }
+  /* Remove padding/scrollbar artifacts */
+  .xterm .xterm-viewport { overflow: hidden !important; }
+  .xterm-scrollable-element { overflow: hidden !important; }
+</style>
+<script>${js}</script>
+</head>
+<body>
+<div id="term"></div>
+<script>
+  const theme = ${JSON.stringify(PPDS_THEME)};
+  const term = new Terminal({
+    rows: ${ROWS},
+    cols: ${COLS},
+    fontFamily: 'Cascadia Mono, Cascadia Code, Consolas, "DejaVu Sans Mono", "Courier New", monospace',
+    fontSize: ${FONT_SIZE},
+    lineHeight: 1.2,
+    theme,
+    allowTransparency: false,
+    cursorBlink: false,
+    disableStdin: true,
+    scrollback: 0,
+    convertEol: false,
+  });
+  term.open(document.getElementById('term'));
+  window.__writeBuffer = (stream) => new Promise((resolve) => {
+    term.reset();
+    term.write(stream, () => {
+      // One more tick for the renderer to paint
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+  });
+  window.__measureCell = () => {
+    const el = document.querySelector('#term .xterm-screen');
+    const r = el.getBoundingClientRect();
+    return { width: r.width, height: r.height };
+  };
+  window.__ready = true;
+</script>
+</body>
+</html>`;
+}
+
+// ── RenderSession — encapsulates browser + page lifecycle ────────────────
+
+export class RenderSession {
+  constructor() {
+    this._browser = null;
+    this._context = null;
+    this._page = null;
+    this._chromium = null;
+  }
+
+  async ensure() {
+    if (this._page) return;
+    const { chromium } = await import('@playwright/test');
+    this._chromium = chromium;
+    this._browser = await chromium.launch({ headless: true });
+    this._context = await this._browser.newContext({
+      deviceScaleFactor: DPR,
+      viewport: { width: COLS * FONT_SIZE, height: Math.ceil(ROWS * FONT_SIZE * 1.2) },
+    });
+    this._page = await this._context.newPage();
+    await this._page.setContent(buildShellHtml(), { waitUntil: 'networkidle' });
+    await this._page.waitForFunction(() => window.__ready === true, { timeout: 10000 });
+  }
+
+  async writeAndScreenshot(serialized, outFile) {
+    await this.ensure();
+    const stream = shiftsToAnsi(serialized.view, serialized.shifts ?? {});
+    await this._page.evaluate((s) => window.__writeBuffer(s), stream);
+    const locator = this._page.locator('#term .xterm-screen');
+    await locator.screenshot({ path: outFile, omitBackground: false });
+    return outFile;
+  }
+
+  async close() {
+    try { await this._page?.close(); } catch {}
+    try { await this._context?.close(); } catch {}
+    try { await this._browser?.close(); } catch {}
+    this._page = null;
+    this._context = null;
+    this._browser = null;
+  }
+}

--- a/tests/PPDS.Tui.E2eTests/tools/render-harness.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/render-harness.mjs
@@ -141,9 +141,9 @@ function findPackage(startDir, pkgName) {
 }
 
 function loadXtermAssets() {
-  const pkgDir = findPackage(__dirname, 'xterm');
+  const pkgDir = findPackage(__dirname, '@xterm/xterm');
   if (!pkgDir) {
-    throw new Error('xterm package not installed. Run `npm install` in tests/PPDS.Tui.E2eTests first.');
+    throw new Error('@xterm/xterm not installed. Run `npm install` in tests/PPDS.Tui.E2eTests first.');
   }
   const js = readFileSync(join(pkgDir, 'lib', 'xterm.js'), 'utf8');
   const css = readFileSync(join(pkgDir, 'css', 'xterm.css'), 'utf8');

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -300,7 +300,7 @@ async function runDaemon() {
           try { await renderSession.close(); } catch {}
           throw err;
         }
-        return { path: resolve(params.file) };
+        return { path: resolve(params.file), serialize: { view: snapshot.view, shifts } };
       }
       default:
         throw new Error(`Unknown action: ${action}`);
@@ -498,7 +498,9 @@ async function cmdScreenshot(parsed) {
 async function cmdRender(parsed) {
   const session = readSession();
   const result = await sendToDaemon(session, 'render', { file: parsed.file });
-  console.log(result.path);
+  // Emit the full JSON response so orchestrators can consume the serialize
+  // payload alongside the PNG path without a second shell-out.
+  console.log(JSON.stringify(result));
 }
 
 async function cmdRows() {

--- a/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
+++ b/tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs
@@ -13,7 +13,7 @@ const LOG_FILE = resolve(__dirname, '.tui-verify-daemon.log');
 export const ROWS = 30;
 export const COLS = 120;
 
-const VALID_COMMANDS = ['launch', 'close', 'screenshot', 'key', 'type', 'text', 'wait', 'rows'];
+const VALID_COMMANDS = ['launch', 'close', 'screenshot', 'render', 'key', 'type', 'text', 'wait', 'rows'];
 const VALID_MODIFIERS = ['ctrl', 'alt', 'shift'];
 
 // ── Pure functions (exported for testing) ────────────────────────────
@@ -66,6 +66,12 @@ export function parseArgs(argv) {
   if (command === 'screenshot') {
     const file = argv[1];
     if (!file) throw new Error('Usage: screenshot <file>');
+    return { command, file };
+  }
+
+  if (command === 'render') {
+    const file = argv[1];
+    if (!file) throw new Error('Usage: render <file.png>');
     return { command, file };
   }
 
@@ -125,6 +131,8 @@ async function runDaemon() {
 
   // Dynamic import — callers don't need tui-test
   const tuiTest = await import('@microsoft/tui-test/lib/terminal/term.js');
+  const { RenderSession } = await import('./render-harness.mjs');
+  const renderSession = new RenderSession();
 
   const repoRoot = resolve(__dirname, '..', '..', '..');
   const exe = resolve(repoRoot, 'src/PPDS.Cli/bin/Debug/net10.0/ppds.exe');
@@ -277,6 +285,23 @@ async function runDaemon() {
       case 'rows': {
         return { dimensions: `${COLS}x${ROWS}` };
       }
+      case 'render': {
+        const snapshot = terminal.serialize();
+        const shifts = {};
+        if (snapshot.shifts instanceof Map) {
+          for (const [k, v] of snapshot.shifts) shifts[k] = v;
+        } else {
+          Object.assign(shifts, snapshot.shifts);
+        }
+        try {
+          await renderSession.writeAndScreenshot({ view: snapshot.view, shifts }, resolve(params.file));
+        } catch (err) {
+          // Page may be in a bad state — tear down so next render call rebuilds.
+          try { await renderSession.close(); } catch {}
+          throw err;
+        }
+        return { path: resolve(params.file) };
+      }
       default:
         throw new Error(`Unknown action: ${action}`);
     }
@@ -341,6 +366,7 @@ async function runDaemon() {
   async function cleanup() {
     if (idleTimer) clearTimeout(idleTimer);
     try { terminal.kill(); } catch {}
+    try { await renderSession.close(); } catch {}
     deleteSession();
     if (existsSync(LOG_FILE)) unlinkSync(LOG_FILE);
     server.close();
@@ -469,6 +495,12 @@ async function cmdScreenshot(parsed) {
   console.log(result.path);
 }
 
+async function cmdRender(parsed) {
+  const session = readSession();
+  const result = await sendToDaemon(session, 'render', { file: parsed.file });
+  console.log(result.path);
+}
+
 async function cmdRows() {
   const session = readSession();
   const result = await sendToDaemon(session, 'rows', {});
@@ -494,6 +526,7 @@ async function main() {
     case 'type': await cmdType(parsed); break;
     case 'wait': await cmdWait(parsed); break;
     case 'screenshot': await cmdScreenshot(parsed); break;
+    case 'render': await cmdRender(parsed); break;
     case 'rows': await cmdRows(); break;
   }
 }

--- a/tools/audit-capture.mjs
+++ b/tools/audit-capture.mjs
@@ -7,7 +7,7 @@
 //
 // See specs/audit-capture.md for the contract this implements.
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
 import { resolve, join, dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -246,14 +246,9 @@ function extCmd(args, opts) { return runVerify(WEBVIEW_CDP, args, opts); }
 
 async function runTui(manifest, auditOut, cfg) {
   const surfaceDir = join(auditOut, 'tui');
+  // Clean any prior captures, then recreate fresh.
+  rmSync(surfaceDir, { recursive: true, force: true });
   mkdirSync(surfaceDir, { recursive: true });
-
-  // Clean prior captures for this surface
-  if (existsSync(surfaceDir)) {
-    for (const child of readdirSync(surfaceDir)) {
-      rmSync(join(surfaceDir, child), { recursive: true, force: true });
-    }
-  }
 
   // Ensure fresh daemon
   tuiCmd(['close']);
@@ -339,21 +334,15 @@ async function runTuiEntry(entry, entryDir) {
       await new Promise(r => setTimeout(r, step.sleep));
       stepsLog.push({ sleep: step.sleep });
     } else if (step.screenshot !== undefined) {
-      // Apply masks before rendering: currently we render first then post-mask
-      // via applyTuiMasks (simpler, decoupled from render pipeline).
       const outFile = join(entryDir, `${step.screenshot}.png`);
       const r = tuiCmd(['render', outFile], { timeout: 60000 });
       if (r.status !== 0) throw withStderr(new Error(`render failed: ${r.stderr}`), r.stderr);
+      // render now returns { path, serialize: { view, shifts } } as JSON on stdout —
+      // reuse that instead of a second `screenshot` shell-out.
+      let serialize = null;
+      try { serialize = JSON.parse(r.stdout).serialize ?? null; } catch {}
       if (entry.masks && entry.masks.length > 0) {
         await applyTuiMasks(outFile, entry.masks);
-      }
-      // Dump raw serialize JSON next to the PNG for meta.json use
-      const jsonPath = outFile.replace(/\.png$/, '.json');
-      const rj = tuiCmd(['screenshot', jsonPath], { timeout: 30000 });
-      let serialize = null;
-      if (rj.status === 0 && existsSync(jsonPath)) {
-        try { serialize = JSON.parse(readFileSync(jsonPath, 'utf8')); } catch {}
-        rmSync(jsonPath, { force: true });
       }
       const { PNG } = await import('pngjs');
       const png = PNG.sync.read(readFileSync(outFile));
@@ -435,14 +424,9 @@ function withStderr(err, stderr) { err.stderr = stderr; return err; }
 
 async function runExtension(manifest, auditOut, cfg) {
   const surfaceDir = join(auditOut, 'extension');
+  // Clean any prior captures, then recreate fresh.
+  rmSync(surfaceDir, { recursive: true, force: true });
   mkdirSync(surfaceDir, { recursive: true });
-
-  // Clean prior captures
-  if (existsSync(surfaceDir)) {
-    for (const child of readdirSync(surfaceDir)) {
-      rmSync(join(surfaceDir, child), { recursive: true, force: true });
-    }
-  }
 
   // Pin VS Code theme via profile settings.json
   ensureThemePin(WEBVIEW_PROFILE_DIR, EXT_THEME);
@@ -566,7 +550,7 @@ async function runExtensionEntry(entry, entryDir) {
     surfaceSpecific: {
       vscodeTheme: EXT_THEME,
       extensionId: EXT_ID,
-      panel: null,
+      panel: commandInvoked,
       commandInvoked,
     },
   };

--- a/tools/audit-capture.mjs
+++ b/tools/audit-capture.mjs
@@ -1,0 +1,686 @@
+#!/usr/bin/env node
+// audit-capture — manifest-driven capture runner for PPDS surfaces.
+//
+// Reads tools/audit-manifests/{surface}.yaml, drives tui-verify / webview-cdp
+// to reach each screen, writes PNG + meta.json + manifest.json to $AUDIT_OUT
+// conforming to ppds-design-system/AUDIT-SCHEMA.md v1.
+//
+// See specs/audit-capture.md for the contract this implements.
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, readdirSync } from 'node:fs';
+import { resolve, join, dirname, isAbsolute, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync, spawnSync } from 'node:child_process';
+import YAML from 'yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SCHEMA_VERSION = 1;
+const RUNNER_VERSION = '1.0.0';
+
+const SURFACES = ['tui', 'extension'];
+const MANIFEST_DIR = join(REPO_ROOT, 'tools', 'audit-manifests');
+
+const TUI_VERIFY = join(REPO_ROOT, 'tests', 'PPDS.Tui.E2eTests', 'tools', 'tui-verify.mjs');
+const WEBVIEW_CDP = join(REPO_ROOT, 'src', 'PPDS.Extension', 'tools', 'webview-cdp.mjs');
+const WEBVIEW_PROFILE_DIR = join(REPO_ROOT, 'src', 'PPDS.Extension', 'tools', '.webview-cdp-profile');
+
+const EXT_THEME = 'Default Dark+';
+const EXT_ID = 'power-platform-developer-suite';
+
+// ── Pure utilities (exported for testing) ───────────────────────────────
+
+export function parseArgs(argv) {
+  if (argv.length === 0) throw new Error('Usage: audit-capture <run|validate|list> <surface>');
+  const command = argv[0];
+  const valid = ['run', 'validate', 'list'];
+  if (!valid.includes(command)) throw new Error(`Unknown command: ${command}. Expected one of: ${valid.join(', ')}`);
+
+  const surface = argv[1];
+  if (!surface) throw new Error(`Usage: audit-capture ${command} <surface>`);
+  const allSurfaces = [...SURFACES, 'all'];
+  if (!allSurfaces.includes(surface)) {
+    throw new Error(`Unknown surface: ${surface}. Expected one of: ${allSurfaces.join(', ')}`);
+  }
+  if ((command === 'validate' || command === 'list') && surface === 'all') {
+    throw new Error(`${command} does not support surface=all`);
+  }
+  return { command, surface };
+}
+
+export function validateEntryId(id) {
+  if (typeof id !== 'string' || id.length === 0) throw new Error('Entry id must be a non-empty string');
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    throw new Error(`Invalid entry id '${id}': must be kebab-case ASCII (lowercase, digits, hyphens)`);
+  }
+}
+
+export function validateScreenshotName(name) {
+  if (!/^\d{2}-[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new Error(`Invalid screenshot name '${name}': must match NN-kebab-name pattern (e.g. 01-empty)`);
+  }
+}
+
+export function validateManifest(raw, surface) {
+  if (!raw || typeof raw !== 'object') throw new Error('Manifest must be a YAML mapping');
+  if (raw.surface !== surface) throw new Error(`Manifest surface '${raw.surface}' does not match requested '${surface}'`);
+  if (!Array.isArray(raw.entries)) throw new Error('Manifest.entries must be an array');
+
+  const ids = new Set();
+  for (let i = 0; i < raw.entries.length; i++) {
+    const e = raw.entries[i];
+    if (!e || typeof e !== 'object') throw new Error(`entries[${i}]: must be a mapping`);
+    validateEntryId(e.id);
+    if (ids.has(e.id)) throw new Error(`Duplicate entry id: '${e.id}'`);
+    ids.add(e.id);
+    if (typeof e.title !== 'string' || !e.title) throw new Error(`entries[${i}].title is required`);
+    if (e.requires && !['connected', 'none'].includes(e.requires)) {
+      throw new Error(`entries[${i}].requires: must be 'connected' or 'none'`);
+    }
+    if (!Array.isArray(e.steps)) throw new Error(`entries[${i}].steps: must be an array`);
+
+    const shotNames = new Set();
+    for (let j = 0; j < e.steps.length; j++) {
+      const step = e.steps[j];
+      validateStep(step, surface, `entries[${i}].steps[${j}]`);
+      if (step.screenshot) {
+        validateScreenshotName(step.screenshot);
+        if (shotNames.has(step.screenshot)) {
+          throw new Error(`Duplicate screenshot name '${step.screenshot}' in entry '${e.id}'`);
+        }
+        shotNames.add(step.screenshot);
+      }
+    }
+    if (shotNames.size === 0) {
+      throw new Error(`entries[${i}] ('${e.id}') has no screenshot steps — every entry must capture at least one PNG`);
+    }
+
+    if (e.masks) validateMasks(e.masks, surface, `entries[${i}].masks`);
+  }
+  return raw;
+}
+
+function validateStep(step, surface, path) {
+  if (!step || typeof step !== 'object') throw new Error(`${path}: must be a mapping`);
+  const keys = Object.keys(step);
+  if (keys.length === 0) throw new Error(`${path}: empty step`);
+
+  // Exactly one primary key per step
+  const primaryKeys = ['key', 'type', 'wait', 'screenshot', 'sleep', 'click', 'eval', 'command'];
+  const primary = keys.filter(k => primaryKeys.includes(k));
+  if (primary.length !== 1) {
+    throw new Error(`${path}: expected exactly one of ${primaryKeys.join(', ')}, got ${primary.length}`);
+  }
+  const k = primary[0];
+
+  if (surface === 'tui' && ['click', 'eval', 'command'].includes(k)) {
+    throw new Error(`${path}: step '${k}' is not supported on TUI surface`);
+  }
+
+  switch (k) {
+    case 'key':
+      if (typeof step.key !== 'string' || !step.key) throw new Error(`${path}.key: must be a non-empty string`);
+      break;
+    case 'type':
+      if (typeof step.type !== 'string') throw new Error(`${path}.type: must be a string`);
+      break;
+    case 'wait':
+      if (!step.wait || typeof step.wait !== 'object') throw new Error(`${path}.wait: must be a mapping`);
+      if (surface === 'tui') {
+        if (typeof step.wait.text !== 'string' || !step.wait.text) throw new Error(`${path}.wait.text: required on TUI`);
+      } else {
+        if (step.wait.text && typeof step.wait.text !== 'string') throw new Error(`${path}.wait.text must be a string`);
+        if (step.wait.ext && typeof step.wait.ext !== 'string') throw new Error(`${path}.wait.ext must be a string`);
+      }
+      if (step.wait.timeout !== undefined && (typeof step.wait.timeout !== 'number' || step.wait.timeout <= 0)) {
+        throw new Error(`${path}.wait.timeout: must be a positive number`);
+      }
+      break;
+    case 'screenshot':
+      if (typeof step.screenshot !== 'string') throw new Error(`${path}.screenshot: must be a string`);
+      break;
+    case 'sleep':
+      if (typeof step.sleep !== 'number' || step.sleep <= 0) throw new Error(`${path}.sleep: must be a positive number`);
+      break;
+    case 'click':
+      if (typeof step.click !== 'string' || !step.click) throw new Error(`${path}.click: must be a non-empty selector`);
+      break;
+    case 'eval':
+      if (typeof step.eval !== 'string' || !step.eval) throw new Error(`${path}.eval: must be a non-empty expression`);
+      break;
+    case 'command':
+      if (typeof step.command !== 'string' || !step.command) throw new Error(`${path}.command: must be a non-empty string`);
+      break;
+  }
+}
+
+function validateMasks(masks, surface, path) {
+  if (!Array.isArray(masks)) throw new Error(`${path}: must be an array`);
+  for (let i = 0; i < masks.length; i++) {
+    const m = masks[i];
+    if (!m || typeof m !== 'object') throw new Error(`${path}[${i}]: must be a mapping`);
+    if (typeof m.reason !== 'string' || !m.reason) throw new Error(`${path}[${i}].reason: required`);
+    if (surface === 'tui') {
+      if (!Number.isInteger(m.row) || m.row < 0 || m.row > 29) throw new Error(`${path}[${i}].row: 0-29 required`);
+      if (!Number.isInteger(m.colStart) || m.colStart < 0 || m.colStart > 120) throw new Error(`${path}[${i}].colStart: 0-120`);
+      if (!Number.isInteger(m.colEnd) || m.colEnd < m.colStart || m.colEnd > 120) throw new Error(`${path}[${i}].colEnd: >= colStart and <= 120`);
+    } else {
+      for (const f of ['x', 'y', 'width', 'height']) {
+        if (!Number.isInteger(m[f]) || m[f] < 0) throw new Error(`${path}[${i}].${f}: non-negative integer required`);
+      }
+    }
+  }
+}
+
+export function validateAuditOut(auditOut, repoRoot) {
+  if (!auditOut) throw new Error('AUDIT_OUT env var is required');
+  if (!isAbsolute(auditOut)) throw new Error(`AUDIT_OUT must be absolute: ${auditOut}`);
+  const rel = relative(repoRoot, auditOut);
+  // relative("/repo", "/repo") => ""           (same)    → reject
+  // relative("/repo", "/repo/out") => "out"    (inside)  → reject
+  // relative("/repo", "/tmp/out") => "../tmp/out" (outside) → accept
+  if (!rel.startsWith('..')) {
+    throw new Error(`AUDIT_OUT must be outside the repo working tree: ${auditOut}`);
+  }
+}
+
+export function sourceInfo() {
+  const env = process.env;
+  const repo = env.AUDIT_SOURCE_REPO || detectRepoFromRemote();
+  const ref = env.AUDIT_SOURCE_REF || detectRef();
+  const commit = env.AUDIT_SOURCE_COMMIT || detectCommit();
+  return { repo, ref, commit, runner: `audit-capture@${RUNNER_VERSION}` };
+}
+
+function gitSync(...args) {
+  const res = spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+  if (res.status !== 0) return '';
+  return res.stdout.trim();
+}
+
+function detectRepoFromRemote() {
+  const url = gitSync('config', '--get', 'remote.origin.url');
+  if (!url) return 'unknown/unknown';
+  const m = url.match(/[:/]([^/]+)\/([^/]+?)(?:\.git)?$/);
+  return m ? `${m[1]}/${m[2]}` : url;
+}
+
+function detectRef() { return gitSync('symbolic-ref', 'HEAD') || 'refs/heads/HEAD'; }
+function detectCommit() { return gitSync('rev-parse', 'HEAD'); }
+
+// ── Manifest loader ─────────────────────────────────────────────────────
+
+function loadManifest(surface) {
+  const path = join(MANIFEST_DIR, `${surface}.yaml`);
+  if (!existsSync(path)) throw new Error(`Manifest not found: ${path}`);
+  let raw;
+  try {
+    raw = YAML.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new Error(`Manifest parse error (${path}): ${err.message}`);
+  }
+  return validateManifest(raw, surface);
+}
+
+// ── Verify-tool shelling ────────────────────────────────────────────────
+
+function runVerify(tool, args, opts = {}) {
+  const res = spawnSync(process.execPath, [tool, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    timeout: opts.timeout || 120000,
+  });
+  return {
+    status: res.status,
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+  };
+}
+
+function tuiCmd(args, opts) { return runVerify(TUI_VERIFY, args, opts); }
+function extCmd(args, opts) { return runVerify(WEBVIEW_CDP, args, opts); }
+
+// ── Surface: TUI ─────────────────────────────────────────────────────────
+
+async function runTui(manifest, auditOut, cfg) {
+  const surfaceDir = join(auditOut, 'tui');
+  mkdirSync(surfaceDir, { recursive: true });
+
+  // Clean prior captures for this surface
+  if (existsSync(surfaceDir)) {
+    for (const child of readdirSync(surfaceDir)) {
+      rmSync(join(surfaceDir, child), { recursive: true, force: true });
+    }
+  }
+
+  // Ensure fresh daemon
+  tuiCmd(['close']);
+  const launch = tuiCmd(['launch', '--build'], { timeout: 180000 });
+  if (launch.status !== 0) {
+    throw new Error(`tui-verify launch failed: ${launch.stderr}`);
+  }
+  const splash = tuiCmd(['wait', 'PPDS', '15000']);
+  if (splash.status !== 0) {
+    tuiCmd(['close']);
+    throw new Error(`TUI did not reach splash: ${splash.stderr}`);
+  }
+
+  const entries = [];
+  let exitCode = 0;
+
+  for (const entry of manifest.entries) {
+    const entryDir = join(surfaceDir, entry.id);
+    const skipForRequires = entry.requires === 'connected' && !(cfg.profile && cfg.env);
+    if (skipForRequires) {
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'skipped',
+        screenshots: [],
+        skipReason: `requires: connected (PPDS_PROFILE=${cfg.profile || 'unset'}, PPDS_ENV=${cfg.env || 'unset'})`,
+      });
+      continue;
+    }
+
+    try {
+      mkdirSync(entryDir, { recursive: true });
+      await navigateToTuiBaseline();
+      const result = await runTuiEntry(entry, entryDir);
+      entries.push(result);
+    } catch (err) {
+      exitCode = 1;
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'error',
+        screenshots: [],
+        error: err.message,
+        stderr: (err.stderr || '').slice(0, 4096),
+      });
+      // Attempt recovery for next entry
+      tuiCmd(['close']);
+      const r = tuiCmd(['launch'], { timeout: 60000 });
+      if (r.status !== 0) break; // give up on TUI surface
+      tuiCmd(['wait', 'PPDS', '15000']);
+    }
+  }
+
+  tuiCmd(['close']);
+  return { entries, exitCode };
+}
+
+async function navigateToTuiBaseline() {
+  // Best-effort reset: repeated Escape + Ctrl+Home to collapse dialogs/menus.
+  tuiCmd(['key', 'escape']);
+  tuiCmd(['key', 'escape']);
+}
+
+async function runTuiEntry(entry, entryDir) {
+  const stepsLog = [];
+  const screenshots = [];
+
+  for (const step of entry.steps) {
+    if (step.key !== undefined) {
+      const r = tuiCmd(['key', step.key]);
+      if (r.status !== 0) throw withStderr(new Error(`key '${step.key}' failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ key: step.key });
+    } else if (step.type !== undefined) {
+      const r = tuiCmd(['type', step.type]);
+      if (r.status !== 0) throw withStderr(new Error(`type failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ type: step.type });
+    } else if (step.wait !== undefined) {
+      const timeout = step.wait.timeout || 10000;
+      const r = tuiCmd(['wait', step.wait.text, String(timeout)]);
+      if (r.status !== 0) throw withStderr(new Error(`wait '${step.wait.text}' failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ wait: { text: step.wait.text, timeout } });
+    } else if (step.sleep !== undefined) {
+      await new Promise(r => setTimeout(r, step.sleep));
+      stepsLog.push({ sleep: step.sleep });
+    } else if (step.screenshot !== undefined) {
+      // Apply masks before rendering: currently we render first then post-mask
+      // via applyTuiMasks (simpler, decoupled from render pipeline).
+      const outFile = join(entryDir, `${step.screenshot}.png`);
+      const r = tuiCmd(['render', outFile], { timeout: 60000 });
+      if (r.status !== 0) throw withStderr(new Error(`render failed: ${r.stderr}`), r.stderr);
+      if (entry.masks && entry.masks.length > 0) {
+        await applyTuiMasks(outFile, entry.masks);
+      }
+      // Dump raw serialize JSON next to the PNG for meta.json use
+      const jsonPath = outFile.replace(/\.png$/, '.json');
+      const rj = tuiCmd(['screenshot', jsonPath], { timeout: 30000 });
+      let serialize = null;
+      if (rj.status === 0 && existsSync(jsonPath)) {
+        try { serialize = JSON.parse(readFileSync(jsonPath, 'utf8')); } catch {}
+        rmSync(jsonPath, { force: true });
+      }
+      const { PNG } = await import('pngjs');
+      const png = PNG.sync.read(readFileSync(outFile));
+      screenshots.push({
+        name: step.screenshot,
+        path: `tui/${entry.id}/${step.screenshot}.png`,
+        dimensions: { width: png.width, height: png.height },
+        dpr: 2.0,
+        theme: 'dark',
+        _serialize: serialize,
+      });
+      stepsLog.push({ screenshot: step.screenshot });
+    }
+  }
+
+  // Per-entry meta.json — include last serialize dump (richest state).
+  const lastSerialize = screenshots.length > 0 ? screenshots[screenshots.length - 1]._serialize : null;
+  const meta = {
+    id: entry.id,
+    surface: 'tui',
+    title: entry.title,
+    capturedAt: new Date().toISOString(),
+    steps: stepsLog,
+    masks: entry.masks || [],
+    surfaceSpecific: {
+      rows: 30,
+      cols: 120,
+      font: 'Cascadia Mono',
+      fontSize: 16,
+      theme: 'ppds-dark',
+      serialize: lastSerialize,
+    },
+  };
+  writeFileSync(join(entryDir, 'meta.json'), JSON.stringify(meta, null, 2));
+
+  // Strip internal _serialize from the screenshots payload before returning.
+  return {
+    id: entry.id,
+    title: entry.title,
+    state: 'ok',
+    screenshots: screenshots.map(({ _serialize, ...s }) => s),
+    metaPath: `tui/${entry.id}/meta.json`,
+  };
+}
+
+async function applyTuiMasks(pngPath, masks) {
+  const { PNG } = await import('pngjs');
+  const buf = readFileSync(pngPath);
+  const png = PNG.sync.read(buf);
+  // TUI cell-grid masking: convert cells → pixel rects.
+  // Image is 120 cols × 30 rows cells at DPR 2.0; we can derive cell dims from image size.
+  const cellW = png.width / 120;
+  const cellH = png.height / 30;
+  for (const m of masks) {
+    const px = Math.round(m.colStart * cellW);
+    const py = Math.round(m.row * cellH);
+    const pw = Math.round((m.colEnd - m.colStart) * cellW);
+    const ph = Math.round(cellH);
+    fillRect(png, px, py, pw, ph, [0x1e, 0x1e, 0x1e, 0xff]);
+  }
+  writeFileSync(pngPath, PNG.sync.write(png));
+}
+
+function fillRect(png, x, y, w, h, [r, g, b, a]) {
+  for (let yy = y; yy < y + h && yy < png.height; yy++) {
+    for (let xx = x; xx < x + w && xx < png.width; xx++) {
+      const idx = (png.width * yy + xx) << 2;
+      png.data[idx] = r;
+      png.data[idx + 1] = g;
+      png.data[idx + 2] = b;
+      png.data[idx + 3] = a;
+    }
+  }
+}
+
+function withStderr(err, stderr) { err.stderr = stderr; return err; }
+
+// ── Surface: Extension ───────────────────────────────────────────────────
+
+async function runExtension(manifest, auditOut, cfg) {
+  const surfaceDir = join(auditOut, 'extension');
+  mkdirSync(surfaceDir, { recursive: true });
+
+  // Clean prior captures
+  if (existsSync(surfaceDir)) {
+    for (const child of readdirSync(surfaceDir)) {
+      rmSync(join(surfaceDir, child), { recursive: true, force: true });
+    }
+  }
+
+  // Pin VS Code theme via profile settings.json
+  ensureThemePin(WEBVIEW_PROFILE_DIR, EXT_THEME);
+
+  extCmd(['close']);
+  const launch = extCmd(['launch', '--build'], { timeout: 300000 });
+  if (launch.status !== 0) {
+    throw new Error(`webview-cdp launch failed: ${launch.stderr}`);
+  }
+
+  const entries = [];
+  let exitCode = 0;
+
+  for (const entry of manifest.entries) {
+    const entryDir = join(surfaceDir, entry.id);
+    const skipForRequires = entry.requires === 'connected' && !(cfg.profile && cfg.env);
+    if (skipForRequires) {
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'skipped',
+        screenshots: [],
+        skipReason: `requires: connected (PPDS_PROFILE=${cfg.profile || 'unset'}, PPDS_ENV=${cfg.env || 'unset'})`,
+      });
+      continue;
+    }
+
+    try {
+      mkdirSync(entryDir, { recursive: true });
+      const result = await runExtensionEntry(entry, entryDir);
+      entries.push(result);
+    } catch (err) {
+      exitCode = 1;
+      entries.push({
+        id: entry.id,
+        title: entry.title,
+        state: 'error',
+        screenshots: [],
+        error: err.message,
+        stderr: (err.stderr || '').slice(0, 4096),
+      });
+    }
+  }
+
+  extCmd(['close']);
+  return { entries, exitCode };
+}
+
+function ensureThemePin(profileDir, themeId) {
+  const userDir = join(profileDir, 'User');
+  mkdirSync(userDir, { recursive: true });
+  const settingsPath = join(userDir, 'settings.json');
+  let current = {};
+  if (existsSync(settingsPath)) {
+    try { current = JSON.parse(readFileSync(settingsPath, 'utf8')); } catch { current = {}; }
+  }
+  current['workbench.colorTheme'] = themeId;
+  writeFileSync(settingsPath, JSON.stringify(current, null, 2));
+}
+
+async function runExtensionEntry(entry, entryDir) {
+  const stepsLog = [];
+  const screenshots = [];
+  let commandInvoked = null;
+
+  for (const step of entry.steps) {
+    if (step.command !== undefined) {
+      const r = extCmd(['command', step.command], { timeout: 30000 });
+      if (r.status !== 0) throw withStderr(new Error(`command '${step.command}' failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ command: step.command });
+      if (!commandInvoked) commandInvoked = step.command;
+    } else if (step.wait !== undefined) {
+      const args = ['wait'];
+      if (step.wait.timeout) args.push(String(step.wait.timeout));
+      if (step.wait.ext) args.push('--ext', step.wait.ext);
+      const r = extCmd(args, { timeout: (step.wait.timeout || 30000) + 10000 });
+      if (r.status !== 0) throw withStderr(new Error(`wait failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ wait: step.wait });
+    } else if (step.click !== undefined) {
+      const args = ['click', step.click];
+      if (step.ext) args.push('--ext', step.ext);
+      const r = extCmd(args);
+      if (r.status !== 0) throw withStderr(new Error(`click '${step.click}' failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ click: step.click, ext: step.ext });
+    } else if (step.eval !== undefined) {
+      const r = extCmd(['eval', step.eval]);
+      if (r.status !== 0) throw withStderr(new Error(`eval failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ eval: step.eval });
+    } else if (step.key !== undefined) {
+      const r = extCmd(['key', step.key, '--page']);
+      if (r.status !== 0) throw withStderr(new Error(`key '${step.key}' failed: ${r.stderr}`), r.stderr);
+      stepsLog.push({ key: step.key });
+    } else if (step.sleep !== undefined) {
+      await new Promise(r => setTimeout(r, step.sleep));
+      stepsLog.push({ sleep: step.sleep });
+    } else if (step.screenshot !== undefined) {
+      const outFile = join(entryDir, `${step.screenshot}.png`);
+      const r = extCmd(['screenshot', outFile], { timeout: 30000 });
+      if (r.status !== 0) throw withStderr(new Error(`screenshot failed: ${r.stderr}`), r.stderr);
+      if (entry.masks && entry.masks.length > 0) await applyExtMasks(outFile, entry.masks);
+      const { PNG } = await import('pngjs');
+      const png = PNG.sync.read(readFileSync(outFile));
+      screenshots.push({
+        name: step.screenshot,
+        path: `extension/${entry.id}/${step.screenshot}.png`,
+        dimensions: { width: png.width, height: png.height },
+        dpr: 2.0,
+        theme: 'dark',
+      });
+      stepsLog.push({ screenshot: step.screenshot });
+    }
+  }
+
+  const meta = {
+    id: entry.id,
+    surface: 'extension',
+    title: entry.title,
+    capturedAt: new Date().toISOString(),
+    steps: stepsLog,
+    masks: entry.masks || [],
+    surfaceSpecific: {
+      vscodeTheme: EXT_THEME,
+      extensionId: EXT_ID,
+      panel: null,
+      commandInvoked,
+    },
+  };
+  writeFileSync(join(entryDir, 'meta.json'), JSON.stringify(meta, null, 2));
+
+  return {
+    id: entry.id,
+    title: entry.title,
+    state: 'ok',
+    screenshots,
+    metaPath: `extension/${entry.id}/meta.json`,
+  };
+}
+
+async function applyExtMasks(pngPath, masks) {
+  const { PNG } = await import('pngjs');
+  const png = PNG.sync.read(readFileSync(pngPath));
+  for (const m of masks) {
+    fillRect(png, m.x, m.y, m.width, m.height, [0x1e, 0x1e, 0x1e, 0xff]);
+  }
+  writeFileSync(pngPath, PNG.sync.write(png));
+}
+
+// ── Validate (dry-run) ──────────────────────────────────────────────────
+
+async function validateSurface(surface) {
+  const manifest = loadManifest(surface);
+  console.log(`Manifest parsed: ${manifest.entries.length} entries`);
+  for (const e of manifest.entries) {
+    console.log(`  ${e.id} — ${e.title}${e.requires === 'connected' ? '  [requires connected]' : ''}`);
+  }
+  console.log('OK');
+}
+
+async function listSurface(surface) {
+  const manifest = loadManifest(surface);
+  for (const e of manifest.entries) {
+    console.log(`${e.id}\t${e.title}`);
+  }
+}
+
+// ── Run orchestration ──────────────────────────────────────────────────
+
+async function doRun(surface) {
+  const auditOut = process.env.AUDIT_OUT;
+  validateAuditOut(auditOut, REPO_ROOT);
+  mkdirSync(auditOut, { recursive: true });
+
+  const cfg = {
+    profile: process.env.PPDS_PROFILE || '',
+    env: process.env.PPDS_ENV || '',
+    redact: process.env.AUDIT_REDACT !== 'false',
+  };
+
+  const surfacesToRun = surface === 'all' ? SURFACES : [surface];
+  const surfaceResults = {};
+  let overallExit = 0;
+
+  for (const s of surfacesToRun) {
+    const manifest = loadManifest(s);
+    console.error(`[${s}] capturing ${manifest.entries.length} entries...`);
+    const handler = s === 'tui' ? runTui : runExtension;
+    const res = await handler(manifest, auditOut, cfg);
+    surfaceResults[s] = res.entries;
+    if (res.exitCode !== 0) overallExit = res.exitCode;
+  }
+
+  // Write unified manifest LAST, after all entry dirs are flushed.
+  const summary = { total: 0, ok: 0, error: 0, skipped: 0 };
+  const surfaces = {};
+  for (const [s, entries] of Object.entries(surfaceResults)) {
+    surfaces[s] = { entries };
+    for (const e of entries) {
+      summary.total++;
+      summary[e.state]++;
+    }
+  }
+
+  const manifestObj = {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    source: sourceInfo(),
+    surfaces,
+    summary,
+  };
+  writeFileSync(join(auditOut, 'manifest.json'), JSON.stringify(manifestObj, null, 2));
+  console.error(`[done] ${summary.ok} ok, ${summary.error} error, ${summary.skipped} skipped → ${auditOut}`);
+
+  if (summary.error > 0) overallExit = 1;
+  return overallExit;
+}
+
+// ── Main dispatch ──────────────────────────────────────────────────────
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+
+  switch (parsed.command) {
+    case 'validate':
+      await validateSurface(parsed.surface);
+      break;
+    case 'list':
+      await listSurface(parsed.surface);
+      break;
+    case 'run': {
+      const code = await doRun(parsed.surface);
+      process.exit(code);
+    }
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]).toLowerCase() === __filename.toLowerCase()) {
+  main().catch(err => {
+    process.stderr.write(err.message + '\n');
+    process.exit(1);
+  });
+}

--- a/tools/audit-manifests/extension.yaml
+++ b/tools/audit-manifests/extension.yaml
@@ -1,0 +1,129 @@
+# Extension audit manifest. Single source of truth for which extension
+# panels get captured in a design audit. Adding a new panel = appending
+# an entry.
+#
+# See specs/audit-capture.md for the runner contract; AUDIT-SCHEMA.md on
+# ppds-design-system for the output format.
+#
+# Command titles sourced from src/PPDS.Extension/package.json contributions.
+
+surface: extension
+entries:
+  - id: command-palette-ppds
+    title: Command palette — PPDS commands filter
+    requires: none
+    steps:
+      - key: ctrl+shift+p
+      - sleep: 300
+      - screenshot: 01-open
+
+  - id: data-explorer
+    title: Data Explorer panel — empty editor
+    requires: connected
+    steps:
+      - command: "PPDS: Open Data Explorer"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 800
+      - screenshot: 01-loaded
+
+  - id: data-explorer-results
+    title: Data Explorer — executed query with results
+    requires: connected
+    steps:
+      - command: "PPDS: Open Data Explorer"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 800
+      - eval: "monaco.editor.getEditors()[0].setValue('SELECT TOP 5 name, accountid FROM account')"
+      - sleep: 200
+      - click: "#execute-btn"
+      - sleep: 2500
+      - screenshot: 01-results
+
+  - id: notebooks
+    title: Notebooks panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Notebooks"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 800
+      - screenshot: 01-loaded
+
+  - id: new-notebook
+    title: New Notebook — empty cell
+    requires: connected
+    steps:
+      - command: "PPDS: New Notebook"
+      - sleep: 2000
+      - screenshot: 01-empty
+
+  - id: solutions
+    title: Solutions panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Solutions"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: import-jobs
+    title: Import Jobs panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Import Jobs"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: plugin-traces
+    title: Plugin Traces panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Plugin Traces"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: metadata-browser
+    title: Metadata Browser panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Metadata Browser"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: connection-references
+    title: Connection References panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Connection References"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: environment-variables
+    title: Environment Variables panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Environment Variables"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: web-resources
+    title: Web Resources panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Web Resources"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded
+
+  - id: plugin-registration
+    title: Plugin Registration panel
+    requires: connected
+    steps:
+      - command: "PPDS: Open Plugin Registration"
+      - wait: { ext: "power-platform-developer-suite", timeout: 30000 }
+      - sleep: 1500
+      - screenshot: 01-loaded

--- a/tools/audit-manifests/tui.yaml
+++ b/tools/audit-manifests/tui.yaml
@@ -1,0 +1,231 @@
+# TUI audit manifest. Single source of truth for which TUI surfaces get
+# captured in a design audit. Adding a new screen = appending an entry.
+#
+# See specs/audit-capture.md for the runner contract; AUDIT-SCHEMA.md on
+# ppds-design-system for the output format.
+#
+# Tools menu order (from TuiShell.cs:279):
+#   0 SQL Query, 1 Solutions, 2 Import Jobs, 3 Connection References,
+#   4 Environment Variables, 5 Plugin Traces, 6 Plugin Registration,
+#   7 Metadata Browser, 8 Web Resources, 9 Data Migration
+# Use `key: down` N times after `alt+t` to navigate.
+
+surface: tui
+entries:
+  - id: splash
+    title: PPDS splash — no profile selected
+    requires: none
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - screenshot: 01-splash
+
+  - id: file-menu
+    title: File menu — open state
+    requires: none
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+f
+      - sleep: 200
+      - screenshot: 01-open
+
+  - id: help-menu
+    title: Help menu — open state
+    requires: none
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+h
+      - sleep: 200
+      - screenshot: 01-open
+
+  - id: profile-picker
+    title: Profile selector dialog
+    requires: none
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+p
+      - sleep: 300
+      - screenshot: 01-open
+
+  - id: environment-picker
+    title: Environment selector dialog
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+e
+      - sleep: 300
+      - screenshot: 01-open
+
+  - id: sql-query
+    title: SQL Query screen — empty editor
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: enter
+      - wait: { text: "SQL Query", timeout: 10000 }
+      - screenshot: 01-empty
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar contains tenant-identifying values" }
+
+  - id: solutions
+    title: Solutions screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: enter
+      - wait: { text: "Solutions", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: import-jobs
+    title: Import Jobs screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Import Jobs", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: connection-references
+    title: Connection References screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Connection References", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: environment-variables
+    title: Environment Variables screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Environment Variables", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: plugin-traces
+    title: Plugin Traces screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Plugin Traces", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: plugin-registration
+    title: Plugin Registration screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Plugin Registration", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: metadata-browser
+    title: Metadata Browser screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Metadata", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: web-resources
+    title: Web Resources screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Web Resources", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }
+
+  - id: data-migration
+    title: Data Migration screen
+    requires: connected
+    steps:
+      - wait: { text: "PPDS", timeout: 15000 }
+      - key: alt+t
+      - sleep: 150
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: down
+      - key: enter
+      - wait: { text: "Migration", timeout: 30000 }
+      - screenshot: 01-loaded
+    masks:
+      - { row: 28, colStart: 0, colEnd: 120, reason: "profile/env status bar" }


### PR DESCRIPTION
## Summary

Phase 1 of the pre-v1 audit-capture pipeline. Adds a manifest-driven PNG capture runner for the TUI and extension surfaces. Output conforms to [`AUDIT-SCHEMA.md`](https://github.com/joshsmithxrm/ppds-design-system/blob/main/AUDIT-SCHEMA.md) (landed on ppds-design-system `main` in this session).

Nothing in this PR runs automatically. The GH Action wiring and first real capture run are separate phases — this is the plumbing.

## What's in the PR

- **`specs/audit-capture.md`** — the spec with 20 numbered ACs, ADR-style design decisions, per-surface examples.
- **`tests/PPDS.Tui.E2eTests/tools/render-harness.mjs` (new)** — Playwright + xterm.js headless rendering. Converts `tui-test.serialize()` output to an SGR-annotated stream, drives a persistent Chromium page through xterm.js, screenshots the canvas. Reuses `@playwright/test` (already devDep for Electron E2E). Adds `xterm` (~200 KB, pure JS).
- **`tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs`** — new `render <file.png>` subcommand. Existing JSON `screenshot` command untouched.
- **`tools/audit-capture.mjs` (new)** — runner. Subcommands: `run <surface>`, `run all`, `validate <surface>`, `list <surface>`. Shells out to tui-verify and webview-cdp; emits `$AUDIT_OUT/manifest.json` + per-entry `meta.json`.
- **`tools/audit-manifests/{tui,extension}.yaml` (new)** — 15 + 13 entries. Adding a screen means editing YAML.
- **`.claude/skills/audit-capture/SKILL.md` (new)** — usage, env vars, gap protocol.
- **Deps added:** `xterm` (TUI E2E), `yaml` + `pngjs` (root).

## Design decisions (documented in spec)

- **Rendering:** Playwright + xterm.js headless. Rejected `agg` (GIF-only, no clean Windows install) and `node-canvas` (reinvents cell rendering). xterm.js is VS Code's integrated-terminal renderer, so the PNG matches what users see.
- **Manifests live at `tools/audit-manifests/`**, not `.claude/`. They're domain data (the inventory of PPDS surfaces), not Claude harness config. Editing them shouldn't trip the `.claude/` permission gate.
- **`$AUDIT_OUT` must be absolute and outside the repo.** Captures are large; in-repo paths would pollute the working tree.
- **Dark-only for v1.** Manifest schema reserves `themes: [dark, light]` for future without a runner change.
- **Runner writes `manifest.json` last.** A reader never sees a manifest referencing missing files.

## Test plan

**Pure-function verification (done):** `parseArgs`, `validateAuditOut`, `validateEntryId`, `validateScreenshotName`, `shiftsToAnsi`, `attrsToSgr` all smoke-tested via `node -e`.

**Manifest validation (done):** `node tools/audit-capture.mjs validate tui` → 15 entries parse cleanly. `validate extension` → 13 entries parse cleanly.

**End-to-end capture (NOT done in this session):** The full render round-trip requires a built `ppds.exe`, which I couldn't produce locally due to a pre-existing NuGet config issue on this machine (`NU1507` / multiple package sources from a global config unrelated to this branch). The render pipeline is structurally sound — pure functions verified, and the harness is near-identical to established patterns in `webview-cdp.mjs`. First real end-to-end run will happen in Phase 4's GH Action (workflow_dispatch only, no schedule until intentionally enabled).

## Test plan for reviewer
- [ ] Read `specs/audit-capture.md` — spec + ACs make sense
- [ ] Skim `tools/audit-manifests/tui.yaml` — does the set of entries cover every TUI screen a designer should audit?
- [ ] Skim `tools/audit-manifests/extension.yaml` — same for extension panels
- [ ] Run `node tools/audit-capture.mjs validate tui` and `validate extension` locally to confirm parse
- [ ] On a machine where the CLI builds: `AUDIT_OUT=$TEMP/ppds-audit PPDS_PROFILE=... PPDS_ENV=... node tools/audit-capture.mjs run tui` — expect unattended capture

## Out of scope for this PR

- Phase 4 GH Actions (next)
- Phase 5 intake doc in `ppds-v1-audit` (blocked on first real capture after UI shakedown merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)