### PR TITLE
feat(skill): /backlog dispatch subverb (durable plan + in-flight coordination)

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -15,6 +15,7 @@ Manage GitHub issues using the label taxonomy, milestone conventions, and triage
 - "Groom issues"
 - "What should we work on next?"
 - "Review backlog priorities"
+- "Dispatch parallel worktrees", "kick off the planned waves", "launch the dispatcher session"
 - After completing work that reveals follow-up issues
 
 ## Reference
@@ -31,6 +32,7 @@ Check `$ARGUMENTS` for the operation:
 - `/backlog triage` — triage untriaged inbox
 - `/backlog review` — review backlog for promotion
 - `/backlog validate` — verify open issues are still valid
+- `/backlog dispatch` — plan and launch parallel worktrees from triage state (see [Subverb: dispatch](#subverb-dispatch) below)
 - `/backlog` (no args) — show backlog summary
 
 ### 2. Read Rules
@@ -190,6 +192,249 @@ echo "=== Inbox (untriaged) ==="
 gh issue list --state open --limit 200 --json number,labels,milestone --jq '[.[] | select(.milestone == null) | select(.labels | map(.name) | any(startswith("status:")) | not)] | length'
 ```
 
+## Subverb: dispatch
+
+Addresses v1-launch retro item #10 / finding B5: the historical
+"dispatcher session" pattern (e.g. session `cd0c578e`) was high-leverage
+but human-gated — Josh has had to be the human dispatcher every time
+because the skill stopped at "here is the plan, please run /start
+yourself N times". This subverb closes that loop while preserving every
+gate the human was applying tacitly: a durable plan, an in-flight
+conflict check per worktree, and an explicit "go" before any
+worktree creates.
+
+### Five-phase flow
+
+The dispatch subverb runs as a strict sequence. Do not skip phases —
+each one feeds state the next phase reads.
+
+#### Phase A — Plan generation
+
+1. Re-run the **Triage Inbox** flow above to identify what is ready to
+   dispatch. Constrain by the user's prompt (e.g. "all v1.0 blockers",
+   "the audit-capture epic", "the next 5 high-priority backlog items").
+2. Group the candidates into worktrees by **file-overlap analysis** (the
+   pattern from session `cd0c578e`'s 6-worktree v1.0 plan): two issues
+   that touch the same code area should land in the same worktree so
+   the in-flight conflict check does not flag the dispatcher's own
+   parallel work as a self-collision. Issues that touch disjoint areas
+   become separate worktrees.
+3. For each grouped worktree, capture:
+   - **worktree name** (kebab-case branch label, e.g. `feat/issue-660-auth-pool` or
+     `feat/audit-capture`)
+   - **issues** (one or more `#NNN`)
+   - **areas** (best-guess code paths the work will touch — used by the
+     conflict check below)
+   - **intent** (one-line human-readable summary)
+4. Persist the plan to `.claude/state/dispatch-plan.md` via the helper
+   so it survives session close (the dispatcher session may be killed
+   between Phase C and Phase D — Phase E re-reads the file):
+
+   ```bash
+   python -c "import sys, json
+   sys.path.insert(0, 'scripts')
+   from dispatch_plan import build_plan_from_dicts, write_plan
+   items = json.loads(sys.stdin.read())
+   write_plan(build_plan_from_dicts(items, generator='session-<id>'))
+   " <<EOF
+   [
+     {"worktree": "feat/issue-660", "issues": [660], "areas": ["src/PPDS.Auth/"], "intent": "env var auth"},
+     {"worktree": "feat/audit-capture", "issues": [101, 102], "areas": ["src/PPDS.Audit/"], "intent": "audit capture pipeline"}
+   ]
+   EOF
+   ```
+
+   The plan path lives at `.claude/state/dispatch-plan.md` —
+   intentionally **not** under `.plans/` (which is gitignored and
+   ephemeral) and **not** under `.claude/settings.local.json` (which is
+   personal). The `.claude/state/` directory is the established home
+   for cross-session durable state (the in-flight registry from
+   PR #813 lives next to it).
+
+#### Phase B — Pre-flight per-worktree conflict check
+
+Before surfacing the plan to the operator, walk every entry and call
+`scripts/inflight-check.py` for each `(issue, area)` pair. The helper
+`annotate_with_conflicts` in `scripts/dispatch_plan.py` does this in one
+call:
+
+```bash
+python -c "
+import sys
+sys.path.insert(0, 'scripts')
+from dispatch_plan import annotate_with_conflicts, load_plan, write_plan
+plan = load_plan()
+annotate_with_conflicts(plan)
+write_plan(plan)
+"
+```
+
+Per-entry behavior:
+
+- **No conflict** — entry stays at status `planned`.
+- **Conflict** — entry status flips to `conflict`, `Conflict:` line
+  records `session <id> on <branch> (<intent>)` for each overlapping
+  open work item.
+
+Halt and report rather than auto-resolving. The operator decides
+whether to re-scope, wait for the conflicting session to finish, or
+override (an override is a manual edit of the plan file flipping
+`Status: conflict` back to `Status: planned`).
+
+If `inflight-check.py` itself fails (exit 2 / unexpected non-zero),
+surface the failure and stop — a broken gate is not the same as an
+empty conflict list.
+
+#### Phase C — User confirmation
+
+Present the plan to the operator with explicit framing:
+
+> "I have a plan for **N worktrees**: M ready to dispatch, K blocked by
+> in-flight conflicts. The plan is written to
+> `.claude/state/dispatch-plan.md` (durable, survives session close).
+>
+> Ready to dispatch the M unblocked worktrees? Type `go` to launch, or
+> tell me which entries to skip / re-scope first."
+
+Show a per-entry summary in the chat (worktree name, issues, intent,
+status). Do **not** create any worktree until the operator types `go`
+(or an equivalent unambiguous confirmation). This is the line that
+keeps a runaway dispatcher from spawning worktrees the human did not
+agree to.
+
+#### Phase D — Dispatch
+
+For each entry whose status is `planned` (in plan-file order):
+
+1. Re-check conflicts immediately before launch — the in-flight state
+   may have changed between Phase B and now (e.g. a sibling session
+   completed). If a new conflict appears, mark the entry `skipped` with
+   the new conflict detail and continue to the next entry.
+2. Invoke the `/start` skill for that worktree. The Skill tool is the
+   inter-skill calling mechanism; pass the entry's data inline so
+   `/start` can extract name + issues using its existing parser:
+
+   ```
+   /start <intent>; issues <#N> <#M>; suggested branch feat/<name>
+   ```
+
+   `/start` already handles: worktree creation, workflow-state init,
+   in-flight registration via `inflight-register.py`, and the inline
+   prompt handoff to a new claude session. **Do not duplicate any of
+   that here.** This subverb's job is to invoke `/start` once per
+   entry, not to re-implement what it does.
+
+   If the inter-skill invocation mechanism is unavailable in the
+   current runtime (e.g. nested `Skill` tool calls are restricted),
+   fall back to printing the exact `/start` prompt the operator should
+   paste into a new session. The plan file already records intent so
+   the manual fallback is recoverable.
+
+3. Capture the session ID returned by `/start` (or the registered
+   session from `.claude/state/in-flight-issues.json` matching the
+   branch name).
+4. Mark the entry launched in the plan file:
+
+   ```bash
+   python -c "
+   import sys
+   sys.path.insert(0, 'scripts')
+   from dispatch_plan import load_plan, mark_launched, write_plan
+   plan = load_plan()
+   mark_launched(plan, '<worktree>', session_id='<sid>')
+   write_plan(plan)
+   "
+   ```
+
+5. Report progress in chat after each launch (`[N/M] launched
+   feat/<name> as session <sid>`).
+
+Do not parallelize the launches — each worktree creation must register
+in the in-flight state before the next one's pre-launch re-check, or
+the second launch may not see the first as a conflict.
+
+#### Phase E — Post-dispatch summary
+
+After the loop completes:
+
+1. Re-read the plan file (it is the source of truth — Phase D wrote to
+   it after every launch).
+2. Print a final summary using the helper:
+
+   ```bash
+   python scripts/dispatch_plan.py summary
+   ```
+
+3. Surface to the operator:
+
+   > "Dispatched **M** worktrees, skipped **K** due to conflicts.
+   > Plan file at `.claude/state/dispatch-plan.md`. Each launched
+   > session is now self-contained — this dispatcher session's job
+   > is done."
+
+The dispatcher session **does not continue working** after Phase E.
+The launched sessions handle their own lifecycle (each one runs the
+existing `/gates` -> `/verify` -> `/pr` pipeline per `/start`'s routing).
+
+### Plan file schema
+
+`.claude/state/dispatch-plan.md` (markdown, parseable by
+`scripts/dispatch_plan.py::parse_plan`):
+
+```markdown
+# Dispatch Plan
+
+Schema: 1
+Generated: 2026-04-19T01:30:00Z
+Generator: session-<id>
+
+Status legend: planned | conflict | in-flight | done | skipped
+
+## Planned
+
+### Worktree: feat/issue-660
+- Issues: #660
+- Areas: src/PPDS.Auth/
+- Intent: env var auth
+- Status: planned
+
+### Worktree: feat/audit-capture
+- Issues: #101, #102
+- Areas: src/PPDS.Audit/
+- Intent: audit capture pipeline
+- Status: in-flight
+- Launched: 2026-04-19T01:32:14Z
+- Session: a1b2c3d4
+```
+
+Allowed status values: `planned`, `conflict`, `in-flight`, `done`,
+`skipped`. The parser is forgiving of human edits (unknown lines
+inside an entry are ignored) so the operator can leave inline notes
+without breaking subsequent dispatch waves.
+
+### Rules
+
+1. **Plan first, dispatch second.** Phase A always writes the plan
+   file before Phase C asks for confirmation. If the dispatcher session
+   dies mid-flow, the next session can pick up by reading the plan.
+2. **Conflict check is mandatory per entry.** Both pre-confirmation
+   (Phase B) and immediately-pre-launch (Phase D step 1). The pre-
+   launch re-check catches state changes during operator deliberation.
+3. **Never auto-resolve a conflict.** Halt, report, let the operator
+   decide. Auto-resolution risks the exact duplicate-work pattern the
+   in-flight registry was built to prevent (#802).
+4. **One `/start` invocation per entry.** This subverb does not create
+   worktrees, init workflow state, or write inline prompts directly —
+   `/start` owns all of that. Bypassing it would re-introduce the
+   duplication that caused B5 in the first place.
+5. **Sequential dispatch.** Do not parallelize Phase D launches. The
+   in-flight registry's race-acceptance contract (PR #813) is "last
+   writer wins, both visible" — fine for two siblings, bad for a
+   dispatcher launching N at once.
+6. **Dispatcher session exits after Phase E.** Do not continue work in
+   the dispatcher session after the launches complete. Each launched
+   session is autonomous.
+
 ## Error Handling
 
 | Error | Recovery |
@@ -197,3 +442,6 @@ gh issue list --state open --limit 200 --json number,labels,milestone --jq '[.[]
 | Permission denied on gh command | Run `gh auth login` to re-authenticate |
 | Label doesn't exist | Check `docs/BACKLOG.md` for current taxonomy, create if needed |
 | Milestone doesn't exist | List milestones with `gh api repos/{owner}/{repo}/milestones`, create if needed |
+| `dispatch-plan.md` parse error | Plan was hand-edited into an invalid state. Restore from `git diff` or delete the file and re-run Phase A. |
+| `inflight-check.py` returns rc=2 | A required arg is missing — the dispatcher constructed a bad CLI line. Halt; do not silently treat as "no conflict". |
+| `mark_launched` raises `KeyError` | The dispatcher passed a worktree name that is not in the plan file (typo, or the file was edited between Phase A and Phase D). Halt and resync. |

--- a/scripts/dispatch_plan.py
+++ b/scripts/dispatch_plan.py
@@ -35,10 +35,19 @@ import json
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Iterator
+
+# Reuse the cross-platform locking primitives from inflight_common rather
+# than duplicating them: same OS-level fcntl/msvcrt strategy, single
+# source of truth for the lock implementation. The plan file lives next
+# to the in-flight registry and shares the same coordination needs
+# (cross-session, cross-worktree, read-modify-write windows during
+# Phase D of the dispatch flow).
+from inflight_common import _lock, _unlock  # noqa: E402
 
 PLAN_SCHEMA_VERSION = 1  # bump if file format changes
 
@@ -250,21 +259,41 @@ def _parse_issues(value: str) -> list[int]:
     return out
 
 
+def _write_plan_payload(path: Path, payload: str) -> None:
+    """Write-then-rename so a partial write never leaves a half-parsed file."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(path)
+
+
 def write_plan(plan: DispatchPlan, path: Path | None = None) -> Path:
     """Atomically (best-effort) write ``plan`` to ``path`` (default location).
 
     Uses a write-then-rename pattern so a partial write never leaves the
     file in a half-parsed state — important because the dispatcher edits
     the plan after every launch.
+
+    Holds an exclusive OS-level lock for the duration of the write so
+    that two concurrent dispatcher runs (or an operator hand-edit racing
+    with the dispatcher) cannot interleave and lose updates.
     """
     if path is None:
         path = plan_path()
     if not plan.generated:
         plan.generated = now_utc_iso()
     payload = plan.as_markdown()
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(payload, encoding="utf-8")
-    tmp.replace(path)
+
+    # Use a sidecar lock file: we cannot lock the plan file itself across
+    # the rename without losing the lock on the renamed inode. The lock
+    # file is durable next to the plan and never written to except as a
+    # lock target. Open in a+ so it gets created on first use.
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with open(lock_path, "a+", encoding="utf-8") as lockfp:
+        _lock(lockfp)
+        try:
+            _write_plan_payload(path, payload)
+        finally:
+            _unlock(lockfp)
     return path
 
 
@@ -274,12 +303,53 @@ def load_plan(path: Path | None = None) -> DispatchPlan:
     Returns an empty plan if the file does not exist — the caller can
     then populate ``entries`` and call :func:`write_plan` for the first
     time without special-casing missing-file logic.
+
+    Acquires the same sidecar lock as :func:`write_plan` so a concurrent
+    writer cannot have the file half-renamed when we read it.
     """
     if path is None:
         path = plan_path()
     if not path.exists():
         return DispatchPlan()
-    return parse_plan(path.read_text(encoding="utf-8"))
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with open(lock_path, "a+", encoding="utf-8") as lockfp:
+        _lock(lockfp)
+        try:
+            return parse_plan(path.read_text(encoding="utf-8"))
+        finally:
+            _unlock(lockfp)
+
+
+@contextmanager
+def locked_plan(path: Path | None = None) -> Iterator[DispatchPlan]:
+    """Read-modify-write helper that holds the plan lock across the window.
+
+    Yields the parsed :class:`DispatchPlan`; on context exit, the plan is
+    written back atomically. Use this from any caller that needs to load
+    the plan, mutate it, and persist the change without another process
+    racing in between (the typical Phase D pattern).
+
+    Example::
+
+        with locked_plan() as plan:
+            mark_launched(plan, "feat/foo", session_id="abc")
+    """
+    if path is None:
+        path = plan_path()
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with open(lock_path, "a+", encoding="utf-8") as lockfp:
+        _lock(lockfp)
+        try:
+            if path.exists():
+                plan = parse_plan(path.read_text(encoding="utf-8"))
+            else:
+                plan = DispatchPlan()
+            yield plan
+            if not plan.generated:
+                plan.generated = now_utc_iso()
+            _write_plan_payload(path, plan.as_markdown())
+        finally:
+            _unlock(lockfp)
 
 
 # ---------------------------------------------------------------------------
@@ -350,8 +420,12 @@ def run_conflict_check(
             continue
         # rc == 2 or anything else: treat as a hard failure rather than
         # a silent pass — the operator should know the gate could not run.
+        # Surface stderr in the error so the operator can diagnose without
+        # re-running the subprocess by hand (Gemini #3106679471).
+        stderr_msg = (_stderr or "").strip()
         raise RuntimeError(
             f"inflight-check.py exited with rc={rc} for cmd={cmd!r}"
+            + (f"; stderr: {stderr_msg}" if stderr_msg else "")
         )
     return (len(all_conflicts) == 0), all_conflicts
 
@@ -427,13 +501,18 @@ def build_plan_from_dicts(
     """
     plan = DispatchPlan(generator=generator, generated=generated or now_utc_iso())
     for raw in items:
+        # AI-generated JSON often emits explicit ``null`` for optional
+        # list/string fields; ``raw.get(k, default)`` returns ``None`` in
+        # that case, which would TypeError downstream. The ``or default``
+        # idiom collapses both missing and explicit-null to the safe
+        # default (Gemini #3106679474).
         plan.entries.append(
             PlanEntry(
                 worktree=str(raw["worktree"]),
-                issues=[int(i) for i in raw.get("issues", [])],
-                areas=[str(a) for a in raw.get("areas", [])],
-                intent=str(raw.get("intent", "")),
-                status=str(raw.get("status", STATUS_PLANNED)),
+                issues=[int(i) for i in (raw.get("issues") or [])],
+                areas=[str(a) for a in (raw.get("areas") or [])],
+                intent=str(raw.get("intent") or ""),
+                status=str(raw.get("status") or STATUS_PLANNED),
             )
         )
     return plan

--- a/scripts/dispatch_plan.py
+++ b/scripts/dispatch_plan.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Helpers for the ``/backlog dispatch`` subverb.
+
+A *dispatch plan* is a markdown file at ``.claude/state/dispatch-plan.md``
+that records the worktrees the dispatcher session intends to launch in
+response to ``/backlog dispatch``. The plan is durable — it survives
+the session that authored it — so that a subsequent dispatcher run can
+see what is in flight, resume an interrupted launch wave, or simply
+audit what happened.
+
+Why a markdown file (not JSON) at ``.claude/state/``:
+
+* ``.plans/`` is gitignored; ``.claude/state/`` is the agreed durable
+  location for cross-session state (the in-flight registry from PR #813
+  also lives there).
+* Markdown is human-skimmable in code review, which matters because the
+  dispatcher session asks the operator to confirm the plan before any
+  worktree create. A JSON dump would be opaque in chat.
+* The format is regular enough to parse mechanically (see
+  :func:`parse_plan`), so the skill can update entry status after each
+  launch without losing operator-edited context.
+
+The plan is *generated* by Phase A of the dispatch flow (after the
+backlog triage identifies what is ready), *gated* by Phase B's per-
+entry conflict check against the in-flight registry, *executed* in
+Phase D when the operator confirms, and *amended* in Phase E with
+launch timestamps and session IDs.
+
+This module is intentionally pure-Python and side-effect-free at import
+time so the unit tests can exercise it without spawning subprocesses.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable
+
+PLAN_SCHEMA_VERSION = 1  # bump if file format changes
+
+# Status vocabulary. Kept narrow so the parser can validate; downstream
+# tooling (status reports, future TUI surface) reads the same set.
+STATUS_PLANNED = "planned"
+STATUS_CONFLICT = "conflict"
+STATUS_IN_FLIGHT = "in-flight"
+STATUS_DONE = "done"
+STATUS_SKIPPED = "skipped"
+
+VALID_STATUSES = {
+    STATUS_PLANNED,
+    STATUS_CONFLICT,
+    STATUS_IN_FLIGHT,
+    STATUS_DONE,
+    STATUS_SKIPPED,
+}
+
+
+def repo_root() -> Path:
+    """Return the repository root (mirror of :mod:`inflight_common`)."""
+    here = Path(__file__).resolve().parent
+    for candidate in [here, *here.parents]:
+        if (candidate / ".claude").is_dir():
+            return candidate
+    return here.parent
+
+
+def plan_path() -> Path:
+    """Absolute path to the dispatch plan file.
+
+    The plan is shared across all worktrees because it represents the
+    dispatcher session's intent for the *whole* repository, not any one
+    branch. Living next to ``in-flight-issues.json`` keeps the two
+    cross-session artifacts colocated.
+    """
+    p = repo_root() / ".claude" / "state" / "dispatch-plan.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def now_utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlanEntry:
+    """One worktree the dispatcher intends to launch."""
+
+    worktree: str  # branch-name-style key, e.g. "feat/issue-660"
+    issues: list[int] = field(default_factory=list)
+    areas: list[str] = field(default_factory=list)
+    intent: str = ""
+    status: str = STATUS_PLANNED
+    conflict_detail: str = ""
+    launched_at: str = ""
+    launched_by_session: str = ""
+
+    def as_markdown(self) -> str:
+        issues_str = ", ".join(f"#{i}" for i in self.issues) if self.issues else "(none)"
+        areas_str = ", ".join(self.areas) if self.areas else "(none)"
+        lines = [
+            f"### Worktree: {self.worktree}",
+            f"- Issues: {issues_str}",
+            f"- Areas: {areas_str}",
+            f"- Intent: {self.intent or '(unspecified)'}",
+            f"- Status: {self.status}",
+        ]
+        if self.conflict_detail:
+            lines.append(f"- Conflict: {self.conflict_detail}")
+        if self.launched_at:
+            lines.append(f"- Launched: {self.launched_at}")
+        if self.launched_by_session:
+            lines.append(f"- Session: {self.launched_by_session}")
+        return "\n".join(lines)
+
+
+@dataclass
+class DispatchPlan:
+    """The full plan: header metadata + ordered list of entries."""
+
+    generated: str = ""
+    generator: str = ""
+    entries: list[PlanEntry] = field(default_factory=list)
+    version: int = PLAN_SCHEMA_VERSION
+
+    def as_markdown(self) -> str:
+        header = [
+            "# Dispatch Plan",
+            "",
+            f"Schema: {self.version}",
+            f"Generated: {self.generated or now_utc_iso()}",
+            f"Generator: {self.generator or '(unknown)'}",
+            "",
+            "Status legend: planned | conflict | in-flight | done | skipped",
+            "",
+            "## Planned",
+            "",
+        ]
+        if not self.entries:
+            header.append("_(no worktrees planned)_")
+            return "\n".join(header) + "\n"
+        body = "\n\n".join(e.as_markdown() for e in self.entries)
+        return "\n".join(header) + body + "\n"
+
+    def find(self, worktree: str) -> PlanEntry | None:
+        for e in self.entries:
+            if e.worktree == worktree:
+                return e
+        return None
+
+    def summary_counts(self) -> dict[str, int]:
+        counts = {s: 0 for s in VALID_STATUSES}
+        for e in self.entries:
+            counts[e.status] = counts.get(e.status, 0) + 1
+        return counts
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+_ENTRY_HEADER_RE = re.compile(r"^###\s+Worktree:\s+(.+)$")
+_KV_RE = re.compile(r"^-\s+(?P<key>[A-Za-z][A-Za-z\- ]*?):\s*(?P<value>.*)$")
+
+
+def parse_plan(text: str) -> DispatchPlan:
+    """Parse a previously-written plan markdown file back into a DispatchPlan.
+
+    The parser is forgiving: unknown lines inside an entry block are
+    ignored so a human can edit the file (e.g. add a note) without
+    breaking subsequent ``write_plan`` round-trips. Required keys
+    (``Status``) are validated; an unknown status is coerced to
+    ``planned`` so the dispatcher does not silently treat a typo as
+    "done".
+    """
+    plan = DispatchPlan()
+    current: PlanEntry | None = None
+
+    def commit():
+        nonlocal current
+        if current is not None:
+            plan.entries.append(current)
+            current = None
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        if line.startswith("Generated:"):
+            plan.generated = line.split(":", 1)[1].strip()
+            continue
+        if line.startswith("Generator:"):
+            plan.generator = line.split(":", 1)[1].strip()
+            continue
+        if line.startswith("Schema:"):
+            try:
+                plan.version = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+            continue
+        m = _ENTRY_HEADER_RE.match(line)
+        if m:
+            commit()
+            current = PlanEntry(worktree=m.group(1).strip())
+            continue
+        if current is None:
+            continue
+        kv = _KV_RE.match(line)
+        if not kv:
+            continue
+        key = kv.group("key").strip().lower()
+        value = kv.group("value").strip()
+        if key == "issues":
+            current.issues = _parse_issues(value)
+        elif key == "areas":
+            current.areas = [] if value in ("(none)", "") else [
+                a.strip() for a in value.split(",") if a.strip()
+            ]
+        elif key == "intent":
+            current.intent = "" if value == "(unspecified)" else value
+        elif key == "status":
+            current.status = value if value in VALID_STATUSES else STATUS_PLANNED
+        elif key == "conflict":
+            current.conflict_detail = value
+        elif key == "launched":
+            current.launched_at = value
+        elif key == "session":
+            current.launched_by_session = value
+    commit()
+    return plan
+
+
+def _parse_issues(value: str) -> list[int]:
+    if value in ("(none)", ""):
+        return []
+    out: list[int] = []
+    for token in value.split(","):
+        token = token.strip().lstrip("#")
+        if token.isdigit():
+            out.append(int(token))
+    return out
+
+
+def write_plan(plan: DispatchPlan, path: Path | None = None) -> Path:
+    """Atomically (best-effort) write ``plan`` to ``path`` (default location).
+
+    Uses a write-then-rename pattern so a partial write never leaves the
+    file in a half-parsed state — important because the dispatcher edits
+    the plan after every launch.
+    """
+    if path is None:
+        path = plan_path()
+    if not plan.generated:
+        plan.generated = now_utc_iso()
+    payload = plan.as_markdown()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    tmp.replace(path)
+    return path
+
+
+def load_plan(path: Path | None = None) -> DispatchPlan:
+    """Read and parse the plan from ``path`` (default location).
+
+    Returns an empty plan if the file does not exist — the caller can
+    then populate ``entries`` and call :func:`write_plan` for the first
+    time without special-casing missing-file logic.
+    """
+    if path is None:
+        path = plan_path()
+    if not path.exists():
+        return DispatchPlan()
+    return parse_plan(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Conflict check integration
+# ---------------------------------------------------------------------------
+
+
+# Exit codes from inflight-check.py:
+#   0 = no conflict, 1 = conflict, 2 = bad args.
+INFLIGHT_OK = 0
+INFLIGHT_CONFLICT = 1
+INFLIGHT_BADARGS = 2
+
+
+def _default_runner(cmd: list[str]) -> tuple[int, str, str]:
+    """Subprocess runner used by :func:`run_conflict_check` in production.
+
+    Tests inject a callable that returns ``(returncode, stdout, stderr)``
+    so the suite never spawns ``python scripts/inflight-check.py``.
+    """
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def run_conflict_check(
+    entry: PlanEntry,
+    *,
+    runner: Callable[[list[str]], tuple[int, str, str]] | None = None,
+    script_path: Path | None = None,
+) -> tuple[bool, list[dict]]:
+    """Run ``inflight-check.py`` for one entry; return ``(ok, conflicts)``.
+
+    ``ok`` is True when no conflict was detected (exit 0). ``conflicts``
+    is the JSON list parsed from stdout when the script reports one
+    (exit 1); empty otherwise.
+
+    The check fans out one invocation per (issue, area) pair so that a
+    single entry covering multiple areas doesn't accidentally mask an
+    overlap on a sibling area. Issue conflicts are checked first because
+    they are usually the cleaner signal (whole-issue duplication).
+    """
+    runner = runner or _default_runner
+    if script_path is None:
+        script_path = repo_root() / "scripts" / "inflight-check.py"
+    all_conflicts: list[dict] = []
+
+    queries: list[list[str]] = []
+    for issue in entry.issues:
+        queries.append(["--issue", str(issue)])
+    for area in entry.areas:
+        queries.append(["--area", area])
+    if not queries:
+        # No issue and no area means nothing to check — treat as ok.
+        return True, []
+
+    for q in queries:
+        cmd = [sys.executable, str(script_path), *q]
+        rc, stdout, _stderr = runner(cmd)
+        if rc == INFLIGHT_OK:
+            continue
+        if rc == INFLIGHT_CONFLICT:
+            try:
+                payload = json.loads(stdout) if stdout.strip() else {}
+            except json.JSONDecodeError:
+                payload = {}
+            for c in payload.get("conflicts", []) or []:
+                all_conflicts.append(c)
+            continue
+        # rc == 2 or anything else: treat as a hard failure rather than
+        # a silent pass — the operator should know the gate could not run.
+        raise RuntimeError(
+            f"inflight-check.py exited with rc={rc} for cmd={cmd!r}"
+        )
+    return (len(all_conflicts) == 0), all_conflicts
+
+
+def annotate_with_conflicts(
+    plan: DispatchPlan,
+    *,
+    runner: Callable[[list[str]], tuple[int, str, str]] | None = None,
+) -> DispatchPlan:
+    """Walk every ``planned`` entry and update its status from a check.
+
+    Entries already at a terminal status (``in-flight``, ``done``,
+    ``skipped``) are left alone — the operator may have hand-curated
+    them, or a previous dispatch wave already executed them.
+    """
+    for entry in plan.entries:
+        if entry.status != STATUS_PLANNED:
+            continue
+        ok, conflicts = run_conflict_check(entry, runner=runner)
+        if ok:
+            continue
+        entry.status = STATUS_CONFLICT
+        # Render a one-line description so the operator sees who owns
+        # the overlapping work without opening another tool.
+        entry.conflict_detail = "; ".join(
+            f"session {c.get('session_id', '?')} on {c.get('branch', '?')}"
+            f" ({c.get('intent') or 'no intent'})"
+            for c in conflicts
+        )
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Post-dispatch annotation
+# ---------------------------------------------------------------------------
+
+
+def mark_launched(
+    plan: DispatchPlan,
+    worktree: str,
+    *,
+    session_id: str = "",
+    when: str | None = None,
+) -> PlanEntry:
+    """Flip an entry to ``in-flight`` and stamp launch metadata.
+
+    Raises ``KeyError`` if no entry matches ``worktree`` — defensive
+    against a typo in the SKILL.md prompt that would otherwise silently
+    drop the launch from the plan.
+    """
+    entry = plan.find(worktree)
+    if entry is None:
+        raise KeyError(f"no plan entry for worktree {worktree!r}")
+    entry.status = STATUS_IN_FLIGHT
+    entry.launched_at = when or now_utc_iso()
+    entry.launched_by_session = session_id
+    return entry
+
+
+def build_plan_from_dicts(
+    items: Iterable[dict],
+    *,
+    generator: str = "",
+    generated: str = "",
+) -> DispatchPlan:
+    """Construct a :class:`DispatchPlan` from a list of dict descriptors.
+
+    Used by the SKILL.md instruction sequence: the dispatcher session
+    triages the backlog, builds an in-memory list of dicts, and hands
+    them here. Keeping the constructor in the helper means we don't
+    duplicate validation in two places when a future caller wires this
+    up.
+    """
+    plan = DispatchPlan(generator=generator, generated=generated or now_utc_iso())
+    for raw in items:
+        plan.entries.append(
+            PlanEntry(
+                worktree=str(raw["worktree"]),
+                issues=[int(i) for i in raw.get("issues", [])],
+                areas=[str(a) for a in raw.get("areas", [])],
+                intent=str(raw.get("intent", "")),
+                status=str(raw.get("status", STATUS_PLANNED)),
+            )
+        )
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# CLI for ad-hoc inspection
+# ---------------------------------------------------------------------------
+
+
+def _format_summary(plan: DispatchPlan) -> str:
+    counts = plan.summary_counts()
+    parts = [f"{k}={v}" for k, v in sorted(counts.items()) if v]
+    if not parts:
+        return "(empty plan)"
+    return ", ".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Tiny CLI: ``python scripts/dispatch_plan.py [show|summary]``.
+
+    ``show`` prints the raw markdown (useful from a non-interactive
+    runner). ``summary`` prints the per-status counts. Anything else
+    (or no args) prints the summary.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    plan = load_plan()
+    if args and args[0] == "show":
+        sys.stdout.write(plan.as_markdown())
+        return 0
+    sys.stdout.write(_format_summary(plan) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/state/test_dispatch_plan.py
+++ b/tests/state/test_dispatch_plan.py
@@ -12,6 +12,7 @@ Covers:
 """
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import sys
 from pathlib import Path
@@ -262,6 +263,36 @@ class TestRunConflictCheck:
         with pytest.raises(RuntimeError, match="rc=2"):
             dp.run_conflict_check(entry, runner=runner)
 
+    def test_inflight_failure_includes_stderr(self):
+        """Gemini #3106679471: stderr from inflight-check.py must surface in
+        the RuntimeError so the operator can diagnose without re-running.
+        """
+        entry = dp.PlanEntry(worktree="feat/x", issues=[1])
+
+        def runner(cmd):
+            return (
+                dp.INFLIGHT_BADARGS,
+                "",
+                "argparse: --issue must be a positive integer\n",
+            )
+
+        with pytest.raises(RuntimeError, match="argparse: --issue must be a positive integer"):
+            dp.run_conflict_check(entry, runner=runner)
+
+    def test_inflight_failure_without_stderr_still_raises(self):
+        """Empty stderr should still produce a sensible error (no trailing
+        ``stderr:`` suffix when nothing to add).
+        """
+        entry = dp.PlanEntry(worktree="feat/x", issues=[1])
+
+        def runner(cmd):
+            return (99, "", "")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            dp.run_conflict_check(entry, runner=runner)
+        assert "rc=99" in str(excinfo.value)
+        assert "stderr:" not in str(excinfo.value)
+
 
 class TestAnnotateWithConflicts:
     def test_planned_entry_with_conflict_flips_status(self, tmp_plan):
@@ -418,3 +449,119 @@ class TestDispatchSimulation:
         )
         # Conflict entry was NOT launched.
         assert final.find("feat/audit-capture").launched_by_session == ""
+
+
+# ---------------------------------------------------------------------------
+# Null-tolerance in build_plan_from_dicts (Gemini #3106679474)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlanNullTolerance:
+    """AI-generated JSON often emits ``null`` for optional fields rather than
+    omitting them. ``build_plan_from_dicts`` must absorb explicit nulls
+    without TypeError.
+    """
+
+    def test_explicit_null_issues_treated_as_empty(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "issues": None, "areas": ["src/A/"]},
+        ])
+        assert plan.entries[0].issues == []
+        assert plan.entries[0].areas == ["src/A/"]
+
+    def test_explicit_null_areas_treated_as_empty(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "issues": [1], "areas": None},
+        ])
+        assert plan.entries[0].issues == [1]
+        assert plan.entries[0].areas == []
+
+    def test_explicit_null_intent_treated_as_empty_string(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "intent": None},
+        ])
+        assert plan.entries[0].intent == ""
+
+    def test_explicit_null_status_falls_back_to_planned(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "status": None},
+        ])
+        assert plan.entries[0].status == dp.STATUS_PLANNED
+
+    def test_all_optionals_null_does_not_raise(self):
+        plan = dp.build_plan_from_dicts([
+            {
+                "worktree": "feat/x",
+                "issues": None,
+                "areas": None,
+                "intent": None,
+                "status": None,
+            },
+        ])
+        e = plan.entries[0]
+        assert e.worktree == "feat/x"
+        assert e.issues == []
+        assert e.areas == []
+        assert e.intent == ""
+        assert e.status == dp.STATUS_PLANNED
+
+
+# ---------------------------------------------------------------------------
+# File locking concurrency (Gemini #3106679468)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanLocking:
+    """Mirror the inflight ThreadPoolExecutor concurrency check: spawn N
+    simultaneous read-modify-writes through ``locked_plan`` and verify
+    every update lands without corrupting the markdown file.
+    """
+
+    def test_concurrent_writes_no_corruption(self, tmp_plan):
+        # Seed an empty plan so locked_plan has something to start from.
+        dp.write_plan(dp.DispatchPlan(generator="seed"))
+
+        def add_entry(i: int) -> str:
+            with dp.locked_plan() as plan:
+                plan.entries.append(
+                    dp.PlanEntry(
+                        worktree=f"feat/parallel-{i}",
+                        issues=[1000 + i],
+                        areas=[f"src/Module{i}/"],
+                        intent=f"parallel work {i}",
+                    )
+                )
+            return f"feat/parallel-{i}"
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+            results = list(pool.map(add_entry, range(5)))
+
+        assert sorted(results) == [f"feat/parallel-{i}" for i in range(5)]
+
+        # Reload from disk: every concurrent append must be present and
+        # the file must still parse cleanly (no half-written tmp files,
+        # no truncated markdown).
+        loaded = dp.load_plan()
+        worktrees = sorted(e.worktree for e in loaded.entries)
+        assert worktrees == [f"feat/parallel-{i}" for i in range(5)]
+
+        # No orphaned .tmp file left behind (atomic rename completed).
+        leftover = tmp_plan.with_suffix(tmp_plan.suffix + ".tmp")
+        assert not leftover.exists()
+
+    def test_locked_plan_persists_mutations(self, tmp_plan):
+        with dp.locked_plan() as plan:
+            plan.entries.append(dp.PlanEntry(worktree="feat/from-cm"))
+
+        loaded = dp.load_plan()
+        assert [e.worktree for e in loaded.entries] == ["feat/from-cm"]
+
+    def test_locked_plan_starts_empty_when_file_missing(self, tmp_plan):
+        assert not tmp_plan.exists()
+        with dp.locked_plan() as plan:
+            assert plan.entries == []
+            plan.entries.append(dp.PlanEntry(worktree="feat/first"))
+
+        assert tmp_plan.exists()
+        loaded = dp.load_plan()
+        assert [e.worktree for e in loaded.entries] == ["feat/first"]

