### PR TITLE
feat(pr-monitor): detect Gemini-decline and approval-equivalent reviews for ready-flip gate

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1110,9 +1110,13 @@ def _ready_flip_gates(worktree, pr_number, result, logger):
       - CI green, AND
       - Gemini dimension is satisfied — either the latest review body
         matches a clean-approval / declined pattern
-        (see ``_gemini_effectively_done``), OR Gemini posted a review and
-        all inline bot comments have replies, AND
-      - no unreplied bot comments remain.
+        (see ``_gemini_effectively_done``), OR Gemini posted a review, AND
+      - no unreplied bot comments remain from ANY reviewer (Gemini,
+        CodeQL / github-advanced-security, or other aggregated sources
+        returned by ``get_unreplied_comments``). A Gemini clean/declined
+        review satisfies the "Gemini reviewed" dimension but does NOT
+        bypass unreplied comments from other reviewers — see PR #846
+        review (gemini-code-assist HIGH, 2026-04-20).
     """
     reasons = []
     if result.get("ci_result") != "pass":
@@ -1131,10 +1135,11 @@ def _ready_flip_gates(worktree, pr_number, result, logger):
         logger.log("ready", "UNREPLIED_CHECK_ERROR", error=str(e))
         unreplied = []
         reasons.append("unreplied_check_error")
-    # Clean/declined reviews never have inline comments to reply to, so
-    # skip the unreplied gate in that branch. For the "flagged issues"
-    # branch, unreplied must be empty.
-    if not gemini_done_clean and unreplied:
+    # Always enforce the unreplied gate — regardless of Gemini's own
+    # state. ``get_unreplied_comments`` aggregates findings across
+    # multiple bots, and a clean Gemini review must not mask CodeQL or
+    # other unreplied bot findings.
+    if unreplied:
         reasons.append(f"unreplied_comments={len(unreplied)}")
     return (not reasons), reasons
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -49,6 +49,30 @@ MAX_TRIAGE_ITERATIONS = 3   # max triage -> CI re-check cycles
 
 SHAKEDOWN = os.environ.get("PPDS_SHAKEDOWN", "")
 
+# Substrings that indicate Gemini has "spoken" but has nothing for us to
+# address — either a clean approval (top-level review with no inline notes)
+# or an explicit decline (file types not currently supported).
+# Both are treated as ready-flip-eligible for the Gemini gate. Extend this
+# list as new Gemini phrasings are discovered. Matching is case-sensitive
+# substring to minimise false positives.
+_GEMINI_CLEAN_PATTERNS = (
+    "I have no feedback to provide",
+    "Gemini is unable to generate a review",
+    # Add future patterns here as discovered.
+)
+
+
+def _gemini_effectively_done(review_body):
+    """Return True if Gemini's latest review body indicates nothing to address.
+
+    Matches clean-approval phrasing OR explicit "unable to review" declines.
+    Does NOT match reviews that flagged issues (those have inline comments
+    and require per-comment triage separately).
+    """
+    if not review_body:
+        return False
+    return any(p in review_body for p in _GEMINI_CLEAN_PATTERNS)
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -128,6 +152,10 @@ def _empty_result():
         # Set to True by _step_gemini whenever a poll returns
         # status="review_received" (meta-retro finding #2 gate).
         "gemini_review_posted": False,
+        # Latest Gemini top-level review body (string). Captured so the
+        # ready-flip gate can distinguish clean-approval / declined reviews
+        # from reviews that flagged issues needing replies.
+        "gemini_review_body": "",
         "timestamp": _timestamp(),
     }
 
@@ -289,7 +317,52 @@ def poll_gemini_comments(worktree, pr_number, logger):
     # (Stashed on the logger instance to avoid changing the return shape —
     # _step_gemini reads and clears it before writing to result.)
     logger.last_gemini_status = status
+    # Capture the latest Gemini top-level review body for the ready-flip
+    # gate's clean/declined pattern detection. Best-effort — on any error
+    # we fall back to "" (which _gemini_effectively_done treats as "not done").
+    logger.last_gemini_review_body = (
+        _fetch_latest_gemini_review_body(worktree, pr_number)
+        if status == "review_received" else ""
+    )
     return comments
+
+
+def _fetch_latest_gemini_review_body(worktree, pr_number):
+    """Return the body of Gemini's most recent top-level review on the PR.
+
+    Returns "" on any error or if no Gemini review is found. Used only by
+    the ready-flip gate to detect clean-approval / declined review phrasing.
+    """
+    repo = get_repo_slug(worktree)
+    if not repo:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{pr_number}/reviews",
+             "--paginate", "--slurp"],
+            cwd=worktree, capture_output=True, text=True, timeout=30,
+        )
+        if proc.returncode != 0:
+            return ""
+        payload = json.loads(proc.stdout or "[]")
+        # --paginate --slurp returns a list of pages; flatten one level.
+        if isinstance(payload, list) and payload and isinstance(payload[0], list):
+            reviews = [r for page in payload for r in page]
+        else:
+            reviews = payload or []
+    except (subprocess.TimeoutExpired, FileNotFoundError,
+            json.JSONDecodeError, ValueError, OSError):
+        return ""
+
+    latest = None
+    for r in reviews:
+        if (r.get("user") or {}).get("login") != GEMINI_BOT_LOGIN:
+            continue
+        ts = r.get("submitted_at") or r.get("created_at") or ""
+        if latest is None or ts > (latest.get("submitted_at")
+                                   or latest.get("created_at") or ""):
+            latest = r
+    return (latest or {}).get("body") or ""
 
 
 def run_triage(worktree, pr_number, comments, logger):
@@ -993,6 +1066,11 @@ def _step_gemini(worktree, pr_number, logger, result, step_suffix=""):
         status = getattr(logger, "last_gemini_status", None)
         if status == "review_received":
             result["gemini_review_posted"] = True
+        # Persist the latest review body (may be empty string) so the
+        # ready-flip gate can detect clean/declined approval patterns.
+        body = getattr(logger, "last_gemini_review_body", "")
+        if body:
+            result["gemini_review_body"] = body
         mark_step(result, step_name, "done")
         write_result(worktree, result)
         return comments
@@ -1026,16 +1104,25 @@ def _step_triage(worktree, pr_number, comments, logger, result,
 
 
 def _ready_flip_gates(worktree, pr_number, result, logger):
-    """Evaluate the 3 gates for auto-ready-flip (meta-retro #2).
+    """Evaluate the gates for auto-ready-flip (meta-retro #2).
 
-    Returns (ok, failing_reasons). ok is True only when all three gates
-    pass: CI green, Gemini posted review, no unreplied bot comments.
+    Returns (ok, failing_reasons). ok is True only when all gates pass:
+      - CI green, AND
+      - Gemini dimension is satisfied — either the latest review body
+        matches a clean-approval / declined pattern
+        (see ``_gemini_effectively_done``), OR Gemini posted a review and
+        all inline bot comments have replies, AND
+      - no unreplied bot comments remain.
     """
     reasons = []
     if result.get("ci_result") != "pass":
         reasons.append(f"ci_result={result.get('ci_result')!r}")
-    if not result.get("gemini_review_posted"):
+
+    review_body = result.get("gemini_review_body") or ""
+    gemini_done_clean = _gemini_effectively_done(review_body)
+    if not gemini_done_clean and not result.get("gemini_review_posted"):
         reasons.append("gemini_review_not_posted")
+
     try:
         unreplied = get_unreplied_comments(
             worktree, pr_number, shakedown=bool(SHAKEDOWN),
@@ -1044,7 +1131,10 @@ def _ready_flip_gates(worktree, pr_number, result, logger):
         logger.log("ready", "UNREPLIED_CHECK_ERROR", error=str(e))
         unreplied = []
         reasons.append("unreplied_check_error")
-    if unreplied:
+    # Clean/declined reviews never have inline comments to reply to, so
+    # skip the unreplied gate in that branch. For the "flagged issues"
+    # branch, unreplied must be empty.
+    if not gemini_done_clean and unreplied:
         reasons.append(f"unreplied_comments={len(unreplied)}")
     return (not reasons), reasons
 

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -972,6 +972,157 @@ class TestReadyFlipGates:
         assert any("unreplied_comments" in r for r in reasons)
 
 
+class TestGeminiEffectivelyDone:
+    """Clean-approval / decline pattern detection for the ready-flip gate."""
+
+    def test_clean_approval_phrase_detected(self):
+        """Classic 'no feedback' body is treated as effectively done."""
+        body = (
+            "## Code Review\n\n"
+            "I have no feedback to provide on this pull request."
+        )
+        assert pr_monitor._gemini_effectively_done(body) is True
+
+    def test_decline_phrase_detected(self):
+        """'Unable to generate a review' body is treated as effectively done."""
+        body = (
+            "Gemini is unable to generate a review for this pull request "
+            "due to the file types involved not being currently supported."
+        )
+        assert pr_monitor._gemini_effectively_done(body) is True
+
+    def test_issues_present_body_not_matched(self):
+        """A body that flagged issues should NOT match the clean patterns."""
+        body = (
+            "## Code Review\n\n"
+            "I found a few issues with this pull request. See inline "
+            "comments for details."
+        )
+        assert pr_monitor._gemini_effectively_done(body) is False
+
+    def test_empty_body_not_matched(self):
+        """Empty string returns False (no patterns can match)."""
+        assert pr_monitor._gemini_effectively_done("") is False
+
+    def test_none_body_not_matched(self):
+        """None body is handled without raising and returns False."""
+        assert pr_monitor._gemini_effectively_done(None) is False
+
+    def test_patterns_are_module_constant(self):
+        """Patterns are exposed for external extension/inspection."""
+        assert isinstance(pr_monitor._GEMINI_CLEAN_PATTERNS, tuple)
+        assert "I have no feedback to provide" in pr_monitor._GEMINI_CLEAN_PATTERNS
+        assert "Gemini is unable to generate a review" \
+            in pr_monitor._GEMINI_CLEAN_PATTERNS
+
+
+class TestReadyFlipGeminiDimension:
+    """Ready-flip gate now accepts clean/declined reviews OR replied-issues."""
+
+    def _base_result(self, **overrides):
+        r = pr_monitor._empty_result()
+        r["ci_result"] = "pass"
+        r.update(overrides)
+        return r
+
+    def test_clean_approval_body_satisfies_gemini_gate(self, tmp_path):
+        """Clean-approval body flips the Gemini gate even when posted flag
+        was somehow missed (and even with no inline-comment replies)."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=False,
+            gemini_review_body="I have no feedback to provide on this PR.",
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is True
+        assert reasons == []
+
+    def test_declined_body_satisfies_gemini_gate(self, tmp_path):
+        """Decline phrasing satisfies the Gemini gate — ready to flip."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=False,
+            gemini_review_body=(
+                "Gemini is unable to generate a review for this pull "
+                "request due to the file types involved not being "
+                "currently supported."
+            ),
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is True
+        assert reasons == []
+
+    def test_issues_present_with_replies_satisfies_gate(self, tmp_path):
+        """Gemini flagged issues (non-clean body) + all replied → gate passes."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=True,
+            gemini_review_body="I found issues with this PR.",
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is True
+        assert reasons == []
+
+    def test_issues_present_without_replies_blocks_gate(self, tmp_path):
+        """Gemini flagged issues + unreplied comments → gate fails."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=True,
+            gemini_review_body="I found issues with this PR.",
+        )
+        unreplied = [{"id": 1, "user": "gemini-code-assist[bot]",
+                      "path": "a.py", "line": 1, "body": "fix this"}]
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=unreplied):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is False
+        assert any("unreplied_comments" in r for r in reasons)
+
+    def test_empty_body_without_posted_flag_blocks_gate(self, tmp_path):
+        """Empty body + no review posted → gate fails with posted reason."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=False,
+            gemini_review_body="",
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is False
+        assert "gemini_review_not_posted" in reasons
+
+    def test_none_body_without_posted_flag_blocks_gate(self, tmp_path):
+        """None body + no review posted → gate fails without raising."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=False,
+            gemini_review_body=None,
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is False
+        assert "gemini_review_not_posted" in reasons
+
+
 class TestReplyDedupe:
     """Meta-retro finding #3: in-process dedupe prevents duplicate POSTs."""
 

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1122,6 +1122,73 @@ class TestReadyFlipGeminiDimension:
         assert ok is False
         assert "gemini_review_not_posted" in reasons
 
