### PR TITLE
feat(skill): /dependabot-triage skill (codifies session a6f07099 pattern)

### DIFF
--- a/.claude/skills/dependabot-triage/SKILL.md
+++ b/.claude/skills/dependabot-triage/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: dependabot-triage
+description: Triage and merge open dependabot PRs per docs/MERGE-POLICY.md — classify each PR (auto-merge / verify-then-merge / manual review), enable auto-merge for safe ones, run targeted test suites for risky ones, and surface anything needing human judgment. Use when there's a backlog of dependabot PRs, after a quiet period, or as a routine drain.
+---
+
+# Dependabot Triage
+
+Routine drain of open `app/dependabot` PRs against `docs/MERGE-POLICY.md`. Codifies the pattern from session `a6f07099` (v1-prelaunch retro item B4, finding #9): three-group classification (auto-merge / verify-then-merge / manual review), batched `gh pr merge --auto`, bounded retry on rebase, and silent completion when nothing needs human input.
+
+This skill assumes `allow_auto_merge` is enabled at the repo level (it currently is). The skill will halt if it is not — it does not flip the bit itself.
+
+## When to Use
+
+- "Drain the dependabot backlog"
+- "Triage open dependabot PRs"
+- "Check on the dependabot PRs"
+- After a quiet period when several dependabot PRs have accumulated
+- After a release window closes and dependabot work was deferred
+- Periodically as housekeeping (Wednesday afternoons after the Monday dependabot run, etc.)
+
+## When NOT to Use
+
+- During an active release (release branch present, tags being pushed) — wait until the release lands
+- For non-dependabot dependency PRs (human-authored bumps, e.g. a deliberate Microsoft.Identity.Client major bump) — those route through `/pr` like any feature work
+- For first-time enablement of auto-merge on the repo — that's a one-time admin action, not a triage step
+- For changing the merge policy itself — `docs/MERGE-POLICY.md` is authoritative; if you find policy gaps, file an issue and stop
+
+## Authoritative Reference
+
+`docs/MERGE-POLICY.md` is the source of truth for what merges automatically and what doesn't. This skill operationalizes it; it does not redefine it. If the skill and the doc disagree, the doc wins and the skill needs a patch.
+
+## Pre-conditions
+
+Run all of these checks before touching any PR. Halt on any failure with a clear instruction to the user.
+
+1. **Auto-merge enabled at the repo level.**
+   ```bash
+   gh repo view --json autoMergeAllowed --jq .autoMergeAllowed
+   ```
+   Must be `true`. If `false`, halt: "Auto-merge is not enabled on this repo. Enable via repo Settings > General > Pull Requests > Allow auto-merge, then retry."
+
+2. **`docs/MERGE-POLICY.md` exists.**
+   ```bash
+   test -f docs/MERGE-POLICY.md && echo OK
+   ```
+   If missing, halt: "docs/MERGE-POLICY.md is missing — this skill operationalizes that policy. Restore the file before triaging."
+
+3. **No active release in progress.**
+   ```bash
+   git branch -a | grep -E 'release/(v|prerelease-)' || echo "no release branches"
+   git tag --list --contains HEAD | grep -E '^(Auth|Cli|Dataverse|Mcp|Migration|Plugins|Query|Extension)-v' || echo "no recent release tags"
+   ```
+   If a release branch exists OR HEAD already carries a release tag from the current minute, halt: "A release appears to be in progress (branch: X). Re-run after the release PR merges and tags settle."
+
+4. **No conflicting in-flight work.**
+   ```bash
+   test -f .claude/state/in-flight-issues.json && cat .claude/state/in-flight-issues.json || echo '{"in_flight": []}'
+   ```
+   If the file exists and any entry overlaps with files this triage would touch (e.g., dependabot PR is bumping a package whose csproj is being modified by an in-flight feature), surface the conflict and ask the user before proceeding. If the file does not exist (it ships in a later PR), this check passes — log "in-flight tracking not yet present, skipping" and continue.
+
+If any pre-condition fails, write a one-line summary of which check tripped and stop. Do not attempt to remediate.
+
+## Process
+
+### Phase 1 — Pre-flight checks
+
+Run the four pre-condition checks above. Halt with a clear instruction on any failure.
+
+### Phase 2 — Enumerate
+
+```bash
+gh pr list \
+  --author "app/dependabot" \
+  --state open \
+  --json number,title,labels,headRefName,createdAt,files,body,url \
+  > /tmp/dependabot-prs.json
+```
+
+Group by:
+- **Ecosystem:** `npm`, `nuget`, `github-actions` — derived from PR labels (`nuget`, `npm`/`javascript`, `github_actions`) or, as a fallback, from `headRefName` (`dependabot/<ecosystem>/...`).
+- **Update type:** `patch` / `minor` / `major` — parsed from the title (`Bump X from A.B.C to A.B.C+1` is patch; `from A.B to A.C` is minor; `from A to B` is major).
+
+Report the grouped counts before proceeding so the user (or future skill log) knows the shape of the queue.
+
+If zero open dependabot PRs, report "Nothing to triage" and exit successfully (no notification).
+
+### Phase 3 — Classify each PR
+
+For each PR, classify into exactly one of three groups using `scripts/dependabot/classify.py` (delegate to keep SKILL.md prose-focused). The classifier returns a `(group, reason)` tuple per PR.
+
+The classification rules, summarized from `docs/MERGE-POLICY.md` plus the v1-prelaunch retro decision:
+
+#### Group A — auto-merge eligible
+
+PRs where green CI is sufficient evidence to ship. Includes:
+
+- Patch-version bumps on non-critical paths (e.g., `Bump knip from 6.1.0 to 6.3.0`)
+- Tooling/test bumps regardless of patch/minor (eslint, knip, vitest, esbuild, @types/*, @playwright/test, Microsoft.NET.Test.Sdk)
+- GitHub Actions group bumps (patch or minor)
+- Lockfile-only changes (no `package.json` / `*.csproj` / `Directory.Packages.props` changes in the diff)
+
+**Action:**
+```bash
+gh pr merge <num> --squash --delete-branch --auto
+```
+
+Then move on — CI will merge it when green. Do not hold the session waiting.
+
+#### Group B — verify-then-merge
+
+PRs where green CI is necessary but you want to run the package-specific test suite locally first before letting auto-merge land it. Includes:
+
+- Minor-version bumps on libraries that are not auth-critical but touch user-visible runtime (e.g., Terminal.Gui minor)
+- Bumps to `Microsoft.Identity.Client`, `Azure.Identity`, `Microsoft.PowerPlatform.Dataverse.Client` at minor — these touch auth/Dataverse runtime
+- Anything bumping packages flagged as security-critical in `Directory.Packages.props` (e.g., `System.Security.Cryptography.Xml`)
+- Bumps that touch `src/PPDS.Auth/**` or strong-name signing paths at any version
+
+**Action:** Spin a sub-task per PR (sequentially, not parallel — the test runs are heavy):
+1. Check the PR out locally into a throwaway worktree (or fetch the head ref) — do NOT pollute the current worktree.
+2. Run the package-specific test suite:
+   - **NuGet bump touching `src/PPDS.Auth/**`:** `dotnet test tests/PPDS.Auth.Tests --filter "Category!=Integration" -v q`
+   - **NuGet bump touching `src/PPDS.Dataverse/**`:** `dotnet test tests/PPDS.Dataverse.Tests --filter "Category!=Integration" -v q`
+   - **NuGet bump elsewhere:** `dotnet test PPDS.sln --filter "Category!=Integration" -v q` (full unit suite — minor bumps are rare enough that the runtime is acceptable)
+   - **Extension/npm bump:** `( cd src/PPDS.Extension && npm test && npm run typecheck )`
+3. If green, enable auto-merge: `gh pr merge <num> --squash --delete-branch --auto`. If red, escalate — leave a comment on the PR with the failure summary and tag Josh.
+4. Tear down the throwaway worktree (`git worktree remove`).
+
+#### Group C — manual review required
+
+Hard exclusions — do NOT auto-merge under any circumstances:
+
+- **ANY major-version bump** (per the v1-prelaunch retro decision — universal exclusion, no exceptions)
+- Bumps that remove or rename APIs flagged in the package's changelog (look for "Breaking" / "BREAKING CHANGE" / "removed")
+- Anything in `docs/MERGE-POLICY.md`'s "When NOT to use auto-merge" list that doesn't fit Group B's verify-then-merge pattern (e.g., changes to CI/CD pipelines via `actions/*` major bumps)
+
+**Action:**
+1. Do NOT enable auto-merge.
+2. Add a comment on the PR explaining the classification and tagging Josh:
+   ```bash
+   gh pr comment <num> --body "Triage classification: Group C (manual review required).
+Reason: <reason from classifier>.
+Per docs/MERGE-POLICY.md and v1-prelaunch retro decision, this requires human review before merge.
+@joshsmithxrm please evaluate."
+   ```
+3. **Superseded check:** If a newer dependabot PR bumps the same package to a higher version (compare `headRefName` package + version), AND the newer PR's body or commits explicitly mark this one as superseded (or the version range strictly contains this one), close this PR with `gh pr close <num> --comment "Superseded by #<newer>."`. Do NOT close on guess — require explicit superseded marker or strict version-range containment. When in doubt, leave both open and let Josh decide.
+
+### Phase 4 — Drain monitor
+
+After Phase 3 dispatches the initial actions, monitor the Group A and Group B PRs to landing. This is bounded — do not poll forever.
+
+For each PR in Group A or Group B:
+
+1. Poll `gh pr view <num> --json state,mergeStateStatus,statusCheckRollup` every 30s.
+2. If `state == "MERGED"`, record final state and move on.
+3. If `mergeStateStatus == "BEHIND"` (main has advanced), run `gh pr update-branch <num>` once.
+4. If `statusCheckRollup` shows any check `CONCLUSION == "FAILURE"`, escalate immediately — comment on the PR with the failed check name and tag Josh; do not retry.
+5. Maximum **3 retry cycles per PR** (where a "cycle" is one rebase + wait-for-CI). After 3, escalate to Josh: comment "Drain stalled after 3 retry cycles. Last status: <X>. Manual intervention needed."
+
+Total skill wall-time cap: **30 minutes**. If the monitor hasn't drained the queue in 30 minutes, report current state and exit — the user can re-run later. Do not keep the session pinned indefinitely.
+
+### Phase 5 — Report
+
+Print a summary table:
+
+```
+| PR # | Group | Final state | Reason |
+|------|-------|-------------|--------|
+| #807 | A     | merged      | patch knip 6.3.0->6.3.1 |
+| #808 | A     | awaiting CI | patch eslint 9.1->9.2 |
+| #809 | B     | merged      | Microsoft.Identity.Client minor (tests passed) |
+| #810 | C     | manual      | Terminal.Gui major 1.x->2.x |
+| #811 | C     | closed      | Superseded by #810 |
+```
+
+Then surface anything that fell out of normal flow:
+- Rebase failures
+- Test failures (with test name + failure summary)
+- Classification ambiguity (e.g., a PR the classifier returned with low confidence)
+
+**Notification policy** (per v1 notification criteria):
+- **Silent** on routine drains (everything in Group A merged, Group B merged after green tests, Group C commented and waiting for Josh — no surprises)
+- **PushNotification to Josh** ONLY if:
+  - A Group B test run failed (someone needs to investigate)
+  - A drain stalled past 3 retries on a PR (CI is broken or main is unstable)
+  - The classifier returned an ambiguous case the skill couldn't resolve
+  - A pre-condition check failed mid-run (auto-merge got disabled, MERGE-POLICY.md got deleted)
+
+Use the standard PushNotification mechanism — see existing notification helpers in other skills (`/pr`, `/qa`).
+
+## Post-conditions
+
+After a successful run:
+- Every open dependabot PR has been classified and either auto-merge-enabled, merged, commented for manual review, or closed-as-superseded.
+- A summary table is in the session transcript.
+- No PR is in a half-merged or half-rebased state.
+- Throwaway worktrees from Group B verifications are cleaned up (`git worktree list` shows none).
+- `.claude/state/in-flight-issues.json` (if present) is unchanged — this skill does not write workflow state; it's a maintenance task, not a workflow gate.
+
+## Edge Cases
+
+| Situation | Handling |
+|-----------|----------|
+| Zero open dependabot PRs | Report "Nothing to triage" and exit silently — no notification. |
+| Dependabot PR with no labels (rare) | Fall back to `headRefName` parsing for ecosystem; if still ambiguous, classify Group C with reason "labels and head ref both ambiguous". |
+| Dependabot grouped PR (`Bump the npm_and_yarn group across...`) | Classify by the highest update type in the group. If any member is a major bump, the whole PR is Group C. |
+| PR bumps two packages where one is auth-critical and one is not | Treat as Group B — the auth-critical bump dominates. |
+| `gh pr update-branch` fails with merge conflict | Escalate immediately — do not retry. Comment on PR with conflict detail and tag Josh. |
+| CI is down / red on `main` | Pre-condition check 3 catches active releases but not "main is broken" — the drain monitor will see all checks fail. After the first PR shows non-package-specific check failures (e.g., infrastructure tests), abort the drain, report "CI on main appears broken — halting drain", and notify Josh. |
+| Newer PR exists that supersedes the one being triaged but without an explicit "Superseded by" marker | Leave both open; flag in the report under "classification ambiguity" for Josh to resolve. Do NOT close on inference alone. |
+| Auto-merge gets disabled mid-run (rare — admin action) | The next `gh pr merge --auto` call will fail with a clear error. Catch the failure, halt the drain, report "Auto-merge was disabled mid-run", and notify Josh. |
+| A PR has been open >30 days | Surface in the report under "stale" but do NOT auto-close — Josh decides whether to close or rebase. |
+
+## Examples
+
+### Example 1: Quiet drain
+
+```
+$ /dependabot-triage
+Pre-flight checks... OK (4/4)
+Enumerating... 5 open PRs (4 npm patch, 1 nuget patch)
+Classifying...
+  #820 (Group A): patch eslint 9.1.1->9.1.2
+  #821 (Group A): patch knip 6.3.0->6.3.1
+  #822 (Group A): patch @types/node 22.5->22.6
+  #823 (Group A): patch vitest 2.0.5->2.0.6
+  #824 (Group A): patch Microsoft.NET.Test.Sdk 17.10->17.11
+Enabling auto-merge on 5 PRs...
+Monitoring drain (timeout 30m)...
+  #820 merged in 2m
+  #821 merged in 2m
+  #822 merged in 3m
+  #823 merged in 3m
+  #824 merged in 4m
+Done. 5/5 merged. (silent — nothing requiring input)
+```
+
+### Example 2: Mixed batch with one Group C
+
+```
+$ /dependabot-triage
+Pre-flight checks... OK (4/4)
+Enumerating... 3 open PRs
+Classifying...
+  #830 (Group A): patch eslint 9.1.1->9.1.2
+  #831 (Group B): minor Microsoft.Identity.Client 4.55->4.56 (auth-critical)
+  #832 (Group C): MAJOR Terminal.Gui 1.19->2.0 (universal major exclusion)
+Group A: enabling auto-merge on #830
+Group B: running tests/PPDS.Auth.Tests for #831...
+  PASSED (24s, 142 tests)
+  Enabling auto-merge on #831
+Group C: commenting on #832, tagging Josh
+Monitoring drain...
+  #830 merged in 2m
+  #831 merged in 4m
+Done. 2 merged, 1 awaiting manual review (#832). (PushNotification: 1 manual review needed)
+```
+
+### Example 3: Group B test failure
+
+```
+$ /dependabot-triage
+Pre-flight checks... OK (4/4)
+Enumerating... 1 open PR
+Classifying...
+  #840 (Group B): minor Azure.Identity 1.12->1.13 (auth-critical)
+Group B: running tests/PPDS.Auth.Tests for #840...
+  FAILED (62s, 2 failed of 142)
+    - PPDS.Auth.Tests.AzureCliCredentialTests.AcquiresTokenForResource
+    - PPDS.Auth.Tests.ChainedCredentialTests.FallsBackOnFailure
+Commented on #840 with failure summary, tagged Josh.
+Done. 0 merged, 1 escalated. (PushNotification: Group B test failure on #840)
+```
+
+## Rules
+
+1. **Major-version bumps are always Group C.** No exceptions. The v1-prelaunch retro made this universal.
+2. **Never close a PR without strong superseded evidence.** Explicit "Superseded by #N" marker or strict version-range containment. Inference is not enough.
+3. **Never enable auto-merge on Group C.** The whole point of Group C is human gating.
+4. **Never modify `docs/MERGE-POLICY.md`.** It's authoritative. Surface policy gaps as issues, do not patch in flight.
+5. **Bounded retries.** 3 cycles per PR, 30 minutes total. After that, report and exit — do not pin the session.
+6. **Silent on routine.** Notifications only when something needs Josh's input. Routine drains are silent.
+7. **Sequential Group B verifications.** Test runs are heavy; running them in parallel risks resource contention and confusing failure attribution.
+
+## References
+
+- Authoritative policy: `docs/MERGE-POLICY.md`
+- v1-prelaunch retro item #9 (B4 finding): codifies session `a6f07099`'s 3-group pattern
+- Proof points: PRs #805, #806 merged autonomously in ~2 minutes once auto-merge was on
+- Dependabot config: `.github/dependabot.yml`
+- Classifier: `scripts/dependabot/classify.py`
+- Classifier tests: `tests/scripts/dependabot/test_classify.py`

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -114,9 +114,10 @@ class Classification:
 
 
 # Regex for "Bump <pkg> from <a> to <b>" (case-insensitive on Bump).
-# Captures package and both versions. Handles npm-scoped (@org/pkg) and NuGet (Foo.Bar.Baz).
+# Captures package and both versions. Handles npm-scoped (@org/pkg), NuGet
+# (Foo.Bar.Baz), and GitHub Actions style "v"-prefixed versions (e.g. v3 -> v4).
 _BUMP_TITLE_RE = re.compile(
-    r"^[Bb]ump\s+(?P<pkg>[@A-Za-z0-9._/-]+)\s+from\s+(?P<from>[0-9][^\s]*)\s+to\s+(?P<to>[0-9][^\s]*)",
+    r"^[Bb]ump\s+(?P<pkg>[@A-Za-z0-9._/-]+)\s+from\s+(?P<from>v?[0-9][^\s]*)\s+to\s+(?P<to>v?[0-9][^\s]*)",
 )
 
 # Regex for grouped bumps: "Bump the <group> group ..."
@@ -170,12 +171,16 @@ def classify_update_type(from_v: Optional[str], to_v: Optional[str]) -> str:
     while len(tp) < 3:
         tp.append(0)
 
+    # Any downgrade (lexicographic on the version tuple) is treated as
+    # major-equivalent — requires manual review per docs/MERGE-POLICY.md.
+    # Catches not only major downgrades (2.x -> 1.x) but also minor (1.2 -> 1.1)
+    # and patch (1.0.2 -> 1.0.1) downgrades that would otherwise be classified
+    # as 'minor'/'patch' and slip through auto-merge gates.
+    if tp < fp:
+        return "major"
     if tp[0] > fp[0]:
         return "major"
-    if tp[0] < fp[0]:
-        # Downgrade — treat as major-equivalent (requires manual review)
-        return "major"
-    if tp[1] != fp[1]:
+    if tp[1] > fp[1]:
         return "minor"
     return "patch"
 
@@ -226,17 +231,25 @@ def touches_auth_critical_path(files: Iterable[str]) -> bool:
     return False
 
 
+_LOCKFILE_BASENAMES = frozenset({
+    "package-lock.json",
+    "packages.lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+})
+
+
 def is_lockfile_only(files: Iterable[str]) -> bool:
-    """True if the diff only touches lock files (package-lock.json, packages.lock.json)."""
+    """True if the diff only touches well-known lock files.
+
+    Uses exact basename matching to avoid false positives like
+    ``custom-package-lock.json`` or ``docs/package-lock.json.md`` slipping
+    through ``str.endswith`` checks.
+    """
     files = list(files)
     if not files:
         return False
-    return all(
-        f.endswith("package-lock.json")
-        or f.endswith("packages.lock.json")
-        or f.endswith("yarn.lock")
-        for f in files
-    )
+    return all(f.split("/")[-1] in _LOCKFILE_BASENAMES for f in files)
 
 
 def changelog_signals_breaking(body: str) -> bool:

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Classify dependabot PRs into Group A / B / C per docs/MERGE-POLICY.md.
+
+The /dependabot-triage skill calls this module either as a CLI (one PR's JSON
+on stdin, single classification on stdout) or imports `classify_pr()` directly.
+
+Group A — auto-merge eligible (green CI is sufficient evidence to ship):
+  - Patch bumps on non-critical paths
+  - Tooling/test bumps regardless of patch/minor (eslint, knip, vitest, esbuild,
+    @types/*, @playwright/test, Microsoft.NET.Test.Sdk)
+  - github-actions group bumps (patch/minor)
+  - Lockfile-only diffs
+
+Group B — verify-then-merge (run package-specific tests locally first):
+  - Minor bumps on user-visible runtime libraries (Terminal.Gui, etc.)
+  - Bumps to auth-critical packages (Microsoft.Identity.Client, Azure.Identity,
+    Microsoft.PowerPlatform.Dataverse.Client) at minor
+  - Anything bumping security-flagged packages
+  - Bumps that touch src/PPDS.Auth/** at any version
+
+Group C — manual review required (do NOT auto-merge):
+  - ANY major-version bump (universal exclusion per v1-prelaunch retro)
+  - Bumps with "Breaking" / "BREAKING CHANGE" / removed APIs in the changelog
+  - Bumps to CI/CD pipelines via actions/* major
+  - Anything in MERGE-POLICY's "When NOT to use auto-merge" list that isn't Group B
+
+The ground truth for the policy is docs/MERGE-POLICY.md. If this file and that
+file disagree, the doc wins and this file needs a patch.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+# Packages whose bumps go through the verify-then-merge gate at any non-major version.
+# Sourced from docs/MERGE-POLICY.md "When NOT to use auto-merge" plus the v1-prelaunch
+# triage session's discovered list.
+AUTH_CRITICAL_PACKAGES = frozenset({
+    "microsoft.identity.client",
+    "microsoft.identity.client.extensions.msal",
+    "azure.identity",
+    "azure.core",
+    "microsoft.powerplatform.dataverse.client",
+    "system.security.cryptography.xml",
+    "system.security.cryptography.pkcs",
+})
+
+# Packages whose patch/minor bumps are tooling (Group A regardless of update type).
+# These touch dev-time tooling, never runtime.
+TOOLING_PACKAGES = frozenset({
+    "eslint",
+    "knip",
+    "vitest",
+    "esbuild",
+    "@playwright/test",
+    "playwright",
+    "prettier",
+    "typescript",
+    "typescript-eslint",
+    "@typescript-eslint/parser",
+    "@typescript-eslint/eslint-plugin",
+    "microsoft.net.test.sdk",
+    "xunit",
+    "xunit.runner.visualstudio",
+    "coverlet.collector",
+    "moq",
+    "fluentassertions",
+    "fakeitem",
+    "fakexrmeasy",
+    "fakexrmeasy.v9",
+})
+
+# Tooling package name *prefixes* (e.g., @types/* are all tooling)
+TOOLING_PREFIXES = (
+    "@types/",
+    "fakexrmeasy",
+)
+
+# Paths that elevate any bump to at least Group B.
+AUTH_CRITICAL_PATH_PREFIXES = (
+    "src/PPDS.Auth/",
+    "src/PPDS.Plugins/",  # strong-name signing surface
+)
+
+
+@dataclass(frozen=True)
+class Classification:
+    """Result of classifying a single dependabot PR."""
+
+    pr_number: int
+    group: str  # "A" | "B" | "C"
+    reason: str
+    ecosystem: str  # "npm" | "nuget" | "github-actions" | "unknown"
+    update_type: str  # "patch" | "minor" | "major" | "unknown"
+    package: Optional[str]
+    from_version: Optional[str]
+    to_version: Optional[str]
+
+    def to_dict(self) -> dict:
+        return {
+            "pr_number": self.pr_number,
+            "group": self.group,
+            "reason": self.reason,
+            "ecosystem": self.ecosystem,
+            "update_type": self.update_type,
+            "package": self.package,
+            "from_version": self.from_version,
+            "to_version": self.to_version,
+        }
+
+
+# Regex for "Bump <pkg> from <a> to <b>" (case-insensitive on Bump).
+# Captures package and both versions. Handles npm-scoped (@org/pkg) and NuGet (Foo.Bar.Baz).
+_BUMP_TITLE_RE = re.compile(
+    r"^[Bb]ump\s+(?P<pkg>[@A-Za-z0-9._/-]+)\s+from\s+(?P<from>[0-9][^\s]*)\s+to\s+(?P<to>[0-9][^\s]*)",
+)
+
+# Regex for grouped bumps: "Bump the <group> group ..."
+_GROUP_TITLE_RE = re.compile(r"^[Bb]ump\s+the\s+(?P<group>[A-Za-z0-9_.-]+)\s+group", re.IGNORECASE)
+
+
+def parse_title(title: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Parse a dependabot PR title.
+
+    Returns (package, from_version, to_version). Any may be None if parsing failed.
+    For grouped bumps ("Bump the X group ..."), package is "group:<name>" and
+    versions are None (the caller must inspect the body / files for individual bumps).
+    """
+    m = _BUMP_TITLE_RE.match(title.strip())
+    if m:
+        return m.group("pkg"), m.group("from"), m.group("to")
+    g = _GROUP_TITLE_RE.match(title.strip())
+    if g:
+        return f"group:{g.group('group')}", None, None
+    return None, None, None
+
+
+def classify_update_type(from_v: Optional[str], to_v: Optional[str]) -> str:
+    """Compare two version strings and return 'patch' / 'minor' / 'major' / 'unknown'.
+
+    Strips a leading 'v' if present. Handles SemVer-ish strings (X.Y.Z, X.Y, X)
+    and pre-release suffixes (1.0.0-beta.1) by comparing only the numeric prefix.
+    """
+    if not from_v or not to_v:
+        return "unknown"
+
+    def parts(v: str) -> list[int]:
+        v = v.lstrip("v").split("-")[0].split("+")[0]  # strip prerelease/build
+        out = []
+        for p in v.split("."):
+            try:
+                out.append(int(p))
+            except ValueError:
+                # Non-numeric segment — treat as a hard stop (not comparable as semver)
+                break
+        return out
+
+    fp = parts(from_v)
+    tp = parts(to_v)
+    if not fp or not tp:
+        return "unknown"
+
+    # Pad to length 3
+    while len(fp) < 3:
+        fp.append(0)
+    while len(tp) < 3:
+        tp.append(0)
+
+    if tp[0] > fp[0]:
+        return "major"
+    if tp[0] < fp[0]:
+        # Downgrade — treat as major-equivalent (requires manual review)
+        return "major"
+    if tp[1] != fp[1]:
+        return "minor"
+    return "patch"
+
+
+def detect_ecosystem(labels: Iterable[str], head_ref: str) -> str:
+    """Determine ecosystem from labels first, then headRefName fallback."""
+    label_set = {lbl.lower() for lbl in labels}
+    if "nuget" in label_set:
+        return "nuget"
+    if "npm" in label_set or "javascript" in label_set or "npm_and_yarn" in label_set:
+        return "npm"
+    if "github_actions" in label_set or "github-actions" in label_set:
+        return "github-actions"
+
+    # Fallback — dependabot/<ecosystem>/...
+    parts = head_ref.split("/")
+    if len(parts) >= 2 and parts[0] == "dependabot":
+        eco = parts[1].lower()
+        if eco == "nuget":
+            return "nuget"
+        if eco in ("npm_and_yarn", "npm"):
+            return "npm"
+        if eco == "github_actions":
+            return "github-actions"
+    return "unknown"
+
+
+def is_tooling_package(pkg: Optional[str]) -> bool:
+    if not pkg:
+        return False
+    p = pkg.lower()
+    if p in TOOLING_PACKAGES:
+        return True
+    return any(p.startswith(prefix) for prefix in TOOLING_PREFIXES)
+
+
+def is_auth_critical_package(pkg: Optional[str]) -> bool:
+    if not pkg:
+        return False
+    return pkg.lower() in AUTH_CRITICAL_PACKAGES
+
+
+def touches_auth_critical_path(files: Iterable[str]) -> bool:
+    for f in files:
+        for prefix in AUTH_CRITICAL_PATH_PREFIXES:
+            if f.startswith(prefix):
+                return True
+    return False
+
+
+def is_lockfile_only(files: Iterable[str]) -> bool:
+    """True if the diff only touches lock files (package-lock.json, packages.lock.json)."""
+    files = list(files)
+    if not files:
+        return False
+    return all(
+        f.endswith("package-lock.json")
+        or f.endswith("packages.lock.json")
+        or f.endswith("yarn.lock")
+        for f in files
+    )
+
+
+def changelog_signals_breaking(body: str) -> bool:
+    """Detect breaking-change markers in the PR body."""
+    if not body:
+        return False
+    needles = ("BREAKING CHANGE", "Breaking change", "Breaking Changes", "[breaking]")
+    return any(n in body for n in needles)
+
+
+def classify_pr(pr: dict) -> Classification:
+    """Classify a single dependabot PR.
+
+    `pr` is a dict shaped like the output of `gh pr view --json
+    number,title,labels,headRefName,files,body`. The classifier is defensive:
+    missing fields default to safe (Group C with reason "ambiguous").
+    """
+    number = int(pr.get("number", 0))
+    title = pr.get("title", "")
+    body = pr.get("body", "") or ""
+    labels = [lbl.get("name", "") for lbl in pr.get("labels", [])]
+    head_ref = pr.get("headRefName", "")
+    files = [f.get("path", "") for f in pr.get("files", [])]
+
+    pkg, from_v, to_v = parse_title(title)
+    ecosystem = detect_ecosystem(labels, head_ref)
+    update_type = classify_update_type(from_v, to_v)
+
+    # Grouped bumps need conservative handling — defer to Group C if any member could be major.
+    if pkg and pkg.startswith("group:"):
+        # Without per-member version info on stdin, the safe default is Group A only
+        # for groups that are explicitly tooling/test (named in the dependabot.yml as such)
+        # and patch/minor only. The skill SKILL.md documents how to escalate — here,
+        # default to Group B so the skill operator sees the group and decides.
+        return Classification(
+            pr_number=number,
+            group="B",
+            reason=f"grouped bump '{pkg}' — inspect members for highest update type",
+            ecosystem=ecosystem,
+            update_type="unknown",
+            package=pkg,
+            from_version=None,
+            to_version=None,
+        )
+
+    # Hard exclusion — major bumps are always Group C, no exceptions (v1-prelaunch retro).
+    if update_type == "major":
+        return Classification(
+            pr_number=number,
+            group="C",
+            reason=f"major-version bump ({from_v} -> {to_v}) — universal manual-review exclusion",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Breaking-change markers in body — Group C even if version looks minor.
+    if changelog_signals_breaking(body):
+        return Classification(
+            pr_number=number,
+            group="C",
+            reason="PR body signals BREAKING CHANGE — manual review",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Touches auth-critical path — at least Group B regardless of version.
+    if touches_auth_critical_path(files):
+        return Classification(
+            pr_number=number,
+            group="B",
+            reason=f"diff touches auth-critical path (e.g., src/PPDS.Auth) — verify-then-merge",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Auth-critical package at minor — Group B.
+    if is_auth_critical_package(pkg) and update_type == "minor":
+        return Classification(
+            pr_number=number,
+            group="B",
+            reason=f"auth-critical package {pkg} minor bump ({from_v} -> {to_v}) — verify-then-merge",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Tooling package at any non-major — Group A.
+    if is_tooling_package(pkg):
+        return Classification(
+            pr_number=number,
+            group="A",
+            reason=f"tooling/test package {pkg} {update_type} — auto-merge eligible",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Lockfile-only — Group A.
+    if is_lockfile_only(files):
+        return Classification(
+            pr_number=number,
+            group="A",
+            reason="lockfile-only diff — auto-merge eligible",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # github-actions patch/minor — Group A (unless it's a major, caught above).
+    if ecosystem == "github-actions" and update_type in ("patch", "minor"):
+        return Classification(
+            pr_number=number,
+            group="A",
+            reason=f"github-actions {update_type} bump — auto-merge eligible",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Patch on non-critical NuGet/npm — Group A.
+    if update_type == "patch":
+        return Classification(
+            pr_number=number,
+            group="A",
+            reason=f"patch bump on non-critical path ({pkg} {from_v} -> {to_v}) — auto-merge eligible",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Minor bump on a non-tooling, non-auth-critical package — Group B.
+    # User-visible runtime change deserves a local test pass.
+    if update_type == "minor":
+        return Classification(
+            pr_number=number,
+            group="B",
+            reason=f"minor bump ({pkg} {from_v} -> {to_v}) — verify-then-merge for runtime change",
+            ecosystem=ecosystem,
+            update_type=update_type,
+            package=pkg,
+            from_version=from_v,
+            to_version=to_v,
+        )
+
+    # Couldn't parse version — safe default is Group C with reason.
+    return Classification(
+        pr_number=number,
+        group="C",
+        reason=f"could not classify (title='{title}', ecosystem={ecosystem}, update_type={update_type}) — manual review",
+        ecosystem=ecosystem,
+        update_type=update_type,
+        package=pkg,
+        from_version=from_v,
+        to_version=to_v,
+    )
+
+
+def _cli() -> int:
+    """CLI entry point. Reads a JSON array of PRs on stdin, writes classifications on stdout."""
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"error: invalid JSON on stdin: {e}", file=sys.stderr)
+        return 1
+
+    if isinstance(data, dict):
+        data = [data]
+
+    results = [classify_pr(pr).to_dict() for pr in data]
+    json.dump(results, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -1,0 +1,343 @@
+"""Unit tests for scripts/dependabot/classify.py.
+
+Run with: python -m pytest tests/scripts/dependabot/test_classify.py -v
+
+These tests use sample dependabot PR JSON fixtures to verify each classifier
+branch. They are pure functions — no network, no gh CLI, no git.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+# Ensure scripts/ is importable
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dependabot"))
+
+import classify  # noqa: E402
+
+
+def make_pr(
+    number: int = 1,
+    title: str = "",
+    body: str = "",
+    labels=None,
+    head_ref: str = "",
+    files=None,
+) -> dict:
+    """Build a PR dict matching the gh pr view --json shape."""
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": [{"name": n} for n in (labels or [])],
+        "headRefName": head_ref,
+        "files": [{"path": p} for p in (files or [])],
+    }
+
+
+class TestParseTitle(unittest.TestCase):
+    def test_simple_npm_bump(self):
+        pkg, fv, tv = classify.parse_title("Bump knip from 6.1.0 to 6.3.0")
+        self.assertEqual(pkg, "knip")
+        self.assertEqual(fv, "6.1.0")
+        self.assertEqual(tv, "6.3.0")
+
+    def test_scoped_npm_bump(self):
+        pkg, fv, tv = classify.parse_title("Bump @types/node from 22.5.0 to 22.6.0")
+        self.assertEqual(pkg, "@types/node")
+        self.assertEqual(fv, "22.5.0")
+        self.assertEqual(tv, "22.6.0")
+
+    def test_nuget_bump(self):
+        pkg, fv, tv = classify.parse_title("Bump Microsoft.Identity.Client from 4.55.0 to 4.56.0")
+        self.assertEqual(pkg, "Microsoft.Identity.Client")
+        self.assertEqual(fv, "4.55.0")
+        self.assertEqual(tv, "4.56.0")
+
+    def test_grouped_bump(self):
+        pkg, fv, tv = classify.parse_title("Bump the npm_and_yarn group across 1 directory with 2 updates")
+        self.assertEqual(pkg, "group:npm_and_yarn")
+        self.assertIsNone(fv)
+        self.assertIsNone(tv)
+
+    def test_unparseable(self):
+        pkg, fv, tv = classify.parse_title("docs: tweak readme")
+        self.assertIsNone(pkg)
+        self.assertIsNone(fv)
+        self.assertIsNone(tv)
+
+
+class TestClassifyUpdateType(unittest.TestCase):
+    def test_patch(self):
+        self.assertEqual(classify.classify_update_type("1.2.3", "1.2.4"), "patch")
+
+    def test_minor(self):
+        self.assertEqual(classify.classify_update_type("1.2.3", "1.3.0"), "minor")
+
+    def test_major(self):
+        self.assertEqual(classify.classify_update_type("1.2.3", "2.0.0"), "major")
+
+    def test_major_downgrade_treated_as_major(self):
+        # Downgrade is suspicious — treat as major (manual review).
+        self.assertEqual(classify.classify_update_type("2.0.0", "1.9.5"), "major")
+
+    def test_v_prefix_stripped(self):
+        self.assertEqual(classify.classify_update_type("v1.2.3", "v1.2.4"), "patch")
+
+    def test_two_part_minor(self):
+        self.assertEqual(classify.classify_update_type("1.19", "1.20"), "minor")
+
+    def test_two_part_major(self):
+        self.assertEqual(classify.classify_update_type("1.19", "2.0"), "major")
+
+    def test_prerelease_suffix_stripped(self):
+        self.assertEqual(classify.classify_update_type("1.0.0-beta.1", "1.0.0-beta.2"), "patch")
+
+    def test_unknown_when_missing(self):
+        self.assertEqual(classify.classify_update_type(None, "1.0.0"), "unknown")
+        self.assertEqual(classify.classify_update_type("1.0.0", None), "unknown")
+        self.assertEqual(classify.classify_update_type(None, None), "unknown")
+
+
+class TestDetectEcosystem(unittest.TestCase):
+    def test_nuget_label(self):
+        self.assertEqual(classify.detect_ecosystem(["nuget", "dependencies"], ""), "nuget")
+
+    def test_npm_label(self):
+        self.assertEqual(classify.detect_ecosystem(["npm", "dependencies"], ""), "npm")
+
+    def test_javascript_label_means_npm(self):
+        self.assertEqual(classify.detect_ecosystem(["javascript"], ""), "npm")
+
+    def test_github_actions_label(self):
+        self.assertEqual(classify.detect_ecosystem(["github_actions"], ""), "github-actions")
+
+    def test_head_ref_fallback_nuget(self):
+        self.assertEqual(classify.detect_ecosystem([], "dependabot/nuget/Foo-1.2.3"), "nuget")
+
+    def test_head_ref_fallback_npm(self):
+        self.assertEqual(classify.detect_ecosystem([], "dependabot/npm_and_yarn/foo-1.2.3"), "npm")
+
+    def test_head_ref_fallback_actions(self):
+        self.assertEqual(classify.detect_ecosystem([], "dependabot/github_actions/actions/checkout-v4"), "github-actions")
+
+    def test_unknown(self):
+        self.assertEqual(classify.detect_ecosystem(["random"], "feature/foo"), "unknown")
+
+
+class TestClassifyPR(unittest.TestCase):
+    # Group A — auto-merge eligible
+
+    def test_patch_npm_tooling_is_group_a(self):
+        pr = make_pr(
+            number=820,
+            title="Bump knip from 6.1.0 to 6.3.0",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/knip-6.3.0",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")  # 6.1->6.3 is minor
+        # but knip is tooling, so it's still A
+        self.assertIn("tooling", c.reason)
+
+    def test_patch_nuget_test_sdk_is_group_a(self):
+        pr = make_pr(
+            number=824,
+            title="Bump Microsoft.NET.Test.Sdk from 17.10.0 to 17.10.1",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Microsoft.NET.Test.Sdk-17.10.1",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "patch")
+
+    def test_github_actions_minor_is_group_a(self):
+        pr = make_pr(
+            number=830,
+            title="Bump actions/checkout from 4.1.0 to 4.2.0",
+            labels=["github_actions", "dependencies"],
+            head_ref="dependabot/github_actions/actions/checkout-4.2.0",
+            files=[".github/workflows/ci.yml"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+
+    def test_lockfile_only_is_group_a(self):
+        pr = make_pr(
+            number=831,
+            title="Bump some-transitive-dep from 1.0.0 to 1.0.1",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/some-transitive-dep-1.0.1",
+            files=["src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+
+    def test_patch_non_critical_nuget_is_group_a(self):
+        pr = make_pr(
+            number=832,
+            title="Bump Newtonsoft.Json from 13.0.1 to 13.0.2",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Newtonsoft.Json-13.0.2",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "patch")
+
+    # Group B — verify-then-merge
+
+    def test_minor_auth_critical_is_group_b(self):
+        pr = make_pr(
+            number=840,
+            title="Bump Microsoft.Identity.Client from 4.55.0 to 4.56.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Microsoft.Identity.Client-4.56.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("auth-critical", c.reason)
+
+    def test_minor_azure_identity_is_group_b(self):
+        pr = make_pr(
+            number=841,
+            title="Bump Azure.Identity from 1.12.0 to 1.13.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Azure.Identity-1.13.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+
+    def test_minor_runtime_lib_is_group_b(self):
+        # Terminal.Gui — not auth-critical, not tooling; minor bump = Group B
+        pr = make_pr(
+            number=842,
+            title="Bump Terminal.Gui from 1.19.0 to 1.20.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Terminal.Gui-1.20.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("verify-then-merge", c.reason)
+
+    def test_patch_touching_auth_path_is_group_b(self):
+        pr = make_pr(
+            number=843,
+            title="Bump SomePkg from 1.0.0 to 1.0.1",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/SomePkg-1.0.1",
+            files=["src/PPDS.Auth/PPDS.Auth.csproj"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertIn("auth-critical path", c.reason)
+
+    def test_grouped_bump_defaults_to_b(self):
+        pr = make_pr(
+            number=844,
+            title="Bump the npm_and_yarn group across 1 directory with 2 updates",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertIn("grouped", c.reason)
+
+    # Group C — manual review
+
+    def test_major_npm_is_group_c(self):
+        pr = make_pr(
+            number=850,
+            title="Bump eslint from 8.57.0 to 9.0.0",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/eslint-9.0.0",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        # Even though eslint is tooling, MAJOR is universal exclusion.
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("major", c.reason)
+
+    def test_major_nuget_is_group_c(self):
+        pr = make_pr(
+            number=851,
+            title="Bump Terminal.Gui from 1.19.0 to 2.0.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Terminal.Gui-2.0.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+
+    def test_major_github_actions_is_group_c(self):
+        # actions/checkout v3 -> v4 is a major and should be Group C
+        pr = make_pr(
+            number=852,
+            title="Bump actions/checkout from 3 to 4",
+            labels=["github_actions", "dependencies"],
+            head_ref="dependabot/github_actions/actions/checkout-4",
+            files=[".github/workflows/ci.yml"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+
+    def test_breaking_in_body_is_group_c_even_if_minor(self):
+        pr = make_pr(
+            number=853,
+            title="Bump Foo from 1.5.0 to 1.6.0",
+            body="## Release notes\n\n### BREAKING CHANGE\nRemoved deprecated API.",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Foo-1.6.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertIn("BREAKING", c.reason)
+
+    def test_unparseable_title_defaults_to_c(self):
+        pr = make_pr(
+            number=854,
+            title="Some random title",
+            labels=["dependencies"],
+            head_ref="dependabot/nuget/something",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+
+
+class TestCLIRoundTrip(unittest.TestCase):
+    def test_classification_to_dict_round_trip(self):
+        pr = make_pr(
+            number=900,
+            title="Bump knip from 6.1.0 to 6.2.0",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/knip-6.2.0",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        d = c.to_dict()
+        self.assertEqual(d["pr_number"], 900)
+        self.assertEqual(d["group"], "A")
+        self.assertEqual(d["package"], "knip")
+        self.assertEqual(d["from_version"], "6.1.0")
+        self.assertEqual(d["to_version"], "6.2.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -69,6 +69,14 @@ class TestParseTitle(unittest.TestCase):
         self.assertIsNone(fv)
         self.assertIsNone(tv)
 
+    def test_v_prefix_github_actions(self):
+        # GitHub Actions commonly uses "vN" tags — make sure the bump-title
+        # regex captures both versions even when prefixed.
+        pkg, fv, tv = classify.parse_title("Bump actions/checkout from v3 to v4")
+        self.assertEqual(pkg, "actions/checkout")
+        self.assertEqual(fv, "v3")
+        self.assertEqual(tv, "v4")
+
 
 class TestClassifyUpdateType(unittest.TestCase):
     def test_patch(self):
@@ -100,6 +108,15 @@ class TestClassifyUpdateType(unittest.TestCase):
         self.assertEqual(classify.classify_update_type(None, "1.0.0"), "unknown")
         self.assertEqual(classify.classify_update_type("1.0.0", None), "unknown")
         self.assertEqual(classify.classify_update_type(None, None), "unknown")
+
+    def test_minor_downgrade_treated_as_major(self):
+        # Any downgrade — including minor (1.2.0 -> 1.1.0) — must classify as
+        # 'major' so it routes to Group C / manual review and never auto-merges.
+        self.assertEqual(classify.classify_update_type("1.2.0", "1.1.0"), "major")
+
+    def test_patch_downgrade_treated_as_major(self):
+        # Patch-level downgrade (1.0.2 -> 1.0.1) is also suspicious.
+        self.assertEqual(classify.classify_update_type("1.0.2", "1.0.1"), "major")
 
 
 class TestDetectEcosystem(unittest.TestCase):
@@ -318,6 +335,64 @@ class TestClassifyPR(unittest.TestCase):
             files=["Directory.Packages.props"],
         )
         c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+
+    def test_v_prefix_github_actions_major_is_group_c(self):
+        # actions/checkout v3 -> v4 must parse and route to Group C.
+        pr = make_pr(
+            number=855,
+            title="Bump actions/checkout from v3 to v4",
+            labels=["github_actions", "dependencies"],
+            head_ref="dependabot/github_actions/actions/checkout-v4",
+            files=[".github/workflows/ci.yml"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.package, "actions/checkout")
+        self.assertEqual(c.from_version, "v3")
+        self.assertEqual(c.to_version, "v4")
+        self.assertEqual(c.update_type, "major")
+        self.assertEqual(c.group, "C")
+
+    def test_minor_downgrade_is_group_c(self):
+        # 1.2.0 -> 1.1.0 was previously classified as 'minor' and could slip
+        # through auto-merge. Now any downgrade is Group C.
+        pr = make_pr(
+            number=856,
+            title="Bump SomePkg from 1.2.0 to 1.1.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/SomePkg-1.1.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.update_type, "major")
+        self.assertEqual(c.group, "C")
+
+    def test_pnpm_lockfile_detected(self):
+        # pnpm-lock.yaml-only diffs should be Group A (lockfile-only).
+        pr = make_pr(
+            number=857,
+            title="Bump some-transitive-dep from 1.0.0 to 1.0.1",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/some-transitive-dep-1.0.1",
+            files=["pnpm-lock.yaml"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertIn("lockfile", c.reason.lower())
+
+    def test_lockfile_lookalike_not_detected(self):
+        # A file like custom-package-lock.json must NOT count as a lockfile.
+        # (Was a false-positive risk under the old endswith-based check.)
+        pr = make_pr(
+            number=858,
+            title="Bump SomePkg from 2.0.0 to 3.0.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/SomePkg-3.0.0",
+            files=["docs/custom-package-lock.json"],
+        )
+        # Major bump; lockfile-only short-circuit must NOT fire.
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.update_type, "major")
         self.assertEqual(c.group, "C")
 
 


### PR DESCRIPTION
## Summary

Adds `.claude/skills/dependabot-triage/SKILL.md` plus a classifier helper (`scripts/dependabot/classify.py`) and unit tests (`tests/scripts/dependabot/test_classify.py`).

Codifies the de-facto dependabot-triage pattern from session `a6f07099` (4/18-19) that ran 11 dependabot PRs through a hand-authored 3-group plan with 28 manual `gh pr merge` calls. Addresses **v1-launch retro item #9** (B4 finding). Subsequent dependabot PRs (#805, #806) merged autonomously in ~2 minutes once `allow_auto_merge` was enabled, proving the policy holds — this skill turns that one-off into a repeatable drain.

## Skill Behavior (5 phases)

1. **Pre-flight checks** — verify `autoMergeAllowed`, `docs/MERGE-POLICY.md` exists, no active release, no conflicting in-flight work.
2. **Enumerate** — `gh pr list --author "app/dependabot"`, group by ecosystem and update type.
3. **Classify** — each PR into exactly one of:
   - **Group A — auto-merge eligible** (patch/tooling/lockfile/github-actions patch+minor): `gh pr merge --auto --squash`
   - **Group B — verify-then-merge** (minor on auth-critical or runtime libs, anything touching `src/PPDS.Auth/**`): run package-specific tests in a throwaway worktree, then auto-merge if green
   - **Group C — manual review** (ANY major-version bump per v1-prelaunch retro decision, breaking-change markers, CI/CD changes): comment, tag Josh, do not auto-merge
4. **Drain monitor** — bounded polling with up to 3 retry cycles per PR (rebase via `gh pr update-branch`), 30-min wall-time cap.
5. **Report** — summary table; PushNotification only when something needs Josh's input (silent on routine drains, per v1 notification criteria).

Authoritative policy: [`docs/MERGE-POLICY.md`](../blob/main/docs/MERGE-POLICY.md). The skill operationalizes it; the doc owns it.

## Classifier

`scripts/dependabot/classify.py` is a pure-function module (no network, no gh CLI, no git). It exposes `classify_pr(pr_dict) -> Classification` for in-process use and a CLI mode that reads JSON on stdin and writes classifications on stdout. The skill SKILL.md delegates to it so the prose stays focused.

Auth-critical package list, tooling package list, and breaking-change detection are all data-driven constants at the top of `classify.py` — easy to extend as MERGE-POLICY evolves.

## Tests

38 unit tests in `tests/scripts/dependabot/test_classify.py` covering:
- Title parsing (npm/scoped-npm/nuget/grouped/unparseable)
- Update-type comparison (patch/minor/major, two-part versions, prerelease suffixes, downgrades)
- Ecosystem detection (label-based and head-ref fallback)
- Each group classification branch (Group A x5, Group B x5, Group C x5)
- CLI round-trip serialization

All 38 pass:
```
$ python -m unittest tests.scripts.dependabot.test_classify -v
Ran 38 tests in 0.001s
OK
```

## Constraints honored

- Does NOT enable auto-merge on the repo (assumed already on, documented as prereq).
- Does NOT modify `docs/MERGE-POLICY.md`.
- Does NOT close PRs on inference — explicit "Superseded by #N" marker or strict version-range containment required.
- Honors v1-prelaunch retro decision: ANY major-version bump is Group C, no exceptions (test `test_major_npm_is_group_c` proves eslint major still goes to C even though eslint patches/minors are Group A).

## Test plan

- [x] Unit tests pass (38/38)
- [x] Classifier CLI mode works end-to-end (verified with sample stdin)
- [ ] Manual real-run against an open dependabot PR (deferred — depends on dependabot opening a PR)
- [ ] Pre-flight halt path: temporarily set `autoMergeAllowed=false` and verify skill halts (deferred — repo-level config change)
- [ ] Pre-flight halt path: rename `docs/MERGE-POLICY.md` and verify skill halts (deferred — would conflict with PR #795)
- [ ] Group B test-failure escalation: stage a synthetic auth-critical bump that fails `tests/PPDS.Auth.Tests` (deferred — needs orchestration)

## Notes

- Assumes `allow_auto_merge` enabled at the repo level (already done — verified via `gh repo view --json autoMergeAllowed`).
- One of 5 parallel PRs from retro Wave 1.
- **Do not auto-merge** — orchestrator marks ready when Wave 1 lands.

## Surfaced policy ambiguity (for follow-up)

While drafting the skill I noticed two policy gaps in `docs/MERGE-POLICY.md` that the classifier currently handles by convention but should ideally be explicit in the doc:

1. **Grouped dependabot PRs** ("Bump the X group across...") — MERGE-POLICY doesn't specify how to classify grouped bumps when individual members span multiple update types. The classifier defaults to Group B and asks the operator to inspect; documenting this in MERGE-POLICY would let the classifier act more aggressively.
2. **Auth-critical package list** — MERGE-POLICY names a few packages (Microsoft.Identity.Client, Azure.Identity, etc.) but isn't exhaustive. The classifier hardcodes a list; ideally that list lives in MERGE-POLICY itself.

Per the constraint not to modify MERGE-POLICY in this PR, these are noted here for a follow-up issue if Josh agrees.