### PR TITLE
fix: v1 shakedown final — FetchXML, auth, S2, exit codes

### DIFF
--- a/docs/qa/shakedown-v1-2026-04-20.md
+++ b/docs/qa/shakedown-v1-2026-04-20.md
@@ -466,6 +466,8 @@ downstream `get`/`url` can find the record.
 
 ### M2 — `ppds logs tail` and `ppds logs dump` don't exist
 
+**Status: FIXED** — `LogsCommandGroup` registered in `Program.cs`; `LogsTailCommand` and `LogsDumpCommand` fully implemented with unit tests.
+
 **Surface:** CLI
 **Evidence:** Both commands are listed in the test matrix but produce
 `"logs" was not matched` when invoked. No `logs` command group is registered
@@ -822,7 +824,7 @@ Areas).
 | 23 | Users / roles | ✅ | — | — | — |
 | 24 | Data schema / analyze | ✅ (L16) | ? | ✅ | — |
 | 25 | Deployment settings | ? | — | — | — |
-| 26 | Logs | ✗ (M2) | ✅ | — | ✅ |
+| 26 | Logs | ✅ | ✅ | — | ✅ |
 | 27 | Notebooks | — | — | — | ✅ (deep) |
 | 28 | Serve / daemon | ✗ (M5) | — | — | ✗ (M9) |
 
@@ -990,8 +992,7 @@ Three items originally slated for Track 3 were also pulled into this PR:
 - **H7** (MCP opaque errors) — commit `6c07ca353` *(originally Track 3)*
 - **M6** (DataQueryService extraction — A1 violation) — commit `35a26b8b3` *(originally Track 3)*
 
-Remaining from the original Track 1 list: **M2** (`logs` command missing —
-decision: implement or strike) is not yet addressed.
+All original Track 1 items are now addressed (M2 resolved — logs commands implemented).
 
 ### Track 2 — `feat/shakedown-guard` (already launched)
 
@@ -1016,7 +1017,6 @@ Remaining Track 3 items (not yet addressed):
 - L7 (FetchXML mode toggle — TUI UX)
 - L12 (auth prompt optimization — needs its own design pass)
 - L16 (docs drift — flag-name discrepancies)
-- M2 (logs command missing — decision: implement or strike)
 - M7 (sovereign cloud Maker URLs — larger refactor)
 
 None of the remaining Track 3 items is release-blocking, but several materially

--- a/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
+++ b/src/PPDS.Auth/Credentials/InteractiveBrowserCredentialProvider.cs
@@ -294,8 +294,7 @@ public sealed class InteractiveBrowserCredentialProvider : ICredentialProvider
             // is issued for the correct tenant while the MSAL app stays on "organizations".
             var interactiveBuilder = _msalClient!
                 .AcquireTokenInteractive(scopes)
-                .WithUseEmbeddedWebView(false) // Use system browser
-                .WithPrompt(Microsoft.Identity.Client.Prompt.SelectAccount); // Always show account picker
+                .WithUseEmbeddedWebView(false); // Use system browser
             if (!string.IsNullOrWhiteSpace(_tenantId))
                 interactiveBuilder = interactiveBuilder.WithTenantId(_tenantId);
             _cachedResult = await interactiveBuilder

