### PR TITLE
fix(query): coerce SQL DML values to Dataverse SDK types

### DIFF
--- a/src/PPDS.Cli/Infrastructure/DaemonConnectionPoolManager.cs
+++ b/src/PPDS.Cli/Infrastructure/DaemonConnectionPoolManager.cs
@@ -402,13 +402,15 @@ public sealed class DaemonConnectionPoolManager : IDaemonConnectionPoolManager
             var tdsExecutor = sp.GetService<ITdsQueryExecutor>();
             var bulkExecutor = sp.GetService<IBulkOperationExecutor>();
             var metadataExecutor = sp.GetService<IMetadataQueryExecutor>();
+            var metadataProvider = sp.GetService<ICachedMetadataProvider>();
             var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             return new SqlQueryService(
                 queryExecutor,
                 tdsExecutor,
                 bulkExecutor,
                 metadataExecutor,
-                pool.GetTotalRecommendedParallelism());
+                pool.GetTotalRecommendedParallelism(),
+                metadataProvider);
         });
 
         // Plugin registration services — used by plugins/* and domain-specific RPC handlers

--- a/src/PPDS.Cli/Services/Query/SqlQueryService.cs
+++ b/src/PPDS.Cli/Services/Query/SqlQueryService.cs
@@ -24,6 +24,7 @@ public sealed class SqlQueryService : ISqlQueryService
     private readonly ITdsQueryExecutor? _tdsQueryExecutor;
     private readonly IBulkOperationExecutor? _bulkOperationExecutor;
     private readonly IMetadataQueryExecutor? _metadataQueryExecutor;
+    private readonly ICachedMetadataProvider? _metadataProvider;
     private readonly int _poolCapacity;
     private readonly ExecutionPlanBuilder _planBuilder;
     private readonly PlanExecutor _planExecutor;
@@ -61,17 +62,22 @@ public sealed class SqlQueryService : ISqlQueryService
     /// <param name="bulkOperationExecutor">Optional bulk operation executor for DML statements.</param>
     /// <param name="metadataQueryExecutor">Optional metadata query executor for metadata virtual tables.</param>
     /// <param name="poolCapacity">Connection pool parallelism capacity for aggregate partitioning.</param>
+    /// <param name="metadataProvider">Optional cached metadata provider. Required for DML type coercion
+    /// (lookup → <c>EntityReference</c>, choice → <c>OptionSetValue</c>, etc.); when null, DML passes
+    /// raw CLR values through to Dataverse, which rejects them for non-scalar columns.</param>
     public SqlQueryService(
         IQueryExecutor queryExecutor,
         ITdsQueryExecutor? tdsQueryExecutor = null,
         IBulkOperationExecutor? bulkOperationExecutor = null,
         IMetadataQueryExecutor? metadataQueryExecutor = null,
-        int poolCapacity = 1)
+        int poolCapacity = 1,
+        ICachedMetadataProvider? metadataProvider = null)
     {
         _queryExecutor = queryExecutor ?? throw new ArgumentNullException(nameof(queryExecutor));
         _tdsQueryExecutor = tdsQueryExecutor;
         _bulkOperationExecutor = bulkOperationExecutor;
         _metadataQueryExecutor = metadataQueryExecutor;
+        _metadataProvider = metadataProvider;
         _poolCapacity = poolCapacity;
         _planBuilder = new ExecutionPlanBuilder(_fetchXmlGeneratorService);
         _planExecutor = new PlanExecutor();
@@ -157,7 +163,8 @@ public sealed class SqlQueryService : ISqlQueryService
             cancellationToken,
             bulkOperationExecutor: _bulkOperationExecutor,
             metadataQueryExecutor: _metadataQueryExecutor,
-            executionOptions: executionOptions);
+            executionOptions: executionOptions,
+            metadataProvider: _metadataProvider);
 
         QueryResult result;
         try
@@ -295,7 +302,8 @@ public sealed class SqlQueryService : ISqlQueryService
             cancellationToken,
             bulkOperationExecutor: _bulkOperationExecutor,
             metadataQueryExecutor: _metadataQueryExecutor,
-            executionOptions: executionOptions);
+            executionOptions: executionOptions,
+            metadataProvider: _metadataProvider);
 
         var chunkRows = new List<IReadOnlyDictionary<string, QueryValue>>(chunkSize);
         IReadOnlyList<QueryColumn>? columns = null;

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -49,13 +49,15 @@ public static class ServiceRegistration
             var tdsExecutor = sp.GetService<ITdsQueryExecutor>();
             var bulkExecutor = sp.GetService<IBulkOperationExecutor>();
             var metadataExecutor = sp.GetService<IMetadataQueryExecutor>();
+            var metadataProvider = sp.GetService<ICachedMetadataProvider>();
             var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             return new SqlQueryService(
                 queryExecutor,
                 tdsExecutor,
                 bulkExecutor,
                 metadataExecutor,
-                pool.GetTotalRecommendedParallelism());
+                pool.GetTotalRecommendedParallelism(),
+                metadataProvider);
         });
 
         // TDS Endpoint executor — per-environment, uses same auth pattern as IConnectionService

--- a/src/PPDS.Dataverse/Query/DmlValueCoercer.cs
+++ b/src/PPDS.Dataverse/Query/DmlValueCoercer.cs
@@ -152,7 +152,9 @@ public static class DmlValueCoercer
             string s when bool.TryParse(s, out var parsed) => parsed,
             string s when s == "1" => true,
             string s when s == "0" => false,
-            IConvertible conv => Convert.ToInt64(conv, CultureInfo.InvariantCulture) != 0,
+            int i => i != 0,
+            long l => l != 0,
+            decimal d => d != 0,
             _ => throw TypeMismatch(value, "Boolean")
         };
     }
@@ -164,8 +166,10 @@ public static class DmlValueCoercer
         return value switch
         {
             long l => l,
-            string s => long.Parse(s, CultureInfo.InvariantCulture),
-            IConvertible conv => Convert.ToInt64(conv, CultureInfo.InvariantCulture),
+            int i => i,
+            decimal d => (long)d,
+            double dbl => (long)dbl,
+            string s when long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l) => l,
             _ => throw TypeMismatch(value, "Int64")
         };
     }
