### PR TITLE
fix(pr-monitor): drop stray -- in gh pr view base-detect call

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -450,7 +450,7 @@ def _detect_base_branch(worktree, pr_number, logger):
     """Detect the PR's base branch via ``gh pr view``. Falls back to 'main'."""
     try:
         result = subprocess.run(
-            ["gh", "pr", "view", "--", str(pr_number),
+            ["gh", "pr", "view", str(pr_number),
              "--json", "baseRefName", "--jq", ".baseRefName"],
             cwd=worktree, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30,
         )

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1207,14 +1207,60 @@ class TestRebaseBeforeReady:
             result = pr_monitor._rebase_source_branch(wt, 88, logger)
 
         assert result is True
-        # Must call gh pr view with PR number and -- separator
+        # Must call gh pr view with PR number as a positional arg.
+        # NOTE: no ``--`` separator before the PR number — gh treats everything
+        # after ``--`` as positional, which makes ``--json``/``--jq`` fail with
+        # "accepts at most 1 arg(s), received 5".
         gh_calls = [c for c in call_log if c[:3] == ["gh", "pr", "view"]]
         assert len(gh_calls) == 1
-        assert "--" in gh_calls[0]
         assert "88" in gh_calls[0]
+        assert "--" not in gh_calls[0]
         # Must fetch and rebase onto origin/develop (not origin/main)
         assert ["git", "fetch", "origin", "--", "develop"] in call_log
         assert ["git", "rebase", "--", "origin/develop"] in call_log
         # Must NOT have used main
         assert not any(
             c == ["git", "fetch", "origin", "--", "main"] for c in call_log)
+
+
+class TestDetectBaseBranch:
+    """Regression: gh pr view argv must not include ``--`` before the PR number.
+
+    Cobra treats everything after ``--`` as positional, so ``--json`` and
+    ``--jq`` become positional args and gh fails with
+    ``accepts at most 1 arg(s), received 5`` — logged as BASE_DETECT_ERROR.
+    """
+
+    def test_detect_base_branch_argv_has_no_separator_before_pr_number(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="main\n", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            base = pr_monitor._detect_base_branch(wt, 856, logger)
+
+        assert base == "main"
+        cmd = captured["cmd"]
+        assert cmd[:3] == ["gh", "pr", "view"]
+        # PR number must come immediately after "view" as the sole positional.
+        assert cmd[3] == "856"
+        assert "--" not in cmd
+        # JSON flags must remain flags, not positionals.
+        assert "--json" in cmd and "--jq" in cmd
+
+    def test_detect_base_branch_falls_back_to_main_on_gh_failure(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="",
+                stderr="accepts at most 1 arg(s), received 5")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            assert pr_monitor._detect_base_branch(wt, 856, logger) == "main"


### PR DESCRIPTION
## Summary

- ``_detect_base_branch`` in ``scripts/pr_monitor.py`` invoked ``gh pr view -- <pr_number> --json baseRefName --jq .baseRefName``. In gh's Cobra parser ``--`` terminates flag parsing, so ``--json``/``--jq`` were treated as positional args and gh failed with ``accepts at most 1 arg(s), received 5``. Every PR-monitor rebase step logged ``BASE_DETECT_ERROR`` and silently fell back to ``"main"`` — harmless for main-based PRs but wrong for any PR targeting a non-main base.
- Fix: drop the stray ``--`` so the PR number is the sole positional and the JSON flags parse as flags.
- Test correctness: an existing regression test (``test_rebase_uses_non_main_base_branch_from_gh_pr_view``) asserted ``"--" in gh_calls[0]`` — literally locking the bug in. Inverted to ``"--" not in cmd`` with a comment explaining the Cobra gotcha. Added a new ``TestDetectBaseBranch`` class covering argv shape and graceful ``"main"`` fallback on gh non-zero exit.

## Observation that prompted the fix

Stderr captured live during a PR-monitor rebase step:

```
accepts at most 1 arg(s), received 5
```

Reproduced locally with ``gh pr view -- 856 --json baseRefName --jq .baseRefName``; fix verified with the same command minus the ``--``.

## Test Plan

- [x] ``python -m pytest tests/test_pr_monitor.py -v`` — 54/54 pass
- [x] New ``TestDetectBaseBranch`` regression suite: argv shape + gh-failure fallback
- [x] Existing ``test_rebase_uses_non_main_base_branch_from_gh_pr_view`` still green after assertion inversion
- [x] Grepped all of ``scripts/`` for ``"gh", ..., "--",`` — this was the only stray occurrence; other ``--`` uses are correct git ref/filename separators (``git fetch origin -- <branch>``, ``git rebase -- <ref>``)

## Verification

- [x] /gates passed (Python-only change; no .NET / TS / TUI gates apply)
- [x] Pre-PR self-review: 0 DEFECTs / 0 CONCERNs / 0 NITs

🤖 Generated with [Claude Code](https://claude.com/claude-code)