--- a/src/PPDS.Cli/Commands/Plugins/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/GetCommand.cs
@@ -49,8 +49,17 @@ public static class GetCommand
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {
-            var type = parseResult.GetValue(typeArgument)!;
-            var nameOrId = parseResult.GetValue(nameOrIdArgument)!;
+            var type = parseResult.GetValue(typeArgument);
+            var nameOrId = parseResult.GetValue(nameOrIdArgument);
+
+            if (string.IsNullOrEmpty(type) || string.IsNullOrEmpty(nameOrId))
+            {
+                Console.Error.WriteLine("Error: Both 'type' and 'name-or-id' arguments are required.");
+                Console.Error.WriteLine($"Usage: ppds plugins get <type> <name-or-id>");
+                Console.Error.WriteLine($"Valid types: {string.Join(", ", ValidTypes)}");
+                return ExitCodes.InvalidArguments;
+            }
+
             var profile = parseResult.GetValue(PluginsCommandGroup.ProfileOption);
             var environment = parseResult.GetValue(PluginsCommandGroup.EnvironmentOption);
             var globalOptions = GlobalOptions.GetValues(parseResult);

--- a/src/PPDS.Cli/Infrastructure/DefaultBrowserLauncher.cs
+++ b/src/PPDS.Cli/Infrastructure/DefaultBrowserLauncher.cs
@@ -18,6 +18,7 @@ public sealed class DefaultBrowserLauncher : IBrowserLauncher
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                // S2: UseShellExecute required to open URL in the user's default browser on Windows.
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/PPDS.Cli/Tui/Dialogs/ErrorDetailsDialog.cs
+++ b/src/PPDS.Cli/Tui/Dialogs/ErrorDetailsDialog.cs
@@ -236,7 +236,7 @@ internal sealed class ErrorDetailsDialog : TuiDialog, ITuiStateCapture<ErrorDeta
 
         try
         {
-            // Use shell execute to open with default text editor
+            // S2: UseShellExecute required to open log file in the user's default text editor.
             Process.Start(new ProcessStartInfo
             {
                 FileName = logPath,

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Services.Query;
 using PPDS.Cli.Tui.Infrastructure;
@@ -29,6 +30,7 @@ internal sealed class SqlQueryPresenter : IDisposable
     private QueryPlanDescription? _lastExecutionPlan;
     private long _lastExecutionTimeMs;
     private bool _useTdsEndpoint;
+    private bool _useFetchXmlMode;
     private bool _confirmedDml;
 
     // Read-only properties
@@ -40,6 +42,7 @@ internal sealed class SqlQueryPresenter : IDisposable
     public QueryPlanDescription? LastExecutionPlan => _lastExecutionPlan;
     public long LastExecutionTimeMs => _lastExecutionTimeMs;
     public bool UseTdsEndpoint => _useTdsEndpoint;
+    public bool UseFetchXmlMode => _useFetchXmlMode;
 
     // Events -- screen subscribes and wraps with Application.MainLoop.Invoke()
 
@@ -105,6 +108,14 @@ internal sealed class SqlQueryPresenter : IDisposable
         StatusChanged?.Invoke(_useTdsEndpoint
             ? "Mode: TDS Read Replica (read-only, slight delay)"
             : "Mode: Dataverse (real-time)");
+    }
+
+    public void ToggleFetchXml()
+    {
+        _useFetchXmlMode = !_useFetchXmlMode;
+        StatusChanged?.Invoke(_useFetchXmlMode
+            ? "Input: FetchXML (paste raw FetchXML)"
+            : "Input: SQL");
     }
 
     public void ConfirmDml()
@@ -248,6 +259,76 @@ internal sealed class SqlQueryPresenter : IDisposable
         {
             _isExecuting = false;
             DmlConfirmationRequired?.Invoke(dmlEx);
+        }
+        catch (Exception ex)
+        {
+            _lastErrorMessage = ex.Message;
+            _isExecuting = false;
+            ErrorOccurred?.Invoke(ex.Message);
+        }
+    }
+
+    public async Task ExecuteFetchXmlAsync(string fetchXml, CancellationToken screenCancellation)
+    {
+        if (string.IsNullOrWhiteSpace(fetchXml))
+        {
+            ErrorOccurred?.Invoke("FetchXML cannot be empty.");
+            return;
+        }
+
+        _queryCts?.Cancel();
+        _queryCts?.Dispose();
+        _queryCts = CancellationTokenSource.CreateLinkedTokenSource(screenCancellation);
+        var queryCt = _queryCts.Token;
+
+        _isExecuting = true;
+        _lastErrorMessage = null;
+        StatusChanged?.Invoke("Executing FetchXML...");
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        try
+        {
+            var provider = await _session.GetServiceProviderAsync(_environmentUrl, queryCt);
+            var executor = provider.GetRequiredService<IQueryExecutor>();
+
+            var result = await executor.ExecuteFetchXmlAsync(fetchXml, cancellationToken: queryCt);
+
+            stopwatch.Stop();
+            var elapsedMs = stopwatch.ElapsedMilliseconds;
+
+            _lastSql = fetchXml;
+            _lastPageNumber = result.PageNumber;
+            _lastPagingCookie = result.PagingCookie;
+            _lastExecutionTimeMs = elapsedMs;
+            _isExecuting = false;
+
+            if (result.Columns.Count > 0)
+                StreamingColumnsReady?.Invoke(result.Columns, result.EntityLogicalName);
+
+            if (result.Records.Count > 0 && result.Columns.Count > 0)
+                StreamingRowsReady?.Invoke(result.Records, result.Columns, true, result.Count);
+
+            var statusText = $"Returned {result.Count:N0} rows in {elapsedMs}ms via FetchXML";
+            ExecutionComplete?.Invoke(statusText, elapsedMs, null);
+
+            _session.GetErrorService().FireAndForget(
+                SaveToHistoryAsync(fetchXml, result.Count, elapsedMs),
+                "SaveHistory");
+        }
+        catch (DataverseAuthenticationException authEx) when (authEx.RequiresReauthentication)
+        {
+            _isExecuting = false;
+            AuthenticationRequired?.Invoke(authEx);
+        }
+        catch (OperationCanceledException) when (_queryCts?.IsCancellationRequested == true && !screenCancellation.IsCancellationRequested)
+        {
+            _isExecuting = false;
+            QueryCancelled?.Invoke();
+        }
+        catch (OperationCanceledException) when (screenCancellation.IsCancellationRequested)
+        {
+            _isExecuting = false;
         }
         catch (Exception ex)
         {

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
@@ -347,22 +347,41 @@ internal sealed class SqlQueryPresenter : IDisposable
 
         try
         {
-            var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, cancellationToken);
-
-            var request = new SqlQueryRequest
+            if (_useFetchXmlMode)
             {
-                Sql = _lastSql,
-                PageNumber = _lastPageNumber + 1,
-                PagingCookie = _lastPagingCookie,
-                EnablePrefetch = true
-            };
+                var provider = await _session.GetServiceProviderAsync(_environmentUrl, cancellationToken);
+                var executor = provider.GetRequiredService<IQueryExecutor>();
 
-            var result = await service.ExecuteAsync(request, cancellationToken);
+                var result = await executor.ExecuteFetchXmlAsync(
+                    _lastSql,
+                    _lastPageNumber + 1,
+                    _lastPagingCookie,
+                    cancellationToken: cancellationToken);
 
-            _lastPagingCookie = result.Result.PagingCookie;
-            _lastPageNumber = result.Result.PageNumber;
+                _lastPagingCookie = result.PagingCookie;
+                _lastPageNumber = result.PageNumber;
 
-            PageLoaded?.Invoke(result.Result);
+                PageLoaded?.Invoke(result);
+            }
+            else
+            {
+                var service = await _session.GetSqlQueryServiceAsync(_environmentUrl, cancellationToken);
+
+                var request = new SqlQueryRequest
+                {
+                    Sql = _lastSql,
+                    PageNumber = _lastPageNumber + 1,
+                    PagingCookie = _lastPagingCookie,
+                    EnablePrefetch = true
+                };
+
+                var result = await service.ExecuteAsync(request, cancellationToken);
+
+                _lastPagingCookie = result.Result.PagingCookie;
+                _lastPageNumber = result.Result.PageNumber;
+
+                PageLoaded?.Invoke(result.Result);
+            }
         }
         catch (DataverseAuthenticationException authEx) when (authEx.RequiresReauthentication)
         {

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryPresenter.cs
@@ -16,6 +16,7 @@ namespace PPDS.Cli.Tui.Screens;
 internal sealed class SqlQueryPresenter : IDisposable
 {
     private const int StreamingChunkSize = 100;
+    private const string UnknownEntityName = "unknown";
 
     private readonly InteractiveSession _session;
     private readonly string _environmentUrl;
@@ -31,6 +32,7 @@ internal sealed class SqlQueryPresenter : IDisposable
     private long _lastExecutionTimeMs;
     private bool _useTdsEndpoint;
     private bool _useFetchXmlMode;
+    private bool _lastExecutionUsedFetchXml;
     private bool _confirmedDml;
 
     // Read-only properties
@@ -191,7 +193,7 @@ internal sealed class SqlQueryPresenter : IDisposable
                 if (isFirstChunk && chunk.Columns != null)
                 {
                     columns = chunk.Columns;
-                    StreamingColumnsReady?.Invoke(columns, chunk.EntityLogicalName ?? "unknown");
+                    StreamingColumnsReady?.Invoke(columns, chunk.EntityLogicalName ?? UnknownEntityName);
                 }
 
                 totalRows = chunk.TotalRowsSoFar;
@@ -223,6 +225,7 @@ internal sealed class SqlQueryPresenter : IDisposable
             _lastPageNumber = 1;
             _lastPagingCookie = null;
             _lastExecutionTimeMs = elapsedMs;
+            _lastExecutionUsedFetchXml = false;
             _isExecuting = false;
 
             var modeText = executionMode == QueryExecutionMode.Tds ? " via TDS" : " via Dataverse";
@@ -301,10 +304,12 @@ internal sealed class SqlQueryPresenter : IDisposable
             _lastPageNumber = result.PageNumber;
             _lastPagingCookie = result.PagingCookie;
             _lastExecutionTimeMs = elapsedMs;
+            _lastExecutionPlan = null;
+            _lastExecutionUsedFetchXml = true;
             _isExecuting = false;
 
             if (result.Columns.Count > 0)
-                StreamingColumnsReady?.Invoke(result.Columns, result.EntityLogicalName);
+                StreamingColumnsReady?.Invoke(result.Columns, result.EntityLogicalName ?? UnknownEntityName);
 
             if (result.Records.Count > 0 && result.Columns.Count > 0)
                 StreamingRowsReady?.Invoke(result.Records, result.Columns, true, result.Count);
@@ -347,7 +352,7 @@ internal sealed class SqlQueryPresenter : IDisposable
 
         try
         {
-            if (_useFetchXmlMode)
+            if (_lastExecutionUsedFetchXml)
             {
                 var provider = await _session.GetServiceProviderAsync(_environmentUrl, cancellationToken);
                 var executor = provider.GetRequiredService<IQueryExecutor>();

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -443,9 +443,11 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
                     TuiDebugLog.Log("User confirmed DML operation, retrying with IsConfirmed=true");
                     _statusLabel.Visible = false;
                     _presenter.ConfirmDml();
-                    ErrorService.FireAndForget(
-                        _presenter.ExecuteAsync(_queryInput.Text.ToString() ?? string.Empty, ScreenCancellation),
-                        "RetryDmlConfirmed");
+                    var queryText = _queryInput.Text.ToString() ?? string.Empty;
+                    var task = _presenter.UseFetchXmlMode
+                        ? _presenter.ExecuteFetchXmlAsync(queryText, ScreenCancellation)
+                        : _presenter.ExecuteAsync(queryText, ScreenCancellation);
+                    ErrorService.FireAndForget(task, "RetryDmlConfirmed");
                 }
                 else
                 {

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -293,14 +293,8 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
 
         // Visual focus indicators - only change title, not colors
         // The table's built-in selection highlighting is sufficient
-        _queryFrame.Enter += (_) =>
-        {
-            _queryFrame.Title = "\u25b6 Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
-        };
-        _queryFrame.Leave += (_) =>
-        {
-            _queryFrame.Title = "Query (F5 to execute, Ctrl+Space for suggestions, Alt+\u2191\u2193 to resize, F6 to toggle focus)";
-        };
+        _queryFrame.Enter += (_) => UpdateQueryFrameTitle(focused: true);
+        _queryFrame.Leave += (_) => UpdateQueryFrameTitle(focused: false);
         _resultsTable.Enter += (_) =>
         {
             _resultsTable.Title = "\u25b6 Results";
@@ -756,11 +750,18 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     private void ToggleFetchXmlMode()
     {
         _presenter.ToggleFetchXml();
-        _queryFrame.Title = _presenter.UseFetchXmlMode
-            ? "FetchXML (F5 to execute, F11 to switch to SQL)"
-            : "Query (F5 to execute, Ctrl+Space for suggestions, Alt+↑↓ to resize, F6 to toggle focus)";
+        UpdateQueryFrameTitle(focused: _queryFrame.HasFocus);
         _statusLabel.SetNeedsDisplay();
         NotifyMenuChanged();
+    }
+
+    private void UpdateQueryFrameTitle(bool focused)
+    {
+        var prefix = focused ? "▶ " : string.Empty;
+        var body = _presenter.UseFetchXmlMode
+            ? "FetchXML (F5 to execute, F11 to switch to SQL)"
+            : "Query (F5 to execute, Ctrl+Space for suggestions, Alt+↑↓ to resize, F6 to toggle focus)";
+        _queryFrame.Title = prefix + body;
     }
 
     private void ShowFilter()

--- a/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/SqlQueryScreen.cs
@@ -67,9 +67,16 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     private string _statusText = "Ready";
 
     /// <inheritdoc />
-    public override string Title => EnvironmentUrl != null
-        ? $"SQL Query - {EnvironmentDisplayName ?? EnvironmentUrl}"
-        : "SQL Query";
+    public override string Title
+    {
+        get
+        {
+            var mode = _presenter.UseFetchXmlMode ? "FetchXML" : "SQL Query";
+            return EnvironmentUrl != null
+                ? $"{mode} - {EnvironmentDisplayName ?? EnvironmentUrl}"
+                : mode;
+        }
+    }
 
     // Note: Keep underscore on MenuBarItem (_Query) for Alt+Q to open menu.
     // Remove underscores from MenuItems - they create global Alt+letter hotkeys in Terminal.Gui.
@@ -85,6 +92,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
             new("", "", () => {}, null, null, Key.Null), // Separator
             new("Filter Results", "/", ShowFilter),
             new("", "", () => {}, null, null, Key.Null), // Separator
+            new(_presenter.UseFetchXmlMode ? "\u2713 FetchXML Input" : "  FetchXML Input", "F11", ToggleFetchXmlMode),
             new(_presenter.UseTdsEndpoint ? "\u2713 TDS Read Replica" : "  TDS Read Replica", "F10", ToggleTdsEndpoint),
         })
     };
@@ -527,6 +535,7 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         // F10 instead of Ctrl+Shift+T: terminals cannot distinguish Ctrl+T from Ctrl+Shift+T
         // (they send the same keycode), so the global Ctrl+T (new tab) always wins. See #580.
         RegisterHotkey(registry, Key.F10, "Toggle TDS Endpoint", ToggleTdsEndpoint);
+        RegisterHotkey(registry, Key.F11, "Toggle FetchXML Input", ToggleFetchXmlMode);
         // F-key alternatives for Linux compatibility (Ctrl+Shift combos don't work on Linux terminals)
         RegisterHotkey(registry, Key.F7, "Show execution plan", ShowExecutionPlanDialog);
         RegisterHotkey(registry, Key.F8, "Query history", ShowHistoryDialog);
@@ -708,9 +717,10 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
         _presenter.AuthenticationRequired += OnAuth;
         _presenter.DmlConfirmationRequired += OnDml;
 
-        ErrorService.FireAndForget(
-            _presenter.ExecuteAsync(sql, ScreenCancellation),
-            "ExecuteQuery");
+        var task = _presenter.UseFetchXmlMode
+            ? _presenter.ExecuteFetchXmlAsync(sql, ScreenCancellation)
+            : _presenter.ExecuteAsync(sql, ScreenCancellation);
+        ErrorService.FireAndForget(task, "ExecuteQuery");
     }
 
     /// <summary>
@@ -737,6 +747,16 @@ internal sealed class SqlQueryScreen : TuiScreenBase, ITuiStateCapture<SqlQueryS
     private void ToggleTdsEndpoint()
     {
         _presenter.ToggleTds();
+        _statusLabel.SetNeedsDisplay();
+        NotifyMenuChanged();
+    }
+
+    private void ToggleFetchXmlMode()
+    {
+        _presenter.ToggleFetchXml();
+        _queryFrame.Title = _presenter.UseFetchXmlMode
+            ? "FetchXML (F5 to execute, F11 to switch to SQL)"
+            : "Query (F5 to execute, Ctrl+Space for suggestions, Alt+↑↓ to resize, F6 to toggle focus)";
         _statusLabel.SetNeedsDisplay();
         NotifyMenuChanged();
     }

--- a/src/PPDS.Cli/Tui/TuiShell.cs
+++ b/src/PPDS.Cli/Tui/TuiShell.cs
@@ -126,6 +126,8 @@ internal sealed class TuiShell : Window, ITuiStateCapture<TuiShellState>
 
     private void OnScreenMenuStateChanged()
     {
+        if (_currentScreen != null)
+            _contentArea.Title = _currentScreen.Title;
         RebuildMenuBar();
     }
 


### PR DESCRIPTION
## Summary
- **#878** Mark M2 logs commands as FIXED in shakedown doc (already implemented)
- **#876** Remove forced `Prompt.SelectAccount` on interactive auth — lets MSAL use cached accounts silently
- **#875** Add FetchXML mode toggle (F11) to SQL Query screen with full execute/paginate support via `IQueryExecutor`
- **#874** Add Constitution S2 justification comments for `UseShellExecute` in `DefaultBrowserLauncher` and `ErrorDetailsDialog`
- **#873** Return non-zero exit code when `ppds plugins get` is called with missing arguments

Plus two follow-up fixes found during QA and code review:
- Refresh content area title when toggling FetchXML mode (tab title now updates)
- Route FetchXML mode correctly in `LoadMoreAsync` pagination and DML retry handler

## Test plan
- [x] `dotnet build PPDS.sln` — 0 errors
- [x] `dotnet test --filter "Category!=Integration"` — 3301 tests pass (net9.0 + net10.0)
- [x] `dotnet test` Dataverse — 1000 tests pass (net8.0 + net9.0 + net10.0)
- [x] TUI interactive verification via tui-verify (FetchXML toggle, title updates)
- [x] QA three-agent blind verification (Functional + UX)
- [x] Code review with review findings fixed

Closes #878, closes #876, closes #875, closes #874, closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)