### PR TITLE
docs(notices): remove Devlooped.CredentialManager mention

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -261,9 +261,7 @@ A minimal subset of the `microsoft/git-credential-manager` source for cross-plat
 credential storage (Windows Credential Manager, macOS Keychain, Linux libsecret) is
 vendored into `src/PPDS.Auth/Internal/CredentialStore/` at commit
 `5fa7116896c82164996a609accd1c5ad90fe730a` (tag v2.7.3). Original Microsoft/GitHub
-MIT copyright is attributed in each vendored file's header. Vendoring rationale:
-removed the `Devlooped.CredentialManager` package to eliminate its OSMFEULA-licensed
-binary distribution for enterprise consumers.
+MIT copyright is attributed in each vendored file's header.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove stale `Devlooped.CredentialManager` rationale sentence from the Vendored Source (MIT) section of `THIRD_PARTY_NOTICES.md`.
- NOTICES is an attribution file for components PPDS currently ships — removal rationale belongs in the spec and PR #803 history, not here.
- Summary table already reflects the post-#803 proprietary/EULA count (2); no numeric change needed.

Closes #810

## Test Plan
- [x] `grep -i devlooped THIRD_PARTY_NOTICES.md` returns no matches
- [x] Vendored-source section still attributes git-credential-manager (project URL, MIT license, commit SHA, tag, copyright header note)
- [x] Summary table line 15 shows `proprietary / Microsoft EULA: 2`

## Verification
Docs-only change; runtime gates/verify/qa not applicable. Content audited against the acceptance criteria in #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)