@@ -177,8 +181,10 @@ public static class DmlValueCoercer
         return value switch
         {
             double d => d,
-            string s => double.Parse(s, CultureInfo.InvariantCulture),
-            IConvertible conv => Convert.ToDouble(conv, CultureInfo.InvariantCulture),
+            int i => i,
+            long l => l,
+            decimal d => (double)d,
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) => d,
             _ => throw TypeMismatch(value, "Double")
         };
     }
@@ -198,7 +204,7 @@ public static class DmlValueCoercer
         {
             DateTime dt => dt,
             DateTimeOffset dto => dto.UtcDateTime,
-            string s => DateTime.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+            string s when DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt) => dt,
             _ => throw TypeMismatch(value, "DateTime")
         };
     }
@@ -218,8 +224,10 @@ public static class DmlValueCoercer
         return value switch
         {
             int i => i,
-            string s => int.Parse(s, CultureInfo.InvariantCulture),
-            IConvertible conv => Convert.ToInt32(conv, CultureInfo.InvariantCulture),
+            long l when l >= int.MinValue && l <= int.MaxValue => (int)l,
+            decimal d when d >= int.MinValue && d <= int.MaxValue => (int)d,
+            double dbl when dbl >= int.MinValue && dbl <= int.MaxValue => (int)dbl,
+            string s when int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) => i,
             _ => throw TypeMismatch(value, "Int32")
         };
     }
@@ -229,8 +237,10 @@ public static class DmlValueCoercer
         return value switch
         {
             decimal d => d,
-            string s => decimal.Parse(s, CultureInfo.InvariantCulture),
-            IConvertible conv => Convert.ToDecimal(conv, CultureInfo.InvariantCulture),
+            int i => i,
+            long l => l,
+            double dbl => (decimal)dbl,
+            string s when decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out var d) => d,
             _ => throw TypeMismatch(value, "Decimal")
         };
     }

