### PR TITLE
fix(cli-reflect): sort options alphabetically by long name (AC-15)

### DIFF
--- a/scripts/docs-gen/cli-reflect/CliReferenceGenerator.cs
+++ b/scripts/docs-gen/cli-reflect/CliReferenceGenerator.cs
@@ -166,9 +166,9 @@ public sealed class CliReferenceGenerator : IReferenceGenerator
         // declaration order — their position is semantic for invocation.
         var options = new List<CommandOption>();
         foreach (var opt in EnumerateChildren(command, "Options")
+            .Where(o => !IsHidden(o))
             .OrderBy(o => GetString(o, "Name") ?? string.Empty, StringComparer.Ordinal))
         {
-            if (IsHidden(opt)) continue;
             var (longName, shortName) = SplitOptionAliases(opt);
             options.Add(new CommandOption(
                 LongName: longName,

--- a/scripts/docs-gen/cli-reflect/CliReferenceGenerator.cs
+++ b/scripts/docs-gen/cli-reflect/CliReferenceGenerator.cs
@@ -160,8 +160,13 @@ public sealed class CliReferenceGenerator : IReferenceGenerator
                 TypeDisplay: DescribeValueType(arg.GetType(), openGenericBase: "Argument")));
         }
 
+        // Options are sorted alphabetically by long name per AC-15 so that
+        // generated markdown does not depend on source-declaration order or
+        // System.CommandLine's enumeration order. Arguments remain in
+        // declaration order — their position is semantic for invocation.
         var options = new List<CommandOption>();
-        foreach (var opt in EnumerateChildren(command, "Options"))
+        foreach (var opt in EnumerateChildren(command, "Options")
+            .OrderBy(o => GetString(o, "Name") ?? string.Empty, StringComparer.Ordinal))
         {
             if (IsHidden(opt)) continue;
             var (longName, shortName) = SplitOptionAliases(opt);

--- a/tests/PPDS.DocsGen.Cli.Tests/CliReflectTests.cs
+++ b/tests/PPDS.DocsGen.Cli.Tests/CliReflectTests.cs
@@ -135,6 +135,39 @@ public class CliReflectTests
     }
 
     /// <summary>
+    /// Options with <c>Hidden = true</c> must be excluded from the generated
+    /// markdown, and the remaining options must still be emitted in
+    /// alphabetical order. The fixture declares a hidden <c>--secret</c>
+    /// option whose long name sorts between <c>--force</c> and <c>--tenant</c>
+    /// — if the filter ran AFTER the sort, the hidden item would still be
+    /// dropped, but the filter-before-sort optimization (Gemini PR #828
+    /// review) avoids comparing it at all. This test guards both the
+    /// exclusion contract AND the alphabetical order it must preserve.
+    /// </summary>
+    [Fact]
+    public async Task ExcludesHiddenOptionsAndPreservesAlphabeticalOrder()
+    {
+        var result = await GenerateAsync();
+
+        var login = result.Files.Single(f => f.RelativePath == "auth/login.md").Contents;
+
+        login.Should().NotContain(
+            "`--secret`",
+            because: "options with Hidden=true must be excluded from generated markdown");
+        login.Should().NotContain(
+            "Internal flag",
+            because: "the hidden option's description must not leak into output");
+
+        var forceIndex = login.IndexOf("`--force`", StringComparison.Ordinal);
+        var tenantIndex = login.IndexOf("`--tenant`", StringComparison.Ordinal);
+
+        forceIndex.Should().BeGreaterThan(0, because: "--force must still appear after filtering");
+        tenantIndex.Should().BeGreaterThan(0, because: "--tenant must still appear after filtering");
+        forceIndex.Should().BeLessThan(tenantIndex,
+            because: "the surviving non-hidden options must remain in alphabetical order");
+    }
+
+    /// <summary>
     /// Leaf commands with <c>Hidden = true</c> must not appear in any emitted
     /// file — including the group index.
     /// </summary>

--- a/tests/PPDS.DocsGen.Cli.Tests/CliReflectTests.cs
+++ b/tests/PPDS.DocsGen.Cli.Tests/CliReflectTests.cs
@@ -112,6 +112,29 @@ public class CliReflectTests
     }
 
     /// <summary>
