### PR TITLE
fix(pr-monitor): push with explicit origin HEAD:<branch> refspec

### DIFF
--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-04-20T23:36:50Z",
+  "updated": "2026-04-21T05:42:33Z",
   "open_work": [
     {
       "session_id": "903eedac",
@@ -25,6 +25,17 @@
         "pipeline"
       ],
       "intent": "Raise HARD_CEILING to 7200s and add --max-stage-seconds override flag"
+    },
+    {
+      "session_id": "df895c3e",
+      "started": "2026-04-21T05:42:33Z",
+      "branch": "fix/pr-monitor-push-refspec",
+      "worktree": ".worktrees/pr-monitor-push-refspec",
+      "issues": [],
+      "areas": [
+        "pr-monitor"
+      ],
+      "intent": "fix pr-monitor git push missing explicit refspec \u2014 causes ready-flip skip when branch name differs from upstream"
     }
   ]
 }

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -542,11 +542,12 @@ def _rebase_source_branch(worktree, pr_number, logger):
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         logger.log("rebase", "BRANCH_DETECT_ERROR", reason=str(e))
         return False
-    if rev.returncode != 0 or not rev.stdout.strip():
-        logger.log("rebase", "BRANCH_DETECT_ERROR",
-                   stderr=rev.stderr.strip()[:200])
-        return False
     current = rev.stdout.strip()