--- a/tests/state/test_dispatch_plan.py
+++ b/tests/state/test_dispatch_plan.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Tests for the ``/backlog dispatch`` plan helpers.
+
+Covers:
+  * Plan markdown round-trip (write -> parse -> write)
+  * ``build_plan_from_dicts`` validation
+  * ``run_conflict_check`` integration with a mocked ``inflight-check.py``
+  * ``annotate_with_conflicts`` updates entry status correctly
+  * ``mark_launched`` flips status + stamps metadata
+  * End-to-end 3-worktree dispatch simulation: plan written, conflict
+    check called per entry, launched markers applied
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import dispatch_plan as dp  # noqa: E402  (path tweak required first)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_plan(tmp_path, monkeypatch):
+    """Redirect plan_path() to a temp file."""
+    target = tmp_path / "dispatch-plan.md"
+    monkeypatch.setattr(dp, "plan_path", lambda: target)
+    return target
+
+
+@pytest.fixture
+def sample_items():
+    return [
+        {
+            "worktree": "feat/issue-660",
+            "issues": [660],
+            "areas": ["src/PPDS.Auth/"],
+            "intent": "env var auth",
+        },
+        {
+            "worktree": "feat/audit-capture",
+            "issues": [101, 102],
+            "areas": ["src/PPDS.Audit/", "src/PPDS.Telemetry/"],
+            "intent": "audit capture pipeline",
+        },
+        {
+            "worktree": "feat/cli-help",
+            "issues": [],
+            "areas": ["src/PPDS.Cli/Help/"],
+            "intent": "cli help text overhaul",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Plan generation / serialization
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlan:
+    def test_build_from_dicts_preserves_order(self, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items, generator="session-test")
+        assert [e.worktree for e in plan.entries] == [
+            "feat/issue-660",
+            "feat/audit-capture",
+            "feat/cli-help",
+        ]
+        assert plan.generator == "session-test"
+        assert plan.version == dp.PLAN_SCHEMA_VERSION
+        assert plan.generated  # timestamp filled in
+
+    def test_build_with_no_items_is_valid(self):
+        plan = dp.build_plan_from_dicts([], generator="g")
+        assert plan.entries == []
+        assert "no worktrees planned" in plan.as_markdown()
+
+    def test_default_status_is_planned(self, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items)
+        assert all(e.status == dp.STATUS_PLANNED for e in plan.entries)
+
+    def test_explicit_status_passes_through(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "status": dp.STATUS_DONE},
+        ])
+        assert plan.entries[0].status == dp.STATUS_DONE
+
+
+class TestPlanFile:
+    def test_write_then_load_round_trip(self, tmp_plan, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items, generator="session-abc")
+        dp.write_plan(plan)
+
+        loaded = dp.load_plan()
+        assert loaded.generator == "session-abc"
+        assert [e.worktree for e in loaded.entries] == [
+            e["worktree"] for e in sample_items
+        ]
+        # Issue / area parsing survives round trip.
+        assert loaded.entries[0].issues == [660]
+        assert loaded.entries[1].issues == [101, 102]
+        assert loaded.entries[1].areas == [
+            "src/PPDS.Audit/",
+            "src/PPDS.Telemetry/",
+        ]
+
+    def test_load_when_file_missing_returns_empty_plan(self, tmp_plan):
+        assert not tmp_plan.exists()
+        plan = dp.load_plan()
+        assert plan.entries == []
+        assert plan.version == dp.PLAN_SCHEMA_VERSION
+
+    def test_write_uses_atomic_rename(self, tmp_plan, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items)
+        dp.write_plan(plan)
+        # The .tmp staging file must not be left behind.
+        leftover = tmp_plan.with_suffix(tmp_plan.suffix + ".tmp")
+        assert not leftover.exists()
+        assert tmp_plan.exists()
+
+    def test_unknown_status_coerced_to_planned(self, tmp_plan):
+        # Hand-write a plan with an invalid status — the parser should not
+        # silently treat the typo as terminal.
+        tmp_plan.write_text(
+            "# Dispatch Plan\n\n"
+            "Schema: 1\n"
+            "Generated: 2026-04-19T00:00:00Z\n"
+            "Generator: t\n\n"
+            "## Planned\n\n"
+            "### Worktree: feat/typo\n"
+            "- Issues: #1\n"
+            "- Areas: src/X/\n"
+            "- Intent: test\n"
+            "- Status: dunne\n",
+            encoding="utf-8",
+        )
+        loaded = dp.load_plan()
+        assert loaded.entries[0].status == dp.STATUS_PLANNED
+
+    def test_human_inline_notes_dont_break_parser(self, tmp_plan):
+        tmp_plan.write_text(
+            "# Dispatch Plan\n\n"
+            "Schema: 1\n"
+            "Generated: 2026-04-19T00:00:00Z\n"
+            "Generator: t\n\n"
+            "## Planned\n\n"
+            "### Worktree: feat/x\n"
+            "- Issues: #1\n"
+            "- Areas: src/X/\n"
+            "- Intent: test\n"
+            "- Status: planned\n"
+            "Note from josh: revisit after PR #999 merges\n",
+            encoding="utf-8",
+        )
+        loaded = dp.load_plan()
+        assert len(loaded.entries) == 1
+        assert loaded.entries[0].worktree == "feat/x"
+
+    def test_summary_counts(self, tmp_plan):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "a", "status": dp.STATUS_PLANNED},
+            {"worktree": "b", "status": dp.STATUS_PLANNED},
+            {"worktree": "c", "status": dp.STATUS_CONFLICT},
+            {"worktree": "d", "status": dp.STATUS_IN_FLIGHT},
+        ])
+        counts = plan.summary_counts()
+        assert counts[dp.STATUS_PLANNED] == 2
+        assert counts[dp.STATUS_CONFLICT] == 1
+        assert counts[dp.STATUS_IN_FLIGHT] == 1
+        assert counts[dp.STATUS_DONE] == 0
+
+
+# ---------------------------------------------------------------------------
+# Conflict-check integration
+# ---------------------------------------------------------------------------
+
+
+def _runner_factory(plan_per_call: list[tuple[int, dict]]):
+    """Build a runner that returns the next (rc, payload) on each call.
+
+    ``plan_per_call`` is consumed in order. Each entry is the simulated
+    inflight-check.py response for one CLI invocation. ``payload`` is the
+    JSON that the script would print on stdout; the runner serializes it
+    automatically.
+    """
+    calls: list[list[str]] = []
+    iterator = iter(plan_per_call)
+
+    def runner(cmd: list[str]) -> tuple[int, str, str]:
+        calls.append(cmd)
+        try:
+            rc, payload = next(iterator)
+        except StopIteration as exc:
+            raise AssertionError(
+                f"runner called more times than scripted; extra cmd={cmd!r}"
+            ) from exc
+        return rc, json.dumps(payload), ""
+
+    return runner, calls
+
+
+class TestRunConflictCheck:
+    def test_no_conflict_when_all_clear(self):
+        entry = dp.PlanEntry(
+            worktree="feat/x",
+            issues=[1, 2],
+            areas=["src/A/"],
+        )
+        # 2 issues + 1 area = 3 calls, all rc=0.
+        runner, calls = _runner_factory([
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+        ])
+        ok, conflicts = dp.run_conflict_check(entry, runner=runner)
+        assert ok is True
+        assert conflicts == []
+        assert len(calls) == 3
+        # Issues are checked before areas (cleaner signal first).
+        assert calls[0][-2:] == ["--issue", "1"]
+        assert calls[1][-2:] == ["--issue", "2"]
+        assert calls[2][-2:] == ["--area", "src/A/"]
+
+    def test_conflict_collected_across_queries(self):
+        entry = dp.PlanEntry(
+            worktree="feat/x",
+            issues=[5],
+            areas=["src/A/", "src/B/"],
+        )
+        runner, _ = _runner_factory([
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_CONFLICT, {"conflicts": [
+                {"session_id": "abc", "branch": "feat/sib1", "intent": "shipped"},
+            ]}),
+            (dp.INFLIGHT_CONFLICT, {"conflicts": [
+                {"session_id": "def", "branch": "feat/sib2", "intent": "wip"},
+            ]}),
+        ])
+        ok, conflicts = dp.run_conflict_check(entry, runner=runner)
+        assert ok is False
+        assert {c["session_id"] for c in conflicts} == {"abc", "def"}
+
+    def test_no_issues_no_areas_treated_as_ok(self):
+        entry = dp.PlanEntry(worktree="feat/empty")
+        runner, calls = _runner_factory([])  # no calls expected
+        ok, conflicts = dp.run_conflict_check(entry, runner=runner)
+        assert ok is True
+        assert conflicts == []
+        assert calls == []
+
+    def test_inflight_badargs_raises(self):
+        entry = dp.PlanEntry(worktree="feat/x", issues=[1])
+        runner, _ = _runner_factory([(dp.INFLIGHT_BADARGS, {})])
+        with pytest.raises(RuntimeError, match="rc=2"):
+            dp.run_conflict_check(entry, runner=runner)
+
+
+class TestAnnotateWithConflicts:
+    def test_planned_entry_with_conflict_flips_status(self, tmp_plan):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "issues": [1], "areas": ["src/A/"]},
+        ])
+        runner, _ = _runner_factory([
+            # 1 issue + 1 area
+            (dp.INFLIGHT_CONFLICT, {"conflicts": [
+                {"session_id": "rival", "branch": "feat/rival",
+                 "intent": "doing the same thing"},
+            ]}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+        ])
+        dp.annotate_with_conflicts(plan, runner=runner)
+
+        entry = plan.find("feat/x")
+        assert entry.status == dp.STATUS_CONFLICT
+        assert "rival" in entry.conflict_detail
+        assert "feat/rival" in entry.conflict_detail
+        assert "doing the same thing" in entry.conflict_detail
+
+    def test_planned_entry_without_conflict_unchanged(self):
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/x", "issues": [1]},
+        ])
+        runner, _ = _runner_factory([(dp.INFLIGHT_OK, {"conflicts": []})])
+        dp.annotate_with_conflicts(plan, runner=runner)
+        assert plan.find("feat/x").status == dp.STATUS_PLANNED
+
+    def test_terminal_status_left_alone(self):
+        # in-flight entries should not be re-checked — they are already
+        # launched, and a re-check would burn an unnecessary subprocess.
+        plan = dp.build_plan_from_dicts([
+            {"worktree": "feat/done", "issues": [1], "status": dp.STATUS_DONE},
+            {"worktree": "feat/wip", "issues": [2], "status": dp.STATUS_IN_FLIGHT},
+            {"worktree": "feat/skip", "issues": [3], "status": dp.STATUS_SKIPPED},
+        ])
+        runner, calls = _runner_factory([])  # zero calls expected
+        dp.annotate_with_conflicts(plan, runner=runner)
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# mark_launched
+# ---------------------------------------------------------------------------
+
+
+class TestMarkLaunched:
+    def test_flips_status_and_stamps_metadata(self, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items)
+        dp.mark_launched(plan, "feat/issue-660", session_id="abc12345")
+
+        entry = plan.find("feat/issue-660")
+        assert entry.status == dp.STATUS_IN_FLIGHT
+        assert entry.launched_by_session == "abc12345"
+        assert entry.launched_at  # auto-stamped
+
+    def test_unknown_worktree_raises(self, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items)
+        with pytest.raises(KeyError):
+            dp.mark_launched(plan, "feat/typo")
+
+    def test_explicit_when_used(self, sample_items):
+        plan = dp.build_plan_from_dicts(sample_items)
+        dp.mark_launched(
+            plan, "feat/issue-660", session_id="x", when="2026-04-19T12:00:00Z",
+        )
+        assert plan.find("feat/issue-660").launched_at == "2026-04-19T12:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: 3-worktree dispatch simulation
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSimulation:
+    """The integration scenario the spec calls out:
+
+    Simulate a 3-worktree dispatch plan. Verify:
+      * plan file written
+      * conflict-check is called per planned entry
+      * launched markers applied to the right entries
+      * a mid-flow entry can be skipped without breaking the plan
+    """
+
+    def test_three_worktree_dispatch_flow(self, tmp_plan, sample_items):
+        # Phase A: build + persist the plan.
+        plan = dp.build_plan_from_dicts(
+            sample_items, generator="session-dispatcher",
+        )
+        dp.write_plan(plan)
+        assert tmp_plan.exists()
+
+        # Phase B: conflict check fires once per (issue, area) pair, in
+        # plan-file order. Entry 1 has 1 issue + 1 area = 2 calls. Entry 2
+        # has 2 issues + 2 areas = 4 calls. Entry 3 has 0 issues + 1 area
+        # = 1 call. Make entry 2 conflict on its first area; the rest pass.
+        runner, calls = _runner_factory([
+            # entry 1: clean
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            # entry 2: issue-101 ok, issue-102 ok, src/PPDS.Audit/ conflict, src/PPDS.Telemetry/ ok
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            (dp.INFLIGHT_CONFLICT, {"conflicts": [
+                {"session_id": "blocker", "branch": "feat/audit-rival",
+                 "intent": "already shipping audit pipeline"},
+            ]}),
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+            # entry 3: clean
+            (dp.INFLIGHT_OK, {"conflicts": []}),
+        ])
+
+        # Reload from disk to prove the on-disk plan is the source of truth.
+        loaded = dp.load_plan()
+        dp.annotate_with_conflicts(loaded, runner=runner)
+        dp.write_plan(loaded)
+
+        # Total expected calls = 2 + 4 + 1 = 7
+        assert len(calls) == 7
+
+        # Verify status flips landed correctly.
+        post_b = dp.load_plan()
+        assert post_b.find("feat/issue-660").status == dp.STATUS_PLANNED
+        assert post_b.find("feat/audit-capture").status == dp.STATUS_CONFLICT
+        assert (
+            "blocker"
+            in post_b.find("feat/audit-capture").conflict_detail
+        )
+        assert post_b.find("feat/cli-help").status == dp.STATUS_PLANNED
+
+        # Phase D: dispatch only the unblocked entries. Mark each launched.
+        for entry in post_b.entries:
+            if entry.status == dp.STATUS_PLANNED:
+                dp.mark_launched(
+                    post_b, entry.worktree,
+                    session_id=f"sid-{entry.worktree.split('/')[-1]}",
+                )
+        dp.write_plan(post_b)
+
+        # Phase E: confirm summary reflects the wave.
+        final = dp.load_plan()
+        counts = final.summary_counts()
+        assert counts[dp.STATUS_IN_FLIGHT] == 2  # issue-660 + cli-help
+        assert counts[dp.STATUS_CONFLICT] == 1   # audit-capture
+        assert counts[dp.STATUS_PLANNED] == 0
+        # Launched entries got a session ID.
+        assert (
+            final.find("feat/issue-660").launched_by_session == "sid-issue-660"
+        )
+        assert (
+            final.find("feat/cli-help").launched_by_session == "sid-cli-help"
+        )
+        # Conflict entry was NOT launched.
+        assert final.find("feat/audit-capture").launched_by_session == ""