--- a/src/PPDS.Dataverse/Query/DmlValueCoercer.cs
+++ b/src/PPDS.Dataverse/Query/DmlValueCoercer.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Globalization;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Metadata.Models;
+using PPDS.Dataverse.Query.Execution;
+
+namespace PPDS.Dataverse.Query;
+
+/// <summary>
+/// Coerces raw CLR values from SQL DML into Dataverse SDK-typed values
+/// (<see cref="EntityReference"/> for lookups, <see cref="OptionSetValue"/> for choices,
+/// <see cref="Money"/> for currency, etc.) using attribute metadata.
+/// </summary>
+/// <remarks>
+/// SQL literals compiled from ScriptDom are primitive CLR values (int, decimal, string).
+/// Dataverse's <c>CreateMultiple</c>/<c>UpdateMultiple</c> reject primitives for typed
+/// attributes (lookup, picklist, money) — they require SDK wrapper types. This helper
+/// bridges that gap. When metadata is unavailable or a type is not recognized, it returns
+/// the value unchanged so callers degrade gracefully to today's behavior.
+/// </remarks>
+public static class DmlValueCoercer
+{
+    /// <summary>
+    /// Coerces <paramref name="value"/> to the Dataverse SDK type implied by
+    /// <paramref name="attribute"/>. Returns the input unchanged when coercion is not
+    /// possible (null input, null metadata, unsupported type).
+    /// </summary>
+    /// <param name="value">The raw CLR value from a compiled SQL expression.</param>
+    /// <param name="attribute">Target attribute metadata, or null if unknown.</param>
+    /// <returns>The coerced value, or <paramref name="value"/> unchanged.</returns>
+    public static object? Coerce(object? value, AttributeMetadataDto? attribute)
+    {
+        if (value is null || attribute is null)
+            return value;
+
+        // AttributeMetadataDto.AttributeType is AttributeTypeCode.ToString().
+        switch (attribute.AttributeType)
+        {
+            case "Lookup":
+            case "Customer":
+            case "Owner":
+                return CoerceLookup(value, attribute);
+
+            case "Picklist":
+            case "State":
+            case "Status":
+                return CoerceOptionSet(value);
+
+            case "Money":
+                return CoerceMoney(value);
+
+            case "Boolean":
+                return CoerceBoolean(value);
+
+            case "Integer":
+                return CoerceInt(value);
+
+            case "BigInt":
+                return CoerceLong(value);
+
+            case "Decimal":
+                return CoerceDecimal(value);
+
+            case "Double":
+                return CoerceDouble(value);
+
+            case "DateTime":
+                return CoerceDateTime(value);
+
+            case "Uniqueidentifier":
+                return CoerceGuid(value);
+
+            case "String":
+            case "Memo":
+                return value is string ? value : value.ToString();
+
+            case "Virtual":
+                // MultiSelectPicklist is modeled as Virtual with AttributeTypeName="MultiSelectPicklistType".
+                // SQL DML does not yet support writing OptionSetValueCollection; fail loudly rather than
+                // passing a raw int/string through to Dataverse (which produces an opaque SDK error).
+                if (attribute.AttributeTypeName == "MultiSelectPicklistType")
+                {
+                    throw new QueryExecutionException(
+                        QueryErrorCode.TypeMismatch,
+                        $"Multi-select choice column '{attribute.LogicalName}' is not yet supported by SQL DML. " +
+                        "Use the Dataverse SDK or a targeted import for multi-select writes.");
+                }
+                return value;
+
+            default:
+                return value;
+        }
+    }
+
+    private static EntityReference CoerceLookup(object value, AttributeMetadataDto attribute)
+    {
+        if (value is EntityReference existing)
+            return existing;
+
+        var target = ResolveLookupTarget(attribute);
+        var id = CoerceGuid(value);
+        if (id is not Guid guid)
+        {
+            throw new QueryExecutionException(
+                QueryErrorCode.TypeMismatch,
+                $"Cannot convert value '{value}' of type {value.GetType().Name} to a GUID " +
+                $"for lookup attribute '{attribute.LogicalName}'.");
+        }
+        return new EntityReference(target, guid);
+    }
+
+    private static string ResolveLookupTarget(AttributeMetadataDto attribute)
+    {
+        var targets = attribute.Targets;
+        if (targets == null || targets.Count == 0)
+        {
+            throw new QueryExecutionException(
+                QueryErrorCode.TypeMismatch,
+                $"Lookup attribute '{attribute.LogicalName}' has no target entity in metadata. " +
+                "Cannot construct an EntityReference.");
+        }
+
+        if (targets.Count == 1)
+            return targets[0];
+
+        throw new QueryExecutionException(
+            QueryErrorCode.TypeMismatch,
+            $"Lookup attribute '{attribute.LogicalName}' is polymorphic with targets [{string.Join(", ", targets)}]. " +
+            "SQL DML cannot currently disambiguate polymorphic lookups. Pass an EntityReference via a parameter, " +
+            "or set the value outside SQL DML.");
+    }
+
+    private static OptionSetValue CoerceOptionSet(object value)
+    {
+        if (value is OptionSetValue existing)
+            return existing;
+        return new OptionSetValue(ToInt32(value));
+    }
+
+    private static Money CoerceMoney(object value)
+    {
+        if (value is Money existing)
+            return existing;
+        return new Money(ToDecimal(value));
+    }
+
+    private static bool CoerceBoolean(object value)
+    {
+        return value switch
+        {
+            bool b => b,
+            string s when bool.TryParse(s, out var parsed) => parsed,
+            string s when s == "1" => true,
+            string s when s == "0" => false,
+            IConvertible conv => Convert.ToInt64(conv, CultureInfo.InvariantCulture) != 0,
+            _ => throw TypeMismatch(value, "Boolean")
+        };
+    }
+
+    private static int CoerceInt(object value) => ToInt32(value);
+
+    private static long CoerceLong(object value)
+    {
+        return value switch
+        {
+            long l => l,
+            string s => long.Parse(s, CultureInfo.InvariantCulture),
+            IConvertible conv => Convert.ToInt64(conv, CultureInfo.InvariantCulture),
+            _ => throw TypeMismatch(value, "Int64")
+        };
+    }
+
+    private static decimal CoerceDecimal(object value) => ToDecimal(value);
+
+    private static double CoerceDouble(object value)
+    {
+        return value switch
+        {
+            double d => d,
+            string s => double.Parse(s, CultureInfo.InvariantCulture),
+            IConvertible conv => Convert.ToDouble(conv, CultureInfo.InvariantCulture),
+            _ => throw TypeMismatch(value, "Double")
+        };
+    }
+
+    /// <summary>
+    /// Parses DateTime values for Dataverse DateTime attributes.
+    /// Uses <see cref="DateTimeStyles.RoundtripKind"/>: strings with a zone designator
+    /// (e.g. <c>"...Z"</c>, <c>"...+05:00"</c>) keep their <see cref="DateTimeKind.Utc"/>
+    /// or Local kind; unqualified strings parse as <see cref="DateTimeKind.Unspecified"/>,
+    /// which the Dataverse SDK serializes per the column's <c>DateTimeBehavior</c>
+    /// (UserLocal / DateOnly / TimeZoneIndependent). Forcing UTC here would silently
+    /// shift UserLocal columns by the caller's offset.
+    /// </summary>
+    private static DateTime CoerceDateTime(object value)
+    {
+        return value switch
+        {
+            DateTime dt => dt,
+            DateTimeOffset dto => dto.UtcDateTime,
+            string s => DateTime.Parse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+            _ => throw TypeMismatch(value, "DateTime")
+        };
+    }
+
+    private static object CoerceGuid(object value)
+    {
+        return value switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var g) => g,
+            _ => throw TypeMismatch(value, "Guid")
+        };
+    }
+
+    private static int ToInt32(object value)
+    {
+        return value switch
+        {
+            int i => i,
+            string s => int.Parse(s, CultureInfo.InvariantCulture),
+            IConvertible conv => Convert.ToInt32(conv, CultureInfo.InvariantCulture),
+            _ => throw TypeMismatch(value, "Int32")
+        };
+    }
+
+    private static decimal ToDecimal(object value)
+    {
+        return value switch
+        {
+            decimal d => d,
+            string s => decimal.Parse(s, CultureInfo.InvariantCulture),
+            IConvertible conv => Convert.ToDecimal(conv, CultureInfo.InvariantCulture),
+            _ => throw TypeMismatch(value, "Decimal")
+        };
+    }
+
+    private static QueryExecutionException TypeMismatch(object value, string targetType) =>
+        new(QueryErrorCode.TypeMismatch,
+            $"Cannot convert value '{value}' of type {value.GetType().Name} to {targetType}.");
+}

--- a/src/PPDS.Dataverse/Query/Planning/Nodes/DmlExecuteNode.cs
+++ b/src/PPDS.Dataverse/Query/Planning/Nodes/DmlExecuteNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Metadata.Models;
 using PPDS.Dataverse.Progress;
 using PPDS.Dataverse.Query.Execution;
 
@@ -209,6 +210,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
         CancellationToken cancellationToken)
     {
         var entities = new List<Microsoft.Xrm.Sdk.Entity>();
+        var attributeMap = await LoadAttributeMapAsync(context, cancellationToken).ConfigureAwait(false);
 
         foreach (var row in InsertValueRows!)
         {
@@ -221,7 +223,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
             for (var i = 0; i < InsertColumns!.Count; i++)
             {
                 var value = row[i](EmptyRow);
-                entity[InsertColumns[i]] = value;
+                entity[InsertColumns[i]] = CoerceForColumn(InsertColumns[i], value, attributeMap);
             }
             entities.Add(entity);
         }
@@ -241,6 +243,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
         CancellationToken cancellationToken)
     {
         var entities = new List<Microsoft.Xrm.Sdk.Entity>();
+        var attributeMap = await LoadAttributeMapAsync(context, cancellationToken).ConfigureAwait(false);
 
         await foreach (var row in SourceNode!.ExecuteAsync(context, cancellationToken))
         {
@@ -259,7 +262,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
                     var sourceKey = SourceColumns[i];
                     if (row.Values.TryGetValue(sourceKey, out var qv))
                     {
-                        entity[InsertColumns[i]] = qv.Value;
+                        entity[InsertColumns[i]] = CoerceForColumn(InsertColumns[i], qv.Value, attributeMap);
                     }
                 }
             }
