### PR TITLE
fix(ci): unblock audit-capture workflow (invalid runner context at job-env)

### DIFF
--- a/.github/workflows/audit-capture.yml
+++ b/.github/workflows/audit-capture.yml
@@ -33,7 +33,6 @@ jobs:
     timeout-minutes: 45
 
     env:
-      AUDIT_OUT: ${{ runner.temp }}\audit-out
       # Git metadata written into manifest.json
       AUDIT_SOURCE_REPO: ${{ github.repository }}
       AUDIT_SOURCE_REF: ${{ github.ref }}
@@ -47,6 +46,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Compute AUDIT_OUT
+        shell: bash
+        run: echo "AUDIT_OUT=$RUNNER_TEMP/audit-out" >> "$GITHUB_ENV"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Summary

- `audit-capture.yml` has had **zero successful runs** since creation in #797 — every push to `main` produces a startup-failure entry (0 jobs, file path shown as name) because the workflow file fails validation at parse time.
- Root cause: `AUDIT_OUT: ${{ runner.temp }}\audit-out` at job-level `env`. Per GitHub's [context availability matrix](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), `jobs.<job_id>.env` only accepts `github`, `secrets`, `needs`, `inputs`, `vars` — the `runner` context is step-scope only.
- Fix: delete the job-level entry, compute `AUDIT_OUT` in a bash setup step via `$RUNNER_TEMP` (the native env-var equivalent). Preserves temp-dir semantics, avoids polluting the checkout.

## Evidence

- `gh api .../actions/workflows/audit-capture.yml/runs` → first run at 2026-04-19T01:57Z, all failure, all `total_count: 0`.
- `audit-capture.yml:36` was the only `runner.*` reference in a job-level `env` block across the repo (confirmed by grep).
- Neither #801 (App-token swap) nor #848 (action bumps) is implicated — the file has been broken from day one.

## Test Plan

- [ ] After merge, the next push to `main` produces an audit-capture run with `total_count > 0` (validation passes) instead of the 0-job startup failure.
- [ ] First manual dispatch (`gh workflow run audit-capture.yml -f surface=all`) proceeds past "Compute AUDIT_OUT" step with `AUDIT_OUT` resolved to `<RUNNER_TEMP>/audit-out`.

## Verification

- [x] Root cause confirmed via GitHub context-availability matrix + grep (only `runner.*` in job env in the repo)
- [x] Diff trivially small (4 additions / 1 deletion in one YAML file) — self-review bypass per /pr skill
- [ ] /gates, /verify, /qa, /review — N/A (workflow-only change, no test coverage applies; true verification requires the file to run on main)

## Pre-merge gate Rule 2 bypass

These four secrets are intentionally optional (env-scoped, guarded by runtime `if: env.X != ''` / `[ -z "$X" ]` checks in the workflow). `gh secret list` doesn't enumerate env-scoped secrets without `--env`, which is the exact bypass case the gate's docstring calls out. They predate this PR and are not touched by this change.

[secret-ref-allow: AUDIT_WEBHOOK_URL]
[secret-ref-allow: PPDS_TEST_ENV]
[secret-ref-allow: PPDS_TEST_PROFILE]
[secret-ref-allow: PPDS_TEST_PROFILE_JSON]

🤖 Generated with [Claude Code](https://claude.com/claude-code)