### PR TITLE
feat(pipeline): raise HARD_CEILING to 7200s, add --max-stage-seconds override

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -18,6 +18,10 @@ Options:
     --resume            Auto-resume from last completed stage in pipeline.log
     --no-retro          Skip the post-PR retro step
     --max-converge <n>  Max converge rounds (default: 3)
+    --max-stage-seconds N
+                        Override HARD_CEILING for this run (default: 7200s).
+                        Positive integer. Applies to the claude heartbeat
+                        loop, the pr stage, and the pr_monitor subprocess.
     --worktree <path>   Use existing worktree instead of creating one
     --issue <N>         GitHub issue number(s) this work closes (repeatable)
     --dry-run           Run orchestration logic without invoking claude -p
@@ -71,7 +75,7 @@ STAGE_OUTCOMES = {
 }
 
 STALL_LIMIT = 5    # consecutive idle heartbeats before kill (5 min at 60s interval)
-HARD_CEILING = 3600  # absolute maximum stage duration in seconds (60 min)
+HARD_CEILING = 7200  # absolute maximum stage duration in seconds (120 min, overridable via --max-stage-seconds)
 
 
 class PipelineFailure(Exception):
@@ -353,11 +357,17 @@ def extract_text_from_jsonl(jsonl_path):
 
 
 def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
-               agent=None):
-    """Run `claude -p` in the worktree directory. Returns (exit_code, logger)."""
+               agent=None, ceiling=None):
+    """Run `claude -p` in the worktree directory. Returns (exit_code, logger).
+
+    ``ceiling`` overrides ``HARD_CEILING`` for this invocation; ``None`` means
+    use the module-level default. The effective ceiling is recorded on the
+    stage START log so operators can confirm which value is in effect.
+    """
     full_prompt = HEADLESS_PREAMBLE + prompt
 
-    log(logger, stage, "START")
+    effective_ceiling = ceiling if ceiling is not None else HARD_CEILING
+    log(logger, stage, "START", ceiling=f"{effective_ceiling}s")
 
     if dry_run:
         time.sleep(0.1)  # Simulate
@@ -421,10 +431,10 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
             elapsed = time.time() - start
 
             # Hard ceiling check — absolute maximum regardless of activity
-            if elapsed > HARD_CEILING:
+            if elapsed > effective_ceiling:
                 log(logger, stage, "HARD_TIMEOUT",
                     elapsed=f"{int(elapsed)}s",
-                    ceiling=f"{HARD_CEILING}s",
+                    ceiling=f"{effective_ceiling}s",
                     activity=activity)
                 proc.terminate()
                 try:
@@ -928,9 +938,15 @@ def _poll_codeql_check(worktree_path, pr_number, logger):
     log(logger, "pr", "CODEQL_TIMEOUT")
 
 
-def run_pr_stage(worktree_path, logger, dry_run=False):
-    """Scripted PR stage: draft → poll Gemini → triage → ready → notify."""
-    log(logger, "pr", "START")
+def run_pr_stage(worktree_path, logger, dry_run=False, ceiling=None):
+    """Scripted PR stage: draft → poll Gemini → triage → ready → notify.
+
+    ``ceiling`` overrides ``HARD_CEILING`` for the stage's internal timeout
+    checks and the PR monitor subprocess timeout; ``None`` means use the
+    module-level default.
+    """
+    effective_ceiling = ceiling if ceiling is not None else HARD_CEILING
+    log(logger, "pr", "START", ceiling=f"{effective_ceiling}s")
     start = time.time()
 
     # PPDS_SHAKEDOWN: skip PR creation entirely
@@ -941,10 +957,10 @@ def run_pr_stage(worktree_path, logger, dry_run=False):
 
     def _check_timeout():
         """Check if stage hard ceiling exceeded. Logs and returns True if timed out."""
-        if (time.time() - start) > HARD_CEILING:
+        if (time.time() - start) > effective_ceiling:
             log(logger, "pr", "HARD_TIMEOUT",
                 elapsed=f"{int(time.time() - start)}s",
-                ceiling=f"{HARD_CEILING}s")
+                ceiling=f"{effective_ceiling}s")
             return True
         return False
 
@@ -1006,7 +1022,7 @@ def run_pr_stage(worktree_path, logger, dry_run=False):
     )
     exit_code, logger = run_claude(
         worktree_path, summary_prompt, logger, "pr-summary",
-        dry_run=dry_run,
+        dry_run=dry_run, ceiling=ceiling,
     )
 
     # Read the generated summary
@@ -1080,7 +1096,7 @@ def run_pr_stage(worktree_path, logger, dry_run=False):
     # PR creation, wait); pr_monitor.py owns the *polling loop*. Single
     # canonical implementation.
     monitor_exit = _delegate_to_pr_monitor(
-        worktree_path, pr_number, logger, dry_run=dry_run)
+        worktree_path, pr_number, logger, dry_run=dry_run, ceiling=ceiling)
     if monitor_exit not in (0,):
         # pr_monitor failed (CI failure, timeout, etc.); pipeline still
         # records the PR URL but reports stage failure so the orchestrator
@@ -1096,7 +1112,8 @@ def run_pr_stage(worktree_path, logger, dry_run=False):
     return 0, logger
 
 
-def _delegate_to_pr_monitor(worktree_path, pr_number, logger, dry_run=False):
+def _delegate_to_pr_monitor(worktree_path, pr_number, logger, dry_run=False,
+                            ceiling=None):
     """Invoke ``scripts/pr_monitor.py`` as a subprocess for the polling loop.
 
     v1-prelaunch retro item #4: the previous pipeline.run_pr_stage embedded a
@@ -1111,10 +1128,13 @@ def _delegate_to_pr_monitor(worktree_path, pr_number, logger, dry_run=False):
         pr_number: PR number (str or int)
         logger: pipeline log handle
         dry_run: if True, log the planned invocation but skip exec
+        ceiling: override HARD_CEILING for the subprocess timeout; ``None``
+            means use the module-level default.
 
     Returns:
         Exit code: 0 on success, non-zero on failure.
     """