+    /// AC-15: options must be ordered alphabetically by long name, independent
+    /// of source-declaration order or System.CommandLine enumeration order.
+    /// The fixture declares <c>--tenant</c> before <c>--force</c>; the
+    /// generator must emit them in the reverse (alphabetical) order.
+    /// </summary>
+    [Fact]
+    public async Task OptionsAreAlphabeticalByLongName()
+    {
+        var result = await GenerateAsync();
+
+        var login = result.Files.Single(f => f.RelativePath == "auth/login.md").Contents;
+
+        var forceIndex = login.IndexOf("`--force`", StringComparison.Ordinal);
+        var tenantIndex = login.IndexOf("`--tenant`", StringComparison.Ordinal);
+
+        forceIndex.Should().BeGreaterThan(0, because: "--force must appear in login.md");
+        tenantIndex.Should().BeGreaterThan(0, because: "--tenant must appear in login.md");
+        forceIndex.Should().BeLessThan(tenantIndex,
+            because: "options must be ordered alphabetically by long name (AC-15), "
+                + "even though the fixture declares --tenant before --force");
+    }
+
+    /// <summary>
     /// Leaf commands with <c>Hidden = true</c> must not appear in any emitted
     /// file — including the group index.
     /// </summary>

--- a/tests/PPDS.DocsGen.Cli.Tests/Fixtures/Commands/Auth/AuthCommandGroup.cs
+++ b/tests/PPDS.DocsGen.Cli.Tests/Fixtures/Commands/Auth/AuthCommandGroup.cs
@@ -29,11 +29,22 @@ public static class AuthCommandGroup
             Description = "Skip the confirmation prompt."
         };
 
+        // Hidden option declared with a long name that sorts between --force
+        // and --tenant alphabetically. It must be filtered out by the generator
+        // (and the filter must run BEFORE the sort, see filter-before-sort
+        // optimization in CliReferenceGenerator).
+        var secret = new Option<string?>("--secret")
+        {
+            Description = "Internal flag — must never appear in generated docs.",
+            Hidden = true,
+        };
+
         return new Command("login", "Sign in to the fixture service.")
         {
             username,
             tenant,
             force,
+            secret,
         };
     }
 

--- a/tests/PPDS.DocsGen.Cli.Tests/Fixtures/Expected/auth/login.md
+++ b/tests/PPDS.DocsGen.Cli.Tests/Fixtures/Expected/auth/login.md
@@ -20,6 +20,6 @@ ppds auth login [options]
 
 | Long | Short | Type | Default | Description |
 | --- | --- | --- | --- | --- |
-| `--tenant` | `-t` | `string` |  | Tenant identifier, if your account belongs to multiple tenants. |
 | `--force` |  | `bool` |  | Skip the confirmation prompt. |
+| `--tenant` | `-t` | `string` |  | Tenant identifier, if your account belongs to multiple tenants. |
 


### PR DESCRIPTION
## Summary

- `CliReferenceGenerator` was emitting options in reflection/source-declared order, silently coupling generated markdown to source layout and System.CommandLine enumeration order — violating AC-15 ("options alphabetical by long name") of the docs-generation spec.
- Sort options by `Name` using `StringComparer.Ordinal`. Arguments remain in declaration order per AC-15 (their position is semantic for invocation).
- Regenerate `auth/login.md` golden (`--force` now precedes `--tenant`) and add `OptionsAreAlphabeticalByLongName` as an explicit regression test alongside the byte-for-byte golden comparison.

Closes #807

## Test Plan

- [x] New unit test `OptionsAreAlphabeticalByLongName` passes
- [x] All 4 `PPDS.DocsGen.Cli.Tests` tests pass
- [x] Full non-integration test suite passes (no regressions)
- [x] End-to-end generator run against fixture produces `--force` before `--tenant` in `auth/login.md`

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] /qa skipped (workflow-only diff per pr-gate hook rules)
- [x] /review completed (3 non-blocking suggestions, 0 critical, 0 important)

🤖 Generated with [Claude Code](https://claude.com/claude-code)