### PR TITLE
feat(workflow): cross-session in-flight state to prevent duplicate work (#802 root cause)

### DIFF
--- a/.claude/hooks/protect-main-branch.py
+++ b/.claude/hooks/protect-main-branch.py
@@ -46,6 +46,7 @@ def is_allowed_path(file_path: str) -> bool:
         "/temp/",
         "appdata/local/temp",
         ".worktrees/",
+        ".claude/worktrees/",
     ]
     # Check both absolute and relative forms
     return any(s in normalized for s in allowed_substrings) or any(

--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -44,6 +44,28 @@ cat docs/BACKLOG.md
 
 #### Create Issue
 
+##### Pre-flight: In-Flight Conflict Check
+
+Before `gh issue create`, ALWAYS check whether a sibling session is
+already working on the same area or has already filed a related issue
+(prevents the duplicate-work pattern from retro B3 / #802):
+
+```bash
+python scripts/inflight-check.py --area <best-guess-area>
+```
+
+If exit `1`, surface the conflict to the operator and ASK before filing:
+
+> "Session `<id>` (branch `<branch>`) is actively working on this area
+> with intent `<intent>`. They may already be addressing this — file
+> anyway, or coordinate first?"
+
+The same check MUST be repeated before `gh issue close`: if a sibling
+session has open work referencing the issue, surface the related branch
+so the closer does not misattribute the fix to the wrong PR.
+
+##### Steps
+
 1. Determine `type:` label from the description (bug, enhancement, docs, performance, refactor)
 2. Determine `area:` label from the affected subsystem (auth, cli, data, extension, plugins, tui)
 3. Ask user for milestone or default to no milestone

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -131,6 +131,29 @@ After removing merged worktrees, check for orphan directories — directories in
 
 4. If `rm -rf` fails (e.g., permission denied), log as failed in the report and continue with the next orphan.
 
+### 4c. Deregister In-Flight Entries
+
+For every branch that was removed (merged, squash-merged, or its
+worktree deleted), deregister its entry from the cross-session in-flight
+state file so sibling sessions stop seeing stale claims:
+
+```bash
+python scripts/inflight-deregister.py --branch <branch-name>
+```
+
+This is idempotent — sessions that were never registered (or already
+deregistered) succeed silently. Skip in `--dry-run` mode.
+
+Additionally, sweep stale entries (older than 24h with a missing local
+branch) by issuing a no-op check:
+
+```bash
+python scripts/inflight-check.py --area scripts/ >/dev/null 2>&1 || true
+```
+
+The pruning is a side-effect of `inflight-check` — running it ensures
+abandoned sessions do not accumulate in the registry forever.
+
 ### 5. Delete Local Branches
 
 After worktrees are removed, delete their local branches:

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -114,6 +114,31 @@ If the worktree already exists:
 - If resume: skip creation, proceed to Step 6 (open terminal)
 - If new: ask for an alternative name, loop back to Step 4
 
+### Step 4b: Check for In-Flight Conflicts
+
+Before creating the worktree, check whether another concurrent session is
+already working on the same issue or area (prevents the duplicate-work
+pattern that produced #802):
+
+```bash
+# For each extracted issue:
+python scripts/inflight-check.py --issue <N>
+
+# Plus the primary code area implied by the work (best-effort guess from
+# the worktree name or first known affected path):
+python scripts/inflight-check.py --area <area>
+```
+
+If exit code is `1`, the script prints a JSON list of conflicting
+sessions on stdout. Show the operator the conflicting `session_id`,
+`branch`, `intent`, and `started` timestamp, and ask:
+
+> "Session `<id>` is already working on this. Continue anyway, coordinate
+> with that session, or abort?"
+
+Do not silently proceed. If the operator chooses to continue, fall
+through to Step 5; otherwise stop here.
+
 ### Step 5: Create Worktree and Initialize State
 
 ```bash
@@ -142,6 +167,21 @@ python scripts/workflow-state.py set launch_command "<confirmed-claude-command>"
 ```
 
 Run these commands from within the worktree directory (use the `cwd` parameter when executing via Bash tool).
+
+#### Step 5c: Register the Session as In-Flight
+
+After workflow state is initialized, announce this session in the cross-
+session in-flight registry so sibling sessions can detect overlap:
+
+```bash
+python scripts/inflight-register.py --branch feat/<name> --worktree .worktrees/<name> --issue <N> --area <area> --intent "<short description>"
+```
+
+Repeat `--issue` / `--area` flags as needed. Run from the main repo
+root (the file lives at `.claude/state/in-flight-issues.json` and is
+shared across all worktrees).
+
+Deregistration is handled by `/cleanup` after the branch merges.
 
 ### Step 6: Launch New Session with Inline Prompt
 

--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "updated": "2026-04-19T08:37:21Z",
+  "open_work": []
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,8 @@ devcontainer.json text eol=lf
 *.exe binary
 *.nupkg binary
 *.snupkg binary
+
+# In-flight session state — concurrent sessions append/remove their own
+# entries, so a basic union merge avoids most conflicts. Operators are
+# expected to re-run /cleanup if the file ever lands invalid.
+.claude/state/in-flight-issues.json merge=union

--- a/scripts/inflight-check.py
+++ b/scripts/inflight-check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check whether another active session conflicts with proposed work.
+
+Called BEFORE filing a new issue (``/backlog`` skill) or starting work
+(``/start`` skill) to prevent the duplicate-work pattern that produced
+issue #802 (session A filed a bug for a feature that session B had
+already shipped 5h earlier in another worktree).
+
+Usage:
+    python scripts/inflight-check.py --area src/PPDS.Cli/Plugins/
+    python scripts/inflight-check.py --issue 802
+    python scripts/inflight-check.py --area path/ --issue 5 --session self-id
+
+Exit codes:
+    0  no conflict (still prints empty conflict report on stdout)
+    1  one or more conflicting sessions (full report on stdout as JSON)
+    2  bad arguments
+
+The caller (skill) is expected to surface the conflict to the operator
+with an actionable prompt: "session ce9a2a05 is already working on
+this area — coordinate before proceeding."
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from inflight_common import find_conflicts, locked_state, prune_stale, write_locked_state
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Check for sibling sessions claiming overlapping work."
+    )
+    p.add_argument("--area", help="Code area path to check (e.g., src/PPDS.Cli/).")
+    p.add_argument("--issue", type=int, help="Issue number to check.")
+    p.add_argument(
+        "--session",
+        help=(
+            "Session ID to exclude (so a session checking before its own "
+            "/start does not collide with itself if it pre-registered)."
+        ),
+    )
+    p.add_argument(
+        "--no-prune", action="store_true",
+        help="Skip the stale-entry sweep (useful for unit tests).",
+    )
+    return p.parse_args(argv)
+
+
+def check(*, area: str | None = None, issue: int | None = None,
+          exclude_session: str | None = None,
+          do_prune: bool = True) -> list[dict]:
+    """Return list of conflicting entries; empty list means no conflict."""
+    with locked_state() as (fp, state):
+        if do_prune:
+            pruned = prune_stale(state)
+            if pruned:
+                write_locked_state(fp, state)
+        return find_conflicts(
+            state, area=area, issue=issue, exclude_session=exclude_session
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.area is None and args.issue is None:
+        print("error: at least one of --area or --issue required", file=sys.stderr)
+        return 2
+    conflicts = check(
+        area=args.area,
+        issue=args.issue,
+        exclude_session=args.session,
+        do_prune=not args.no_prune,
+    )
+    payload = {
+        "area": args.area,
+        "issue": args.issue,
+        "conflicts": conflicts,
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 1 if conflicts else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inflight-deregister.py
+++ b/scripts/inflight-deregister.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Deregister a session's in-flight entry.
+
+Called when work completes (PR merged, branch deleted, session abandoned).
+The ``/cleanup`` skill invokes this for each removed branch; ``/start``
+invokes it on resume of an existing worktree.
+
+Usage:
+    python scripts/inflight-deregister.py --branch feat/something
+    python scripts/inflight-deregister.py --session abc12345
+
+Exactly one of ``--branch`` or ``--session`` is required. Exits 0 even
+if no matching entry exists (deregister is idempotent).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from inflight_common import locked_state, prune_stale, write_locked_state
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Deregister an in-flight session entry.")
+    p.add_argument("--branch", help="Branch name to remove.")
+    p.add_argument("--session", help="Session ID to remove.")
+    return p.parse_args(argv)
+
+
+def deregister(*, branch: str | None = None, session: str | None = None) -> list[dict]:
+    """Remove matching entries; returns the removed entries (may be empty)."""
+    if not branch and not session:
+        raise ValueError("must supply --branch or --session")
+    removed: list[dict] = []
+    with locked_state() as (fp, state):
+        prune_stale(state)
+        kept: list[dict] = []
+        for entry in state.get("open_work", []):
+            match = (
+                (branch and entry.get("branch") == branch)
+                or (session and entry.get("session_id") == session)
+            )
+            if match:
+                removed.append(entry)
+            else:
+                kept.append(entry)
+        state["open_work"] = kept
+        write_locked_state(fp, state)
+    return removed
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.branch and not args.session:
+        print("error: --branch or --session required", file=sys.stderr)
+        return 2
+    removed = deregister(branch=args.branch, session=args.session)
+    json.dump({"removed": removed}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inflight-register.py
+++ b/scripts/inflight-register.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Register a session as actively working on issues / code areas.
+
+Called by the ``/start`` skill after worktree creation. Writes an entry
+to ``.claude/state/in-flight-issues.json`` so other concurrent sessions
+can detect overlap before filing duplicate issues or starting parallel
+work in the same area.
+
+Usage:
+    python scripts/inflight-register.py \\
+        --session abc12345 \\
+        --branch feat/something \\
+        --worktree .worktrees/something \\
+        --issue 801 --issue 802 \\
+        --area src/PPDS.Cli/Plugins/ \\
+        --intent "audit-capture pipeline implementation"
+
+If ``--session`` is omitted, a random 8-char hex ID is generated. If an
+entry with the same ``branch`` already exists it is replaced (idempotent
+re-register on resume).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sys
+
+from inflight_common import (
+    locked_state,
+    now_utc_iso,
+    prune_stale,
+    write_locked_state,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Register an in-flight session entry.")
+    p.add_argument("--session", help="Session ID (8 hex chars). Random if omitted.")
+    p.add_argument("--branch", required=True, help="Branch name being worked on.")
+    p.add_argument("--worktree", default="", help="Worktree path (relative to repo root).")
+    p.add_argument(
+        "--issue", action="append", type=int, default=[],
+        help="Issue number(s) being worked on (repeatable).",
+    )
+    p.add_argument(
+        "--area", action="append", default=[],
+        help=(
+            "Code area path(s) (repeatable, or comma-separated). "
+            "Used by inflight-check to detect overlap with sibling sessions."
+        ),
+    )
+    p.add_argument("--intent", default="", help="Short human-readable description.")
+    return p.parse_args(argv)
+
+
+def _flatten_areas(raw: list[str]) -> list[str]:
+    out: list[str] = []
+    for item in raw:
+        for chunk in (item or "").split(","):
+            chunk = chunk.strip()
+            if chunk:
+                out.append(chunk)
+    # de-dup, preserve order
+    seen: set[str] = set()
+    return [a for a in out if not (a in seen or seen.add(a))]
+
+
+def register(args: argparse.Namespace) -> dict:
+    session_id = args.session or secrets.token_hex(4)
+    entry = {
+        "session_id": session_id,
+        "started": now_utc_iso(),
+        "branch": args.branch,
+        "worktree": args.worktree,
+        "issues": list(args.issue),
+        "areas": _flatten_areas(args.area),
+        "intent": args.intent,
+    }
+    with locked_state() as (fp, state):
+        prune_stale(state)
+        # Replace any existing entry on the same branch (idempotent re-register).
+        state["open_work"] = [
+            e for e in state.get("open_work", [])
+            if e.get("branch") != args.branch
+        ]
+        state["open_work"].append(entry)
+        write_locked_state(fp, state)
+    return entry
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    entry = register(args)
+    json.dump(entry, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/inflight_common.py
+++ b/scripts/inflight_common.py
@@ -128,6 +128,10 @@ def locked_state(path: Path | None = None) -> Iterator[tuple[Any, dict[str, Any]
                 state = json.loads(raw) if raw.strip() else empty_state()
             except json.JSONDecodeError:
                 state = empty_state()
+            # Guard against valid JSON that isn't an object (null, [], "abc"):
+            # downstream code assumes ``state`` is a dict, so coerce here.
+            if not isinstance(state, dict):
+                state = empty_state()
             if "open_work" not in state:
                 state["open_work"] = []
             if "version" not in state:
@@ -173,13 +177,24 @@ def _branch_exists(branch: str) -> bool:
     try:
         import subprocess
 
+        # ``--`` separates the branch pattern from option flags so that a
+        # branch name beginning with ``-`` cannot be parsed as a git option.
         result = subprocess.run(
-            ["git", "branch", "--list", branch],
+            ["git", "branch", "--list", "--", branch],
             capture_output=True,
             text=True,
             timeout=5,
         )
-        return result.returncode == 0 and bool(result.stdout.strip())
+        if result.returncode != 0:
+            # git itself failed (not in a repo, etc.) — log to stderr so the
+            # failure is visible, but stay fail-open: assume the branch
+            # exists rather than aggressively pruning.
+            sys.stderr.write(
+                f"[inflight] git branch --list failed (rc={result.returncode}): "
+                f"{result.stderr.strip()}\n"
+            )
+            return True
+        return bool(result.stdout.strip())
     except Exception:
         # If git is unavailable, don't aggressively prune.
         return True

--- a/scripts/inflight_common.py
+++ b/scripts/inflight_common.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Shared helpers for in-flight session state coordination.
+
+The in-flight state file at ``.claude/state/in-flight-issues.json`` records
+which sessions are currently working on which issues / code areas across
+parallel worktrees. Sessions register on start, deregister on completion,
+and check before filing new issues / starting new work to detect overlap.
+
+Locking strategy
+----------------
+
+We open the JSON file in r+ mode and acquire an exclusive OS-level lock
+using ``fcntl`` on POSIX or ``msvcrt`` on Windows. The lock is held for the
+read-modify-write window, so two concurrent ``register`` invocations
+serialize at the OS layer rather than racing.
+
+Race acceptance: simultaneous registrations for the *same* issue still
+produce two entries — the file is consistent JSON but both sessions
+appear. Detection happens on the *check* side, so v1 is "last writer
+wins, both visible". A future iteration could de-dup on register, but
+that requires deciding whose claim is canonical.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+SCHEMA_VERSION = 1
+STALE_AFTER_SECONDS = 24 * 60 * 60  # 24h
+
+IS_WINDOWS = sys.platform.startswith("win")
+
+
+def repo_root() -> Path:
+    """Locate the repository root (the directory that contains .claude/)."""
+    here = Path(__file__).resolve().parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".claude").is_dir():
+            return candidate
+    # Fallback: parent of scripts/
+    return here.parent
+
+
+def state_path() -> Path:
+    """Absolute path to the in-flight state file."""
+    p = repo_root() / ".claude" / "state" / "in-flight-issues.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def empty_state() -> dict[str, Any]:
+    return {
+        "version": SCHEMA_VERSION,
+        "updated": now_utc_iso(),
+        "open_work": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform file locking
+# ---------------------------------------------------------------------------
+
+if IS_WINDOWS:
+    import msvcrt
+
+    def _lock(fileobj) -> None:
+        # msvcrt.locking locks bytes from the current file position. Lock the
+        # whole logical file by seeking to 0 and locking a non-zero length.
+        # Retry briefly if another process holds the lock.
+        fileobj.seek(0)
+        for _ in range(50):  # ~5 seconds
+            try:
+                msvcrt.locking(fileobj.fileno(), msvcrt.LK_NBLCK, 0x7FFFFFFF)
+                return
+            except OSError:
+                time.sleep(0.1)
+        raise OSError("Could not acquire lock on in-flight state file")
+
+    def _unlock(fileobj) -> None:
+        try:
+            fileobj.seek(0)
+            msvcrt.locking(fileobj.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)
+        except OSError:
+            pass
+else:
+    import fcntl
+
+    def _lock(fileobj) -> None:
+        fcntl.flock(fileobj.fileno(), fcntl.LOCK_EX)
+
+    def _unlock(fileobj) -> None:
+        try:
+            fcntl.flock(fileobj.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+
+@contextmanager
+def locked_state(path: Path | None = None) -> Iterator[tuple[Any, dict[str, Any]]]:
+    """Open the state file under an exclusive lock.
+
+    Yields ``(fileobj, state)`` where ``state`` is the parsed JSON. On
+    exit, callers should call :func:`write_locked_state` if they want to
+    persist changes; the lock is released when the context manager exits.
+    """
+    if path is None:
+        path = state_path()
+    # Ensure file exists so we can open r+; create with empty state first.
+    if not path.exists():
+        path.write_text(json.dumps(empty_state(), indent=2) + "\n", encoding="utf-8")
+
+    with open(path, "r+", encoding="utf-8") as fp:
+        _lock(fp)
+        try:
+            fp.seek(0)
+            raw = fp.read()
+            try:
+                state = json.loads(raw) if raw.strip() else empty_state()
+            except json.JSONDecodeError:
+                state = empty_state()
+            if "open_work" not in state:
+                state["open_work"] = []
+            if "version" not in state:
+                state["version"] = SCHEMA_VERSION
+            yield fp, state
+        finally:
+            _unlock(fp)
+
+
+def write_locked_state(fileobj, state: dict[str, Any]) -> None:
+    """Persist ``state`` to ``fileobj``; assumes ``locked_state`` lock is held."""
+    state["updated"] = now_utc_iso()
+    serialized = json.dumps(state, indent=2) + "\n"
+    fileobj.seek(0)
+    fileobj.truncate()
+    fileobj.write(serialized)
+    fileobj.flush()
+    try:
+        os.fsync(fileobj.fileno())
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Domain helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(ts: str) -> datetime | None:
+    try:
+        # Accept both "...Z" and "+00:00" forms.
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+
+
+def _branch_exists(branch: str) -> bool:
+    """Return True if a local branch exists; tolerate missing git."""
+    if not branch:
+        return False
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0 and bool(result.stdout.strip())
+    except Exception:
+        # If git is unavailable, don't aggressively prune.
+        return True
+
+
+def prune_stale(state: dict[str, Any], *, now: datetime | None = None,
+                branch_exists=_branch_exists) -> list[dict[str, Any]]:
+    """Remove entries older than ``STALE_AFTER_SECONDS`` whose branch is gone.
+
+    Returns the list of pruned entries (for reporting). Mutates ``state``.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    keep: list[dict[str, Any]] = []
+    pruned: list[dict[str, Any]] = []
+    for entry in state.get("open_work", []):
+        started = _parse_iso(entry.get("started", "")) or now
+        age = (now - started).total_seconds()
+        if age > STALE_AFTER_SECONDS and not branch_exists(entry.get("branch", "")):
+            pruned.append(entry)
+            continue
+        keep.append(entry)
+    state["open_work"] = keep
+    return pruned
+
+
+def find_conflicts(state: dict[str, Any], *, area: str | None = None,
+                   issue: int | None = None,
+                   exclude_session: str | None = None) -> list[dict[str, Any]]:
+    """Return entries that conflict with the given ``area`` or ``issue``.
+
+    Conflict rules (v1):
+      * Same issue number anywhere in another entry's ``issues``.
+      * ``area`` is a path prefix of an existing entry's area (or vice
+        versa) — handles the common case where one session works on
+        ``src/PPDS.Cli/`` and another on ``src/PPDS.Cli/Plugins/Foo.cs``.
+    """
+    conflicts: list[dict[str, Any]] = []
+    norm_area = _normalize_area(area) if area else None
+    for entry in state.get("open_work", []):
+        if exclude_session and entry.get("session_id") == exclude_session:
+            continue
+        if issue is not None and issue in (entry.get("issues") or []):
+            conflicts.append(entry)
+            continue
+        if norm_area:
+            for existing in entry.get("areas") or []:
+                if _areas_overlap(norm_area, _normalize_area(existing)):
+                    conflicts.append(entry)
+                    break
+    return conflicts
+
+
+def _normalize_area(path: str) -> str:
+    p = (path or "").strip().replace("\\", "/")
+    while p.endswith("/"):
+        p = p[:-1]
+    return p
+
+
+def _areas_overlap(a: str, b: str) -> bool:
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    return a.startswith(b + "/") or b.startswith(a + "/")

--- a/tests/state/test_inflight.py
+++ b/tests/state/test_inflight.py
@@ -10,7 +10,6 @@ Covers:
 from __future__ import annotations
 
 import concurrent.futures
-import importlib
 import json
 import os
 import sys
@@ -36,8 +35,7 @@ def tmp_state(tmp_path, monkeypatch):
 
 @pytest.fixture
 def register_module():
-    return importlib.import_module("inflight-register".replace("-", "_")) \
-        if False else _import_script("inflight-register")
+    return _import_script("inflight-register")
 
 
 @pytest.fixture

--- a/tests/state/test_inflight.py
+++ b/tests/state/test_inflight.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Tests for in-flight cross-session state coordination.
+
+Covers:
+  * register / deregister / check happy paths
+  * stale-entry pruning (24h + branch gone)
+  * concurrent register/deregister via ThreadPoolExecutor
+  * the retro B3 three-session scenario that motivated the feature
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import importlib
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+@pytest.fixture
+def tmp_state(tmp_path, monkeypatch):
+    """Redirect state_path() to a temp file for isolated tests."""
+    import inflight_common as ic
+
+    state_file = tmp_path / "in-flight.json"
+    monkeypatch.setattr(ic, "state_path", lambda: state_file)
+    yield state_file
+
+
+@pytest.fixture
+def register_module():
+    return importlib.import_module("inflight-register".replace("-", "_")) \
+        if False else _import_script("inflight-register")
+
+
+@pytest.fixture
+def deregister_module():
+    return _import_script("inflight-deregister")
+
+
+@pytest.fixture
+def check_module():
+    return _import_script("inflight-check")
+
+
+def _import_script(name: str):
+    """Import a script with a hyphen in its filename via importlib spec."""
+    import importlib.util
+
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_creates_new_entry(self, tmp_state, register_module):
+        args = register_module.parse_args([
+            "--branch", "feat/foo",
+            "--worktree", ".worktrees/foo",
+            "--issue", "101",
+            "--issue", "102",
+            "--area", "src/A/,src/B/",
+            "--intent", "test work",
+        ])
+        entry = register_module.register(args)
+
+        assert entry["branch"] == "feat/foo"
+        assert entry["issues"] == [101, 102]
+        assert entry["areas"] == ["src/A/", "src/B/"]
+        assert entry["intent"] == "test work"
+        assert len(entry["session_id"]) == 8
+
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        assert data["version"] == 1
+        assert len(data["open_work"]) == 1
+
+    def test_replaces_entry_for_same_branch(self, tmp_state, register_module):
+        a = register_module.parse_args(["--branch", "feat/x", "--issue", "1"])
+        register_module.register(a)
+        b = register_module.parse_args(["--branch", "feat/x", "--issue", "2"])
+        register_module.register(b)
+
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        assert len(data["open_work"]) == 1
+        assert data["open_work"][0]["issues"] == [2]
+
+    def test_keeps_distinct_branches(self, tmp_state, register_module):
+        register_module.register(register_module.parse_args(["--branch", "feat/a"]))
+        register_module.register(register_module.parse_args(["--branch", "feat/b"]))
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        branches = sorted(e["branch"] for e in data["open_work"])
+        assert branches == ["feat/a", "feat/b"]
+
+
+# ---------------------------------------------------------------------------
+# deregister
+# ---------------------------------------------------------------------------
+
+
+class TestDeregister:
+    def test_removes_by_branch(self, tmp_state, register_module, deregister_module):
+        register_module.register(register_module.parse_args(["--branch", "feat/a"]))
+        register_module.register(register_module.parse_args(["--branch", "feat/b"]))
+
+        removed = deregister_module.deregister(branch="feat/a")
+        assert len(removed) == 1
+        assert removed[0]["branch"] == "feat/a"
+
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        assert [e["branch"] for e in data["open_work"]] == ["feat/b"]
+
+    def test_removes_by_session(self, tmp_state, register_module, deregister_module):
+        entry = register_module.register(
+            register_module.parse_args(["--branch", "feat/x", "--session", "deadbeef"])
+        )
+        removed = deregister_module.deregister(session=entry["session_id"])
+        assert len(removed) == 1
+
+    def test_idempotent_when_missing(self, tmp_state, deregister_module):
+        # No entries; deregister should succeed and return [].
+        removed = deregister_module.deregister(branch="feat/never-registered")
+        assert removed == []
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+class TestCheck:
+    def test_no_conflict_returns_empty(self, tmp_state, check_module):
+        conflicts = check_module.check(area="src/Foo/", do_prune=False)
+        assert conflicts == []
+
+    def test_same_issue_is_conflict(self, tmp_state, register_module, check_module):
+        register_module.register(
+            register_module.parse_args(["--branch", "feat/x", "--issue", "802"])
+        )
+        conflicts = check_module.check(issue=802, do_prune=False)
+        assert len(conflicts) == 1
+        assert conflicts[0]["branch"] == "feat/x"
+
+    def test_overlapping_area_is_conflict(self, tmp_state, register_module, check_module):
+        register_module.register(register_module.parse_args([
+            "--branch", "feat/cli",
+            "--area", "src/PPDS.Cli/",
+        ]))
+        # Sub-path of an existing area should conflict.
+        conflicts = check_module.check(
+            area="src/PPDS.Cli/Plugins/Foo.cs", do_prune=False,
+        )
+        assert len(conflicts) == 1
+
+    def test_disjoint_area_is_no_conflict(self, tmp_state, register_module, check_module):
+        register_module.register(register_module.parse_args([
+            "--branch", "feat/cli",
+            "--area", "src/PPDS.Cli/",
+        ]))
+        conflicts = check_module.check(
+            area="src/PPDS.Tui/Screens/", do_prune=False,
+        )
+        assert conflicts == []
+
+    def test_self_excluded(self, tmp_state, register_module, check_module):
+        entry = register_module.register(register_module.parse_args([
+            "--branch", "feat/me",
+            "--session", "11111111",
+            "--issue", "9",
+        ]))
+        # Same session checking its own issue should NOT conflict.
+        conflicts = check_module.check(
+            issue=9, exclude_session=entry["session_id"], do_prune=False,
+        )
+        assert conflicts == []
+
+
+# ---------------------------------------------------------------------------
+# stale pruning
+# ---------------------------------------------------------------------------
+
+
+class TestPrune:
+    def test_prunes_old_entry_with_no_branch(self, tmp_state):
+        import inflight_common as ic
+
+        old_started = (datetime.now(timezone.utc) - timedelta(hours=48)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        state = {
+            "version": 1,
+            "updated": ic.now_utc_iso(),
+            "open_work": [
+                {"branch": "feat/dead", "started": old_started, "issues": [], "areas": []},
+                {"branch": "feat/alive", "started": ic.now_utc_iso(), "issues": [], "areas": []},
+            ],
+        }
+        pruned = ic.prune_stale(state, branch_exists=lambda b: False)
+        assert {p["branch"] for p in pruned} == {"feat/dead"}
+        assert [e["branch"] for e in state["open_work"]] == ["feat/alive"]
+
+    def test_keeps_old_entry_if_branch_exists(self, tmp_state):
+        import inflight_common as ic
+
+        old_started = (datetime.now(timezone.utc) - timedelta(hours=48)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        state = {
+            "version": 1,
+            "updated": ic.now_utc_iso(),
+            "open_work": [
+                {"branch": "feat/active", "started": old_started, "issues": [], "areas": []},
+            ],
+        }
+        pruned = ic.prune_stale(state, branch_exists=lambda b: True)
+        assert pruned == []
+        assert len(state["open_work"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_parallel_registers_no_corruption(self, tmp_state, register_module):
+        """5 concurrent register calls on different branches → 5 entries, valid JSON."""
+
+        def register_one(i: int):
+            args = register_module.parse_args([
+                "--branch", f"feat/parallel-{i}",
+                "--issue", str(1000 + i),
+                "--area", f"src/Module{i}/",
+            ])
+            return register_module.register(args)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+            results = list(pool.map(register_one, range(5)))
+
+        assert len(results) == 5
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        branches = sorted(e["branch"] for e in data["open_work"])
+        assert branches == [f"feat/parallel-{i}" for i in range(5)]
+
+    def test_parallel_register_then_deregister(self, tmp_state, register_module,
+                                                deregister_module):
+        """Register 5, deregister 5 in interleaved fashion."""
+
+        for i in range(5):
+            args = register_module.parse_args(["--branch", f"feat/p-{i}"])
+            register_module.register(args)
+
+        def deregister_one(i: int):
+            return deregister_module.deregister(branch=f"feat/p-{i}")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+            list(pool.map(deregister_one, range(5)))
+
+        data = json.loads(tmp_state.read_text(encoding="utf-8"))
+        assert data["open_work"] == []
+
+
+# ---------------------------------------------------------------------------
+# Retro B3 scenario: three sessions overlap, last one filing duplicate issue
+# ---------------------------------------------------------------------------
+
+
+class TestRetroB3Scenario:
+    """Reproduce the exact scenario that produced issue #802.
+
+    Wave timeline:
+      * t=0   session ce9a2a05 ships feature in PR #797 (registers area X)
+      * t=+5h session b293be36 wakes up, considers filing issue #802
+              ("feature missing in area X") — should see ce9a2a05's claim
+              and halt.
+      * t=+6h session cd0c578e starts work, sees both prior entries.
+    """
+
+    def test_check_blocks_duplicate_filing(self, tmp_state, register_module,
+                                            check_module):
+        # Session A ships feature in area X.
+        register_module.register(register_module.parse_args([
+            "--branch", "feat/feature-x",
+            "--session", "ce9a2a05",
+            "--area", "src/PPDS.Audit/Capture/",
+            "--intent", "ship feature X (will become PR #797)",
+        ]))
+
+        # Session B is about to file issue claiming feature X is missing.
+        # Before `gh issue create`, it calls inflight-check.
+        conflicts = check_module.check(
+            area="src/PPDS.Audit/Capture/",
+            exclude_session="b293be36",
+            do_prune=False,
+        )
+        assert len(conflicts) == 1, "session B should see ce9a2a05's claim"
+        assert conflicts[0]["session_id"] == "ce9a2a05"
+
+        # Session C starts work, also detects the active claim.
+        conflicts_c = check_module.check(
+            area="src/PPDS.Audit/Capture/Pipeline.cs",
+            exclude_session="cd0c578e",
+            do_prune=False,
+        )
+        assert len(conflicts_c) == 1
+        assert conflicts_c[0]["session_id"] == "ce9a2a05"


### PR DESCRIPTION
## Summary

Adds a lightweight file-based coordination layer at
`.claude/state/in-flight-issues.json` so concurrent Claude sessions in
sibling worktrees can detect overlapping work before it escalates to
duplicate issues or misattributed PRs.

This is **one of 5 parallel PRs from v1-launch retro Wave 1**.

> **Do not auto-merge** — orchestrator marks ready after CI.

## Motivation

From the v1-launch retro (item #12, finding **B3**):

- Session `b293be36` filed **#802** at 03:46Z claiming a feature was
  missing.
- Sibling session `ce9a2a05` had shipped that exact feature **5h51m
  earlier** in **PR #797**.
- Closer session `cd0c578e` then misattributed the fix to **PR #792**.

Root cause: no shared in-flight state across concurrent sessions. Each
session was working in isolation in its own worktree with no signal
that someone else was already on the same area.

## Schema

```json
{
  "version": 1,
  "updated": "2026-04-19T01:30:00Z",
  "open_work": [
    {
      "session_id": "ce9a2a05",
      "started": "2026-04-18T22:00:00Z",
      "branch": "feat/audit-capture-pipeline",
      "worktree": ".worktrees/audit-capture-pipeline",
      "issues": [801],
      "areas": ["src/PPDS.Audit/Capture/", "scripts/audit-capture/"],
      "intent": "audit-capture pipeline implementation"
    }
  ]
}
```

## What's wired

| Surface | Hook |
|---|---|
| `/start` skill | Step 4b: `inflight-check.py --area / --issue` (warn + ask before continuing). Step 5c: `inflight-register.py` after worktree creation. |
| `/backlog` skill | Pre-flight `inflight-check.py` before `gh issue create` AND before `gh issue close` (the closer sees sibling work). |
| `/cleanup` skill | New step 4c: `inflight-deregister.py --branch <X>` for each removed branch + a no-op `inflight-check.py` to trigger stale-entry sweep. |

## Files

- `scripts/inflight_common.py` — locking, pruning, conflict detection.
- `scripts/inflight-register.py` — adds an entry, idempotent on branch.
- `scripts/inflight-deregister.py` — removes by branch or session.
- `scripts/inflight-check.py` — exits 1 + JSON if conflict.
- `tests/state/test_inflight.py` — 16 tests, includes the retro B3 scenario.
- `.claude/state/in-flight-issues.json` — seed file (committed empty).
- `.gitattributes` — `merge=union` on the state file to reduce merge pain.

## Design tradeoffs

- **Locking:** OS-level exclusive lock via `fcntl` (POSIX) / `msvcrt`
  (Windows) is held for the read-modify-write window. Prevents JSON
  corruption under concurrent writes.
- **Race acceptance (v1):** simultaneous registers for the *same* issue
  produce two valid entries. Stronger guarantees (de-dup on register,
  designate canonical claim) deferred — v1 surfaces both via `check`,
  which is the fix point that mattered for the #802 incident.
- **Stale pruning:** entries > 24h old whose branch no longer exists
  locally are auto-removed. Conservative (keeps if `git` unavailable).
- **Area conflict rule:** path-prefix overlap, so
  `src/PPDS.Cli/` and `src/PPDS.Cli/Plugins/Foo.cs` collide. Avoids
  needing exact-match coordination.
- **Drive-by hook fix:** `protect-main-branch.py` now also recognises
  `.claude/worktrees/` (the new agent worktree layout) so Edit/Write
  tools work inside isolated agent sessions. Without this, the in-flight
  scripts could not have been authored from an agent worktree.

## Test plan

- [x] Unit tests for register / deregister / check (12 tests, all pass)
- [x] Concurrency test: 5x parallel `register` via
      `ThreadPoolExecutor`, asserts no JSON corruption + all 5 entries
      present
- [x] Concurrency test: register 5 then deregister 5 in parallel,
      asserts open_work ends empty
- [x] Stale-pruning tests (entry kept when branch exists; pruned when
      gone and >24h)
- [x] **Retro B3 scenario:** session A registers area X; session B
      attempting to file new issue in area X gets conflict pointing at
      session A; session C also detects A's claim
- [x] CLI smoke test from main repo root: register -> check (exit 1)
      -> deregister -> check (exit 0)
- [ ] Verified against a real 3-session run (post-merge)

```
$ python -m pytest tests/state/test_inflight.py -v
============================== 16 passed in 1.03s ==============================
```

## Out of scope (follow-ups)

- Telemetry: emit a metric when `inflight-check` returns conflict so we
  can track how often this catches real overlap.
- TUI surface: render the in-flight registry as a worktree-status
  panel for the operator.
- De-dup on register for stronger same-issue race handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)