### PR TITLE
chore(state): populate safe-envs.json with PPDS Demo - Dev

### DIFF
--- a/.claude/state/safe-envs.json
+++ b/.claude/state/safe-envs.json
@@ -1,4 +1,4 @@
 {
-  "safe_envs": [],
+  "safe_envs": ["PPDS Demo - Dev"],
   "_comment": "Add env names that are safe to use for shakedown/verify operations (e.g. dev/test envs only). Names are matched case-insensitively against the active profile Environment.DisplayName, Environment.UniqueName, or the host portion of Environment.Url. Used by .claude/hooks/dev-env-check.py."
 }


### PR DESCRIPTION
Unblocks Wave 4 + shakedown by populating the new env allowlist (#822). Single-line config; trivial.

The empty array template from #822 was deliberately conservative for first-time setup. This populates with the active dev env name visible from `ppds env list`. Future contributors append their own; merge=union in .gitattributes prevents conflicts.