+    if rev.returncode != 0 or not current or current == "HEAD":
+        reason = "Detached HEAD" if current == "HEAD" else "Empty output"
+        logger.log("rebase", "BRANCH_DETECT_ERROR",
+                   stderr=rev.stderr.strip()[:200] if rev.returncode != 0 else reason)
+        return False
 
     # 4. Push with lease using explicit origin + HEAD:<branch> refspec.
     try:

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -480,9 +480,11 @@ def _rebase_source_branch(worktree, pr_number, logger):
     Detects the base branch via ``gh pr view`` (Gemini review #3107696762)
     so PRs targeting non-main branches rebase correctly. Runs
     ``git fetch origin <base>`` -> ``git rebase origin/<base>`` ->
-    ``git push --force-with-lease``. On rebase conflict, aborts cleanly
-    and returns False (caller must NOT flip-to-ready). Returns True only
-    on clean rebase+push. SHAKEDOWN short-circuits True.
+    ``git push --force-with-lease origin HEAD:<branch>`` (explicit refspec
+    so push.default=simple accepts it when local name differs from upstream).
+    On rebase conflict, aborts cleanly and returns False (caller must NOT
+    flip-to-ready). Returns True only on clean rebase+push. SHAKEDOWN
+    short-circuits True.
     """
     if SHAKEDOWN:
         logger.log("rebase", "SHAKEDOWN_SKIPPED")
@@ -532,9 +534,26 @@ def _rebase_source_branch(worktree, pr_number, logger):
             logger.log("rebase", "ABORT_ERROR", reason=str(e))
         return False
 
-    # 3. Push with lease
+    # 3. Resolve the local branch name so we can push with an explicit
+    # refspec. Bare ``git push`` fails under push.default=simple when the
+    # local branch name differs from its upstream tracking ref.
     try:
-        push = _run(["git", "push", "--force-with-lease"], timeout=60)
+        rev = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], timeout=10)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.log("rebase", "BRANCH_DETECT_ERROR", reason=str(e))
+        return False
+    if rev.returncode != 0 or not rev.stdout.strip():
+        logger.log("rebase", "BRANCH_DETECT_ERROR",
+                   stderr=rev.stderr.strip()[:200])
+        return False
+    current = rev.stdout.strip()
+
+    # 4. Push with lease using explicit origin + HEAD:<branch> refspec.
+    try:
+        push = _run(
+            ["git", "push", "--force-with-lease", "origin", f"HEAD:{current}"],
+            timeout=60,
+        )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         logger.log("rebase", "PUSH_ERROR", reason=str(e))
         return False

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -1117,7 +1117,7 @@ class TestRebaseBeforeReady:
     """Meta-retro finding #6: rebase source branch before flipping ready."""
 
     def test_rebase_clean_path_calls_all_three_git_commands(self, tmp_path):
-        """Clean rebase: detect-base + fetch + rebase + push --force-with-lease all succeed."""
+        """Clean rebase: detect-base + fetch + rebase + rev-parse + push all succeed."""
         wt = _make_worktree(tmp_path)
         logger = _make_logger(tmp_path)
 
@@ -1130,6 +1130,9 @@ class TestRebaseBeforeReady:
             call_log.append(cmd)
             if cmd[:3] == ["gh", "pr", "view"]:
                 return ok_base
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feature-branch\n", stderr="")
             return ok
 
         with patch("pr_monitor.subprocess.run", side_effect=fake_run):
@@ -1138,11 +1141,15 @@ class TestRebaseBeforeReady:
         assert result is True
         # First call: gh pr view to detect base
         assert call_log[0][:3] == ["gh", "pr", "view"]
-        # Then fetch + rebase + push (with -- separators on git fetch/rebase)
+        # Then fetch + rebase + rev-parse + push with explicit refspec
         assert call_log[1] == ["git", "fetch", "origin", "--", "main"]
         assert call_log[2] == ["git", "rebase", "--", "origin/main"]
-        assert call_log[3] == ["git", "push", "--force-with-lease"]
-        assert len(call_log) == 4  # no abort path
+        assert call_log[3] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        assert call_log[4] == [
+            "git", "push", "--force-with-lease",
+            "origin", "HEAD:feature-branch",
+        ]
+        assert len(call_log) == 5  # no abort path
 
     def test_rebase_conflict_aborts_and_returns_false(self, tmp_path):
         """On rebase conflict: git rebase --abort is called; no push; returns False."""
@@ -1215,6 +1222,9 @@ class TestRebaseBeforeReady:
             if cmd[:3] == ["gh", "pr", "view"]:
                 return subprocess.CompletedProcess(
                     args=cmd, returncode=0, stdout="develop\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="feature-x\n", stderr="")
             return subprocess.CompletedProcess(
                 args=cmd, returncode=0, stdout="", stderr="")
 
@@ -1279,3 +1289,103 @@ class TestDetectBaseBranch:
 
         with patch("pr_monitor.subprocess.run", side_effect=fake_run):
             assert pr_monitor._detect_base_branch(wt, 856, logger) == "main"
+
+
+class TestRebasePushRefspec:
+    """Regression: git push must use explicit origin + HEAD:<branch> refspec.
+
+    Modern git's ``push.default=simple`` refuses a bare ``git push`` when the
+    local branch name differs from its upstream tracking ref, logging
+    ``rebase: PUSH_ERROR`` and leaving the PR in draft. Fix: detect the local
+    branch via ``git rev-parse --abbrev-ref HEAD`` and push with an explicit
+    refspec that is unambiguous regardless of upstream config.
+    """
+
+    def test_push_uses_explicit_origin_and_head_refspec(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0,
+                    stdout="fix/pr-monitor-push-refspec\n", stderr="")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is True
+        push_calls = [c for c in call_log if c[:2] == ["git", "push"]]
+        assert len(push_calls) == 1
+        # Exact argv shape — no bare ``git push``.
+        assert push_calls[0] == [
+            "git", "push", "--force-with-lease",
+            "origin", "HEAD:fix/pr-monitor-push-refspec",
+        ]
+        # rev-parse must have run before push.
+        rev_parse_idx = next(
+            i for i, c in enumerate(call_log)
+            if c[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        push_idx = next(
+            i for i, c in enumerate(call_log) if c[:2] == ["git", "push"])
+        assert rev_parse_idx < push_idx
+
+    def test_rev_parse_failure_returns_false_and_does_not_push(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=128, stdout="",
+                    stderr="fatal: not a git repository")
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        log_path = str(tmp_path / "test.log")
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is False
+        # Must NOT have attempted any git push.
+        assert not any(c[:2] == ["git", "push"] for c in call_log)
+        # Must have logged a structured BRANCH_DETECT_ERROR event.
+        with open(log_path, encoding="utf-8") as f:
+            log_contents = f.read()
+        assert "BRANCH_DETECT_ERROR" in log_contents
+
+    def test_rev_parse_subprocess_exception_returns_false(self, tmp_path):
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        call_log = []
+
+        def fake_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0, stdout="main\n", stderr="")
+            if cmd[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr="")
+
+        log_path = str(tmp_path / "test.log")
+        with patch("pr_monitor.subprocess.run", side_effect=fake_run):
+            result = pr_monitor._rebase_source_branch(wt, 42, logger)
+
+        assert result is False
+        assert not any(c[:2] == ["git", "push"] for c in call_log)
+        with open(log_path, encoding="utf-8") as f:
+            assert "BRANCH_DETECT_ERROR" in f.read()


### PR DESCRIPTION
## Summary

- Bare `git push --force-with-lease` in `_rebase_source_branch` fails under `push.default=simple` when the local branch name differs from its upstream tracking ref — `PUSH_ERROR` logged, ready-flip skipped, PR left in draft for manual intervention.
- Fix: resolve the local branch via `git rev-parse --abbrev-ref HEAD`, push with explicit `origin HEAD:<branch>` refspec so the destination is unambiguous regardless of upstream-tracking config.
- Resolution failure logs a new structured `BRANCH_DETECT_ERROR` event and returns False — does **not** silently fall back to a hardcoded branch name.

Live evidence from PR #863's pr-monitor log:

```
[22:20:32] rebase: BASE branch=main
[22:20:32] rebase: PUSH_ERROR stderr=fatal: The upstream branch of your current branch does not match
                                        the name of your current branch.
                                        To push to the upstream branch on the remote, use
                                            git push origin HEAD:main
[22:20:32] ready: SKIPPED_REBASE_FAILED
```

## Test Plan

- [x] New `TestRebasePushRefspec` class — 3 regression tests:
  - Happy path asserts exact argv `["git", "push", "--force-with-lease", "origin", "HEAD:<branch>"]` and that `rev-parse` runs before push
  - `rev-parse` non-zero returncode → returns False, no push, `BRANCH_DETECT_ERROR` logged
  - `rev-parse` subprocess exception (`TimeoutExpired`) → returns False, no push, `BRANCH_DETECT_ERROR` logged
- [x] Existing `TestRebaseBeforeReady` tests updated to mock the new `rev-parse` call and assert the new push argv shape
- [x] All 58 tests in `tests/test_pr_monitor.py` pass
- [x] Full Python suite: 3 pre-existing failures on main (confirmed unrelated via `git stash` baseline)

## Verification

- [x] /gates passed
- [x] /verify completed (surface: workflow)
- [x] /review completed (findings: 3 suggestions, 0 critical/important — stale docstring addressed inline; detached-HEAD edge case and empty-stdout test gap are scope-creep for this surgical fix)

## Follow-up (not in this PR)

- Detached-HEAD edge case: if `rev-parse --abbrev-ref HEAD` returns the literal string `HEAD` (detached state), the guard doesn't catch it — unlikely to be reached after a successful rebase, but a defensive check would be cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)