### PR TITLE
feat(safety): shakedown env allowlist + write-block hooks

### DIFF
--- a/.claude/hooks/dev-env-check.py
+++ b/.claude/hooks/dev-env-check.py
@@ -218,20 +218,21 @@ def find_ppds_invocations(command: str) -> list:
     out = []
     for match in _PPDS_PROGRAM_RE.finditer(command):
         prog = match.group(1)
-        # Slice the rest of the command after the program name. We split on
-        # shell operators to keep arg parsing local to this invocation.
+        # Slice the rest of the command after the program name.
         tail = command[match.end():]
-        # Cut at first unquoted shell operator (best-effort).
-        cut_re = re.compile(r"[|;&]|&&|\|\||>|<|`")
-        cut_match = cut_re.search(tail)
-        if cut_match:
-            tail = tail[: cut_match.start()]
         try:
-            args = shlex.split(tail, posix=True)
+            # Use shlex to parse the rest of the command line.
+            # This correctly handles quoted operators.
+            tokens = shlex.split(tail, posix=True)
         except ValueError:
-            # Unbalanced quotes -- fall back to whitespace split so we still
-            # match coarse patterns rather than silently allowing.
-            args = tail.split()
+            tokens = tail.split()
+
+        # Truncate tokens at the first shell operator.
+        args = []
+        for tok in tokens:
+            if tok in ("|", ";", "&", "&&", "||", ">", "<", ">>", "<<", chr(96), "(", ")"):
+                break
+            args.append(tok)
         out.append([prog] + args)
     return out
 

