### PR TITLE
fix(hook): pr-gate enforces /pr-skill entry point for agent PRs (meta-retro bug #2 actual fix)

### DIFF
--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -14,7 +14,8 @@ Commit-aware validation (v8.0):
 Agent-entry-point enforcement (v9.0):
   - Agent-context PR creation MUST go through the `/pr` skill.
   - Agent context = cwd inside ``.claude/worktrees/agent-*`` OR one of the
-    Claude Code agent env vars (``CLAUDE_CODE_AGENT``, ``CLAUDE_AGENT_ID``) set.
+    Claude Code agent env vars (``CLAUDE_CODE_AGENT``, ``CLAUDE_AGENT_ID``,
+    ``CLAUDE_CODE_SUBAGENT``) set.
   - Agent context requires ``pr.invoked_via_skill=true`` in workflow state;
     the ``/pr`` skill sets this marker at entry.
   - Human context (main checkout, no agent env vars) keeps the previous

--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -10,6 +10,17 @@ Commit-aware validation (v8.0):
   - qa.{surface}_commit_ref is ancestor-of-HEAD (per non-workflow surface)
   - Workflow-only diffs skip QA requirement
   - Triage completeness when PR already exists in state
+
+Agent-entry-point enforcement (v9.0):
+  - Agent-context PR creation MUST go through the `/pr` skill.
+  - Agent context = cwd inside ``.claude/worktrees/agent-*`` OR one of the
+    Claude Code agent env vars (``CLAUDE_CODE_AGENT``, ``CLAUDE_AGENT_ID``) set.
+  - Agent context requires ``pr.invoked_via_skill=true`` in workflow state;
+    the ``/pr`` skill sets this marker at entry.
+  - Human context (main checkout, no agent env vars) keeps the previous
+    behavior -- workflow-step validation only.
+  - Explicit override: ``PPDS_PR_GATE_HUMAN=1`` forces human context for
+    the rare case of a human running ``gh pr create`` from a worktree.
 """
 import json
 import os
@@ -21,6 +32,61 @@ from _pathfix import get_project_dir
 
 # Valid surface keys
 VALID_SURFACES = frozenset(("ext", "tui", "mcp", "cli", "workflow"))
+
+# Env vars that indicate we're running inside a Claude Code agent/subagent.
+# If Claude Code ever formalizes a canonical name, add it here.
+_AGENT_ENV_VARS = (
+    "CLAUDE_CODE_AGENT",
+    "CLAUDE_AGENT_ID",
+    "CLAUDE_CODE_SUBAGENT",
+)
+
+# Explicit override: humans running gh pr create from a worktree can set
+# PPDS_PR_GATE_HUMAN=1 to opt out of agent-context enforcement.
+_HUMAN_OVERRIDE_ENV = "PPDS_PR_GATE_HUMAN"
+
+
+def _is_agent_context(cwd=None, env=None):
+    """Return True if this invocation looks like a Claude Code agent.
+
+    Heuristics (any one triggers agent context):
+      1. cwd path contains ``.claude/worktrees/agent-`` segment
+      2. Any known Claude Code agent env var is set to a non-empty value
+
+    The explicit override ``PPDS_PR_GATE_HUMAN=1`` forces False regardless.
+    """
+    env = env if env is not None else os.environ
+    if env.get(_HUMAN_OVERRIDE_ENV, "").strip() == "1":
+        return False
+
+    # Env-var signal takes priority -- most reliable once Claude Code sets one.
+    for var in _AGENT_ENV_VARS:
+        if env.get(var, "").strip():
+            return True
+
+    # Fall back to path sniffing. Normalize to forward slashes.
+    cwd = cwd if cwd is not None else os.getcwd()
+    normalized = cwd.replace("\\", "/")
+    if "/.claude/worktrees/agent-" in normalized:
+        return True
+    return False
+
+
+def _has_pr_skill_marker(state):
+    """Return True if the ``/pr`` skill recorded its entry marker."""
+    pr_section = state.get("pr") or {}
+    return bool(pr_section.get("invoked_via_skill"))
+
+
+_AGENT_BYPASS_MESSAGE = (
+    "PR blocked. Agent PR creation must go through the `/pr` skill.\n"
+    "  Invoke `/pr` to create PRs. See `.claude/skills/pr/SKILL.md` "
+    "Canonical Entry Point.\n"
+    "  Raw `gh pr create` bypasses monitor spawn, draft-gating, and state "
+    "tracking.\n"
+    "  If you are a human running from a worktree, set "
+    "PPDS_PR_GATE_HUMAN=1 to override."
+)
 
 # Path prefix -> surface mapping (order matters: more specific first)
 _SURFACE_RULES = [
@@ -157,13 +223,19 @@ def main():
     state_path = os.path.join(project_dir, ".workflow", "state.json")
     os.makedirs(os.path.dirname(state_path), exist_ok=True)
 
-    # No state file = no evidence of any workflow steps
+    agent_context = _is_agent_context()
+
+    # No state file = no evidence of any workflow steps (and, for agents,
+    # no /pr skill marker either -- block with the clearer agent message).
     if not os.path.exists(state_path):
-        print(
-            "PR blocked. No workflow state found.\n"
-            "  Run /gates, /verify, /qa, and /review before creating a PR.",
-            file=sys.stderr,
-        )
+        if agent_context:
+            print(_AGENT_BYPASS_MESSAGE, file=sys.stderr)
+        else:
+            print(
+                "PR blocked. No workflow state found.\n"
+                "  Run /gates, /verify, /qa, and /review before creating a PR.",
+                file=sys.stderr,
+            )
         sys.exit(2)
 
     try:
@@ -175,6 +247,16 @@ def main():
             "  Delete .workflow/state.json and re-run workflow steps.",
             file=sys.stderr,
         )
+        sys.exit(2)
+
+    # -----------------------------------------------------------------
+    # Agent-entry-point enforcement (runs before commit-ref checks)
+    # Agents MUST invoke via the `/pr` skill, which sets
+    # pr.invoked_via_skill=true. Raw `gh pr create` from an agent
+    # bypasses monitor spawn, draft-gating, and state tracking.
+    # -----------------------------------------------------------------
+    if agent_context and not _has_pr_skill_marker(state):
+        print(_AGENT_BYPASS_MESSAGE, file=sys.stderr)
         sys.exit(2)
 
     # Get current HEAD

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -16,7 +16,9 @@ This skill is the ONLY sanctioned path for automated PR creation in this repo. A
 - Direct invocation bypasses state tracking (`.workflow/state.json` records for `/gates`, `/verify`, etc.)
 - Direct invocation bypasses prerequisite enforcement (the PR gate hook described in Prerequisites below)
 
-Human-initiated PR creation via `gh pr create` from a terminal is fine — this rule applies to automated/agent PR creation only.
+Human-initiated PR creation via `gh pr create` from a terminal on a non-worktree checkout is fine — this rule applies to automated/agent PR creation only.
+
+This rule is hook-enforced: `.claude/hooks/pr-gate.py` detects agent context (cwd in `.claude/worktrees/agent-*` or Claude Code agent env vars) and blocks `gh pr create` unless the `/pr` skill has set `pr.invoked_via_skill=true` in workflow state. Humans running from a worktree can set `PPDS_PR_GATE_HUMAN=1` to override.
 
 ## Prerequisites
 
@@ -28,10 +30,13 @@ workflow state before invoking `/pr`.
 
 ## Process
 
-Set the PR phase at entry:
+Set the PR phase and skill-entry marker at entry:
 
 ```bash
 python scripts/workflow-state.py set phase pr
+# Required: tells `.claude/hooks/pr-gate.py` this PR went through the skill.
+# Without this marker, an agent-context `gh pr create` is blocked.
+python scripts/workflow-state.py set pr.invoked_via_skill true
 ```
 
 ### 1. Rebase on Main and Push

--- a/tests/hooks/test_pr_gate_agent_enforcement.py
+++ b/tests/hooks/test_pr_gate_agent_enforcement.py
@@ -1,0 +1,222 @@
+"""Tests for the pr-gate hook's agent-vs-human entry-point enforcement.
+
+Covers the three branches the hook distinguishes:
+  1. Agent context WITHOUT ``/pr`` skill marker -> BLOCKED
+  2. Agent context WITH    ``/pr`` skill marker -> proceeds to workflow checks
+  3. Human context                              -> existing workflow checks only
+
+See ``.claude/hooks/pr-gate.py`` and ``.claude/skills/pr/SKILL.md`` Canonical
+Entry Point. Complements ``test_hook_envelope.py`` which covers stdin contract.
+
+Run: ``pytest tests/hooks/test_pr_gate_agent_enforcement.py -v``
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+HOOK_PATH = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "pr-gate.py"
+
+
+def _load_hook():
+    hooks_dir = str(HOOK_PATH.parent)
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+    spec = importlib.util.spec_from_file_location("pr_gate", str(HOOK_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hook = _load_hook()
+
+
+# ---------------------------------------------------------------------------
+# subprocess helpers (Windows-safe stdio handling for pytest captured mode)
+# ---------------------------------------------------------------------------
+
+
+def _run(argv, cwd=None, env=None, input_str=None):
+    kw = dict(cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+              text=True, timeout=30)
+    if input_str is not None:
+        return subprocess.run(argv, input=input_str, **kw)
+    return subprocess.run(argv, stdin=subprocess.DEVNULL, **kw)
+
+
+def _git(path, args):
+    r = _run(["git", *args], cwd=str(path))
+    if r.returncode != 0:
+        raise RuntimeError(f"git {args} failed: {r.stderr}")
+    return r.stdout
+
+
+def _init_repo(path):
+    _git(path, ["init", "-q", "-b", "main"])
+    _git(path, ["config", "user.email", "test@example.com"])
+    _git(path, ["config", "user.name", "Test"])
+    (path / "README.md").write_text("x\n")
+    _git(path, ["add", "."])
+    _git(path, ["commit", "-q", "-m", "init"])
+    _git(path, ["update-ref", "refs/remotes/origin/main", "HEAD"])
+    return _git(path, ["rev-parse", "HEAD"]).strip()
+
+
+def _clean_env():
+    env = os.environ.copy()
+    for v in ("CLAUDE_CODE_AGENT", "CLAUDE_AGENT_ID", "CLAUDE_CODE_SUBAGENT",
+              "PPDS_PR_GATE_HUMAN"):
+        env.pop(v, None)
+    return env
+
+
+def _run_hook(command, cwd, env_extra=None):
+    env = _clean_env()
+    env["CLAUDE_PROJECT_DIR"] = str(cwd)
+    if env_extra:
+        env.update(env_extra)
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}}
+    return _run([sys.executable, str(HOOK_PATH)], cwd=str(cwd), env=env,
+                input_str=json.dumps(payload))
+
+
+def _write_state(cwd, state):
+    (cwd / ".workflow").mkdir(exist_ok=True)
+    (cwd / ".workflow" / "state.json").write_text(json.dumps(state))
+
+
+def _passing_state(head):
+    # Minimal state that clears commit-ref + verify + qa checks for a
+    # no-diff branch (affected-surfaces set is empty -> "require at least
+    # one verify/qa" heuristic applies).
+    return {
+        "gates": {"passed": "2026-04-19T00:00:00+00:00", "commit_ref": head},
+        "review": {"passed": "2026-04-19T00:01:00+00:00", "commit_ref": head},
+        "verify": {"cli_commit_ref": head},
+        "qa": {"cli_commit_ref": head},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on helpers
+# ---------------------------------------------------------------------------
+
+
+import pytest
+
+
+@pytest.mark.parametrize("cwd,env,expected", [
+    # Human context
+    ("/home/j/ppds", {}, False),
+    ("/x", {"CLAUDE_CODE_AGENT": ""}, False),
+    # Agent context via cwd or env
+    ("/home/j/ppds/.claude/worktrees/agent-abcd/src", {}, True),
+    (r"C:\ppds\.claude\worktrees\agent-1234", {}, True),
+    ("/x", {"CLAUDE_CODE_AGENT": "1"}, True),
+    ("/x", {"CLAUDE_AGENT_ID": "xyz"}, True),
+    ("/x", {"CLAUDE_CODE_SUBAGENT": "1"}, True),
+    # Human override beats both signals
+    ("/home/j/ppds/.claude/worktrees/agent-abcd", {"PPDS_PR_GATE_HUMAN": "1"}, False),
+    ("/x", {"CLAUDE_CODE_AGENT": "1", "PPDS_PR_GATE_HUMAN": "1"}, False),
+    # Override value != "1" does not override
+    ("/home/j/ppds/.claude/worktrees/agent-abcd", {"PPDS_PR_GATE_HUMAN": "true"}, True),
+])
+def test_is_agent_context(cwd, env, expected):
+    assert hook._is_agent_context(cwd=cwd, env=env) is expected
+
+
+@pytest.mark.parametrize("state,expected", [
+    ({}, False),
+    ({"pr": {"url": "..."}}, False),
+    ({"pr": {"invoked_via_skill": False}}, False),
+    ({"pr": {"invoked_via_skill": True}}, True),
+    ({"pr": None}, False),
+])
+def test_has_pr_skill_marker(state, expected):
+    assert hook._has_pr_skill_marker(state) is expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the three branches
+# ---------------------------------------------------------------------------
+
+
+class TestAgentBlockedWithoutMarker:
+    def test_agent_cwd_no_state_blocks(self, tmp_path):
+        agent_dir = tmp_path / ".claude" / "worktrees" / "agent-deadbeef"
+        agent_dir.mkdir(parents=True)
+        _init_repo(agent_dir)
+        r = _run_hook("gh pr create --draft", cwd=agent_dir)
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" in r.stderr
+        assert "Canonical Entry Point" in r.stderr
+
+    def test_agent_env_with_full_state_but_no_marker_blocks(self, tmp_path):
+        _init_repo(tmp_path)
+        head = _git(tmp_path, ["rev-parse", "HEAD"]).strip()
+        _write_state(tmp_path, _passing_state(head))
+        r = _run_hook(
+            "gh pr create --draft -t t -b b",
+            cwd=tmp_path,
+            env_extra={"CLAUDE_CODE_AGENT": "1"},
+        )
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" in r.stderr
+
+
+class TestAgentAllowedWithMarker:
+    def test_agent_with_marker_and_full_state_passes(self, tmp_path):
+        _init_repo(tmp_path)
+        head = _git(tmp_path, ["rev-parse", "HEAD"]).strip()
+        state = _passing_state(head)
+        state["pr"] = {"invoked_via_skill": True}
+        _write_state(tmp_path, state)
+        r = _run_hook(
+            "gh pr create --draft -t t -b b",
+            cwd=tmp_path,
+            env_extra={"CLAUDE_CODE_AGENT": "1"},
+        )
+        assert r.returncode == 0, r.stderr
+        assert "must go through the `/pr` skill" not in r.stderr
+
+
+class TestHumanUnaffected:
+    def test_human_no_state_sees_original_message(self, tmp_path):
+        _init_repo(tmp_path)
+        r = _run_hook("gh pr create --draft", cwd=tmp_path)
+        assert r.returncode == 2
+        assert "must go through the `/pr` skill" not in r.stderr
+        assert "No workflow state found" in r.stderr
+
+    def test_human_full_state_passes(self, tmp_path):
+        _init_repo(tmp_path)
+        head = _git(tmp_path, ["rev-parse", "HEAD"]).strip()
+        _write_state(tmp_path, _passing_state(head))
+        r = _run_hook("gh pr create --draft -t t -b b", cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+
+    def test_human_override_from_worktree_passes(self, tmp_path):
+        agent_dir = tmp_path / ".claude" / "worktrees" / "agent-1234"
+        agent_dir.mkdir(parents=True)
+        _init_repo(agent_dir)
+        head = _git(agent_dir, ["rev-parse", "HEAD"]).strip()
+        _write_state(agent_dir, _passing_state(head))
+        r = _run_hook(
+            "gh pr create --draft -t t -b b",
+            cwd=agent_dir,
+            env_extra={"PPDS_PR_GATE_HUMAN": "1"},
+        )
+        assert r.returncode == 0, r.stderr
+
+
+def test_non_pr_create_from_agent_passes(tmp_path):
+    # Non-``gh pr create`` commands must fall through even from agent cwd.
+    agent_dir = tmp_path / ".claude" / "worktrees" / "agent-abcd"
+    agent_dir.mkdir(parents=True)
+    assert _run_hook("gh pr list", cwd=agent_dir).returncode == 0
+    assert _run_hook("echo hi", cwd=agent_dir).returncode == 0


### PR DESCRIPTION
## Summary
- Adds hook-level enforcement so agents cannot bypass `/pr` with raw `gh pr create`.
- `.claude/hooks/pr-gate.py` now detects agent context (cwd in `.claude/worktrees/agent-*` or `CLAUDE_CODE_AGENT`/`CLAUDE_AGENT_ID`/`CLAUDE_CODE_SUBAGENT` env var) and blocks unless the `/pr` skill has set `pr.invoked_via_skill=true` in workflow state.
- `/pr` skill writes the marker at entry; SKILL.md carries the Canonical Entry Point section documenting the rule and the hook enforcement.

## Rule change

**Context.** PR #844 documented the rule ("agents MUST invoke `/pr`, not raw `gh pr create`") but added zero enforcement. All 9 agents in the 2026-04-19 meta-retro dispatch bundle bypassed `/pr` and called `gh pr create --draft` directly, which meant `pr_monitor.py` never spawned and no ready-flip automation fired. Meta-retro bug #2 was logged as "agent bypass of `/pr`" and this PR is the actual fix.

**Old rule.** `pr-gate.py` treated missing/partial workflow state as "manual human invocation" and let the call through as long as the existing commit-ref checks could be satisfied (or there was no state at all, which blocked with a generic message but never distinguished agent from human).

**New rule.** Agent context is detected explicitly:
- cwd path contains `.claude/worktrees/agent-*` segment, OR
- `CLAUDE_CODE_AGENT`, `CLAUDE_AGENT_ID`, or `CLAUDE_CODE_SUBAGENT` env var is set to a non-empty value.

Agent context requires `pr.invoked_via_skill=true` in `.workflow/state.json`. The `/pr` skill writes this marker at entry (Step 0). Raw `gh pr create` from an agent without the marker is blocked with a clear message pointing at `.claude/skills/pr/SKILL.md` Canonical Entry Point.

**Why.** Closes the hole that let bundle agents bypass `pr_monitor.py` spawn, draft-gating, and state tracking -- the three things PR #834 and PR #844 were designed to guarantee.

**Falsification.** If agent-context detection produces false positives (humans running `gh pr create` from an agent worktree), the explicit override `PPDS_PR_GATE_HUMAN=1` forces human context and restores pre-PR behavior. The override is documented inline in the hook, in SKILL.md Canonical Entry Point, and in the block message itself.

## Test Plan
- [x] Unit tests on `_is_agent_context` cover cwd + env + override combinations (parametrized, 10 cases).
- [x] Unit tests on `_has_pr_skill_marker` cover missing section / missing key / false / true / null-section.
- [x] End-to-end tests (subprocess against the hook) cover:
  - agent cwd with no state file -> BLOCKED with agent-bypass message
  - agent env var with full workflow state but no marker -> BLOCKED
  - agent context + marker + full state -> PASSES
  - human with no state -> original "No workflow state found" message (not the agent message)
  - human with full state -> PASSES
  - human override from worktree -> PASSES
  - non-`gh pr create` commands from agent cwd -> fall through
- [x] `pytest tests/hooks/test_pr_gate_agent_enforcement.py` green (22 passed).
- [x] Full hook suite green (`pytest tests/hooks/`, 112 passed).

## Verification
- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] /review completed (self-review, no blockers)

Tag: meta-retro bug #2 actual fix.

[Bot] Generated with [Claude Code](https://claude.com/claude-code)