@@ -271,7 +274,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
                     var columnName = InsertColumns[i];
                     if (row.Values.TryGetValue(columnName, out var qv))
                     {
-                        entity[columnName] = qv.Value;
+                        entity[columnName] = CoerceForColumn(columnName, qv.Value, attributeMap);
                     }
                 }
             }
@@ -297,6 +300,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
     {
         var entities = new List<Microsoft.Xrm.Sdk.Entity>();
         var idColumn = EntityLogicalName + "id";
+        var attributeMap = await LoadAttributeMapAsync(context, cancellationToken).ConfigureAwait(false);
 
         await foreach (var row in SourceNode!.ExecuteAsync(context, cancellationToken))
         {
@@ -318,7 +322,7 @@ public sealed class DmlExecuteNode : IQueryPlanNode
             foreach (var clause in SetClauses!)
             {
                 var value = clause.Value(row.Values);
-                entity[clause.ColumnName] = value;
+                entity[clause.ColumnName] = CoerceForColumn(clause.ColumnName, value, attributeMap);
             }
 
             entities.Add(entity);
@@ -369,6 +373,45 @@ public sealed class DmlExecuteNode : IQueryPlanNode
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return result.SuccessCount;
+    }
+
+    /// <summary>
+    /// Loads the attribute metadata map for <see cref="EntityLogicalName"/> from
+    /// <see cref="QueryPlanContext.MetadataProvider"/>. Returns null when no provider
+    /// is configured (callers fall back to raw CLR values, matching pre-coercion behavior).
+    /// </summary>
+    private async System.Threading.Tasks.Task<IReadOnlyDictionary<string, AttributeMetadataDto>?> LoadAttributeMapAsync(
+        QueryPlanContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context.MetadataProvider == null)
+            return null;
+
+        var attrs = await context.MetadataProvider
+            .GetAttributesAsync(EntityLogicalName, cancellationToken)
+            .ConfigureAwait(false);
+
+        var map = new Dictionary<string, AttributeMetadataDto>(StringComparer.OrdinalIgnoreCase);
+        foreach (var a in attrs)
+        {
+            map[a.LogicalName] = a;
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Coerces <paramref name="value"/> using metadata for <paramref name="columnName"/>
+    /// when available. Unknown columns and missing maps pass through unchanged.
+    /// </summary>
+    private static object? CoerceForColumn(
+        string columnName,
+        object? value,
+        IReadOnlyDictionary<string, AttributeMetadataDto>? attributeMap)
+    {
+        if (attributeMap == null)
+            return value;
+        attributeMap.TryGetValue(columnName, out var attr);
+        return DmlValueCoercer.Coerce(value, attr);
     }
 
     /// <summary>

--- a/src/PPDS.Dataverse/Query/Planning/QueryPlanContext.cs
+++ b/src/PPDS.Dataverse/Query/Planning/QueryPlanContext.cs
@@ -36,6 +36,14 @@ public sealed class QueryPlanContext
     public VariableScope? VariableScope { get; }
 
     /// <summary>
+    /// Optional cached metadata provider. When supplied, DML nodes use this to coerce
+    /// SQL literals into Dataverse SDK types (<c>EntityReference</c>, <c>OptionSetValue</c>, etc.)
+    /// for lookup, choice, and money attributes. Null disables coercion (raw CLR values are
+    /// passed through to <c>Entity[attr]</c>).
+    /// </summary>
+    public Metadata.ICachedMetadataProvider? MetadataProvider { get; }
+
+    /// <summary>
     /// Maximum rows a node may materialize in memory (e.g., for sorting or aggregation).
     /// Default is 500,000. Set to 0 for unlimited.
     /// </summary>
@@ -59,7 +67,8 @@ public sealed class QueryPlanContext
         IBulkOperationExecutor? bulkOperationExecutor = null,
         VariableScope? variableScope = null,
         int maxMaterializationRows = 500_000,
-        QueryExecutionOptions? executionOptions = null)
+        QueryExecutionOptions? executionOptions = null,
+        Metadata.ICachedMetadataProvider? metadataProvider = null)
     {
         QueryExecutor = queryExecutor ?? throw new ArgumentNullException(nameof(queryExecutor));
         CancellationToken = cancellationToken;
@@ -71,5 +80,6 @@ public sealed class QueryPlanContext
         VariableScope = variableScope;
         MaxMaterializationRows = maxMaterializationRows;
         ExecutionOptions = executionOptions;
+        MetadataProvider = metadataProvider;
     }
 }

--- a/tests/PPDS.Dataverse.Tests/Query/DmlValueCoercerTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Query/DmlValueCoercerTests.cs
@@ -248,4 +248,93 @@ public class DmlValueCoercerTests
         var result = DmlValueCoercer.Coerce(42, Attr("SomeFutureType"));
         Assert.Equal(42, result);
     }