### PR DESCRIPTION
## Summary

Adds a new `/backlog dispatch` subverb that closes the human-dispatcher
gap from **v1-launch retro item #10 / finding B5**. The historical
dispatcher session pattern (e.g. `cd0c578e`: 19 user turns drove inbox
to 0, closed 4 issues, produced a 6-worktree v1.0 plan but did **zero**
worktree creates) was always human-gated — Josh has had to be the
dispatcher every time.

The new subverb runs a strict **5-phase flow** that preserves the gates
the human was applying tacitly while removing the manual relay:

- **Phase A — Plan generation:** triage + file-overlap grouping, persisted
  to `.claude/state/dispatch-plan.md` (durable, survives session close;
  not gitignored like `.plans/`).
- **Phase B — Pre-flight conflict check:** every entry checked against
  `scripts/inflight-check.py` for both issue-level and area-level overlap.
  Conflicts flip status to `conflict` with detail; never auto-resolved.
- **Phase C — User confirmation:** plan surfaced to operator with explicit
  "ready to dispatch N worktrees, type `go`" prompt.
- **Phase D — Dispatch:** sequential `/start` invocation per planned entry
  (re-checks conflicts immediately before each launch). The `/start`
  skill already owns worktree creation, workflow-state init, and
  in-flight registration via `inflight-register.py` — this subverb does
  not duplicate any of that.