+    def test_clean_gemini_with_other_unreplied_blocks_gate(self, tmp_path):
+        """Gemini clean-approval must NOT mask unreplied comments from
+        other reviewers (e.g. CodeQL). PR #846 review regression guard.
+        """
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=True,
+            gemini_review_body="I have no feedback to provide on this PR.",
+        )
+        # Simulate an unreplied CodeQL finding aggregated by
+        # get_unreplied_comments (which covers multiple bots).
+        unreplied = [{"id": 99, "user": "github-advanced-security[bot]",
+                      "path": "scripts/pr_monitor.py", "line": 1,
+                      "body": "Potential security issue"}]
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=unreplied):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is False
+        assert any("unreplied_comments" in r for r in reasons)
+
+    def test_declined_gemini_with_other_unreplied_blocks_gate(self, tmp_path):
+        """Gemini decline must NOT mask unreplied comments from other
+        reviewers — decline satisfies the Gemini dimension only.
+        """
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=True,
+            gemini_review_body=(
+                "Gemini is unable to generate a review for this pull "
+                "request due to the file types involved not being "
+                "currently supported."
+            ),
+        )
+        unreplied = [{"id": 77, "user": "github-advanced-security[bot]",
+                      "path": "scripts/pr_monitor.py", "line": 1,
+                      "body": "CodeQL finding"}]
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=unreplied):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is False
+        assert any("unreplied_comments" in r for r in reasons)
+
+    def test_declined_gemini_with_zero_unreplied_passes_gate(self, tmp_path):
+        """Gemini decline + zero unreplied comments (e.g. yml-only PR)
+        → gate passes. Complements the regression guards above.
+        """
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(
+            gemini_review_posted=False,
+            gemini_review_body=(
+                "Gemini is unable to generate a review for this pull "
+                "request due to the file types involved not being "
+                "currently supported."
+            ),
+        )
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+
+        assert ok is True
+        assert reasons == []
+
 
 class TestReplyDedupe:
     """Meta-retro finding #3: in-process dedupe prevents duplicate POSTs."""