+    effective_ceiling = ceiling if ceiling is not None else HARD_CEILING
     script_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "pr_monitor.py")
     cmd = [
@@ -1141,10 +1161,10 @@ def _delegate_to_pr_monitor(worktree_path, pr_number, logger, dry_run=False):
             env=env,
             capture_output=True,
             text=True,
-            timeout=HARD_CEILING,
+            timeout=effective_ceiling,
         )
     except subprocess.TimeoutExpired:
-        log(logger, "pr", "MONITOR_TIMEOUT", ceiling=f"{HARD_CEILING}s")
+        log(logger, "pr", "MONITOR_TIMEOUT", ceiling=f"{effective_ceiling}s")
         return -1
     except (FileNotFoundError, OSError) as e:
         log(logger, "pr", "MONITOR_ERROR", error=str(e))
@@ -1236,10 +1256,26 @@ def main():
     parser.add_argument("--name", help="Override worktree name (default: derived from plan/spec)")
     parser.add_argument("--no-retro", action="store_true", help="Skip the post-PR retro step")
     parser.add_argument("--max-converge", type=int, default=3, help="Max converge rounds (default: 3)")
+    parser.add_argument(
+        "--max-stage-seconds",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Override the per-stage hard ceiling for this run "
+            f"(default: {HARD_CEILING}s). Must be a positive integer. "
+            "Applies to the claude heartbeat loop, the pr stage, and the "
+            "pr_monitor subprocess timeout."
+        ),
+    )
     parser.add_argument("--worktree", help="Use existing worktree instead of creating one")
     parser.add_argument("--issue", type=int, action="append", default=[], help="GitHub issue number(s) (repeatable)")
     parser.add_argument("--dry-run", action="store_true", help="Run orchestration without invoking claude -p")
     args = parser.parse_args()
+
+    if args.max_stage_seconds is not None and args.max_stage_seconds <= 0:
+        parser.error("--max-stage-seconds must be a positive integer")
+    stage_ceiling = args.max_stage_seconds  # None → use HARD_CEILING default
 
     # Handle backward compat: positional plan arg
     plan_path = args.plan or args.plan_positional
@@ -1416,7 +1452,7 @@ def main():
                     prompt = f"/implement {plan_rel}"
                 else:
                     prompt = "/implement"  # Will generate plan from spec
-                exit_code, logger = run_claude(worktree_path, prompt, logger, "implement", args.dry_run)
+                exit_code, logger = run_claude(worktree_path, prompt, logger, "implement", args.dry_run, ceiling=stage_ceiling)
                 if exit_code != 0:
                     log(logger, "pipeline", "FAILED", failed_stage="implement")
                     _pipeline_fail("implement")
@@ -1424,7 +1460,7 @@ def main():
                 # P4: Outcome verification + retry
                 if not verify_outcome(worktree_path, "implement", pre_commits) and not args.dry_run:
                     log(logger, "implement", "OUTCOME_MISS", reason="no new commits, retrying")
-                    exit_code, logger = run_claude(worktree_path, prompt, logger, "implement-retry", args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, prompt, logger, "implement-retry", args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0 or not verify_outcome(worktree_path, "implement", pre_commits):
                         log(logger, "pipeline", "FAILED", failed_stage="implement", reason="outcome verification failed")
                         _pipeline_fail("implement", "outcome verification failed")
@@ -1434,7 +1470,7 @@ def main():
 
             elif stage in ("gates", "verify", "qa", "review"):
                 prompt = f"/{stage}"
-                exit_code, logger = run_claude(worktree_path, prompt, logger, stage, args.dry_run)
+                exit_code, logger = run_claude(worktree_path, prompt, logger, stage, args.dry_run, ceiling=stage_ceiling)
                 if exit_code != 0:
                     # Review FAIL must advance to converge, not abort (AC-20)
                     if stage == "review":
@@ -1447,7 +1483,7 @@ def main():
                 # P4: Outcome verification + retry (skip for review — converge handles it)
                 if stage != "review" and not verify_outcome(worktree_path, stage, 0) and not args.dry_run:
                     log(logger, stage, "OUTCOME_MISS", reason="expected state not set, retrying")
-                    exit_code, logger = run_claude(worktree_path, prompt, logger, f"{stage}-retry", args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, prompt, logger, f"{stage}-retry", args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage=stage)
                         _pipeline_fail(stage)
@@ -1465,31 +1501,31 @@ def main():
                     log(logger, "converge", "ROUND_START", round=round_num + 1, max=args.max_converge)
 
                     converge_log = f"converge-r{round_num + 1}"
-                    exit_code, logger = run_claude(worktree_path, "/converge", logger, converge_log, args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, "/converge", logger, converge_log, args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage="converge")
                         _pipeline_fail("converge", log_stage=converge_log)
 
                     gates_log = f"gates-r{round_num + 1}"
-                    exit_code, logger = run_claude(worktree_path, "/gates", logger, gates_log, args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, "/gates", logger, gates_log, args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage="gates-reconverge")
                         _pipeline_fail("gates-reconverge", log_stage=gates_log)
 
                     verify_log = f"verify-r{round_num + 1}"
-                    exit_code, logger = run_claude(worktree_path, "/verify", logger, verify_log, args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, "/verify", logger, verify_log, args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage="verify-reconverge")
                         _pipeline_fail("verify-reconverge", log_stage=verify_log)
 
                     qa_log = f"qa-r{round_num + 1}"
-                    exit_code, logger = run_claude(worktree_path, "/qa", logger, qa_log, args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, "/qa", logger, qa_log, args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage="qa-reconverge")
                         _pipeline_fail("qa-reconverge", log_stage=qa_log)
 
                     review_log = f"review-r{round_num + 1}"
-                    exit_code, logger = run_claude(worktree_path, "/review", logger, review_log, args.dry_run)
+                    exit_code, logger = run_claude(worktree_path, "/review", logger, review_log, args.dry_run, ceiling=stage_ceiling)
                     if exit_code != 0:
                         log(logger, "pipeline", "FAILED", failed_stage="review-reconverge")
                         _pipeline_fail("review-reconverge", log_stage=review_log)
@@ -1506,14 +1542,15 @@ def main():
 
             elif stage == "pr":
                 exit_code, logger = run_pr_stage(
-                    worktree_path, logger, dry_run=args.dry_run)
+                    worktree_path, logger, dry_run=args.dry_run,
+                    ceiling=stage_ceiling)
                 if exit_code != 0:
                     log(logger, "pipeline", "FAILED", failed_stage="pr")
                     _pipeline_fail("pr")
                 pr_url = check_pr_created(worktree_path)
 
             elif stage == "retro":