- **Phase E — Post-dispatch summary:** plan re-read, counts surfaced,
  dispatcher session exits.

## Dependency

Depends on **PR #813** (cross-session in-flight state) — already merged
to main. This branch is rebased on top.

## Files

- `.claude/skills/backlog/SKILL.md` — new `## Subverb: dispatch` section
  (~250 lines) documenting the 5-phase flow, plan schema, and rules.
- `scripts/dispatch_plan.py` (new, ~340 lines) — pure-Python helper
  exposing `build_plan_from_dicts`, `write_plan` / `load_plan` /
  `parse_plan`, `run_conflict_check` (subprocess-injectable),
  `annotate_with_conflicts`, `mark_launched`, plus a tiny CLI
  (`python scripts/dispatch_plan.py [show|summary]`).
- `tests/state/test_dispatch_plan.py` (new) — 21 tests covering
  generation, serialization, conflict-check integration, and a 3-worktree
  end-to-end dispatch simulation.

## Test plan

- [x] `python -m pytest tests/state/test_dispatch_plan.py -v` — 21/21 pass
- [x] `python -m pytest tests/state/ -v` — 37/37 pass (no regression in
      existing inflight tests from #813)
- [x] `python scripts/dispatch_plan.py summary` runs cleanly on an empty
      plan
- [ ] Operator-driven smoke test: invoke `/backlog dispatch` against a
      live triaged backlog, verify plan file written, conflict check
      fires per entry, `/start` invoked per unblocked entry on `go`

## Wave context

- This is **Wave 2** work; Wave 1 PRs (#812-#816, #819) are being merged
  in parallel.
- **Do not auto-merge.** Orchestrator will mark ready after CI green
  and Gemini review.

## Notes for reviewer

- The plan file lives at `.claude/state/dispatch-plan.md` (alongside
  `in-flight-issues.json` from #813). Markdown chosen over JSON so the
  operator can review it in chat before confirming, and so a forgiving
  parser tolerates hand-edits (verified in
  `test_human_inline_notes_dont_break_parser`).
- The SKILL.md leaves a clear contract for the inter-skill `/start`
  invocation but does not hard-code a particular Skill-tool calling
  convention; the runtime can fall back to printing the prompt for the
  operator to paste if nested skill invocation is restricted.
- Conflict check is **mandatory and never auto-resolves** — that was
  the entire point of the in-flight registry from #813 (#802 root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)