### PR DESCRIPTION
## Summary

- Adds `_gemini_effectively_done(review_body)` helper + `_GEMINI_CLEAN_PATTERNS` module constant to `scripts/pr_monitor.py`.
- Fetches the latest Gemini top-level review body after `poll_gemini_review` returns `review_received`, persists it to the monitor result, and consumes it in `_ready_flip_gates`.
- Net script delta: ~90 LOC (Lane B constraint: <100 LOC).

## Rule change

**Context:** PR #834 introduced the auto-ready-flip gate with a boolean `gemini_review_posted` check — presence of any `gemini-code-assist[bot]` review satisfied the Gemini dimension. That check missed three semantically distinct review shapes:

1. **Clean approval** — body says "I have no feedback to provide" (e.g. #835, #842). Nothing to address.
2. **Declined-to-review** — body says "Gemini is unable to generate a review for this pull request due to the file types involved not being currently supported" (e.g. #838, yml-only PR). Gemini cannot review, but there is nothing for us to do.
3. **Flagged issues** — non-matching body + inline comments needing per-comment triage + replies.

**Old rule:** Any review object on the PR counts as "Gemini dimension satisfied" for the ready-flip gate.

**New rule:** The Gemini dimension is satisfied when either:
- `_gemini_effectively_done(latest_review_body)` is True (matches a clean-approval or declined-to-review pattern in `_GEMINI_CLEAN_PATTERNS`), OR
- A Gemini review was posted AND all inline bot comments have replies (existing "flagged-issues-addressed" semantic, unchanged).

**Why:** Closes the gap surfaced when #838 got Gemini-declined and the monitor left it stuck in draft, forcing a manual flip. Aligns the automated gate with the manual ready-flips we have been doing for these cases.

**Falsification:** If Gemini introduces new approval-equivalent phrasing not in `_GEMINI_CLEAN_PATTERNS`, affected PRs will stay in draft until either the pattern is added or a reviewer manually flips to ready. Patterns list is a module-level tuple for easy extension.

## Test plan

- [x] Unit test: `_gemini_effectively_done` detects "I have no feedback to provide" body
- [x] Unit test: `_gemini_effectively_done` detects "Gemini is unable to generate a review" body
- [x] Unit test: `_gemini_effectively_done` returns False on body that flagged issues
- [x] Unit test: `_gemini_effectively_done` returns False on empty body
- [x] Unit test: `_gemini_effectively_done` returns False on None body (no raise)
- [x] Unit test: `_GEMINI_CLEAN_PATTERNS` exposed as a module-level tuple
- [x] Gate test: clean-approval body satisfies gate even without `gemini_review_posted` flag
- [x] Gate test: declined body satisfies gate
- [x] Gate test: issues-present body + all replies satisfies gate
- [x] Gate test: issues-present body + unreplied comments blocks gate
- [x] Gate test: empty/None body without posted flag blocks gate with `gemini_review_not_posted` reason
- [x] Full `tests/test_pr_monitor.py` (52) + `tests/test_poll_gemini.py` + `tests/test_triage_common.py` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)