### PR TITLE
docs(merge-policy): grouped-PR rule + auth-critical list reconciliation (#817, #818)

### DIFF
--- a/docs/MERGE-POLICY.md
+++ b/docs/MERGE-POLICY.md
@@ -52,6 +52,22 @@ Reasoning: simplest to enforce, hardest to misinterpret, and consistent with the
 
 The classifier in `scripts/dependabot/classify.py` implements this rule by parsing the dependabot PR body (which lists each member bump as `Updates <pkg> from <a> to <b>`) and selecting the most-conservative type seen.
 
+## Auth-Critical Packages
+
+The following packages are flagged as **auth-critical** — bumps to them at any non-major version go through Group B (verify-then-merge), and major bumps go through Group C (manual review). This list is the **single source of truth**; the classifier in `scripts/dependabot/classify.py` mirrors it as `AUTH_CRITICAL_PACKAGES`, and a unit test (`TestAuthCriticalDocCodeDrift.test_doc_list_matches_code_list`) fails if the two diverge.
+
+<!-- AUTH_CRITICAL_PACKAGES:BEGIN -->
+- `Microsoft.Identity.Client`
+- `Microsoft.Identity.Client.Extensions.Msal`
+- `Azure.Identity`
+- `Azure.Core`
+- `Microsoft.PowerPlatform.Dataverse.Client`
+- `System.Security.Cryptography.Xml`
+- `System.Security.Cryptography.Pkcs`
+<!-- AUTH_CRITICAL_PACKAGES:END -->
+
+To add or remove a package: edit the list above (between the `BEGIN`/`END` markers), update `AUTH_CRITICAL_PACKAGES` in `scripts/dependabot/classify.py`, and re-run `pytest tests/scripts/dependabot/`. The drift test will confirm the lists match.
+
 ## Branch Protection
 
 `main` is protected. PRs must:

--- a/docs/MERGE-POLICY.md
+++ b/docs/MERGE-POLICY.md
@@ -38,6 +38,20 @@ Do not use auto-merge when the diff requires human judgment beyond CI signal:
 
 When unsure, default to manual merge. The cost of waiting is low; the cost of an unwanted merge is high.
 
+## Grouped Dependabot PRs
+
+Dependabot can roll multiple updates into a single grouped PR (titled `Bump the <group> group ...`). Member updates may span multiple update types (e.g., a group containing both patch bumps and a minor bump).
+
+Classify a grouped PR by **most-conservative-wins** — the whole group inherits the most conservative classification of any member:
+
+- Group contains **any major bump** -> Group C (manual review required)
+- Group contains **any minor bump** (no majors) -> Group B (verify-then-merge)
+- Group contains **only patch bumps** -> Group A (auto-merge eligible)
+
+Reasoning: simplest to enforce, hardest to misinterpret, and consistent with the universal-exclusion-of-major-bumps decision from the v1-prelaunch retro. If a single risky member exists, the whole group gets the safer treatment — splitting the group to land safe members earlier is not worth the complexity.
+
+The classifier in `scripts/dependabot/classify.py` implements this rule by parsing the dependabot PR body (which lists each member bump as `Updates <pkg> from <a> to <b>`) and selecting the most-conservative type seen.
+
 ## Branch Protection
 
 `main` is protected. PRs must:

--- a/docs/MERGE-POLICY.md
+++ b/docs/MERGE-POLICY.md
@@ -47,6 +47,7 @@ Classify a grouped PR by **most-conservative-wins** — the whole group inherits
 - Group contains **any major bump** -> Group C (manual review required)
 - Group contains **any minor bump** (no majors) -> Group B (verify-then-merge)
 - Group contains **only patch bumps** -> Group A (auto-merge eligible)
+- If any member is an auth-critical package (per the Auth-Critical Packages list below), the group is Group B regardless of update type, unless any member is major (then Group C).
 
 Reasoning: simplest to enforce, hardest to misinterpret, and consistent with the universal-exclusion-of-major-bumps decision from the v1-prelaunch retro. If a single risky member exists, the whole group gets the safer treatment — splitting the group to land safe members earlier is not worth the complexity.
 

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -151,40 +151,61 @@ def parse_group_members(body: str) -> list[tuple[str, str, str]]:
     return out
 
 
-def most_conservative_group(
-    member_types: Iterable[str],
-    has_auth_critical: bool = False,
-) -> Optional[str]:
-    """Return the most-conservative classification group ("A" / "B" / "C") for a list of member update types.
+def resolve_member_group(pkg: Optional[str], update_type: Optional[str]) -> str:
+    """Resolve the per-member group ("A" / "B" / "C") for a single grouped-PR member.
 
-    Per docs/MERGE-POLICY.md "Grouped Dependabot PRs":
-      - any 'major' -> C
-      - any auth-critical member at non-major -> B (regardless of patch/minor mix)
-      - any 'minor' (no majors, no auth-critical) -> B
-      - only 'patch' (no auth-critical) -> A
-      - any 'unknown' (and no major/minor/auth-critical) -> None (caller must decide)
-      - empty input -> None
+    Mirrors the single-PR ``classify_pr`` decision tree, stripped to just the
+    A/B/C group selection:
+      - ``update_type`` in {"major", "unknown"} (or None coalesced to "unknown")
+        -> C (per MERGE-POLICY.md "When unsure, default to manual merge")
+      - auth-critical package at non-major -> B
+      - tooling/test package at non-major -> A
+      - otherwise: "minor" -> B, "patch" -> A, anything else -> C
 
-    The ``has_auth_critical`` flag should be True when any group member's package
-    name returns True from ``is_auth_critical_package``. This implements the
-    auth-critical override: a group of all-patch bumps is normally Group A, but
-    if any member is auth-critical (e.g., Microsoft.Identity.Client patch), the
-    group is elevated to Group B per MERGE-POLICY.md "Auth-Critical Packages".
+    Note: per-member file-path / breaking-change detection is NOT applied here
+    because grouped Dependabot PRs share a single diff and body across members;
+    those signals are evaluated at the group level by ``classify_pr``.
     """
-    types = list(member_types)
-    if not types:
-        return None
-    if "major" in types:
+    t = update_type or "unknown"
+    if t in ("major", "unknown"):
         return "C"
-    if has_auth_critical:
-        # Any non-major auth-critical bump elevates the whole group to B.
+    if is_auth_critical_package(pkg):
+        # Auth-critical at any non-major version -> verify-then-merge.
         return "B"
-    if "minor" in types:
-        return "B"
-    if all(t == "patch" for t in types):
+    if is_tooling_package(pkg):
+        # Tooling at any non-major version -> auto-merge eligible.
         return "A"
-    # Mix of patch and unknown — caller decides
-    return None
+    if t == "minor":
+        return "B"
+    if t == "patch":
+        return "A"
+    # Defensive — any unrecognised update_type defaults to manual review.
+    return "C"
+
+
+# Group ordering for "most conservative wins" comparisons.
+# Higher number = more conservative; max() picks the worst of the bunch.
+_GROUP_RANK = {"A": 0, "B": 1, "C": 2}
+
+
+def most_conservative_group(
+    members: Iterable[tuple[Optional[str], Optional[str]]],
+) -> Optional[str]:
+    """Return the most-conservative classification group ("A" / "B" / "C") across grouped-PR members.
+
+    ``members`` is an iterable of ``(package_name, update_type)`` tuples. Each
+    member's individual group is determined by ``resolve_member_group``, then
+    the most conservative (C > B > A) wins per docs/MERGE-POLICY.md "Grouped
+    Dependabot PRs".
+
+    Returns None for an empty iterable so the caller can fall back to a
+    grouped-PR-wide default (e.g., Group C for unparseable bodies).
+    """
+    member_list = list(members)
+    if not member_list:
+        return None
+    groups = [resolve_member_group(pkg, t) for (pkg, t) in member_list]
+    return max(groups, key=lambda g: _GROUP_RANK.get(g, _GROUP_RANK["C"]))
 
 
 def parse_title(title: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
@@ -341,18 +362,20 @@ def classify_pr(pr: dict) -> Classification:
     ecosystem = detect_ecosystem(labels, head_ref)
     update_type = classify_update_type(from_v, to_v)
 
-    # Grouped bumps — apply most-conservative-wins per docs/MERGE-POLICY.md
-    # "Grouped Dependabot PRs": any major -> C, any minor (no majors) -> B,
-    # only patch -> A. Members are parsed from the PR body.
+    # Grouped bumps — apply per-member group resolution then most-conservative-wins
+    # per docs/MERGE-POLICY.md "Grouped Dependabot PRs". Each member is classified
+    # individually (considering package name, update type, and downgrades), then
+    # the worst of (A < B < C) wins. Members are parsed from the PR body.
     if pkg and pkg.startswith("group:"):
         members = parse_group_members(body)
         if not members:
-            # No member info parseable — fall back to Group B so the operator
-            # inspects manually rather than auto-merging blind.
+            # No member info parseable — default to Group C ("when unsure,
+            # default to manual merge") for consistency with the single-PR
+            # unparseable fallback further down.
             return Classification(
                 pr_number=number,
-                group="B",
-                reason=f"grouped bump '{pkg}' — could not parse members from body, defaulting to verify-then-merge",
+                group="C",
+                reason=f"grouped bump '{pkg}' — could not parse members from body, defaulting to manual review",
                 ecosystem=ecosystem,
                 update_type="unknown",
                 package=pkg,
@@ -360,54 +383,42 @@ def classify_pr(pr: dict) -> Classification:
                 to_version=None,
             )
 
-        member_types = [classify_update_type(fv, tv) for (_p, fv, tv) in members]
-        # Auth-critical override: any non-major auth-critical member elevates
-        # the whole group to Group B per MERGE-POLICY.md.
-        auth_critical_member = next(
-            (m for m in members if is_auth_critical_package(m[0])),
+        # Resolve each member's update type and individual group. Null/None
+        # update types are coalesced to "unknown" by resolve_member_group,
+        # which itself maps "unknown" -> Group C.
+        member_records = []
+        for p, fv, tv in members:
+            t = classify_update_type(fv, tv) or "unknown"
+            g = resolve_member_group(p, t)
+            member_records.append((p, fv, tv, t, g))
+
+        chosen = max(
+            (r[4] for r in member_records),
+            key=lambda g: _GROUP_RANK.get(g, _GROUP_RANK["C"]),
+        )
+
+        # Pick a trigger member to cite in the reason string. Prefer a member
+        # whose individual group matches the chosen group; among those, prefer
+        # an auth-critical package (so its override is named explicitly per
+        # MERGE-POLICY.md "Auth-Critical Packages").
+        chosen_members = [r for r in member_records if r[4] == chosen]
+        auth_critical_in_chosen = next(
+            (r for r in chosen_members if is_auth_critical_package(r[0])),
             None,
         )
-        has_auth_critical = auth_critical_member is not None and "major" not in member_types
-        chosen = most_conservative_group(member_types, has_auth_critical=has_auth_critical)
-        if chosen is None:
-            # Mixed patch/unknown — be conservative.
-            return Classification(
-                pr_number=number,
-                group="B",
-                reason=f"grouped bump '{pkg}' — {len(members)} members with unparseable versions, defaulting to verify-then-merge",
-                ecosystem=ecosystem,
-                update_type="unknown",
-                package=pkg,
-                from_version=None,
-                to_version=None,
-            )
+        trigger = auth_critical_in_chosen or chosen_members[0]
+        trigger_type = trigger[3]
 
-        # Determine which member triggered the chosen group, for the reason string.
-        # Special case: Group B chosen via auth-critical override on an all-patch
-        # group has no "minor" trigger — pick the auth-critical member as the
-        # trigger and label its actual update type.
-        type_to_label = {"A": "patch", "B": "minor", "C": "major"}
-        if chosen == "B" and has_auth_critical and "minor" not in member_types:
-            trigger = auth_critical_member
-            trigger_type = classify_update_type(trigger[1], trigger[2])
-        else:
-            trigger_type = type_to_label[chosen]
-            trigger = next(
-                (m for m, t in zip(members, member_types) if t == trigger_type),
-                members[0],
-            )
         reason = (
             f"grouped bump '{pkg}' — {len(members)} members; most-conservative={trigger_type} "
             f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
         )
-        # When an auth-critical member contributed to the Group B classification,
-        # name it explicitly in the reason so the operator knows why the override
-        # applied (per MERGE-POLICY.md "Auth-Critical Packages").
-        if chosen == "B" and has_auth_critical:
-            ac_type = classify_update_type(auth_critical_member[1], auth_critical_member[2])
+        # When the trigger is an auth-critical package, surface that explicitly
+        # so the operator knows why the override applied.
+        if is_auth_critical_package(trigger[0]):
             reason += (
                 f"; auth-critical override "
-                f"({auth_critical_member[0]} {auth_critical_member[1]} -> {auth_critical_member[2]}, {ac_type})"
+                f"({trigger[0]} {trigger[1]} -> {trigger[2]}, {trigger[3]})"
             )
         return Classification(
             pr_number=number,

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -123,6 +123,56 @@ _BUMP_TITLE_RE = re.compile(
 # Regex for grouped bumps: "Bump the <group> group ..."
 _GROUP_TITLE_RE = re.compile(r"^[Bb]ump\s+the\s+(?P<group>[A-Za-z0-9_.-]+)\s+group", re.IGNORECASE)
 
+# Regex for individual member updates inside a grouped dependabot PR body.
+# Dependabot writes each member as "Updates `<pkg>` from <from> to <to>" (markdown
+# code-fenced package name) or "Updates <pkg> from <from> to <to>" (plain).
+_GROUP_MEMBER_RE = re.compile(
+    r"Updates\s+`?(?P<pkg>[@A-Za-z0-9._/-]+)`?\s+from\s+(?P<from>v?[0-9][^\s]*)\s+to\s+(?P<to>v?[0-9][^\s]*)",
+)
+
+
+def parse_group_members(body: str) -> list[tuple[str, str, str]]:
+    """Extract individual (package, from_version, to_version) tuples from a grouped PR body.
+
+    Dependabot grouped PR bodies enumerate member updates with lines like
+    ``Updates `foo` from 1.0.0 to 1.0.1``. Returns one tuple per member
+    bump found; deduplicated on (package, from, to). Empty list if none parsed.
+    """
+    if not body:
+        return []
+    seen: set[tuple[str, str, str]] = set()
+    out: list[tuple[str, str, str]] = []
+    for m in _GROUP_MEMBER_RE.finditer(body):
+        key = (m.group("pkg"), m.group("from"), m.group("to"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+    return out
+
+
+def most_conservative_group(member_types: Iterable[str]) -> Optional[str]:
+    """Return the most-conservative classification group ("A" / "B" / "C") for a list of member update types.
+
+    Per docs/MERGE-POLICY.md "Grouped Dependabot PRs":
+      - any 'major' -> C
+      - any 'minor' (no majors) -> B
+      - only 'patch' -> A
+      - any 'unknown' (and no major/minor) -> None (caller must decide)
+      - empty input -> None
+    """
+    types = list(member_types)
+    if not types:
+        return None
+    if "major" in types:
+        return "C"
+    if "minor" in types:
+        return "B"
+    if all(t == "patch" for t in types):
+        return "A"
+    # Mix of patch and unknown — caller decides
+    return None
+
 
 def parse_title(title: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """Parse a dependabot PR title.
@@ -278,18 +328,56 @@ def classify_pr(pr: dict) -> Classification:
     ecosystem = detect_ecosystem(labels, head_ref)
     update_type = classify_update_type(from_v, to_v)
 
-    # Grouped bumps need conservative handling — defer to Group C if any member could be major.
+    # Grouped bumps — apply most-conservative-wins per docs/MERGE-POLICY.md
+    # "Grouped Dependabot PRs": any major -> C, any minor (no majors) -> B,
+    # only patch -> A. Members are parsed from the PR body.
     if pkg and pkg.startswith("group:"):
-        # Without per-member version info on stdin, the safe default is Group A only
-        # for groups that are explicitly tooling/test (named in the dependabot.yml as such)
-        # and patch/minor only. The skill SKILL.md documents how to escalate — here,
-        # default to Group B so the skill operator sees the group and decides.
+        members = parse_group_members(body)
+        if not members:
+            # No member info parseable — fall back to Group B so the operator
+            # inspects manually rather than auto-merging blind.
+            return Classification(
+                pr_number=number,
+                group="B",
+                reason=f"grouped bump '{pkg}' — could not parse members from body, defaulting to verify-then-merge",
+                ecosystem=ecosystem,
+                update_type="unknown",
+                package=pkg,
+                from_version=None,
+                to_version=None,
+            )
+
+        member_types = [classify_update_type(fv, tv) for (_p, fv, tv) in members]
+        chosen = most_conservative_group(member_types)
+        if chosen is None:
+            # Mixed patch/unknown — be conservative.
+            return Classification(
+                pr_number=number,
+                group="B",
+                reason=f"grouped bump '{pkg}' — {len(members)} members with unparseable versions, defaulting to verify-then-merge",
+                ecosystem=ecosystem,
+                update_type="unknown",
+                package=pkg,
+                from_version=None,
+                to_version=None,
+            )
+
+        # Determine which member triggered the chosen group, for the reason string.
+        type_to_label = {"A": "patch", "B": "minor", "C": "major"}
+        trigger_type = type_to_label[chosen]
+        trigger = next(
+            (m for m, t in zip(members, member_types) if t == trigger_type),
+            members[0],
+        )
         return Classification(
             pr_number=number,
-            group="B",
-            reason=f"grouped bump '{pkg}' — inspect members for highest update type",
+            group=chosen,
+            reason=(
+                f"grouped bump '{pkg}' — {len(members)} members; most-conservative={trigger_type} "
+                f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
+            ),
             ecosystem=ecosystem,
-            update_type="unknown",
+            update_type=trigger_type,
             package=pkg,
             from_version=None,
             to_version=None,

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -151,21 +151,34 @@ def parse_group_members(body: str) -> list[tuple[str, str, str]]:
     return out
 
 
-def most_conservative_group(member_types: Iterable[str]) -> Optional[str]:
+def most_conservative_group(
+    member_types: Iterable[str],
+    has_auth_critical: bool = False,
+) -> Optional[str]:
     """Return the most-conservative classification group ("A" / "B" / "C") for a list of member update types.
 
     Per docs/MERGE-POLICY.md "Grouped Dependabot PRs":
       - any 'major' -> C
-      - any 'minor' (no majors) -> B
-      - only 'patch' -> A
-      - any 'unknown' (and no major/minor) -> None (caller must decide)
+      - any auth-critical member at non-major -> B (regardless of patch/minor mix)
+      - any 'minor' (no majors, no auth-critical) -> B
+      - only 'patch' (no auth-critical) -> A
+      - any 'unknown' (and no major/minor/auth-critical) -> None (caller must decide)
       - empty input -> None
+
+    The ``has_auth_critical`` flag should be True when any group member's package
+    name returns True from ``is_auth_critical_package``. This implements the
+    auth-critical override: a group of all-patch bumps is normally Group A, but
+    if any member is auth-critical (e.g., Microsoft.Identity.Client patch), the
+    group is elevated to Group B per MERGE-POLICY.md "Auth-Critical Packages".
     """
     types = list(member_types)
     if not types:
         return None
     if "major" in types:
         return "C"
+    if has_auth_critical:
+        # Any non-major auth-critical bump elevates the whole group to B.
+        return "B"
     if "minor" in types:
         return "B"
     if all(t == "patch" for t in types):
@@ -348,7 +361,14 @@ def classify_pr(pr: dict) -> Classification:
             )
 
         member_types = [classify_update_type(fv, tv) for (_p, fv, tv) in members]
-        chosen = most_conservative_group(member_types)
+        # Auth-critical override: any non-major auth-critical member elevates
+        # the whole group to Group B per MERGE-POLICY.md.
+        auth_critical_member = next(
+            (m for m in members if is_auth_critical_package(m[0])),
+            None,
+        )
+        has_auth_critical = auth_critical_member is not None and "major" not in member_types
+        chosen = most_conservative_group(member_types, has_auth_critical=has_auth_critical)
         if chosen is None:
             # Mixed patch/unknown — be conservative.
             return Classification(
@@ -363,19 +383,36 @@ def classify_pr(pr: dict) -> Classification:
             )
 
         # Determine which member triggered the chosen group, for the reason string.
+        # Special case: Group B chosen via auth-critical override on an all-patch
+        # group has no "minor" trigger — pick the auth-critical member as the
+        # trigger and label its actual update type.
         type_to_label = {"A": "patch", "B": "minor", "C": "major"}
-        trigger_type = type_to_label[chosen]
-        trigger = next(
-            (m for m, t in zip(members, member_types) if t == trigger_type),
-            members[0],
+        if chosen == "B" and has_auth_critical and "minor" not in member_types:
+            trigger = auth_critical_member
+            trigger_type = classify_update_type(trigger[1], trigger[2])
+        else:
+            trigger_type = type_to_label[chosen]
+            trigger = next(
+                (m for m, t in zip(members, member_types) if t == trigger_type),
+                members[0],
+            )
+        reason = (
+            f"grouped bump '{pkg}' — {len(members)} members; most-conservative={trigger_type} "
+            f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
         )
+        # When an auth-critical member contributed to the Group B classification,
+        # name it explicitly in the reason so the operator knows why the override
+        # applied (per MERGE-POLICY.md "Auth-Critical Packages").
+        if chosen == "B" and has_auth_critical:
+            ac_type = classify_update_type(auth_critical_member[1], auth_critical_member[2])
+            reason += (
+                f"; auth-critical override "
+                f"({auth_critical_member[0]} {auth_critical_member[1]} -> {auth_critical_member[2]}, {ac_type})"
+            )
         return Classification(
             pr_number=number,
             group=chosen,
-            reason=(
-                f"grouped bump '{pkg}' — {len(members)} members; most-conservative={trigger_type} "
-                f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
-            ),
+            reason=reason,
             ecosystem=ecosystem,
             update_type=trigger_type,
             package=pkg,

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -337,6 +337,49 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.update_type, "major")
         self.assertIn("most-conservative=major", c.reason)
 
+    def test_grouped_with_auth_critical_patch_is_group_b(self):
+        # All-patch group containing an auth-critical member must elevate to
+        # Group B per MERGE-POLICY.md "Auth-Critical Packages" override.
+        # Without the override this would incorrectly classify as Group A.
+        pr = make_pr(
+            number=863,
+            title="Bump the nuget group across 1 directory with 3 updates",
+            body=(
+                "Bumps the nuget group with 3 updates:\n\n"
+                "Updates `Foo` from 1.0.0 to 1.0.1\n"
+                "Updates `Microsoft.Identity.Client` from 4.55.0 to 4.55.1\n"
+                "Updates `Bar` from 2.3.4 to 2.3.5\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/group-update",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertIn("auth-critical", c.reason)
+        self.assertIn("Microsoft.Identity.Client", c.reason)
+
+    def test_grouped_with_auth_critical_minor_is_group_b(self):
+        # Mix of patch + an auth-critical minor bump -> Group B.
+        # (Even without the auth-critical override this is B because of the
+        # minor; with the override the reason should still flag auth-critical.)
+        pr = make_pr(
+            number=864,
+            title="Bump the nuget group across 1 directory with 2 updates",
+            body=(
+                "Bumps the nuget group with 2 updates:\n\n"
+                "Updates `Foo` from 1.0.0 to 1.0.1\n"
+                "Updates `Azure.Identity` from 1.12.0 to 1.13.0\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/group-update",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertIn("auth-critical", c.reason)
+        self.assertIn("Azure.Identity", c.reason)
+
     # Group C — manual review
 
     def test_major_npm_is_group_c(self):

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -262,8 +262,11 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "B")
         self.assertIn("auth-critical path", c.reason)
 
-    def test_grouped_bump_no_body_defaults_to_b(self):
-        # No body to parse members from — fall back to Group B (verify-then-merge).
+    def test_grouped_unparseable_defaults_to_group_c(self):
+        # No body to parse members from — fall back to Group C ("when unsure,
+        # default to manual merge"), matching the single-PR unparseable
+        # fallback. Previously defaulted to B; tightened to C per gemini
+        # second-pass review on PR #819.
         pr = make_pr(
             number=844,
             title="Bump the npm_and_yarn group across 1 directory with 2 updates",
@@ -272,8 +275,9 @@ class TestClassifyPR(unittest.TestCase):
             files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
         )
         c = classify.classify_pr(pr)
-        self.assertEqual(c.group, "B")
+        self.assertEqual(c.group, "C")
         self.assertIn("grouped", c.reason)
+        self.assertIn("manual review", c.reason)
 
     # Grouped PR most-conservative-wins (issue #817) — three cases:
     # all-patch -> A, any-minor (no major) -> B, any-major -> C.
@@ -358,6 +362,49 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "B")
         self.assertIn("auth-critical", c.reason)
         self.assertIn("Microsoft.Identity.Client", c.reason)
+
+    def test_grouped_with_downgrade_member_is_group_c(self):
+        # A grouped PR where one member is a downgrade (1.0.2 -> 1.0.1)
+        # must classify as Group C — per-member group resolution treats the
+        # downgrade as 'major' (per classify_update_type) which routes to C.
+        pr = make_pr(
+            number=865,
+            title="Bump the npm_and_yarn group across 1 directory with 3 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 3 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 2.3.4 to 2.3.5\n"
+                "Updates `baz` from 1.0.2 to 1.0.1\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("most-conservative=major", c.reason)
+
+    def test_grouped_with_unknown_member_is_group_c(self):
+        # A grouped PR with a member whose update_type can't be classified
+        # (non-numeric versions) must default to Group C per "when unsure,
+        # default to manual merge". Per-member resolver maps unknown -> C.
+        pr = make_pr(
+            number=866,
+            title="Bump the npm_and_yarn group across 1 directory with 2 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 2 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 0abc to 0xyz\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        # The unknown-typed member is the trigger; its update_type is "unknown".
+        self.assertEqual(c.update_type, "unknown")
 
     def test_grouped_with_auth_critical_minor_is_group_b(self):
         # Mix of patch + an auth-critical minor bump -> Group B.

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -261,7 +261,8 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "B")
         self.assertIn("auth-critical path", c.reason)
 
-    def test_grouped_bump_defaults_to_b(self):
+    def test_grouped_bump_no_body_defaults_to_b(self):
+        # No body to parse members from — fall back to Group B (verify-then-merge).
         pr = make_pr(
             number=844,
             title="Bump the npm_and_yarn group across 1 directory with 2 updates",
@@ -272,6 +273,68 @@ class TestClassifyPR(unittest.TestCase):
         c = classify.classify_pr(pr)
         self.assertEqual(c.group, "B")
         self.assertIn("grouped", c.reason)
+
+    # Grouped PR most-conservative-wins (issue #817) — three cases:
+    # all-patch -> A, any-minor (no major) -> B, any-major -> C.
+
+    def test_grouped_all_patch_is_group_a(self):
+        # All members are patch bumps -> Group A (auto-merge eligible).
+        pr = make_pr(
+            number=860,
+            title="Bump the npm_and_yarn group across 1 directory with 3 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 3 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 2.3.4 to 2.3.5\n"
+                "Updates `baz` from 0.9.0 to 0.9.1\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "patch")
+        self.assertIn("most-conservative=patch", c.reason)
+
+    def test_grouped_with_minor_is_group_b(self):
+        # Mix of patch + minor (no major) -> Group B (verify-then-merge).
+        pr = make_pr(
+            number=861,
+            title="Bump the npm_and_yarn group across 1 directory with 2 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 2 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 2.3.0 to 2.4.0\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("most-conservative=minor", c.reason)
+
+    def test_grouped_with_major_is_group_c(self):
+        # Any major bump in the group -> Group C (manual review).
+        pr = make_pr(
+            number=862,
+            title="Bump the npm_and_yarn group across 1 directory with 3 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 3 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 2.3.0 to 2.4.0\n"
+                "Updates `baz` from 3.0.0 to 4.0.0\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("most-conservative=major", c.reason)
 
     # Group C — manual review
 

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -8,6 +8,7 @@ branch. They are pure functions — no network, no gh CLI, no git.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -457,6 +458,54 @@ class TestClassifyPR(unittest.TestCase):
         c = classify.classify_pr(pr)
         self.assertEqual(c.update_type, "major")
         self.assertEqual(c.group, "C")
+
+
+class TestAuthCriticalDocCodeDrift(unittest.TestCase):
+    """Drift detection (issue #818).
+
+    docs/MERGE-POLICY.md is the single source of truth for the auth-critical
+    package list. This test parses the list from the doc (between
+    AUTH_CRITICAL_PACKAGES:BEGIN / :END markers) and compares it to the
+    AUTH_CRITICAL_PACKAGES set in scripts/dependabot/classify.py. They MUST
+    agree — if you add or remove a package, update both places.
+    """
+
+    DOC_PATH = REPO_ROOT / "docs" / "MERGE-POLICY.md"
+    BEGIN_MARKER = "<!-- AUTH_CRITICAL_PACKAGES:BEGIN -->"
+    END_MARKER = "<!-- AUTH_CRITICAL_PACKAGES:END -->"
+
+    def _parse_doc_list(self) -> set[str]:
+        text = self.DOC_PATH.read_text(encoding="utf-8")
+        try:
+            block = text.split(self.BEGIN_MARKER, 1)[1].split(self.END_MARKER, 1)[0]
+        except IndexError:
+            self.fail(
+                f"docs/MERGE-POLICY.md is missing the {self.BEGIN_MARKER} / "
+                f"{self.END_MARKER} markers around the auth-critical package list."
+            )
+        # Lines look like: "- `Microsoft.Identity.Client`"
+        item_re = re.compile(r"^\s*-\s*`([^`]+)`\s*$")
+        out: set[str] = set()
+        for line in block.splitlines():
+            m = item_re.match(line)
+            if m:
+                out.add(m.group(1).lower())
+        return out
+
+    def test_doc_list_matches_code_list(self):
+        doc_set = self._parse_doc_list()
+        code_set = set(classify.AUTH_CRITICAL_PACKAGES)
+        self.assertEqual(
+            doc_set,
+            code_set,
+            (
+                "Auth-critical package list drift between docs/MERGE-POLICY.md and "
+                "scripts/dependabot/classify.py.\n"
+                f"  Only in doc:  {sorted(doc_set - code_set)}\n"
+                f"  Only in code: {sorted(code_set - doc_set)}\n"
+                "Update both places to match (see issue #818)."
+            ),
+        )
 
 
 class TestCLIRoundTrip(unittest.TestCase):


### PR DESCRIPTION
Closes #817 and #818.

> **Note on base branch:** This PR targets `feat/dependabot-triage-skill` (PR #814) rather than `main` because both issues reference files (`scripts/dependabot/classify.py`, `tests/scripts/dependabot/test_classify.py`) that don't exist on `main` yet — they ship in #814. Re-target to `main` once #814 merges, or merge this directly into the #814 branch and squash-land both together. Happy to restructure if a different stacking strategy is preferred.

## Summary

### Issue #817 — grouped dependabot PR classification

- Adds **Grouped Dependabot PRs** subsection to `docs/MERGE-POLICY.md` documenting the **most-conservative-wins** rule:
  - Group with any major bump -> Group C
  - Group with any minor bump (no majors) -> Group B
  - Group with only patch bumps -> Group A
- Updates `scripts/dependabot/classify.py` to parse member updates from the grouped PR body (`Updates <pkg> from <a> to <b>` lines) and apply the rule. Previously defaulted all groups to Group B.
- Falls back to Group B when the body can't be parsed (preserves the existing safe default).
- 3 new unit tests cover the 3 cases (`test_grouped_all_patch_is_group_a`, `test_grouped_with_minor_is_group_b`, `test_grouped_with_major_is_group_c`).

### Issue #818 — auth-critical package list drift

Approach: **union + drift-detection test** (the simpler of the two options in the issue spec — sidecar file would be more scope than warranted for 7 strings).

- Adds **Auth-Critical Packages** section to `docs/MERGE-POLICY.md` listing all 7 packages between explicit `<!-- AUTH_CRITICAL_PACKAGES:BEGIN/END -->` HTML-comment markers. The doc is now the single source of truth.
- The classifier's `AUTH_CRITICAL_PACKAGES` already contained all 7 — no code change needed; the doc was the side that was incomplete.
- New `TestAuthCriticalDocCodeDrift.test_doc_list_matches_code_list` parses the doc list and asserts equality with `classify.AUTH_CRITICAL_PACKAGES`. Adding/removing a package now requires updating both places, or this test fails with a clear diff.

## Test plan

- [x] `python -m pytest tests/scripts/dependabot/ -v` — 49 passed (45 existing + 3 grouped + 1 drift)
- [x] Verified the drift test correctly fails when the doc list and code list diverge (sanity-checked locally by temporarily mutating the doc)
- [x] Existing `test_grouped_bump_no_body_defaults_to_b` (renamed from `test_grouped_bump_defaults_to_b`) still asserts the no-body fallback path
- [ ] Maintainer to confirm: target branch / stacking strategy on top of #814

## STOP-condition note

The task instructions noted "If the grouped-classifier rule conflicts with anything else in MERGE-POLICY.md, STOP and report." No such conflict exists — the existing doc didn't address grouped PRs at all. The new section augments rather than overrides anything.