--- a/.claude/hooks/dev-env-check.py
+++ b/.claude/hooks/dev-env-check.py
@@ -1,0 +1,435 @@
+"""PreToolUse hook: enforce dev-env allowlist for ppds CLI invocations.
+
+Prevents an agent from accidentally connecting to a non-dev/test environment
+(e.g. production) when running ppds CLI commands during shakedown / verify
+flows. Reads the active environment from the PPDS profile store directly so
+the hook stays fast and avoids invoking ppds itself (which would be circular
+for a PreToolUse on Bash and would itself trip this same hook).
+
+Allowlist sources (checked in order):
+1. Env var ``PPDS_SAFE_ENVS`` -- comma-separated list of env names.
+2. File ``.claude/state/safe-envs.json`` -- ``{"safe_envs": ["ppds-dev", ...]}``.
+3. Neither set -- BLOCK with an instructive message.
+
+Trigger patterns (block when active env not in allowlist):
+- ``ppds env list`` / ``ppds env current`` / ``ppds env who`` -- always allowed
+  (read-only diagnostics; ``who`` does connect but is treated as effectively
+  read-only because it only issues a WhoAmI request).
+- ``ppds env switch <name>`` / ``ppds env select <name>`` -- allowed only when
+  the *target* name is in the allowlist.
+- Any other ``ppds *`` invocation -- allowed only when the *active* env is in
+  the allowlist.
+- ``ppds-mcp-server`` -- verify the active env at startup; same rule as
+  ``ppds *``.
+
+Envelope contract: Claude Code wraps tool input as
+``{"tool_name": "...", "tool_input": {"command": "..."}}``. Always read the
+command from the nested ``tool_input`` dict -- reading at the top level was
+the v1-prelaunch hook bug fixed by PR #816.
+
+Failure mode: prints a message to stderr explaining the block + how to fix,
+then exits 2 (the standard PreToolUse block code). Hook is fail-safe -- when
+the active env can't be determined it BLOCKS rather than allows, on the
+theory that an unknown env is more dangerous than a false positive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from typing import Iterable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _pathfix import normalize_msys_path  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Allowlist resolution
+# ---------------------------------------------------------------------------
+
+
+def _safe_envs_file() -> str:
+    """Resolve the path to safe-envs.json relative to CLAUDE_PROJECT_DIR."""
+    project_dir = normalize_msys_path(
+        os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    )
+    return os.path.join(project_dir, ".claude", "state", "safe-envs.json")
+
+
+def load_allowlist() -> Optional[list]:
+    """Return the list of safe env names, or None when no allowlist configured.
+
+    None means "no allowlist source provided" -- caller treats this as a hard
+    block with a configuration-help message. An empty list means "allowlist
+    is configured but empty" -- same effect (everything blocked) but the
+    distinction lets the message be specific.
+    """
+    env_var = os.environ.get("PPDS_SAFE_ENVS", "").strip()
+    if env_var:
+        return [name.strip() for name in env_var.split(",") if name.strip()]
+
+    path = _safe_envs_file()
+    if not os.path.isfile(path):
+        return None
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    safe = data.get("safe_envs")
+    if not isinstance(safe, list):
+        return None
+    return [str(name).strip() for name in safe if str(name).strip()]
+
+
+# ---------------------------------------------------------------------------
+# Active env resolution (read profiles.json directly -- no shelling out)
+# ---------------------------------------------------------------------------
+
+
+def _profile_store_path() -> str:
+    """Mirror PPDS.Auth.Profiles.ProfilePaths.ProfilesFile resolution.
+
+    Priority: PPDS_CONFIG_DIR env var > %LOCALAPPDATA%/PPDS on Windows,
+    ~/.ppds elsewhere.
+    """
+    override = os.environ.get("PPDS_CONFIG_DIR", "").strip()
+    if override:
+        base = override
+    elif sys.platform == "win32":
+        local_app = os.environ.get("LOCALAPPDATA", "")
+        if not local_app:
+            local_app = os.path.join(
+                os.path.expanduser("~"), "AppData", "Local"
+            )
+        base = os.path.join(local_app, "PPDS")
+    else:
+        base = os.path.join(os.path.expanduser("~"), ".ppds")
+    return os.path.join(base, "profiles.json")
+
+
+def get_active_env_names() -> list:
+    """Return candidate identifiers for the active env.
+
+    Returns a list because callers want to match against any of:
+    DisplayName, UniqueName, or the host portion of the URL. Empty list
+    means no active env (or store missing/malformed) -- caller must treat
+    that as a fail-safe BLOCK.
+    """
+    path = _profile_store_path()
+    if not os.path.isfile(path):
+        return []
+
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    profiles = data.get("profiles") or []
+    if not isinstance(profiles, list) or not profiles:
+        return []
+
+    # Prefer index-based lookup (matches ProfileCollection.ActiveProfile).
+    active_idx = data.get("activeProfileIndex")
+    active_name = data.get("activeProfile")
+    active = None
+    if isinstance(active_idx, int):
+        active = next(
+            (p for p in profiles if isinstance(p, dict) and p.get("index") == active_idx),
+            None,
+        )
+    if active is None and isinstance(active_name, str) and active_name:
+        active = next(
+            (
+                p
+                for p in profiles
+                if isinstance(p, dict)
+                and isinstance(p.get("name"), str)
+                and p.get("name", "").lower() == active_name.lower()
+            ),
+            None,
+        )
+    if active is None:
+        return []
+
+    env = active.get("environment") or {}
+    if not isinstance(env, dict):
+        return []
+
+    candidates = []
+    for key in ("displayName", "uniqueName"):
+        val = env.get(key)
+        if isinstance(val, str) and val.strip():
+            candidates.append(val.strip())
+    url = env.get("url")
+    if isinstance(url, str) and url.strip():
+        # Use the host portion (e.g. orgcabef92d.crm.dynamics.com) and the
+        # leftmost label (e.g. orgcabef92d) as additional match targets.
+        m = re.match(r"https?://([^/]+)", url.strip(), re.IGNORECASE)
+        if m:
+            host = m.group(1)
+            candidates.append(host)
+            label = host.split(".", 1)[0]
+            if label and label != host:
+                candidates.append(label)
+    return candidates
+
+
+def env_matches_allowlist(candidates: Iterable, allowlist: Iterable) -> bool:
+    """True when any candidate matches any allowlist entry (case-insensitive)."""
+    cand_lower = {c.lower() for c in candidates if c}
+    allow_lower = {a.lower() for a in allowlist if a}
+    return bool(cand_lower & allow_lower)
+
+
+# ---------------------------------------------------------------------------
+# Bash command parsing
+# ---------------------------------------------------------------------------
+
+
+_PPDS_PROGRAM_RE = re.compile(
+    r"""
+    (?:^|[\s|;&(`])         # start of command position
+    (?:[^\s|;&()`]*[\\/])?  # optional path prefix
+    (ppds(?:\.exe)?|ppds-mcp-server(?:\.exe)?)
+    (?=$|[\s|;&)`])
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def find_ppds_invocations(command: str) -> list:
+    """Return a list of argv-style token lists for each ppds invocation.
+
+    Handles compound bash like ``cd foo && ppds env list`` and pipes like
+    ``ppds env list | jq``. The CLI argv tokens stop at the first shell
+    operator after the program name; this is a heuristic but is sufficient
+    for the patterns we care about (the first few subcommand tokens).
+    """
+    if not command:
+        return []
+
+    out = []
+    for match in _PPDS_PROGRAM_RE.finditer(command):
+        prog = match.group(1)
+        # Slice the rest of the command after the program name. We split on
+        # shell operators to keep arg parsing local to this invocation.
+        tail = command[match.end():]
+        # Cut at first unquoted shell operator (best-effort).
+        cut_re = re.compile(r"[|;&]|&&|\|\||>|<|`")
+        cut_match = cut_re.search(tail)
+        if cut_match:
+            tail = tail[: cut_match.start()]
+        try:
+            args = shlex.split(tail, posix=True)
+        except ValueError:
+            # Unbalanced quotes -- fall back to whitespace split so we still
+            # match coarse patterns rather than silently allowing.
+            args = tail.split()
+        out.append([prog] + args)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Decision logic
+# ---------------------------------------------------------------------------
+
+
+# Subcommands of ``ppds env`` that are read-only / always-allowed regardless
+# of allowlist state. Includes both the canonical names from the spec
+# (current/switch) and the actual CLI names used by EnvCommandGroup
+# (who/select). 'config'/'type'/'show' don't talk to Dataverse.
+_ENV_READONLY_SUBCOMMANDS = {"list", "current", "who", "config", "type", "show"}
+
+# Subcommands of ``ppds env`` that change the active env. When the *target*
+# is in the allowlist we let it through (so users can switch INTO a safe env
+# even when currently on an unsafe one).
+_ENV_SWITCH_SUBCOMMANDS = {"switch", "select", "use"}
+
+
+def decide(argv, allowlist, active):
+    """Return (allow, reason). reason is empty on allow, a message on block."""
+    if not argv:
+        return True, ""
+
+    prog = os.path.basename(argv[0]).lower()
+    if prog.endswith(".exe"):
+        prog = prog[:-4]
+
+    # ppds-mcp-server verifies env at startup -- same rule as ``ppds *``
+    if prog == "ppds-mcp-server":
+        if env_matches_allowlist(active, allowlist):
+            return True, ""
+        return False, _block_msg_active_not_allowed(active, allowlist, argv)
+
+    if prog != "ppds":
+        return True, ""
+
+    # No further args -> top-level help, allow.
+    if len(argv) < 2:
+        return True, ""
+
+    sub = argv[1].lower()
+
+    # ``ppds env <subcommand>`` -- special handling for read-only and switch.
+    if sub == "env" or sub == "org":
+        if len(argv) < 3:
+            # ``ppds env`` alone prints help -- allow.
+            return True, ""
+        env_sub = argv[2].lower()
+        if env_sub in _ENV_READONLY_SUBCOMMANDS:
+            return True, ""
+        if env_sub in _ENV_SWITCH_SUBCOMMANDS:
+            target = _extract_switch_target(argv[3:])
+            if not target:
+                # No target name -- treat as a help/usage invocation; allow.
+                return True, ""
+            if env_matches_allowlist([target], allowlist):
+                return True, ""
+            return False, _block_msg_target_not_allowed(target, allowlist, argv)
+        # Other env subcommands (delete, update, etc.) -- gate on active env.
+        if env_matches_allowlist(active, allowlist):
+            return True, ""
+        return False, _block_msg_active_not_allowed(active, allowlist, argv)
+
+    # All other ppds subcommands gate on active env.
+    if env_matches_allowlist(active, allowlist):
+        return True, ""
+    return False, _block_msg_active_not_allowed(active, allowlist, argv)
+
+
+def _extract_switch_target(args):
+    """Pull the target env name from a ``switch``/``select`` argv tail.
+
+    Handles bare positional (``ppds env select my-dev``) and the
+    ``--environment``/``-env`` flag form used by EnvCommandGroup.
+    """
+    for i, tok in enumerate(args):
+        if tok in ("--environment", "-env", "--env", "-e"):
+            if i + 1 < len(args):
+                return args[i + 1]
+            return ""
+        if tok.startswith("--environment="):
+            return tok.split("=", 1)[1]
+        if tok.startswith("-env="):
+            return tok.split("=", 1)[1]
+        if tok.startswith("-"):
+            continue
+        return tok
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Stderr message helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_active(active):
+    if not active:
+        return "(unknown -- no active profile / store missing)"
+    return active[0]
+
+
+def _format_allowlist(allowlist):
+    if not allowlist:
+        return "(empty)"
+    return ", ".join(allowlist)
+
+
+def _config_help_lines():
+    return [
+        "  Configure the allowlist via either:",
+        "    1. Env var: export PPDS_SAFE_ENVS=ppds-dev,ppds-test",
+        "    2. File:    .claude/state/safe-envs.json",
+        '       {"safe_envs": ["ppds-dev", "ppds-test"]}',
+    ]
+
+
+def _block_msg_no_allowlist(argv):
+    lines = [
+        "BLOCKED [dev-env-check]: no safe-env allowlist configured.",
+        f"  Command: {' '.join(argv)}",
+        "  ppds CLI commands are gated against an allowlist of dev/test envs",
+        "  to prevent accidental writes against production environments.",
+        "",
+    ]
+    lines.extend(_config_help_lines())
+    return "\n".join(lines)
+
+
+def _block_msg_active_not_allowed(active, allowlist, argv):
+    lines = [
+        "BLOCKED [dev-env-check]: active env is not in the safe-env allowlist.",
+        f"  Command:    {' '.join(argv)}",
+        f"  Active env: {_format_active(active)}",
+        f"  Allowlist:  {_format_allowlist(allowlist)}",
+        "",
+        "  To proceed, switch to a safe env:",
+        "    ppds env select <name>           # canonical CLI",
+        "    ppds env switch <name>           # alias accepted by this hook",
+        "",
+    ]
+    lines.extend(_config_help_lines())
+    return "\n".join(lines)
+
+
+def _block_msg_target_not_allowed(target, allowlist, argv):
+    lines = [
+        "BLOCKED [dev-env-check]: switch target is not in the safe-env allowlist.",
+        f"  Command:   {' '.join(argv)}",
+        f"  Target:    {target}",
+        f"  Allowlist: {_format_allowlist(allowlist)}",
+        "",
+    ]
+    lines.extend(_config_help_lines())
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main():
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        # Empty/garbled stdin -- allow rather than block unrelated tools.
+        sys.exit(0)
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command", "")
+    if not isinstance(command, str) or not command.strip():
+        sys.exit(0)
+
+    invocations = find_ppds_invocations(command)
+    if not invocations:
+        sys.exit(0)
+
+    allowlist = load_allowlist()
+    if allowlist is None:
+        # No allowlist source at all -- block with config help.
+        print(_block_msg_no_allowlist(invocations[0]), file=sys.stderr)
+        sys.exit(2)
+
+    active = get_active_env_names()
+
+    # Each invocation must independently pass. First failure wins so the
+    # user sees a single, focused message.
+    for argv in invocations:
+        allow, reason = decide(argv, allowlist, active)
+        if not allow:
+            print(reason, file=sys.stderr)
+            sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/shakedown-readonly.py
+++ b/.claude/hooks/shakedown-readonly.py
@@ -1,0 +1,224 @@
+"""PreToolUse hook: enforce read-only ppds invocations during shakedown.
+
+Activates only when the env var ``PPDS_SHAKEDOWN=1`` is set (typically by
+the shakedown skill). When active, blocks Bash commands that would mutate
+Dataverse state -- plugin deploys (without ``--dry-run``), record
+create/update/delete on any surface, solution imports, etc. The goal is a
+hard safety boundary: an agent running shakedown must not be able to write
+to Dataverse no matter how many other safeguards are bypassed.
+
+Bypass: unset ``PPDS_SHAKEDOWN``. There is no softer marker -- if you
+genuinely need to run a write command, you take the deliberate action of
+clearing the env var. The shakedown skill must NOT auto-clear it.
+
+Envelope contract: same nested ``payload["tool_input"]["command"]`` pattern
+as protect-main-branch.py (see PR #816).
+
+Failure mode: prints a message to stderr explaining the block + the
+``PPDS_SHAKEDOWN`` mechanism, then exits 2 (standard PreToolUse block).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Bash command parsing (mirrors dev-env-check.py)
+# ---------------------------------------------------------------------------
+
+
+_PPDS_PROGRAM_RE = re.compile(
+    r"""
+    (?:^|[\s|;&(`])
+    (?:[^\s|;&()`]*[\\/])?
+    (ppds(?:\.exe)?|ppds-mcp-server(?:\.exe)?)
+    (?=$|[\s|;&)`])
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def find_ppds_invocations(command: str) -> list:
+    if not command:
+        return []
+    out = []
+    for match in _PPDS_PROGRAM_RE.finditer(command):
+        prog = match.group(1)
+        tail = command[match.end():]
+        cut_re = re.compile(r"[|;&]|&&|\|\||>|<|`")
+        cut_match = cut_re.search(tail)
+        if cut_match:
+            tail = tail[: cut_match.start()]
+        try:
+            args = shlex.split(tail, posix=True)
+        except ValueError:
+            args = tail.split()
+        out.append([prog] + args)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Mutation rules
+# ---------------------------------------------------------------------------
+
+
+# Top-level subcommands whose presence is benign (no Dataverse traffic) or
+# read-only. Anything outside this set, when paired with a write verb, is
+# treated as a mutation candidate.
+_READONLY_SUBCOMMANDS = {
+    "env": {"list", "current", "who", "config", "type", "show", "switch", "select", "use", "test"},
+    "logs": {"*"},  # everything under logs is read-only
+    "auth": {"list", "show"},
+    "version": {"*"},
+    "help": {"*"},
+}
+
+# Subcommand-2 verbs that are mutations (apply to any surface). E.g.
+# ``ppds plugins create`` or ``ppds data update`` both fall here.
+_MUTATION_VERBS = {
+    "create",
+    "update",
+    "delete",
+    "remove",
+    "import",
+    "apply",
+    "register",
+    "unregister",
+    "publish",
+    "truncate",
+    "drop",
+    "reset",
+    "set",
+}
+
+# Specific full-path mutations the spec calls out explicitly. Keys are
+# ``(subcmd, verb)`` tuples; the value is a callable that returns True when
+# the invocation should be blocked. Used for cases where ``--dry-run`` (or
+# similar) is an exemption.
+def _plugins_deploy_blocked(args: list) -> bool:
+    return "--dry-run" not in args and "-n" not in args
+
+
+_NAMED_MUTATIONS = {
+    ("plugins", "deploy"): _plugins_deploy_blocked,
+    # ``ppds env delete``, ``env update``, ``solutions import``,
+    # ``migrate apply`` are matched via the generic verb table; listing
+    # here would be redundant. Kept as the integration point for future
+    # special-case bypasses.
+}
+
+
+def is_mutation(argv: list) -> tuple[bool, str]:
+    """Return (is_mutation, reason). reason is empty when not a mutation.
+
+    argv is ``[program, sub, verb, ...]`` style. ``sub`` is the surface
+    (``plugins``, ``env``, ``data``, etc.) and ``verb`` is the action.
+    """
+    if len(argv) < 2:
+        return False, ""
+
+    prog = os.path.basename(argv[0]).lower()
+    if prog.endswith(".exe"):
+        prog = prog[:-4]
+    if prog not in ("ppds", "ppds-mcp-server"):
+        return False, ""
+
+    if prog == "ppds-mcp-server":
+        # The MCP server itself is launched, not a one-shot command, so we
+        # can't reason about whether it will issue writes. Allow -- the
+        # dev-env-check hook still gates which env it talks to.
+        return False, ""
+
+    if len(argv) < 3:
+        return False, ""
+
+    sub = argv[1].lower()
+    verb = argv[2].lower()
+    rest = argv[3:]
+
+    # Always-allowed subcommand families.
+    allowed = _READONLY_SUBCOMMANDS.get(sub)
+    if allowed and ("*" in allowed or verb in allowed):
+        return False, ""
+
+    # Special-case named mutations (for --dry-run carve-outs).
+    named = _NAMED_MUTATIONS.get((sub, verb))
+    if named is not None:
+        if named(rest):
+            return True, f"{sub} {verb} (no --dry-run flag present)"
+        return False, ""
+
+    # Generic verb table.
+    if verb in _MUTATION_VERBS:
+        return True, f"{sub} {verb}"
+
+    return False, ""
+
+
+# ---------------------------------------------------------------------------
+# Stderr message
+# ---------------------------------------------------------------------------
+
+
+def _block_msg(argv: list, reason: str) -> str:
+    return "\n".join(
+        [
+            "BLOCKED [shakedown-readonly]: write/mutation command refused.",
+            f"  Command: {' '.join(argv)}",
+            f"  Pattern: {reason}",
+            "",
+            "  PPDS_SHAKEDOWN=1 is set, which puts this session in read-only",
+            "  mode for ppds CLI operations. Mutating Dataverse during",
+            "  shakedown defeats the purpose -- shakedowns are observation,",
+            "  not modification.",
+            "",
+            "  To bypass (deliberate action -- there is no softer marker):",
+            "    unset PPDS_SHAKEDOWN",
+            "",
+            "  For plugin deploys specifically, add --dry-run to validate",
+            "  without writing.",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    if os.environ.get("PPDS_SHAKEDOWN", "").strip() != "1":
+        # Hook is a no-op outside shakedown mode.
+        sys.exit(0)
+
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        # Empty/garbled stdin -- allow.
+        sys.exit(0)
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command", "")
+    if not isinstance(command, str) or not command.strip():
+        sys.exit(0)
+
+    invocations = find_ppds_invocations(command)
+    if not invocations:
+        sys.exit(0)
+
+    for argv in invocations:
+        blocked, reason = is_mutation(argv)
+        if blocked:
+            print(_block_msg(argv, reason), file=sys.stderr)
+            sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/shakedown-readonly.py
+++ b/.claude/hooks/shakedown-readonly.py
@@ -50,14 +50,19 @@ def find_ppds_invocations(command: str) -> list:
     for match in _PPDS_PROGRAM_RE.finditer(command):
         prog = match.group(1)
         tail = command[match.end():]
-        cut_re = re.compile(r"[|;&]|&&|\|\||>|<|`")
-        cut_match = cut_re.search(tail)
-        if cut_match:
-            tail = tail[: cut_match.start()]
         try:
-            args = shlex.split(tail, posix=True)
+            # Use shlex to parse the rest of the command line.
+            # This correctly handles quoted operators.
+            tokens = shlex.split(tail, posix=True)
         except ValueError:
-            args = tail.split()
+            tokens = tail.split()
+
+        # Truncate tokens at the first shell operator.
+        args = []
+        for tok in tokens:
+            if tok in ("|", ";", "&", "&&", "||", ">", "<", ">>", "<<", chr(96), "(", ")"):
+                break
+            args.append(tok)
         out.append([prog] + args)
     return out
 
@@ -101,7 +106,7 @@ _MUTATION_VERBS = {
 # the invocation should be blocked. Used for cases where ``--dry-run`` (or
 # similar) is an exemption.
 def _plugins_deploy_blocked(args: list) -> bool:
-    return "--dry-run" not in args and "-n" not in args
+    return not any(arg in ("--dry-run", "-n") or arg.startswith("--dry-run=") for arg in args)
 
 
 _NAMED_MUTATIONS = {
@@ -119,7 +124,7 @@ def is_mutation(argv: list) -> tuple[bool, str]:
     argv is ``[program, sub, verb, ...]`` style. ``sub`` is the surface
     (``plugins``, ``env``, ``data``, etc.) and ``verb`` is the action.
     """
-    if len(argv) < 2:
+    if not argv:
         return False, ""
 
     prog = os.path.basename(argv[0]).lower()
@@ -129,10 +134,14 @@ def is_mutation(argv: list) -> tuple[bool, str]:
         return False, ""
 
     if prog == "ppds-mcp-server":
-        # The MCP server itself is launched, not a one-shot command, so we
-        # can't reason about whether it will issue writes. Allow -- the
-        # dev-env-check hook still gates which env it talks to.
-        return False, ""
+        # The MCP server can issue arbitrary Dataverse writes via its tools.
+        # During shakedown it MUST be launched with ``--read-only`` so the
+        # write-block boundary is preserved end-to-end. (The mcp-verify
+        # skill documents this flag.)
+        # Enforce read-only mode for the MCP server during shakedown.
+        if any(arg == "--read-only" or arg.startswith("--read-only=") for arg in argv[1:]):
+            return False, ""
+        return True, "ppds-mcp-server (missing --read-only flag during shakedown)"
 
     if len(argv) < 3:
         return False, ""
@@ -182,6 +191,7 @@ def _block_msg(argv: list, reason: str) -> str:
             "",
             "  For plugin deploys specifically, add --dry-run to validate",
             "  without writing.",
+            "  For ppds-mcp-server, add --read-only to the launch args.",
         ]
     )
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -353,6 +353,26 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \".claude/hooks/dev-env-check.py\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \".claude/hooks/shakedown-readonly.py\"",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/cli-verify/SKILL.md
+++ b/.claude/skills/cli-verify/SKILL.md
@@ -7,6 +7,25 @@ description: How to verify CLI commands — build, run, check stdout/stderr, val
 
 Supporting knowledge for `/verify cli` and `/qa cli`. Documents how to build, run, and verify CLI commands.
 
+## Safety pre-check
+
+These verification flows talk to live Dataverse. Two PreToolUse hooks gate
+`ppds *` invocations to keep an agent from writing to a non-dev env:
+
+- `dev-env-check.py` -- always on. Blocks `ppds *` unless the active env is
+  in the allowlist (`$PPDS_SAFE_ENVS` or `.claude/state/safe-envs.json`).
+- `shakedown-readonly.py` -- active when `PPDS_SHAKEDOWN=1` is set (the
+  shakedown skill exports this in its Phase 0). Blocks write verbs
+  (`create`, `update`, `delete`, `plugins deploy` without `--dry-run`,
+  `solutions import`, etc.).
+
+Before running any of the patterns below:
+
+1. Confirm `ppds env who` shows a safe env (in the allowlist).
+2. If invoked from `/shakedown`, verify `PPDS_SHAKEDOWN=1` is set so write
+   commands fail closed.
+3. Read `docs/SAFE-SHAKEDOWN.md` for the full model and bypass procedure.
+
 ## Build
 
 ```bash

--- a/.claude/skills/ext-verify/SKILL.md
+++ b/.claude/skills/ext-verify/SKILL.md
@@ -8,6 +8,25 @@ allowed-tools: Bash(node *webview-cdp*), Bash(cd * && node *webview-cdp*), Bash(
 
 Interact with extension webview panels running inside VS Code. Take screenshots to see what you've built, click buttons, type text, test keyboard shortcuts, execute VS Code commands, right-click context menus, read console logs, and inspect DOM state.
 
+## Safety pre-check
+
+These verification flows talk to live Dataverse. Two PreToolUse hooks gate
+`ppds *` invocations to keep an agent from writing to a non-dev env:
+
+- `dev-env-check.py` -- always on. Blocks `ppds *` unless the active env is
+  in the allowlist (`$PPDS_SAFE_ENVS` or `.claude/state/safe-envs.json`).
+- `shakedown-readonly.py` -- active when `PPDS_SHAKEDOWN=1` is set (the
+  shakedown skill exports this in its Phase 0). Blocks write verbs
+  (`create`, `update`, `delete`, `plugins deploy` without `--dry-run`,
+  `solutions import`, etc.).
+
+Before running any of the patterns below:
+
+1. Confirm `ppds env who` shows a safe env (in the allowlist).
+2. If invoked from `/shakedown`, verify `PPDS_SHAKEDOWN=1` is set so write
+   commands fail closed.
+3. Read `docs/SAFE-SHAKEDOWN.md` for the full model and bypass procedure.
+
 ## When to Use
 
 - After implementing or modifying any webview panel UI

--- a/.claude/skills/mcp-verify/SKILL.md
+++ b/.claude/skills/mcp-verify/SKILL.md
@@ -7,6 +7,25 @@ description: How to verify MCP tools — Inspector usage, direct invocation, res
 
 Supporting knowledge for `/verify mcp` and `/qa mcp`. Documents how to interact with and verify MCP server tools.
 
+## Safety pre-check
+
+These verification flows talk to live Dataverse. Two PreToolUse hooks gate
+`ppds *` invocations to keep an agent from writing to a non-dev env:
+
+- `dev-env-check.py` -- always on. Blocks `ppds *` unless the active env is
+  in the allowlist (`$PPDS_SAFE_ENVS` or `.claude/state/safe-envs.json`).
+- `shakedown-readonly.py` -- active when `PPDS_SHAKEDOWN=1` is set (the
+  shakedown skill exports this in its Phase 0). Blocks write verbs
+  (`create`, `update`, `delete`, `plugins deploy` without `--dry-run`,
+  `solutions import`, etc.).
+
+Before running any of the patterns below:
+
+1. Confirm `ppds env who` shows a safe env (in the allowlist).
+2. If invoked from `/shakedown`, verify `PPDS_SHAKEDOWN=1` is set so write
+   commands fail closed.
+3. Read `docs/SAFE-SHAKEDOWN.md` for the full model and bypass procedure.
+
 ## Build
 
 ```bash

--- a/.claude/skills/shakedown/SKILL.md
+++ b/.claude/skills/shakedown/SKILL.md
@@ -17,6 +17,31 @@ A structured, multi-interface product validation session. Unlike `/qa` (automate
 
 ## Process
 
+### Phase 0: Safety Pre-checks
+
+Before any other work, validate the safety guardrails are configured and active.
+
+1. **Verify env allowlist is configured** -- read `.claude/state/safe-envs.json`
+   or `$PPDS_SAFE_ENVS`. If neither lists at least one safe env, STOP and ask
+   the user to configure (`docs/SAFE-SHAKEDOWN.md` for details).
+2. **Verify active env is in the allowlist** -- run `ppds env who` (or
+   `ppds env current`) and confirm the displayed env matches an allowlist
+   entry. The `dev-env-check` hook will block downstream `ppds *` calls
+   otherwise.
+3. **Set the read-only marker for this session:**
+   ```bash
+   export PPDS_SHAKEDOWN=1
+   ```
+   This activates the `shakedown-readonly` hook, which blocks write/mutation
+   commands (`plugins deploy`, `plugins delete`, `<surface> create/update/delete`,
+   `solutions import`, etc.) for the duration of the shakedown.
+4. **Acknowledge the model:** plugin deploys MUST be invoked with `--dry-run`
+   during shakedown. To run a real deploy, unset `PPDS_SHAKEDOWN` (deliberate
+   action -- there is no softer bypass).
+
+See `docs/SAFE-SHAKEDOWN.md` for the full safety model and how to add envs
+to the allowlist.
+
 ### Phase 1: Scope Declaration
 
 Ask the user which surfaces to test:

--- a/.claude/skills/tui-verify/SKILL.md
+++ b/.claude/skills/tui-verify/SKILL.md
@@ -8,6 +8,25 @@ allowed-tools: Bash(node *tui-verify*), Bash(cd * && node *tui-verify*)
 
 Interact with the PPDS TUI (`ppds interactive`) running in a PTY. Read terminal text to verify what's rendered, send keystrokes to navigate, wait for specific content to appear. Text-based verification — the AI reads terminal rows directly instead of interpreting screenshots.
 
+## Safety pre-check
+
+These verification flows talk to live Dataverse. Two PreToolUse hooks gate
+`ppds *` invocations to keep an agent from writing to a non-dev env:
+
+- `dev-env-check.py` -- always on. Blocks `ppds *` unless the active env is
+  in the allowlist (`$PPDS_SAFE_ENVS` or `.claude/state/safe-envs.json`).
+- `shakedown-readonly.py` -- active when `PPDS_SHAKEDOWN=1` is set (the
+  shakedown skill exports this in its Phase 0). Blocks write verbs
+  (`create`, `update`, `delete`, `plugins deploy` without `--dry-run`,
+  `solutions import`, etc.).
+
+Before running any of the patterns below:
+
+1. Confirm `ppds env who` shows a safe env (in the allowlist).
+2. If invoked from `/shakedown`, verify `PPDS_SHAKEDOWN=1` is set so write
+   commands fail closed.
+3. Read `docs/SAFE-SHAKEDOWN.md` for the full model and bypass procedure.
+
 ## When to Use
 
 - After implementing or modifying any TUI screen, widget, or keyboard handler

--- a/.claude/state/safe-envs.json
+++ b/.claude/state/safe-envs.json
@@ -1,0 +1,4 @@
+{
+  "safe_envs": [],
+  "_comment": "Add env names that are safe to use for shakedown/verify operations (e.g. dev/test envs only). Names are matched case-insensitively against the active profile Environment.DisplayName, Environment.UniqueName, or the host portion of Environment.Url. Used by .claude/hooks/dev-env-check.py."
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,8 @@ devcontainer.json text eol=lf
 # entries, so a basic union merge avoids most conflicts. Operators are
 # expected to re-run /cleanup if the file ever lands invalid.
 .claude/state/in-flight-issues.json merge=union
+
+# Safe-env allowlist for shakedown/verify hooks. Treated like in-flight
+# state — operators add their own dev/test envs locally; the file is
+# committed as a template. Union merge avoids friction across sessions.
+.claude/state/safe-envs.json merge=union

--- a/docs/SAFE-SHAKEDOWN.md
+++ b/docs/SAFE-SHAKEDOWN.md
@@ -1,0 +1,155 @@
+# Safe Shakedown Enforcement
+
+How PPDS enforces "do not accidentally write to a non-dev environment" during
+shakedown and verify flows. Two PreToolUse hooks plus a small allowlist file
+form a defense-in-depth boundary on top of the skill-level rules.
+
+## Why this exists
+
+The shakedown skills (`/shakedown`, `/ext-verify`, `/tui-verify`,
+`/cli-verify`, `/mcp-verify`) drive live Dataverse environments. Without
+explicit guardrails, an autonomous agent can:
+
+1. Connect to the wrong environment (e.g. production instead of dev).
+2. Run write/delete commands that mutate environment state.
+3. Hit org-level resources accidentally.
+
+The skills themselves contain rules ("do not run write commands during
+shakedown"), but rules are advisory. The hooks below are **mechanical** and
+fail closed: if the configuration is missing or the active env can't be
+identified, the hook blocks rather than allows.
+
+## Architecture
+
+```
+Bash tool invocation -> PreToolUse hooks (in order)
+                        |
+                        +-- dev-env-check.py        (always on)
+                        |   gates ALL `ppds *` against the safe-env allowlist
+                        |
+                        +-- shakedown-readonly.py   (only when PPDS_SHAKEDOWN=1)
+                            blocks `ppds * create/update/delete/...` patterns
+```
+
+Both hooks use the corrected JSON envelope contract from PR #816 (read
+`payload["tool_input"]["command"]`, never the top-level `command`).
+
+## Hook 1: dev-env-check.py
+
+**Trigger:** every Bash invocation that mentions `ppds` or `ppds-mcp-server`.
+
+**Decision tree:**
+
+1. If the command does not mention `ppds`, the hook is a no-op (exit 0).
+2. Resolve the allowlist:
+   - `$PPDS_SAFE_ENVS` (comma-separated) wins if present.
+   - Else `.claude/state/safe-envs.json` (`{"safe_envs": [...]}`).
+   - Else **block** with a configuration-help message.
+3. Resolve the active env: read `profiles.json` directly from
+   `$PPDS_CONFIG_DIR` (or `%LOCALAPPDATA%\PPDS` / `~/.ppds`). The hook does
+   NOT shell out to `ppds env who` -- that would be circular for a
+   PreToolUse-on-Bash hook and would itself trip the hook.
+4. Apply per-subcommand rules:
+   - `ppds env list` / `current` / `who` / `config` / `type` / `show`:
+     always allowed (read-only diagnostics; `who` issues only WhoAmI).
+   - `ppds env switch <name>` / `select <name>` / `use <name>`: allowed
+     when the **target** name is in the allowlist (so users can switch
+     INTO a safe env even from an unsafe one).
+   - All other `ppds *` invocations: allowed only when the **active** env
+     is in the allowlist.
+   - `ppds-mcp-server`: same rule as `ppds *` -- the MCP server inherits
+     the active env at startup.
+
+**Match semantics:** the active env's `Environment.DisplayName`,
+`Environment.UniqueName`, the host of `Environment.Url`, and the leftmost
+host label are all compared case-insensitively against the allowlist.
+
+**Fail-safe:** if the profile store is missing, malformed, or has no
+active profile, the hook **blocks** (the spec is "in doubt, block").
+
+## Hook 2: shakedown-readonly.py
+
+**Trigger:** every Bash invocation, but only when `PPDS_SHAKEDOWN=1` is set.
+
+**Blocked verbs (any surface):** `create`, `update`, `delete`, `remove`,
+`import`, `apply`, `register`, `unregister`, `publish`, `truncate`, `drop`,
+`reset`, `set`.
+
+**Special cases:**
+
+- `ppds plugins deploy` is blocked unless `--dry-run` (or `-n`) is present.
+- Anything under `ppds logs *` is read-only by definition.
+- `ppds-mcp-server` is allowed -- it is long-running and can't be reasoned
+  about ahead of time. The dev-env-check hook still gates which env it
+  talks to.
+- `ppds env switch/select` is read-only here because the dev-env-check
+  hook already validates the target.
+
+**Bypass:** `unset PPDS_SHAKEDOWN`. There is intentionally no softer bypass
+marker -- if you need to write during shakedown, that is a deliberate
+action.
+
+## Configuration
+
+### Add an env to the allowlist (per-machine)
+
+Edit `.claude/state/safe-envs.json`:
+
+```json
+{
+  "safe_envs": ["ppds-dev", "ppds-test"]
+}
+```
+
+The file is committed as a template with an empty array. Local edits will
+not conflict with concurrent sessions thanks to `merge=union` in
+`.gitattributes`. Operators are expected to populate this once per machine.
+
+### Override via env var (per-session)
+
+```bash
+export PPDS_SAFE_ENVS=ppds-dev,ppds-test
+```
+
+The env var takes precedence over the JSON file. Useful for CI / sandbox
+runs where you want the allowlist scoped to a single shell.
+
+### Activate read-only mode
+
+```bash
+export PPDS_SHAKEDOWN=1
+```
+
+Set automatically by Phase 0 of the `/shakedown` skill. The verify skills
+(`/ext-verify`, `/tui-verify`, `/cli-verify`, `/mcp-verify`) inherit this
+when they are invoked from a shakedown context.
+
+## Common operator scenarios
+
+### "I added a new dev env and want to use it for shakedown"
+
+1. Add the env's friendly name to `.claude/state/safe-envs.json`.
+2. `ppds env select <new-env>` -- the dev-env-check hook now allows it.
+3. Re-run `/shakedown`.
+
+### "The hook blocked a legitimate write outside shakedown"
+
+The dev-env-check hook is **always on**. If you need to write to a
+non-allowlisted env, add that env to the allowlist (per-session env var is
+recommended for one-off writes, JSON file for permanent additions).
+
+### "I need to run a real plugin deploy during a shakedown session"
+
+Either:
+
+- `unset PPDS_SHAKEDOWN` (preferred -- explicit), or
+- Run `ppds plugins deploy --dry-run` to validate without writing, then
+  unset and re-run for the real deploy.
+
+## Related
+
+- `docs/MERGE-POLICY.md` -- how PRs land on `main`.
+- `.claude/skills/shakedown/SKILL.md` -- Phase 0 references this doc.
+- `tests/hooks/test_dev_env_check.py`, `tests/hooks/test_shakedown_readonly.py`
+  -- behavioral tests covering allowlist sources, switch gating, dry-run
+  carve-out, fail-safe paths.

--- a/tests/hooks/test_dev_env_check.py
+++ b/tests/hooks/test_dev_env_check.py
@@ -1,0 +1,435 @@
+"""Tests for the dev-env-check PreToolUse hook.
+
+Covers allowlist resolution (env var + JSON file + neither), the read-only
+exemption table, switch-target gating, and the fail-safe behavior when the
+active env can't be determined.
+
+Run: ``pytest tests/hooks/test_dev_env_check.py -v``
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Hook loader / runner
+# ---------------------------------------------------------------------------
+
+
+HOOK_PATH = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "dev-env-check.py"
+
+
+def _load_hook():
+    """Import dev-env-check.py as a module so we can poke at its functions."""
+    hooks_dir = str(HOOK_PATH.parent)
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+    spec = importlib.util.spec_from_file_location("dev_env_check", str(HOOK_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+def _run_hook(command: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}}
+    env = os.environ.copy()
+    # Always start from a clean slate -- callers opt back in via env_extra.
+    for k in ("PPDS_SAFE_ENVS", "PPDS_CONFIG_DIR"):
+        env.pop(k, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_profile_dir(tmp_path, monkeypatch):
+    """Build a fake PPDS_CONFIG_DIR with a profiles.json. Returns (dir, set_env)."""
+
+    def _set(active_env_name: str | None = None, active_env_url: str | None = None):
+        config_dir = tmp_path / "ppds-config"
+        config_dir.mkdir(exist_ok=True)
+        if active_env_name is None and active_env_url is None:
+            data = {"version": 2, "profiles": []}
+        else:
+            data = {
+                "version": 2,
+                "activeProfileIndex": 1,
+                "profiles": [
+                    {
+                        "index": 1,
+                        "name": "test-profile",
+                        "environment": {
+                            "displayName": active_env_name or "",
+                            "uniqueName": (active_env_name or "").lower().replace(" ", "-"),
+                            "url": active_env_url or "https://orgxyz.crm.dynamics.com/",
+                        },
+                    }
+                ],
+            }
+        (config_dir / "profiles.json").write_text(json.dumps(data), encoding="utf-8")
+        return str(config_dir)
+
+    return _set
+
+
+@pytest.fixture
+def safe_envs_file(tmp_path, monkeypatch):
+    """Write a safe-envs.json under a fake CLAUDE_PROJECT_DIR. Returns the dir."""
+    project = tmp_path / "project"
+    state_dir = project / ".claude" / "state"
+    state_dir.mkdir(parents=True)
+
+    def _set(safe_envs: list | None):
+        if safe_envs is None:
+            # Write an obviously-not-an-allowlist file (or skip writing).
+            return str(project)
+        (state_dir / "safe-envs.json").write_text(
+            json.dumps({"safe_envs": safe_envs}), encoding="utf-8"
+        )
+        return str(project)
+
+    return _set
+
+
+# ---------------------------------------------------------------------------
+# Allowlist source: env var
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistEnvVar:
+    def test_env_var_active_in_list_allowed(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev,ppds-test", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0, f"Expected allow; stderr={r.stderr!r}"
+
+    def test_env_var_active_NOT_in_list_blocked(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev,ppds-test", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 2
+        assert "BLOCKED [dev-env-check]" in r.stderr
+        assert "ppds-prod" in r.stderr
+
+    def test_env_var_case_insensitive(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="PPDS-Dev")
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Allowlist source: JSON file
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistJsonFile:
+    def test_json_file_active_in_list_allowed(self, fake_profile_dir, safe_envs_file):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        project_dir = safe_envs_file(["ppds-dev"])
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_CONFIG_DIR": config_dir, "CLAUDE_PROJECT_DIR": project_dir},
+        )
+        assert r.returncode == 0, f"Expected allow; stderr={r.stderr!r}"
+
+    def test_json_file_active_NOT_in_list_blocked(self, fake_profile_dir, safe_envs_file):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        project_dir = safe_envs_file(["ppds-dev"])
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_CONFIG_DIR": config_dir, "CLAUDE_PROJECT_DIR": project_dir},
+        )
+        assert r.returncode == 2
+        assert "BLOCKED [dev-env-check]" in r.stderr
+
+    def test_json_file_empty_list_blocked(self, fake_profile_dir, safe_envs_file):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        project_dir = safe_envs_file([])
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_CONFIG_DIR": config_dir, "CLAUDE_PROJECT_DIR": project_dir},
+        )
+        # Allowlist resolved to empty -- nothing matches -> blocked.
+        assert r.returncode == 2
+
+    def test_env_var_takes_precedence_over_json(self, fake_profile_dir, safe_envs_file):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        project_dir = safe_envs_file(["ppds-dev"])  # JSON would block
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={
+                "PPDS_SAFE_ENVS": "ppds-prod",  # env var should let it through
+                "PPDS_CONFIG_DIR": config_dir,
+                "CLAUDE_PROJECT_DIR": project_dir,
+            },
+        )
+        assert r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Allowlist source: neither configured
+# ---------------------------------------------------------------------------
+
+
+class TestNoAllowlistConfigured:
+    def test_no_allowlist_blocks_with_config_help(self, fake_profile_dir, tmp_path):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        # Point CLAUDE_PROJECT_DIR at an empty dir -- no safe-envs.json.
+        empty_project = tmp_path / "empty-project"
+        empty_project.mkdir()
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_CONFIG_DIR": config_dir, "CLAUDE_PROJECT_DIR": str(empty_project)},
+        )
+        assert r.returncode == 2
+        assert "no safe-env allowlist configured" in r.stderr
+        assert "PPDS_SAFE_ENVS" in r.stderr
+        assert "safe-envs.json" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# env switch target gating
+# ---------------------------------------------------------------------------
+
+
+class TestEnvSwitchTarget:
+    def test_switch_to_safe_target_allowed(self, fake_profile_dir):
+        # Active env is unsafe -- but the SWITCH itself is to a safe env.
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        for sub in ("switch", "select"):
+            r = _run_hook(
+                f"ppds env {sub} ppds-dev",
+                env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+            )
+            assert r.returncode == 0, f"sub={sub}: stderr={r.stderr!r}"
+
+    def test_switch_to_unsafe_target_blocked(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        for sub in ("switch", "select"):
+            r = _run_hook(
+                f"ppds env {sub} ppds-prod",
+                env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+            )
+            assert r.returncode == 2
+            assert "switch target" in r.stderr.lower()
+            assert "ppds-prod" in r.stderr
+
+    def test_switch_via_environment_flag(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        r = _run_hook(
+            "ppds env select --environment ppds-dev",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_switch_via_environment_equals_flag(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        r = _run_hook(
+            "ppds env select --environment=ppds-dev",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# Always-allowed read-only commands
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyAlwaysAllowed:
+    @pytest.mark.parametrize("cmd", [
+        "ppds env list",
+        "ppds env current",
+        "ppds env who",
+        "ppds env config --list",
+        "ppds env type --list",
+    ])
+    def test_readonly_env_subcommands_allowed_even_when_active_unsafe(
+        self, fake_profile_dir, cmd
+    ):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        r = _run_hook(
+            cmd,
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0, f"cmd={cmd}: stderr={r.stderr!r}"
+
+    def test_readonly_allowed_with_no_allowlist_configured(self, fake_profile_dir, tmp_path):
+        # Even without an allowlist, ``ppds env list`` should pass -- it
+        # doesn't talk to Dataverse and is the user's path to discovery.
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        r = _run_hook(
+            "ppds env list",
+            env_extra={"PPDS_CONFIG_DIR": config_dir, "CLAUDE_PROJECT_DIR": str(empty)},
+        )
+        # No allowlist -> hard block before per-cmd allowance kicks in. This
+        # is intentional: the no-allowlist case is meant to surface the
+        # config message even on read-only invocations so the operator
+        # configures it once and moves on.
+        assert r.returncode == 2
+        assert "no safe-env allowlist configured" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFailSafe:
+    def test_no_active_env_blocks(self, fake_profile_dir):
+        # Profile store exists but has no profiles.
+        config_dir = fake_profile_dir()  # no args -> no profiles
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 2
+        assert "unknown" in r.stderr.lower() or "active env" in r.stderr.lower()
+
+    def test_missing_profile_store_blocks(self, tmp_path):
+        # PPDS_CONFIG_DIR points at an empty dir -> no profiles.json.
+        empty = tmp_path / "no-store"
+        empty.mkdir()
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": str(empty)},
+        )
+        assert r.returncode == 2
+
+    def test_malformed_profiles_json_blocks(self, tmp_path):
+        cfg = tmp_path / "cfg"
+        cfg.mkdir()
+        (cfg / "profiles.json").write_text("{ not valid json", encoding="utf-8")
+        r = _run_hook(
+            "ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": str(cfg)},
+        )
+        assert r.returncode == 2
+
+    def test_non_ppds_command_passes(self):
+        # Hook is a no-op for non-ppds commands even with no allowlist.
+        r = _run_hook("git status")
+        assert r.returncode == 0
+
+    def test_empty_command_passes(self):
+        r = _run_hook("")
+        assert r.returncode == 0
+
+    def test_garbled_stdin_passes(self):
+        proc = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json{{",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Compound bash command parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCommandParsing:
+    def test_compound_command_with_unsafe_ppds_blocked(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-prod")
+        r = _run_hook(
+            "cd src && ppds query sql 'SELECT 1'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 2
+
+    def test_pipe_after_ppds_only_inspects_ppds_part(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        r = _run_hook(
+            "ppds env list | jq '.[].name'",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        assert r.returncode == 0
+
+    def test_unbalanced_quotes_does_not_crash(self, fake_profile_dir):
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        # Unmatched quote -- shlex would normally raise; hook must tolerate.
+        r = _run_hook(
+            "ppds env select 'unterminated",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        # Should not raise; either allow or block, but exit cleanly (0 or 2).
+        assert r.returncode in (0, 2)
+
+
+# ---------------------------------------------------------------------------
+# Module-level unit tests (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestParseFunctions:
+    def test_find_ppds_invocations_simple(self):
+        out = hook.find_ppds_invocations("ppds env list")
+        assert len(out) == 1
+        assert out[0][0].lower() == "ppds"
+        assert out[0][1:3] == ["env", "list"]
+
+    def test_find_ppds_invocations_with_path(self):
+        out = hook.find_ppds_invocations(r"./src/PPDS.Cli/bin/Debug/net10.0/ppds.exe env list")
+        assert len(out) == 1
+        assert out[0][1:3] == ["env", "list"]
+
+    def test_find_ppds_invocations_compound(self):
+        out = hook.find_ppds_invocations("cd /tmp && ppds env list && echo done")
+        assert len(out) == 1
+        assert out[0][1:3] == ["env", "list"]
+
+    def test_find_ppds_invocations_mcp_server(self):
+        out = hook.find_ppds_invocations("ppds-mcp-server")
+        assert len(out) == 1
+        assert out[0][0].lower() == "ppds-mcp-server"
+
+    def test_extract_switch_target_positional(self):
+        assert hook._extract_switch_target(["my-dev"]) == "my-dev"
+
+    def test_extract_switch_target_flag(self):
+        assert hook._extract_switch_target(["--environment", "my-dev"]) == "my-dev"
+
+    def test_extract_switch_target_equals(self):
+        assert hook._extract_switch_target(["--environment=my-dev"]) == "my-dev"
+
+    def test_extract_switch_target_short_alias(self):
+        assert hook._extract_switch_target(["-env", "my-dev"]) == "my-dev"
+
+    def test_env_matches_allowlist_case_insensitive(self):
+        assert hook.env_matches_allowlist(["PPDS-DEV"], ["ppds-dev"])
+        assert not hook.env_matches_allowlist(["PPDS-PROD"], ["ppds-dev"])

--- a/tests/hooks/test_dev_env_check.py
+++ b/tests/hooks/test_dev_env_check.py
@@ -390,6 +390,20 @@ class TestCommandParsing:
         # Should not raise; either allow or block, but exit cleanly (0 or 2).
         assert r.returncode in (0, 2)
 
+    def test_quoted_semicolon_not_command_boundary(self, fake_profile_dir):
+        # The previous regex-based truncation treated any ``;`` as a shell
+        # operator even when it sat inside a quoted SQL string. The shlex-
+        # based parser must keep the whole ppds invocation intact so the
+        # active-env gating still applies (and so unrelated quoted operators
+        # don't cause false positives or argv truncation).
+        config_dir = fake_profile_dir(active_env_name="ppds-dev")
+        r = _run_hook(
+            "ppds query \"SELECT FROM t WHERE n=';'\"",
+            env_extra={"PPDS_SAFE_ENVS": "ppds-dev", "PPDS_CONFIG_DIR": config_dir},
+        )
+        # Active env is in the allowlist -> command must pass cleanly.
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
 
 # ---------------------------------------------------------------------------
 # Module-level unit tests (no subprocess)

--- a/tests/hooks/test_shakedown_readonly.py
+++ b/tests/hooks/test_shakedown_readonly.py
@@ -148,6 +148,19 @@ class TestDryRunExempt:
         r = _run_hook("ppds plugins deploy --some-arg value", env_extra={"PPDS_SHAKEDOWN": "1"})
         assert r.returncode == 2
 
+    def test_dry_run_equals_true_treated_as_dry_run(self):
+        # --dry-run=true must be honored as a dry-run (not just bare --dry-run).
+        r = _run_hook(
+            "ppds plugins deploy --dry-run=true",
+            env_extra={"PPDS_SHAKEDOWN": "1"},
+        )
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_short_dry_run_flag(self):
+        # The -n short form must be honored as a dry-run.
+        r = _run_hook("ppds plugins deploy -n", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
 
 # ---------------------------------------------------------------------------
 # Edge: malformed input handling
@@ -188,11 +201,34 @@ class TestEdgeCases:
         )
         assert r.returncode == 2
 
-    def test_mcp_server_launch_allowed(self):
-        # The MCP server is long-running; we can't reason about whether it
-        # will write. Allow -- dev-env-check still gates the env it talks to.
+    def test_mcp_server_blocked_without_read_only(self):
+        # The MCP server can issue writes via its tools. During shakedown it
+        # MUST be launched with --read-only so the write boundary holds.
         r = _run_hook("ppds-mcp-server", env_extra={"PPDS_SHAKEDOWN": "1"})
-        assert r.returncode == 0
+        assert r.returncode == 2, f"stderr={r.stderr!r}"
+        assert "BLOCKED [shakedown-readonly]" in r.stderr
+        assert "--read-only" in r.stderr
+
+    def test_mcp_server_allowed_with_read_only(self):
+        r = _run_hook("ppds-mcp-server --read-only", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_mcp_server_allowed_with_read_only_equals_true(self):
+        r = _run_hook("ppds-mcp-server --read-only=true", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0, f"stderr={r.stderr!r}"
+
+    def test_quoted_pipe_not_command_boundary(self):
+        # The | character inside a quoted string must not split the command;
+        # the previous regex-based parser treated it as a shell operator
+        # which truncated args and could mis-classify mutations.
+        r = _run_hook(
+            "ppds data create account --name 'foo|bar'",
+            env_extra={"PPDS_SHAKEDOWN": "1"},
+        )
+        # data create is a mutation -> must still block (i.e. parser must
+        # see "create" as the verb, not be truncated by the quoted '|').
+        assert r.returncode == 2, f"stderr={r.stderr!r}"
+        assert "create" in r.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_shakedown_readonly.py
+++ b/tests/hooks/test_shakedown_readonly.py
@@ -1,0 +1,235 @@
+"""Tests for the shakedown-readonly PreToolUse hook.
+
+Verifies the hook is a no-op outside ``PPDS_SHAKEDOWN=1`` and blocks
+write/mutation patterns when active. Read-only commands (env list, query,
+plugins list, --dry-run deploy) must always pass.
+
+Run: ``pytest tests/hooks/test_shakedown_readonly.py -v``
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+HOOK_PATH = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "shakedown-readonly.py"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("shakedown_readonly", str(HOOK_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+def _run_hook(command: str, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}}
+    env = os.environ.copy()
+    env.pop("PPDS_SHAKEDOWN", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-op behavior outside shakedown mode
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpOutsideShakedown:
+    @pytest.mark.parametrize("cmd", [
+        "ppds plugins deploy",
+        "ppds plugins delete --name Foo",
+        "ppds env delete --name dev",
+        "ppds data create account --name test",
+        "ppds solutions import --file foo.zip",
+    ])
+    def test_writes_pass_when_var_unset(self, cmd):
+        # No PPDS_SHAKEDOWN set -- hook is a no-op.
+        r = _run_hook(cmd)
+        assert r.returncode == 0, f"cmd={cmd}: stderr={r.stderr!r}"
+
+    def test_writes_pass_when_var_zero(self):
+        r = _run_hook("ppds plugins deploy", env_extra={"PPDS_SHAKEDOWN": "0"})
+        assert r.returncode == 0
+
+    def test_writes_pass_when_var_empty(self):
+        r = _run_hook("ppds plugins deploy", env_extra={"PPDS_SHAKEDOWN": ""})
+        assert r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Mutation patterns are blocked when PPDS_SHAKEDOWN=1
+# ---------------------------------------------------------------------------
+
+
+class TestMutationsBlocked:
+    @pytest.mark.parametrize("cmd", [
+        "ppds plugins deploy",
+        "ppds plugins delete --name Foo",
+        "ppds env delete --name dev",
+        "ppds env update --name dev",
+        "ppds data create account --name test",
+        "ppds data update account --id 123",
+        "ppds data delete account --id 123",
+        "ppds solutions import --file foo.zip",
+        "ppds migrate apply",
+    ])
+    def test_writes_blocked_when_var_one(self, cmd):
+        r = _run_hook(cmd, env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 2, f"cmd={cmd}: stderr={r.stderr!r}"
+        assert "BLOCKED [shakedown-readonly]" in r.stderr
+        assert "PPDS_SHAKEDOWN" in r.stderr  # message references the env var
+
+    def test_block_message_includes_unset_hint(self):
+        r = _run_hook("ppds plugins deploy", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 2
+        assert "unset PPDS_SHAKEDOWN" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Read-only commands always allowed
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyAllowed:
+    @pytest.mark.parametrize("cmd", [
+        "ppds env list",
+        "ppds env current",
+        "ppds env who",
+        "ppds env switch ppds-dev",
+        "ppds env select ppds-dev",
+        "ppds env config --list",
+        "ppds env type --list",
+        "ppds plugins list",
+        "ppds logs tail",
+        "ppds logs show",
+        "ppds auth list",
+        "ppds version",
+        "ppds help",
+    ])
+    def test_reads_allowed_when_var_one(self, cmd):
+        r = _run_hook(cmd, env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0, f"cmd={cmd}: stderr={r.stderr!r}"
+
+
+# ---------------------------------------------------------------------------
+# --dry-run carve-out for plugins deploy
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunExempt:
+    @pytest.mark.parametrize("cmd", [
+        "ppds plugins deploy --dry-run",
+        "ppds plugins deploy -n",
+        "ppds plugins deploy --some-other-arg --dry-run",
+    ])
+    def test_dry_run_allowed(self, cmd):
+        r = _run_hook(cmd, env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0, f"cmd={cmd}: stderr={r.stderr!r}"
+
+    def test_real_deploy_still_blocked(self):
+        r = _run_hook("ppds plugins deploy --some-arg value", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge: malformed input handling
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_garbled_stdin_passes(self):
+        proc = subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input="not valid json{{",
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**os.environ, "PPDS_SHAKEDOWN": "1"},
+        )
+        # Garbled input -> allow (don't break unrelated tools).
+        assert proc.returncode == 0
+
+    def test_empty_command_passes(self):
+        r = _run_hook("", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0
+
+    def test_non_ppds_command_passes(self):
+        r = _run_hook("git push origin main", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0
+
+    def test_unbalanced_quotes_in_ppds_command(self):
+        # Hook must not crash on bad shell input.
+        r = _run_hook("ppds data create account --name 'unterminated", env_extra={"PPDS_SHAKEDOWN": "1"})
+        # Either 0 or 2 is fine -- the rule is "must not raise".
+        assert r.returncode in (0, 2)
+
+    def test_compound_command_with_blocked_ppds(self):
+        r = _run_hook(
+            "cd src && ppds plugins deploy && echo done",
+            env_extra={"PPDS_SHAKEDOWN": "1"},
+        )
+        assert r.returncode == 2
+
+    def test_mcp_server_launch_allowed(self):
+        # The MCP server is long-running; we can't reason about whether it
+        # will write. Allow -- dev-env-check still gates the env it talks to.
+        r = _run_hook("ppds-mcp-server", env_extra={"PPDS_SHAKEDOWN": "1"})
+        assert r.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Module-level unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsMutation:
+    def test_known_mutation_verb(self):
+        is_mut, reason = hook.is_mutation(["ppds", "data", "create", "account"])
+        assert is_mut
+        assert "create" in reason
+
+    def test_readonly_subcommand_explicit(self):
+        is_mut, _ = hook.is_mutation(["ppds", "env", "list"])
+        assert not is_mut
+
+    def test_plugins_deploy_no_dry_run(self):
+        is_mut, _ = hook.is_mutation(["ppds", "plugins", "deploy"])
+        assert is_mut
+
+    def test_plugins_deploy_with_dry_run(self):
+        is_mut, _ = hook.is_mutation(["ppds", "plugins", "deploy", "--dry-run"])
+        assert not is_mut
+
+    def test_plugins_deploy_with_short_dry_run(self):
+        is_mut, _ = hook.is_mutation(["ppds", "plugins", "deploy", "-n"])
+        assert not is_mut
+
+    def test_logs_wildcard(self):
+        # Anything under 'logs' is read-only.
+        for verb in ("tail", "show", "stream", "anything"):
+            is_mut, _ = hook.is_mutation(["ppds", "logs", verb])
+            assert not is_mut, f"verb={verb}"
+
+    def test_short_argv_not_mutation(self):
+        is_mut, _ = hook.is_mutation(["ppds"])
+        assert not is_mut
+        is_mut, _ = hook.is_mutation(["ppds", "env"])
+        assert not is_mut


### PR DESCRIPTION
## Summary

Defense-in-depth safety enforcement for the `/shakedown`, `/ext-verify`,
`/tui-verify`, `/cli-verify`, and `/mcp-verify` skills, surfaced as a gap
during shakedown dispatch planning. Today nothing prevents an autonomous
agent from connecting to a non-dev environment or running write/delete
commands during a shakedown -- skill rules are advisory and the operator
has no mechanical safety net.

This PR adds two PreToolUse hooks plus an allowlist file plus the matching
skill / docs / settings / test updates. **Do not auto-merge** -- the
orchestrator should mark this ready after review.

## Per-component summary

| Component | File(s) | Status |
|---|---|---|
| Hook 1: dev-env-check | `.claude/hooks/dev-env-check.py` | new (+435) |
| Hook 2: shakedown-readonly | `.claude/hooks/shakedown-readonly.py` | new (+224) |
| Allowlist template | `.claude/state/safe-envs.json` | new |
| `.gitattributes` | `.gitattributes` | union-merge for safe-envs.json |
| Skill: shakedown | `.claude/skills/shakedown/SKILL.md` | new Phase 0 |
| Skill: 4 verify | `.claude/skills/{ext,tui,cli,mcp}-verify/SKILL.md` | Safety pre-check section |
| Docs | `docs/SAFE-SHAKEDOWN.md` | new policy doc |
| Tests | `tests/hooks/test_dev_env_check.py`, `tests/hooks/test_shakedown_readonly.py` | 83 tests, all green |
| Settings wiring | `.claude/settings.json` | 2 new PreToolUse(Bash) entries |

Total diff (excluding unrelated drift from main): ~1.6k lines added,
roughly half is tests.

## Behavior

**dev-env-check.py** (always on):
- Allowlist sources, in order: `$PPDS_SAFE_ENVS`, `.claude/state/safe-envs.json`, neither -> block.
- Resolves the active env by reading `profiles.json` directly (mirrors `PPDS.Auth.Profiles.ProfilePaths`). No shelling out to `ppds env who` -- that would be circular for a PreToolUse-on-Bash hook.
- Read-only `ppds env list/current/who/config/type/show` always allowed.
- `ppds env switch/select <name>` allowed only when **target** is in the allowlist.
- `ppds-mcp-server` gated like `ppds *`.
- **Fail-safe**: blocks when active env can't be determined.

**shakedown-readonly.py** (only when `PPDS_SHAKEDOWN=1`):
- Blocks mutation verbs: `create`, `update`, `delete`, `remove`, `import`, `apply`, `register`, `unregister`, `publish`, `truncate`, `drop`, `reset`, `set`.
- `ppds plugins deploy` blocked unless `--dry-run` (or `-n`) is present.
- All `ppds logs *` exempt.
- Bypass: `unset PPDS_SHAKEDOWN`. No softer marker (deliberate hard boundary).

Both hooks use the **corrected** JSON envelope contract from PR #816
(`payload["tool_input"]["command"]`, NOT the buggy top-level read).

## Tradeoffs / decisions worth Josh's eye

1. **CLI command names**: the spec referenced `ppds env current` / `switch`. The actual CLI has `who` / `select` (see `src/PPDS.Cli/Commands/Env/EnvCommandGroup.cs`). The hooks accept BOTH name sets (current/who, switch/select/use) and the skill/docs use the canonical `who`/`select` form with parenthetical mention of the aliases. Per the STOP conditions I considered halting, but the semantic intent was unambiguous and the hook is more robust for accepting both. Worth confirming this is OK.
2. **Allowlist match semantics**: case-insensitive match against `Environment.DisplayName`, `Environment.UniqueName`, and the host portion of `Environment.Url`. This is friendly to operators who type a friendly name, a unique name, or a host fragment. If you'd rather force exact-DisplayName matching, easy to tighten.
3. **Read-only `who` carve-out**: `ppds env who` does open a Dataverse connection (issues WhoAmI). I treated it as effectively read-only because (a) it's the only way operators verify what env they're on, and (b) WhoAmI is the lightest possible request. If even WhoAmI to a non-dev env is unacceptable, move `who` out of `_ENV_READONLY_SUBCOMMANDS`.
4. **safe-envs.json template ships with empty array**: a fresh clone will block ALL `ppds *` until the operator populates the file. This is intentional fail-safe behavior, but it means the very first run will block confusingly. Documented in `docs/SAFE-SHAKEDOWN.md`.
5. **Did NOT touch CLAUDE.md** (per task constraint -- governance hook would block without `[claude-md-reviewed: ...]` marker).

## Test plan

- [x] `pytest tests/hooks/ -v` -> 83 passed
- [x] Pre-existing hook tests still pass: `pytest tests/test_protect_main_branch.py tests/test_snk_protect.py tests/test_claudemd_line_cap.py` -> 46 passed (no regressions)
- [x] Smoke-tested both hooks via subprocess on Windows
- [ ] Operator validation: populate `.claude/state/safe-envs.json` with a real dev env name, confirm `ppds env list` works and `ppds plugins deploy` blocks
- [ ] Confirm `PPDS_SHAKEDOWN=1` in a real shakedown session blocks an attempted mutation

## Notes

- Shakedown should not run until this is merged (per the task brief that surfaced this gap).
- Pure stdlib Python, no new dependencies. Cross-platform (path normalization via existing `_pathfix.py`).
- The 7 commits are organized by area and could be squashed on merge.