-                exit_code, logger = run_claude(worktree_path, "/retro", logger, "retro", args.dry_run)
+                exit_code, logger = run_claude(worktree_path, "/retro", logger, "retro", args.dry_run, ceiling=stage_ceiling)
                 if exit_code != 0:
                     log(logger, "retro", "FAILED_NON_BLOCKING")
                 else:
@@ -1574,7 +1611,8 @@ def main():
             log(logger, "retro", "START", mode="failure-retro")
             try:
                 exit_code, logger = run_claude(
-                    worktree_path, "/retro", logger, "retro", args.dry_run)
+                    worktree_path, "/retro", logger, "retro", args.dry_run,
+                    ceiling=stage_ceiling)
                 if exit_code != 0:
                     log(logger, "retro", "FAILED_NON_BLOCKING")
                 else:

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -75,7 +75,7 @@ STAGE_OUTCOMES = {
 }
 
 STALL_LIMIT = 5    # consecutive idle heartbeats before kill (5 min at 60s interval)
-HARD_CEILING = 7200  # absolute maximum stage duration in seconds (120 min, overridable via --max-stage-seconds)
+HARD_CEILING = 7200  # max duration per AI invocation in seconds (120 min, overridable via --max-stage-seconds). Applied per run_claude call; stages with retries or converge rounds can accumulate multiple invocations.
 
 
 class PipelineFailure(Exception):
@@ -1027,7 +1027,8 @@ def run_pr_stage(worktree_path, logger, dry_run=False, ceiling=None):
     )
     exit_code, logger = run_claude(
         worktree_path, summary_prompt, logger, "pr-summary",
-        dry_run=dry_run, ceiling=ceiling,
+        dry_run=dry_run,
+        ceiling=int(max(0, effective_ceiling - (time.time() - start))),
     )
 
     # Read the generated summary
@@ -1101,7 +1102,8 @@ def run_pr_stage(worktree_path, logger, dry_run=False, ceiling=None):
     # PR creation, wait); pr_monitor.py owns the *polling loop*. Single
     # canonical implementation.
     monitor_exit = _delegate_to_pr_monitor(
-        worktree_path, pr_number, logger, dry_run=dry_run, ceiling=ceiling)
+        worktree_path, pr_number, logger, dry_run=dry_run,
+        ceiling=int(max(0, effective_ceiling - (time.time() - start))))
     if monitor_exit not in (0,):
         # pr_monitor failed (CI failure, timeout, etc.); pipeline still
         # records the PR URL but reports stage failure so the orchestrator

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -879,13 +879,18 @@ def poll_gemini(worktree_path, pr_number, logger, min_wait=90, max_wait=300):
     return comments
 
 
-def run_triage(worktree_path, pr_number, comments, logger, dry_run=False):
-    """Invoke gemini-triage agent to fix/dismiss comments. Returns list or None."""
+def run_triage(worktree_path, pr_number, comments, logger, dry_run=False,
+               ceiling=None):
+    """Invoke gemini-triage agent to fix/dismiss comments. Returns list or None.
+
+    ``ceiling`` is forwarded to ``run_claude`` for symmetry with other stage
+    wrappers; ``None`` means use the module-level ``HARD_CEILING``.
+    """
     prompt = build_triage_prompt(worktree_path, pr_number, comments)
 
     exit_code, logger_out = run_claude(
         worktree_path, prompt, logger, "pr-triage",
-        dry_run=dry_run, agent="gemini-triage",
+        dry_run=dry_run, agent="gemini-triage", ceiling=ceiling,
     )
 
     if exit_code != 0:

--- a/specs/pipeline-observability.md
+++ b/specs/pipeline-observability.md
@@ -13,7 +13,7 @@ Pipeline runs are black boxes once launched. Two failed pipelines (cmt-parity, v
 
 ### Goals
 
-- **Smarter timeouts**: Kill stuck stages fast (5 min stall), let active stages run (up to 60 min ceiling). Fixed timeouts are the wrong tool.
+- **Smarter timeouts**: Kill stuck stages fast (5 min stall), let active stages run (up to 120 min ceiling, overridable per run via `--max-stage-seconds N`). Fixed timeouts are the wrong tool.
 - **Survive timeout**: When a stage is killed, extract whatever assistant text exists in the JSONL. Don't lose 20 minutes of work.
 - **Failed pipeline retro**: Run a lightweight retro even when a stage fails. "QA timed out at Phase 2 after completing Phase 1" is actionable.
 - **Partial QA persistence**: QA writes results per-phase as they complete, not only on clean exit.
@@ -256,7 +256,7 @@ except PipelineFailure:
 **Fix**: Replace fixed timeouts with a hybrid model — stall timeout + hard ceiling:
 
 - **Stall timeout**: Kill the stage after 5 consecutive idle heartbeats (5 minutes of no activity across all signals). Stuck processes die fast.
-- **Hard ceiling**: Kill the stage after 3600s (60 min) regardless of activity. Safety net so nothing runs forever.
+- **Hard ceiling**: Kill the stage after 7200s (120 min) regardless of activity. Safety net so nothing runs forever. Overridable per-run via the `--max-stage-seconds N` CLI flag on `scripts/pipeline.py` when a specific run needs more (or less) budget — e.g., cross-cutting architectural refactors where 17+ parallel agents are legitimately working for longer than the default.
 
 **Current timeout check** (pipeline.py:352-361):
 ```python
@@ -269,7 +269,7 @@ if timeout is not None and elapsed > timeout:
 **New timeout check:**
 ```python
 STALL_LIMIT = 5       # consecutive idle heartbeats (5 min at 60s interval)
-HARD_CEILING = 3600   # 60 min absolute maximum
+HARD_CEILING = 7200   # 120 min absolute maximum (override with --max-stage-seconds N)
 
 # In heartbeat block (after consecutive_idle is updated):
 if consecutive_idle >= STALL_LIMIT:
@@ -310,11 +310,17 @@ if elapsed > HARD_CEILING:
 |----------|--------|-------|
 | QA actively working, hits 20 min | Killed (timeout) | Keeps running (active) |
 | QA stuck, 0 bytes for 5 min | Waits 20 min to kill | Killed at 5 min (stall) |
-| QA active for 55 min | N/A (killed at 20 min) | Killed at 60 min (hard ceiling) |
+| QA active for 55 min | N/A (killed at 20 min) | Keeps running (well under 120 min ceiling) |
+| Active stage for 130 min | N/A | Killed at 120 min (hard ceiling) |
+| Active stage for 130 min, `--max-stage-seconds 10800` | N/A | Keeps running (override raised ceiling to 180 min) |
 | Implement actively coding for 40 min | Keeps running (45 min timeout) | Keeps running (active) |
 | Gates stuck on build error | Waits 15 min | Killed at 5 min (stall) |
 
 **Log event differentiation**: `STALL_TIMEOUT` vs `HARD_TIMEOUT` in pipeline.log makes it clear why the stage was killed. The existing `TIMEOUT` event is replaced by these two specific events.
+
+**Effective ceiling logged on stage start**: Each stage's `START` event records the effective ceiling (default or override) as `ceiling=<N>s`. Operators inspecting `pipeline.log` can see which value is in effect for a given run without re-deriving it from the CLI invocation.
+
+**Override flag — `--max-stage-seconds N`**: `scripts/pipeline.py` accepts `--max-stage-seconds N` where `N` is a positive integer number of seconds. When present, `N` replaces `HARD_CEILING` for every stage in that pipeline run (including `run_claude` heartbeat comparisons, the `pr` stage's internal checks, and the `pr_monitor.py` subprocess timeout). The flag is intended for one-off runs where the caller knows the work will exceed the default — cross-cutting architectural refactors, large-batch QA rounds, multi-domain features. The default is deliberately generous enough that most runs will never need it; if a whole class of work consistently hits the ceiling, raise the default rather than normalizing the override.
 
 **What counts as activity** (unchanged, already implemented in heartbeat):
 - `output_bytes` grew (JSONL file size increased — AI is producing text)
@@ -659,7 +665,7 @@ else:
 | AC-10 | tui-verify daemon self-terminates after 30 minutes of no HTTP requests | `test_daemon_self_terminates_after_idle_timeout` (Node.js test) | 🔲 |
 | AC-11 | Cleanup skill sends `/shutdown` to daemons found via `*-session.json` before worktree removal | Manual — skill behavior, verified via `/cleanup` with active daemon | 🔲 |
 | AC-12 | Stage is killed after 5 consecutive idle heartbeats (5 min no activity) with `STALL_TIMEOUT` log event | `test_stall_timeout_kills_after_consecutive_idle` | 🔲 |
-| AC-13 | Stage is killed after 3600s regardless of activity with `HARD_TIMEOUT` log event | `test_hard_timeout_kills_at_ceiling` | 🔲 |
+| AC-13 | Stage is killed after the effective hard ceiling (default 7200s, overridable via `--max-stage-seconds N`) regardless of activity, with `HARD_TIMEOUT` log event | `test_hard_timeout_kills_at_ceiling` | 🔲 |
 | AC-14 | Active stage (output_bytes growing) is NOT killed by stall timeout — idle counter resets on activity | `test_active_stage_not_killed_by_stall_timeout` | 🔲 |
 | AC-15 | `STAGE_TIMEOUTS` dict is removed; all stages use stall-based + hard ceiling logic | `test_no_per_stage_fixed_timeouts` | 🔲 |
 | AC-16 | QA skill commits each fix immediately after applying it (`git add` + `git commit`) — fixes survive timeout | `test_qa_commits_fixes` (integration: run QA skill on fixture with known issue, verify git log contains QA fix commit) | 🔲 |
@@ -672,6 +678,9 @@ else:
 | AC-23 | QA writes findings to `qa_findings` array in workflow state (id, surface, description, file, severity, fixed, fix_commit) | Manual — run QA, read state file, verify `qa_findings` entries | 🔲 |
 | AC-24 | Review reads `qa_findings` from state and passes to subagents as "already found by QA" context | Manual — run QA then review, observe review skipping duplicate findings | 🔲 |
 | AC-25 | Review does not re-report QA findings that were fixed (`fixed: true`) unless the fix introduced a new problem | Manual — verify dedup in review output | 🔲 |
+| AC-26 | `HARD_CEILING` default is 7200 seconds (120 min) | `test_hard_ceiling_default_is_7200` | 🔲 |
+| AC-27 | `scripts/pipeline.py --max-stage-seconds N` parses as a positive integer and replaces `HARD_CEILING` for the run; the effective ceiling is threaded into `run_claude`, `run_pr_stage`, and the PR monitor subprocess timeout | `test_max_stage_seconds_flag_overrides_ceiling` | 🔲 |
+| AC-28 | `run_claude` records the effective ceiling on stage start (`START` log entry includes `ceiling=<N>s`) so operators can see which value is in effect | `test_run_claude_logs_effective_ceiling_on_start` | 🔲 |
 
 ### Edge Cases
 

--- a/specs/pipeline-observability.md
+++ b/specs/pipeline-observability.md
@@ -40,7 +40,7 @@ Pipeline Timeout Today:
                                                   → write_result: {failed_stage: "qa"} → no detail
 
 Pipeline Timeout After:
-  claude -p → JSONL grows → heartbeat: active? → keep running (up to 60 min ceiling)
+  claude -p → JSONL grows → heartbeat: active? → keep running (up to 120 min ceiling)
               (active)       idle 5 min? → STALL_TIMEOUT → proc.kill()
                                                           → extract assistant text → meaningful .log
                                                           → write_result: {last_output: [...]} → actionable
@@ -233,7 +233,7 @@ except PipelineFailure:
     _result_written = True
 
     # Best-effort failure retro — outside SystemExit, safe to spawn subprocesses
-    # Uses standard stall-based timeout (5 min idle) + hard ceiling (60 min)
+    # Uses standard stall-based timeout (5 min idle) + hard ceiling (120 min)
     log(logger, "retro", "START", mode="failure-retro")
     try:
         run_claude(worktree_path, "/retro", logger, "retro")
@@ -723,7 +723,7 @@ else:
 
 **Context:** QA currently gets 1200s (20 min). Both cmt-parity and v1-polish timed out at exactly this limit. cmt-parity was actively working (970KB output, Phase 1 complete, mid-Phase 2). v1-polish's first two runs were genuinely stuck (0 bytes). A fixed timeout can't distinguish these cases.
 
-**Decision:** Replace fixed per-stage timeouts with stall-based timeout (5 min idle) + hard ceiling (60 min).
+**Decision:** Replace fixed per-stage timeouts with stall-based timeout (5 min idle) + hard ceiling (120 min, overridable per-run via `--max-stage-seconds N`).
 
 **Alternatives considered:**
 - Raise fixed timeout to 45 min for QA (brute force — genuinely stuck runs waste 45 min instead of 20, doesn't solve the problem)
@@ -741,9 +741,9 @@ else:
 | v1-polish | QA #3 | 48KB → 2MB | active | Killed at 30 min | NOT killed (would keep running) |
 
 **Consequences:**
-- Positive: Stuck processes die 4x faster (5 min vs 20 min). Active processes get as long as they need (up to 60 min). The data already exists — `consecutive_idle` is computed every heartbeat.
+- Positive: Stuck processes die 4x faster (5 min vs 20 min). Active processes get as long as they need (up to 120 min by default, raisable per-run via `--max-stage-seconds`). The data already exists — `consecutive_idle` is computed every heartbeat.
 - Positive: No per-stage tuning needed. The stall threshold is universal because activity detection is multi-signal.
-- Negative: An active-but-not-converging process could run up to 60 min. The partial-results fixes in this spec make this acceptable — even if the ceiling fires, we capture the work done.
+- Negative: An active-but-not-converging process could run up to 120 min (or longer if `--max-stage-seconds` raises it). The partial-results fixes in this spec make this acceptable — even if the ceiling fires, we capture the work done.
 - Negative: A stage that produces output but is logically stuck (e.g., infinite retry loop with verbose logging) won't be caught by stall timeout. The hard ceiling catches this.
 
 ### Why Run Retro on Failure Instead of a Lightweight Diagnostic?

--- a/specs/pipeline-observability.md
+++ b/specs/pipeline-observability.md
@@ -679,8 +679,8 @@ else:
 | AC-24 | Review reads `qa_findings` from state and passes to subagents as "already found by QA" context | Manual — run QA then review, observe review skipping duplicate findings | 🔲 |
 | AC-25 | Review does not re-report QA findings that were fixed (`fixed: true`) unless the fix introduced a new problem | Manual — verify dedup in review output | 🔲 |
 | AC-26 | `HARD_CEILING` default is 7200 seconds (120 min) | `test_hard_ceiling_default_is_7200` | 🔲 |
-| AC-27 | `scripts/pipeline.py --max-stage-seconds N` parses as a positive integer and replaces `HARD_CEILING` for the run; the effective ceiling is threaded into `run_claude`, `run_pr_stage`, and the PR monitor subprocess timeout | `test_max_stage_seconds_flag_overrides_ceiling` | 🔲 |
-| AC-28 | `run_claude` records the effective ceiling on stage start (`START` log entry includes `ceiling=<N>s`) so operators can see which value is in effect | `test_run_claude_logs_effective_ceiling_on_start` | 🔲 |
+| AC-27 | `scripts/pipeline.py --max-stage-seconds N` parses as a positive integer and replaces `HARD_CEILING` for the run; the effective ceiling is threaded into `run_claude`, `run_pr_stage`, and the PR monitor subprocess timeout | `test_max_stage_seconds_flag_overrides_ceiling`, `test_run_pr_stage_threads_ceiling_to_summary_and_monitor`, `test_pr_monitor_uses_effective_ceiling` | 🔲 |
+| AC-28 | `run_claude` records the effective ceiling on stage start (`START` log entry includes `ceiling=<N>s`) so operators can see which value is in effect | `test_run_claude_logs_effective_ceiling_on_start_default`, `test_run_claude_logs_effective_ceiling_on_start_override` | 🔲 |
 
 ### Edge Cases
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -199,7 +199,8 @@ class TestHeartbeat:
 # ---------------------------------------------------------------------------
 class TestTimeout:
     def test_stall_and_hard_ceiling_constants_exist(self):
-        """AC-26: Stall-based and hard ceiling timeout constants are defined."""
+        """AC-12 + AC-26: Stall-based and hard ceiling timeout constants are
+        defined with the documented values (STALL_LIMIT=5, HARD_CEILING=7200)."""
         import pipeline
 
         assert hasattr(pipeline, "STALL_LIMIT")
@@ -1592,6 +1593,110 @@ class TestMaxStageSecondsOverride:
                 f"Error message for bad --max-stage-seconds={bad} should "
                 f"mention the flag, got:\n{err}"
             )
+
+    def test_run_pr_stage_threads_ceiling_to_summary_and_monitor(self, tmp_path, monkeypatch):
+        """AC-27: ``run_pr_stage`` forwards its ``ceiling`` argument to both
+        the internal ``run_claude`` (pr-summary) call and the
+        ``_delegate_to_pr_monitor`` subprocess, and records the effective
+        ceiling on the stage START log."""
+        import pipeline
+
+        (tmp_path / ".workflow" / "stages").mkdir(parents=True)
+        log_path = tmp_path / ".workflow" / "pipeline.log"
+        logger = pipeline.open_logger(str(log_path))
+
+        # Ensure the shakedown shortcut is inactive so the full PR path runs
+        monkeypatch.delenv("PPDS_SHAKEDOWN", raising=False)
+
+        # Mock all subprocess.run calls: fetch, rebase, rev-parse HEAD, push,
+        # workflow-state get issues, gh pr create, and any follow-ups.
+        def fake_subprocess_run(cmd, **kwargs):
+            result = unittest.mock.MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            if cmd and cmd[0] == "gh" and len(cmd) > 2 and cmd[1] == "pr" and cmd[2] == "create":
+                # gh pr create returns the PR URL on stdout
+                result.stdout = "https://github.com/owner/repo/pull/42\n"
+            elif "rev-parse" in cmd:
+                result.stdout = "feat/test-branch\n"
+            elif len(cmd) > 1 and "workflow-state.py" in cmd[1]:
+                result.stdout = "[]"  # no issues
+            else:
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("subprocess.run", fake_subprocess_run)
+
+        # Capture run_claude kwargs
+        captured_run_claude = {}
+
+        def fake_run_claude(worktree_path, prompt, logger_, stage, dry_run=False,
+                            agent=None, ceiling=None):
+            captured_run_claude["ceiling"] = ceiling
+            captured_run_claude["stage"] = stage
+            # Write a minimal summary log so the caller's file read succeeds
+            summary_log = os.path.join(
+                worktree_path, ".workflow", "stages", f"{stage}.log")
+            with open(summary_log, "w") as f:
+                f.write("test: stub title\n\n- bullet 1\n")
+            return 0, logger_
+
+        monkeypatch.setattr(pipeline, "run_claude", fake_run_claude)
+
+        # Capture _delegate_to_pr_monitor kwargs and short-circuit
+        captured_monitor = {}
+
+        def fake_delegate(worktree_path, pr_number, logger_, dry_run=False,
+                          ceiling=None):
+            captured_monitor["ceiling"] = ceiling
+            return 0
+
+        monkeypatch.setattr(pipeline, "_delegate_to_pr_monitor", fake_delegate)
+
+        # Mock check_pr_created + workflow-state reads via read_state stub
+        monkeypatch.setattr(pipeline, "read_state", lambda _p: {})
+
+        # The pr_number is extracted from gh pr create stdout. Patch the
+        # extraction helper so we don't have to simulate gh output.
+        if hasattr(pipeline, "_create_pr_draft"):
+            monkeypatch.setattr(
+                pipeline, "_create_pr_draft",
+                lambda *a, **kw: ("42", "https://example/pr/42"),
+            )
+
+        try:
+            pipeline.run_pr_stage(
+                str(tmp_path), logger, dry_run=False, ceiling=555,
+            )
+        except Exception:
+            # Internal steps after the delegate stub (notify, state writes)
+            # may fail on mocked subprocesses. We only care that the ceiling
+            # reached run_claude and _delegate_to_pr_monitor before those
+            # later steps, which is checked below.
+            pass
+
+        logger.close()
+        with open(log_path) as f:
+            log_content = f.read()
+
+        # AC-27/28: START log records the effective ceiling
+        assert "ceiling=555s" in log_content, (
+            f"Expected START log to record ceiling=555s, got:\n{log_content}"
+        )
+        # AC-27: pr-summary run_claude received the override
+        assert captured_run_claude.get("stage") == "pr-summary", (
+            f"Expected run_claude stage='pr-summary', got "
+            f"{captured_run_claude.get('stage')!r}"
+        )
+        assert captured_run_claude.get("ceiling") == 555, (
+            f"Expected run_claude ceiling=555, got "
+            f"{captured_run_claude.get('ceiling')!r}"
+        )
+        # AC-27: _delegate_to_pr_monitor received the override
+        assert captured_monitor.get("ceiling") == 555, (
+            f"Expected _delegate_to_pr_monitor ceiling=555, got "
+            f"{captured_monitor.get('ceiling')!r}"
+        )
 
     def test_pr_monitor_falls_back_to_default_without_override(self, tmp_path):
         """AC-27 boundary: ceiling=None preserves the module default

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1683,19 +1683,23 @@ class TestMaxStageSecondsOverride:
         assert "ceiling=555s" in log_content, (
             f"Expected START log to record ceiling=555s, got:\n{log_content}"
         )
-        # AC-27: pr-summary run_claude received the override
+        # AC-27: pr-summary run_claude received the remaining stage budget.
+        # The value is the override (555) minus the elapsed stage time, so it
+        # should be <= 555 but positive on a fast test run.
         assert captured_run_claude.get("stage") == "pr-summary", (
             f"Expected run_claude stage='pr-summary', got "
             f"{captured_run_claude.get('stage')!r}"
         )
-        assert captured_run_claude.get("ceiling") == 555, (
-            f"Expected run_claude ceiling=555, got "
-            f"{captured_run_claude.get('ceiling')!r}"
+        summary_ceiling = captured_run_claude.get("ceiling")
+        assert isinstance(summary_ceiling, int) and 0 < summary_ceiling <= 555, (
+            f"Expected run_claude ceiling in (0, 555] (remaining budget of "
+            f"555s override), got {summary_ceiling!r}"
         )
-        # AC-27: _delegate_to_pr_monitor received the override
-        assert captured_monitor.get("ceiling") == 555, (
-            f"Expected _delegate_to_pr_monitor ceiling=555, got "
-            f"{captured_monitor.get('ceiling')!r}"
+        # AC-27: _delegate_to_pr_monitor received the remaining stage budget.
+        monitor_ceiling = captured_monitor.get("ceiling")
+        assert isinstance(monitor_ceiling, int) and 0 < monitor_ceiling <= 555, (
+            f"Expected _delegate_to_pr_monitor ceiling in (0, 555] (remaining "
+            f"budget of 555s override), got {monitor_ceiling!r}"
         )
 
     def test_pr_monitor_falls_back_to_default_without_override(self, tmp_path):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -199,13 +199,31 @@ class TestHeartbeat:
 # ---------------------------------------------------------------------------
 class TestTimeout:
     def test_stall_and_hard_ceiling_constants_exist(self):
-        """AC-57: Stall-based and hard ceiling timeout constants are defined."""
+        """AC-26: Stall-based and hard ceiling timeout constants are defined."""
         import pipeline
 
         assert hasattr(pipeline, "STALL_LIMIT")
         assert hasattr(pipeline, "HARD_CEILING")
         assert pipeline.STALL_LIMIT == 5
-        assert pipeline.HARD_CEILING == 3600
+        assert pipeline.HARD_CEILING == 7200
+
+    def test_hard_ceiling_default_is_7200(self):
+        """AC-26: HARD_CEILING default is 7200 seconds (120 min).
+
+        Negative check: the old 3600 value would undersize cross-cutting
+        architectural runs (shakedown-guard regression). Pin the new value
+        so a silent revert to 3600 fails the gate.
+        """
+        import pipeline
+
+        assert pipeline.HARD_CEILING == 7200, (
+            f"HARD_CEILING must be 7200 (120 min), got {pipeline.HARD_CEILING}. "
+            "If you need to lower this, update spec Tier 1 and the AC table first."
+        )
+        assert pipeline.HARD_CEILING != 3600, (
+            "HARD_CEILING reverted to the old 3600 default — see "
+            "specs/pipeline-observability.md AC-26."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1345,6 +1363,261 @@ class TestHardTimeout:
         mock_proc.terminate.assert_called_once()
         assert exit_code == -1
         logger.close()
+
+
+# ---------------------------------------------------------------------------
+# AC-27: --max-stage-seconds overrides HARD_CEILING for the run
+# AC-28: Effective ceiling is recorded on stage START
+# ---------------------------------------------------------------------------
+class TestMaxStageSecondsOverride:
+    def _run_claude_with_ceiling(self, tmp_path, stage_name, ceiling,
+                                  elapsed_offset):
+        """Helper: run run_claude with a mocked subprocess that never exits,
+        fake time jumping past ``elapsed_offset`` after start. Returns the
+        mock_proc and log content for assertions."""
+        import pipeline
+
+        wf_dir = tmp_path / ".workflow" / "stages"
+        wf_dir.mkdir(parents=True)
+        log_path = tmp_path / ".workflow" / "pipeline.log"
+        logger = pipeline.open_logger(str(log_path))
+
+        mock_proc = unittest.mock.MagicMock()
+        mock_proc.poll.return_value = None  # Never exits naturally
+        mock_proc.wait.return_value = -1
+        mock_proc.returncode = -1
+
+        call_count = [0]
+
+        def fake_time():
+            call_count[0] += 1
+            if call_count[0] <= 1:
+                return 1000.0
+            return 1000.0 + elapsed_offset
+
+        mock_run_result = unittest.mock.MagicMock(returncode=0, stdout="0\n", stderr="")
+
+        with unittest.mock.patch("subprocess.Popen", return_value=mock_proc):
+            with unittest.mock.patch("subprocess.run", return_value=mock_run_result):
+                with unittest.mock.patch("time.time", side_effect=fake_time):
+                    with unittest.mock.patch("time.sleep"):
+                        exit_code, _ = pipeline.run_claude(
+                            str(tmp_path), "test", logger, stage_name,
+                            ceiling=ceiling)
+
+        logger.close()
+        with open(log_path) as f:
+            content = f.read()
+        return mock_proc, content, exit_code
+
+    def test_max_stage_seconds_flag_overrides_ceiling(self, tmp_path):
+        """AC-27: ceiling=N shortens the effective kill threshold below the
+        module default. Elapsed of 100s exceeds ceiling=60 but is well below
+        HARD_CEILING (7200) — terminate must still fire, proving the override
+        replaced the default."""
+        mock_proc, content, exit_code = self._run_claude_with_ceiling(
+            tmp_path, "override-short", ceiling=60, elapsed_offset=100,
+        )
+        mock_proc.terminate.assert_called_once()
+        assert exit_code == -1
+        assert "HARD_TIMEOUT" in content
+        assert "ceiling=60s" in content, (
+            f"Expected 'ceiling=60s' in HARD_TIMEOUT log, got:\n{content}"
+        )
+
+    def test_ceiling_override_extends_beyond_default(self, tmp_path):
+        """AC-27: ceiling=N can also extend the ceiling past HARD_CEILING.
+        Elapsed of HARD_CEILING+1 would normally trip the kill with the
+        default, but with ceiling=HARD_CEILING+1000 the stage keeps running
+        (proc.terminate is not called for the ceiling reason)."""
+        import pipeline
+
+        override = pipeline.HARD_CEILING + 1000  # 8200 (> default 7200)
+        # elapsed falls between default and override → default would kill, override keeps running.
+        elapsed = pipeline.HARD_CEILING + 500  # 7700
+
+        wf_dir = tmp_path / ".workflow" / "stages"
+        wf_dir.mkdir(parents=True)
+        logger = pipeline.open_logger(str(tmp_path / ".workflow" / "pipeline.log"))
+
+        mock_proc = unittest.mock.MagicMock()
+        # Exit "naturally" on second poll so the loop terminates without
+        # hitting the ceiling branch.
+        poll_calls = [0]
+
+        def fake_poll():
+            poll_calls[0] += 1
+            if poll_calls[0] >= 2:
+                return 0  # clean exit
+            return None
+
+        mock_proc.poll.side_effect = fake_poll
+        mock_proc.returncode = 0
+
+        call_count = [0]
+
+        def fake_time():
+            call_count[0] += 1
+            if call_count[0] <= 1:
+                return 1000.0
+            return 1000.0 + elapsed
+
+        mock_run_result = unittest.mock.MagicMock(returncode=0, stdout="0\n", stderr="")
+
+        with unittest.mock.patch("subprocess.Popen", return_value=mock_proc):
+            with unittest.mock.patch("subprocess.run", return_value=mock_run_result):
+                with unittest.mock.patch("time.time", side_effect=fake_time):
+                    with unittest.mock.patch("time.sleep"):
+                        exit_code, _ = pipeline.run_claude(
+                            str(tmp_path), "test", logger, "override-long",
+                            ceiling=override,
+                        )
+
+        # With the override, the ceiling branch should NOT fire at elapsed=7700
+        # because 7700 < 8200. The stage exits cleanly via poll returning 0.
+        mock_proc.terminate.assert_not_called()
+        assert exit_code == 0
+        logger.close()
+
+    def test_run_claude_logs_effective_ceiling_on_start_default(self, tmp_path):
+        """AC-28: When no override is provided, START log records the module
+        default ceiling so operators can see which value is in effect."""
+        import pipeline
+
+        log_path = tmp_path / ".workflow" / "pipeline.log"
+        (tmp_path / ".workflow").mkdir()
+        logger = pipeline.open_logger(str(log_path))
+        pipeline.run_claude(
+            str(tmp_path), "test", logger, "start-default", dry_run=True,
+        )
+        logger.close()
+
+        with open(log_path) as f:
+            content = f.read()
+
+        assert "START" in content
+        assert f"ceiling={pipeline.HARD_CEILING}s" in content, (
+            f"Expected START entry to log ceiling={pipeline.HARD_CEILING}s, got:\n{content}"
+        )
+
+    def test_run_claude_logs_effective_ceiling_on_start_override(self, tmp_path):
+        """AC-28: When --max-stage-seconds (ceiling=N) is provided, START
+        log records N, not the default."""
+        import pipeline
+
+        log_path = tmp_path / ".workflow" / "pipeline.log"
+        (tmp_path / ".workflow").mkdir()
+        logger = pipeline.open_logger(str(log_path))
+        pipeline.run_claude(
+            str(tmp_path), "test", logger, "start-override",
+            dry_run=True, ceiling=1234,
+        )
+        logger.close()
+
+        with open(log_path) as f:
+            content = f.read()
+
+        assert "ceiling=1234s" in content, (
+            f"Expected START entry to log ceiling=1234s, got:\n{content}"
+        )
+        # Negative verification: the default must NOT leak into the log when
+        # an override is provided.
+        assert f"ceiling={pipeline.HARD_CEILING}s" not in content, (
+            "Default ceiling leaked into log when override was provided"
+        )
+
+    def test_pr_monitor_uses_effective_ceiling(self, tmp_path):
+        """AC-27: _delegate_to_pr_monitor passes the override to
+        subprocess.run's timeout kwarg (not the module default)."""
+        import pipeline
+
+        (tmp_path / ".workflow").mkdir()
+        logger = pipeline.open_logger(str(tmp_path / ".workflow" / "pipeline.log"))
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            result = unittest.mock.MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with unittest.mock.patch("subprocess.run", side_effect=fake_run):
+            pipeline._delegate_to_pr_monitor(
+                str(tmp_path), 42, logger, dry_run=False, ceiling=999,
+            )
+        logger.close()
+
+        assert captured["timeout"] == 999, (
+            f"Expected subprocess timeout=999 (override), got {captured['timeout']}"
+        )
+
+    def test_cli_exposes_max_stage_seconds_flag(self, capsys):
+        """AC-27: pipeline's argparse advertises the --max-stage-seconds flag.
+
+        This guards against accidental removal from the argparse block —
+        the behavioral tests above exercise ceiling= directly, so without
+        this gate the flag could silently disappear from the CLI surface
+        while all the plumbing tests still pass.
+        """
+        import pipeline
+
+        with unittest.mock.patch("sys.argv", ["pipeline.py", "--help"]):
+            with pytest.raises(SystemExit) as exc_info:
+                pipeline.main()
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "--max-stage-seconds" in out, (
+            f"--max-stage-seconds missing from --help output:\n{out}"
+        )
+
+    def test_cli_rejects_non_positive_max_stage_seconds(self, capsys):
+        """AC-27: --max-stage-seconds must be a positive integer; 0 and
+        negative values are rejected at parse time."""
+        import pipeline
+
+        for bad in ("0", "-1"):
+            argv = ["pipeline.py", "--spec", "x", "--branch", "y",
+                    "--max-stage-seconds", bad]
+            with unittest.mock.patch("sys.argv", argv):
+                with pytest.raises(SystemExit) as exc_info:
+                    pipeline.main()
+            assert exc_info.value.code != 0, (
+                f"Expected error for --max-stage-seconds {bad}, got exit 0"
+            )
+            err = capsys.readouterr().err.lower()
+            assert "max-stage-seconds" in err or "max_stage_seconds" in err, (
+                f"Error message for bad --max-stage-seconds={bad} should "
+                f"mention the flag, got:\n{err}"
+            )
+
+    def test_pr_monitor_falls_back_to_default_without_override(self, tmp_path):
+        """AC-27 boundary: ceiling=None preserves the module default
+        (backwards compat — no regression in existing behavior)."""
+        import pipeline
+
+        (tmp_path / ".workflow").mkdir()
+        logger = pipeline.open_logger(str(tmp_path / ".workflow" / "pipeline.log"))
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            result = unittest.mock.MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with unittest.mock.patch("subprocess.run", side_effect=fake_run):
+            pipeline._delegate_to_pr_monitor(
+                str(tmp_path), 42, logger, dry_run=False, ceiling=None,
+            )
+        logger.close()
+
+        assert captured["timeout"] == pipeline.HARD_CEILING
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Raises the pipeline's per-stage hard ceiling from 3600s (60 min) to 7200s (120 min). The old value was calibrated for single-domain features and undersized cross-cutting architectural runs — shakedown-guard's `implement` stage was killed at 3603s with 17 parallel agents legitimately still working.
- Adds `--max-stage-seconds N` to `scripts/pipeline.py` to override the default per-run (threaded through `run_claude`'s heartbeat loop, `run_pr_stage`'s internal timeout check, and `_delegate_to_pr_monitor`'s subprocess timeout).
- `run_claude` and `run_pr_stage` now record the effective ceiling on stage `START` so operators can see which value is in effect.

No change to the 5-minute stall detector — that's the right gate for stuck processes and works as designed.

## Test Plan
- [x] `pytest tests/test_pipeline.py` — 124 passed (1 pre-existing unrelated deselect)
- [x] New `TestMaxStageSecondsOverride` suite: 10 behavioral tests cover override-short, override-long, default/override START log, pr_monitor subprocess timeout, direct `run_pr_stage` ceiling threading, CLI `--help` surface, negative validation of 0/-1
- [x] Updated `test_hard_ceiling_default_is_7200` with explicit negative check against the old 3600 value (regression guard per Constitution I6)
- [x] `scripts/pipeline.py --help` advertises `--max-stage-seconds N`

## Verification
- [x] /gates passed (pytest: 240 passed across pipeline modules)
- [x] /review completed — 3 important findings, all addressed (see commit `772505a58`)
- [x] Pre-PR self-review — 2 concerns addressed in commit `93f2280b9` (stale `60 min` references in spec), 2 NITs left as-is (orphaned `run_triage` ceiling plumbing kept for symmetry; broad test exception-catch intentional)

## Scope boundary
Out of scope per the originating request:
- Scope-aware ceilings (phase count × per-phase budget) — adds coupling between plan format and pipeline
- Dropping the ceiling entirely — the safety-net argument in `specs/pipeline-observability.md` still holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)