+
+    // -----------------------------------------------------------------------
+    // Structured-error coverage for Gemini findings on PR #827 (DmlValueCoercer
+    // lines 155, 168, 181, 201, 222, 233). Verifies that bad inputs surface as
+    // QueryExecutionException(TypeMismatch) instead of raw Format/Overflow
+    // exceptions from Convert.To* / Parse.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Coerce_BooleanFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("yes", Attr("Boolean")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Boolean", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_BooleanFromUnsupportedType_ThrowsQueryExecutionException()
+    {
+        // DateTime is not in the Boolean coercion switch — must throw structured.
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce(DateTime.UtcNow, Attr("Boolean")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Coerce_BigIntFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("not-a-number", Attr("BigInt")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Int64", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_DoubleFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("nan-not-a-num", Attr("Double")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Double", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_DateTimeFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("not-a-date", Attr("DateTime")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("DateTime", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_IntegerFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("xyz", Attr("Integer")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Int32", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_IntegerFromOverflowLong_ThrowsQueryExecutionException()
+    {
+        // long > int.MaxValue must surface a structured error rather than a
+        // checked-conversion OverflowException from Convert.ToInt32.
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce((long)int.MaxValue + 1L, Attr("Integer")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Coerce_DecimalFromBadString_ThrowsQueryExecutionException()
+    {
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("not-a-decimal", Attr("Decimal")));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Decimal", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_BigIntFromInvariantString_Parses()
+    {
+        // Confirms the explicit InvariantCulture-bound TryParse path works for the
+        // common ScriptDom string-literal case.
+        var result = DmlValueCoercer.Coerce("9223372036854775807", Attr("BigInt"));
+        Assert.Equal(long.MaxValue, Assert.IsType<long>(result));
+    }
 }

--- a/tests/PPDS.Dataverse.Tests/Query/DmlValueCoercerTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Query/DmlValueCoercerTests.cs
@@ -1,0 +1,251 @@
+using System;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.Metadata.Models;
+using PPDS.Dataverse.Query;
+using PPDS.Dataverse.Query.Execution;
+using Xunit;
+
+namespace PPDS.Dataverse.Tests.Query;
+
+/// <summary>
+/// Unit tests for <see cref="DmlValueCoercer"/> — the helper that turns primitive CLR
+/// values from SQL DML into Dataverse SDK types. Regression coverage for issue #787
+/// ("ppds query sql DML does not coerce lookup or choice values into Dataverse types").
+/// </summary>
+[Trait("Category", "TuiUnit")]
+public class DmlValueCoercerTests
+{
+    private static AttributeMetadataDto Attr(
+        string type,
+        string name = "col",
+        System.Collections.Generic.List<string>? targets = null,
+        string? attributeTypeName = null)
+        => new()
+        {
+            LogicalName = name,
+            DisplayName = name,
+            SchemaName = name,
+            AttributeType = type,
+            Targets = targets,
+            AttributeTypeName = attributeTypeName
+        };
+
+    [Fact]
+    public void Coerce_NullValue_ReturnsNull()
+    {
+        Assert.Null(DmlValueCoercer.Coerce(null, Attr("String")));
+    }
+
+    [Fact]
+    public void Coerce_NullMetadata_ReturnsValueUnchanged()
+    {
+        Assert.Equal(42, DmlValueCoercer.Coerce(42, null));
+    }
+
+    [Fact]
+    public void Coerce_PicklistInt_ReturnsOptionSetValue()
+    {
+        var result = DmlValueCoercer.Coerce(100000000, Attr("Picklist"));
+        var option = Assert.IsType<OptionSetValue>(result);
+        Assert.Equal(100000000, option.Value);
+    }
+
+    [Fact]
+    public void Coerce_StateStatusNumericString_ReturnsOptionSetValue()
+    {
+        var state = DmlValueCoercer.Coerce("1", Attr("State"));
+        var status = DmlValueCoercer.Coerce(2, Attr("Status"));
+
+        Assert.IsType<OptionSetValue>(state);
+        Assert.Equal(1, ((OptionSetValue)state!).Value);
+        Assert.IsType<OptionSetValue>(status);
+        Assert.Equal(2, ((OptionSetValue)status!).Value);
+    }
+
+    [Fact]
+    public void Coerce_PicklistPassthrough_WhenAlreadyOptionSetValue()
+    {
+        var existing = new OptionSetValue(7);
+        var result = DmlValueCoercer.Coerce(existing, Attr("Picklist"));
+        Assert.Same(existing, result);
+    }
+
+    [Fact]
+    public void Coerce_LookupGuidString_ReturnsEntityReference()
+    {
+        var id = Guid.NewGuid();
+        var result = DmlValueCoercer.Coerce(
+            id.ToString(),
+            Attr("Lookup", "hsl_clinic", targets: new() { "hsl_clinic" }));
+
+        var reference = Assert.IsType<EntityReference>(result);
+        Assert.Equal("hsl_clinic", reference.LogicalName);
+        Assert.Equal(id, reference.Id);
+    }
+
+    [Fact]
+    public void Coerce_LookupGuidValue_ReturnsEntityReference()
+    {
+        var id = Guid.NewGuid();
+        var result = DmlValueCoercer.Coerce(
+            id,
+            Attr("Lookup", "primarycontactid", targets: new() { "contact" }));
+
+        var reference = Assert.IsType<EntityReference>(result);
+        Assert.Equal("contact", reference.LogicalName);
+        Assert.Equal(id, reference.Id);
+    }
+
+    [Fact]
+    public void Coerce_LookupPolymorphic_ThrowsQueryExecutionException()
+    {
+        var attr = Attr("Customer", "customerid", targets: new() { "account", "contact" });
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce(Guid.NewGuid().ToString(), attr));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("polymorphic", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Coerce_LookupNoTargets_ThrowsQueryExecutionException()
+    {
+        var attr = Attr("Lookup", "orphan");
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce(Guid.NewGuid().ToString(), attr));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Coerce_LookupBadGuid_ThrowsQueryExecutionException()
+    {
+        var attr = Attr("Lookup", "hsl_clinic", targets: new() { "hsl_clinic" });
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("not-a-guid", attr));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Coerce_MultiSelectPicklist_ThrowsUnsupported()
+    {
+        var attr = Attr("Virtual", "hsl_tags", attributeTypeName: "MultiSelectPicklistType");
+        var ex = Assert.Throws<QueryExecutionException>(
+            () => DmlValueCoercer.Coerce("1,2,3", attr));
+        Assert.Equal(QueryErrorCode.TypeMismatch, ex.ErrorCode);
+        Assert.Contains("Multi-select", ex.Message);
+    }
+
+    [Fact]
+    public void Coerce_VirtualNonMultiSelect_PassesThrough()
+    {
+        // Virtual attributes that are not MultiSelectPicklist (e.g., File, Image) pass
+        // through unchanged — the coercer does not know how to serialize them, and
+        // today's behavior of letting the SDK raise a type error is preserved.
+        var attr = Attr("Virtual", "hsl_file", attributeTypeName: "FileType");
+        Assert.Equal("some-bytes", DmlValueCoercer.Coerce("some-bytes", attr));
+    }
+
+    [Fact]
+    public void Coerce_DateTimeWithOffset_PreservesUtcKind()
+    {
+        var result = DmlValueCoercer.Coerce("2026-04-19T12:00:00Z", Attr("DateTime"));
+        var dt = Assert.IsType<DateTime>(result);
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
+    }
+
+    [Fact]
+    public void Coerce_DateTimeUnqualified_ParsesAsUnspecified()
+    {
+        // Bare "yyyy-MM-dd HH:mm:ss" stays Unspecified so the Dataverse SDK serializes
+        // it per the column's DateTimeBehavior (UserLocal / TimeZoneIndependent / DateOnly).
+        var result = DmlValueCoercer.Coerce("2026-04-19 09:00:00", Attr("DateTime"));
+        var dt = Assert.IsType<DateTime>(result);
+        Assert.Equal(DateTimeKind.Unspecified, dt.Kind);
+        Assert.Equal(9, dt.Hour);
+    }
+
+    [Fact]
+    public void Coerce_MoneyDecimal_ReturnsMoney()
+    {
+        var result = DmlValueCoercer.Coerce(1234.56m, Attr("Money"));
+        var money = Assert.IsType<Money>(result);
+        Assert.Equal(1234.56m, money.Value);
+    }
+
+    [Fact]
+    public void Coerce_MoneyInt_ReturnsMoney()
+    {
+        var result = DmlValueCoercer.Coerce(500, Attr("Money"));
+        var money = Assert.IsType<Money>(result);
+        Assert.Equal(500m, money.Value);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    public void Coerce_BooleanFromString_ReturnsBool(string input, bool expected)
+    {
+        var result = DmlValueCoercer.Coerce(input, Attr("Boolean"));
+        Assert.Equal(expected, Assert.IsType<bool>(result));
+    }
+
+    [Fact]
+    public void Coerce_UniqueidentifierFromString_ReturnsGuid()
+    {
+        var id = Guid.NewGuid();
+        var result = DmlValueCoercer.Coerce(id.ToString(), Attr("Uniqueidentifier"));
+        Assert.Equal(id, Assert.IsType<Guid>(result));
+    }
+
+    [Fact]
+    public void Coerce_BigIntFromInt_ReturnsLong()
+    {
+        var result = DmlValueCoercer.Coerce(42, Attr("BigInt"));
+        Assert.Equal(42L, Assert.IsType<long>(result));
+    }
+
+    [Fact]
+    public void Coerce_IntegerFromDecimal_ReturnsInt()
+    {
+        var result = DmlValueCoercer.Coerce(7m, Attr("Integer"));
+        Assert.Equal(7, Assert.IsType<int>(result));
+    }
+
+    [Fact]
+    public void Coerce_DecimalPassthrough()
+    {
+        var result = DmlValueCoercer.Coerce(3.14m, Attr("Decimal"));
+        Assert.Equal(3.14m, Assert.IsType<decimal>(result));
+    }
+
+    [Fact]
+    public void Coerce_DoubleFromDecimal_ReturnsDouble()
+    {
+        var result = DmlValueCoercer.Coerce(2.5m, Attr("Double"));
+        Assert.Equal(2.5, Assert.IsType<double>(result));
+    }
+
+    [Fact]
+    public void Coerce_DateTimeFromString_ReturnsDateTime()
+    {
+        var result = DmlValueCoercer.Coerce("2026-04-19T12:00:00Z", Attr("DateTime"));
+        var dt = Assert.IsType<DateTime>(result);
+        Assert.Equal(2026, dt.Year);
+        Assert.Equal(4, dt.Month);
+    }
+
+    [Fact]
+    public void Coerce_StringPassthrough()
+    {
+        var result = DmlValueCoercer.Coerce("hello", Attr("String"));
+        Assert.Equal("hello", result);
+    }
+
+    [Fact]
+    public void Coerce_UnknownType_PassesThrough()
+    {
+        var result = DmlValueCoercer.Coerce(42, Attr("SomeFutureType"));
+        Assert.Equal(42, result);
+    }
+}

--- a/tests/PPDS.Dataverse.Tests/Query/Planning/Nodes/DmlExecuteNodeCoercionTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Query/Planning/Nodes/DmlExecuteNodeCoercionTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk;
+using PPDS.Dataverse.BulkOperations;
+using PPDS.Dataverse.Client;
+using PPDS.Dataverse.Metadata;
+using PPDS.Dataverse.Metadata.Models;
+using PPDS.Dataverse.Progress;
+using PPDS.Dataverse.Query;
+using PPDS.Dataverse.Query.Execution;
+using PPDS.Dataverse.Query.Planning;
+using PPDS.Dataverse.Query.Planning.Nodes;
+using Xunit;
+
+namespace PPDS.Dataverse.Tests.Query.Planning.Nodes;
+
+/// <summary>
+/// Regression tests for issue #787: <c>DmlExecuteNode</c> must coerce primitive SQL
+/// literals into Dataverse SDK types (<see cref="EntityReference"/>, <see cref="OptionSetValue"/>,
+/// <see cref="Money"/>) when metadata is available. Tests drive the node end-to-end with
+/// in-memory metadata + bulk executor stubs.
+/// </summary>
+[Trait("Category", "TuiUnit")]
+public class DmlExecuteNodeCoercionTests
+{
+    [Fact]
+    public async Task InsertValues_CoercesLookupAndChoice_ToSdkTypes()
+    {
+        var clinicId = Guid.NewGuid();
+        var bulk = new RecordingBulkExecutor();
+        var metadata = new StubMetadataProvider(PetAttributes());
+        var context = new QueryPlanContext(
+            new StubQueryExecutor(),
+            bulkOperationExecutor: bulk,
+            metadataProvider: metadata);
+
+        CompiledScalarExpression nameExpr = _ => "Sir Waggington";
+        CompiledScalarExpression breedExpr = _ => "Corgi";
+        CompiledScalarExpression speciesExpr = _ => 100000000;
+        CompiledScalarExpression clinicExpr = _ => clinicId.ToString();
+
+        var node = DmlExecuteNode.InsertValues(
+            "hsl_pet",
+            new[] { "hsl_name", "hsl_breed", "hsl_species", "hsl_clinic" },
+            new IReadOnlyList<CompiledScalarExpression>[]
+            {
+                new[] { nameExpr, breedExpr, speciesExpr, clinicExpr }
+            });
+
+        await ConsumeAsync(node, context);
+
+        var entity = Assert.Single(bulk.Created);
+        Assert.Equal("Sir Waggington", entity["hsl_name"]);
+        Assert.Equal("Corgi", entity["hsl_breed"]);
+
+        var species = Assert.IsType<OptionSetValue>(entity["hsl_species"]);
+        Assert.Equal(100000000, species.Value);
+
+        var clinic = Assert.IsType<EntityReference>(entity["hsl_clinic"]);
+        Assert.Equal("hsl_clinic", clinic.LogicalName);
+        Assert.Equal(clinicId, clinic.Id);
+    }
+
+    [Fact]
+    public async Task InsertValues_WithoutMetadataProvider_PassesRawValues()
+    {
+        var bulk = new RecordingBulkExecutor();
+        var context = new QueryPlanContext(
+            new StubQueryExecutor(),
+            bulkOperationExecutor: bulk);
+
+        CompiledScalarExpression speciesExpr = _ => 100000000;
+        var node = DmlExecuteNode.InsertValues(
+            "hsl_pet",
+            new[] { "hsl_species" },
+            new IReadOnlyList<CompiledScalarExpression>[]
+            {
+                new[] { speciesExpr }
+            });
+
+        await ConsumeAsync(node, context);
+
+        // No provider → no coercion (documents the degraded fallback)
+        var entity = Assert.Single(bulk.Created);
+        Assert.IsType<int>(entity["hsl_species"]);
+    }
+
+    [Fact]
+    public async Task Update_CoercesSetClauseValue_ToOptionSetValue()
+    {
+        var petId = Guid.NewGuid();
+        var bulk = new RecordingBulkExecutor();
+        var metadata = new StubMetadataProvider(PetAttributes());
+        var context = new QueryPlanContext(
+            new StubQueryExecutor(),
+            bulkOperationExecutor: bulk,
+            metadataProvider: metadata);
+
+        var source = new StaticPlanNode(new[]
+        {
+            new QueryRow(
+                new Dictionary<string, QueryValue>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hsl_petid"] = QueryValue.Simple(petId)
+                },
+                "hsl_pet")
+        });
+
+        CompiledScalarExpression speciesExpr = _ => 100000000;
+        var node = DmlExecuteNode.Update(
+            "hsl_pet",
+            source,
+            new[] { new CompiledSetClause("hsl_species", speciesExpr) });
+
+        await ConsumeAsync(node, context);
+
+        var entity = Assert.Single(bulk.Updated);
+        Assert.Equal(petId, entity.Id);
+        var species = Assert.IsType<OptionSetValue>(entity["hsl_species"]);
+        Assert.Equal(100000000, species.Value);
+    }
+
+    [Fact]
+    public async Task InsertSelect_CoercesSourceColumnValues_ToSdkTypes()
+    {
+        var clinicId = Guid.NewGuid();
+        var bulk = new RecordingBulkExecutor();
+        var metadata = new StubMetadataProvider(PetAttributes());
+        var context = new QueryPlanContext(
+            new StubQueryExecutor(),
+            bulkOperationExecutor: bulk,
+            metadataProvider: metadata);
+
+        // Source row has primitive values — INSERT ... SELECT should coerce via metadata.
+        var source = new StaticPlanNode(new[]
+        {
+            new QueryRow(
+                new Dictionary<string, QueryValue>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["hsl_name"] = QueryValue.Simple("Fido"),
+                    ["hsl_species"] = QueryValue.Simple(100000001),
+                    ["hsl_clinic"] = QueryValue.Simple(clinicId.ToString())
+                },
+                "hsl_pet")
+        });
+
+        var node = DmlExecuteNode.InsertSelect(
+            "hsl_pet",
+            new[] { "hsl_name", "hsl_species", "hsl_clinic" },
+            source);
+
+        await ConsumeAsync(node, context);
+
+        var entity = Assert.Single(bulk.Created);
+        Assert.Equal("Fido", entity["hsl_name"]);
+        Assert.Equal(100000001, Assert.IsType<OptionSetValue>(entity["hsl_species"]).Value);
+        Assert.Equal(clinicId, Assert.IsType<EntityReference>(entity["hsl_clinic"]).Id);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static async Task ConsumeAsync(IQueryPlanNode node, QueryPlanContext context)
+    {
+        await foreach (var _ in node.ExecuteAsync(context, CancellationToken.None))
+        {
+            // drain
+        }
+    }
+
+    private static IReadOnlyList<AttributeMetadataDto> PetAttributes() => new[]
+    {
+        new AttributeMetadataDto
+        {
+            LogicalName = "hsl_petid",
+            DisplayName = "Pet ID",
+            SchemaName = "hsl_petid",
+            AttributeType = "Uniqueidentifier",
+            IsPrimaryId = true
+        },
+        new AttributeMetadataDto
+        {
+            LogicalName = "hsl_name",
+            DisplayName = "Name",
+            SchemaName = "hsl_name",
+            AttributeType = "String"
+        },
+        new AttributeMetadataDto
+        {
+            LogicalName = "hsl_breed",
+            DisplayName = "Breed",
+            SchemaName = "hsl_breed",
+            AttributeType = "String"
+        },
+        new AttributeMetadataDto
+        {
+            LogicalName = "hsl_species",
+            DisplayName = "Species",
+            SchemaName = "hsl_species",
+            AttributeType = "Picklist"
+        },
+        new AttributeMetadataDto
+        {
+            LogicalName = "hsl_clinic",
+            DisplayName = "Clinic",
+            SchemaName = "hsl_clinic",
+            AttributeType = "Lookup",
+            Targets = new List<string> { "hsl_clinic" }
+        }
+    };
+
+    private sealed class RecordingBulkExecutor : IBulkOperationExecutor
+    {
+        public List<Entity> Created { get; } = new();
+        public List<Entity> Updated { get; } = new();
+        public List<Guid> Deleted { get; } = new();
+
+        public Task<BulkOperationResult> CreateMultipleAsync(
+            string entityLogicalName,
+            IEnumerable<Entity> entities,
+            BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
+            IProgress<ProgressSnapshot>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            Created.AddRange(entities);
+            return Task.FromResult(new BulkOperationResult { SuccessCount = Created.Count });
+        }
+
+        public Task<BulkOperationResult> UpdateMultipleAsync(
+            string entityLogicalName,
+            IEnumerable<Entity> entities,
+            BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
+            IProgress<ProgressSnapshot>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            Updated.AddRange(entities);
+            return Task.FromResult(new BulkOperationResult { SuccessCount = Updated.Count });
+        }
+
+        public Task<BulkOperationResult> UpsertMultipleAsync(
+            string entityLogicalName,
+            IEnumerable<Entity> entities,
+            BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
+            IProgress<ProgressSnapshot>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            Created.AddRange(entities);
+            return Task.FromResult(new BulkOperationResult { SuccessCount = Created.Count });
+        }
+
+        public Task<BulkOperationResult> DeleteMultipleAsync(
+            string entityLogicalName,
+            IEnumerable<Guid> ids,
+            BulkOperationOptions? options = null,
+            DataverseClientOptions? clientOptions = null,
+            IProgress<ProgressSnapshot>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            Deleted.AddRange(ids);
+            return Task.FromResult(new BulkOperationResult { SuccessCount = Deleted.Count });
+        }
+    }
+
+    private sealed class StubMetadataProvider : ICachedMetadataProvider
+    {
+        private readonly IReadOnlyList<AttributeMetadataDto> _attrs;
+
+        public StubMetadataProvider(IReadOnlyList<AttributeMetadataDto> attrs)
+        {
+            _attrs = attrs;
+        }
+
+        public Task<IReadOnlyList<EntitySummary>> GetEntitiesAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<EntitySummary>>(Array.Empty<EntitySummary>());
+
+        public Task<IReadOnlyList<AttributeMetadataDto>> GetAttributesAsync(string entityLogicalName, CancellationToken ct = default)
+            => Task.FromResult(_attrs);
+
+        public Task<EntityRelationshipsDto> GetRelationshipsAsync(string entityLogicalName, CancellationToken ct = default)
+            => Task.FromResult(new EntityRelationshipsDto { EntityLogicalName = entityLogicalName });
+
+        public Task PreloadAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public void InvalidateAll() { }
+        public void InvalidateEntity(string entityLogicalName) { }
+        public void InvalidateEntityList() { }
+        public void InvalidateGlobalOptionSets() { }
+    }
+
+    private sealed class StubQueryExecutor : IQueryExecutor
+    {
+        public Task<QueryResult> ExecuteFetchXmlAsync(
+            string fetchXml,
+            int? pageNumber = null,
+            string? pagingCookie = null,
+            bool includeCount = false,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(QueryResult.Empty(""));
+
+        public Task<QueryResult> ExecuteFetchXmlAllPagesAsync(
+            string fetchXml,
+            int maxRecords = 5000,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(QueryResult.Empty(""));
+    }
+
+    private sealed class StaticPlanNode : IQueryPlanNode
+    {
+        private readonly IEnumerable<QueryRow> _rows;
+
+        public StaticPlanNode(IEnumerable<QueryRow> rows) { _rows = rows; }
+
+        public string Description => "Static";
+        public long EstimatedRows => _rows.Count();
+        public IReadOnlyList<IQueryPlanNode> Children => Array.Empty<IQueryPlanNode>();
+
+        public async IAsyncEnumerable<QueryRow> ExecuteAsync(
+            QueryPlanContext context,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var row in _rows)
+            {
+                await Task.Yield();
+                yield return row;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ppds query sql` DML now coerces SQL literals into Dataverse SDK types (`EntityReference` for lookups, `OptionSetValue` for choices, `Money` for currency, etc.) using cached attribute metadata threaded through `QueryPlanContext`.
- Runs once per DML-node execution (not per row) so the metadata cache's 5-min TTL is respected.
- Polymorphic lookups, multi-select choices, bad GUIDs, and missing metadata raise `QueryExecutionException` with `Query.TypeMismatch` — structured error codes, not raw `FormatException` (CLAUDE.md NEVER rule).
- `DateTime` strings use `DateTimeStyles.RoundtripKind` so unqualified values stay `Unspecified` (SDK serializes per the column's `DateTimeBehavior`) — prevents silent UTC shift on `UserLocal` columns.
- Absent `MetadataProvider` degrades gracefully to today's raw-passthrough behavior, covered by an explicit regression test.

Closes #787

## Test Plan
- [x] 19 `DmlValueCoercerTests` — every attribute type branch, polymorphic rejection, multi-select block, DateTime kind preservation
- [x] 4 `DmlExecuteNodeCoercionTests` — INSERT VALUES, INSERT SELECT, UPDATE paths drive `ExecuteAsync` through a recording bulk executor + stub metadata provider and assert `EntityReference` / `OptionSetValue` land in `Entity[col]`
- [x] Full `dotnet test PPDS.sln --filter "Category!=Integration"`: all suites green across net8/9/10
- [x] CLI smoke: `ppds.exe --version` + `ppds query sql --help` load cleanly

## Verification
- [x] /gates passed (0 errors, 0 failures across all TFMs)
- [x] /verify completed (cli)
- [x] /qa skipped — service-layer fix, no UI/CLI/MCP/Extension surface; runtime path covered by `DmlExecuteNodeCoercionTests`
- [x] /review completed — 0 critical, 3 important (all fixed), 3 suggestion (deferred as non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)