### PR TITLE
fix(ci): use -p: instead of /p: for MSBuild props in bash

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -113,8 +113,8 @@ jobs:
             # Key path comes from RUNNER_TEMP (set by the decode step) so the
             # private key never enters the workspace tree.
             dotnet pack "$project" --configuration Release --output ./nupkgs \
-              /p:PublicSign=false \
-              /p:AssemblyOriginatorKeyFile="$PLUGINS_SNK_PATH"
+              -p:PublicSign=false \
+              -p:AssemblyOriginatorKeyFile="$PLUGINS_SNK_PATH"
           else
             dotnet pack "$project" --configuration Release --no-build --output ./nupkgs
           fi


### PR DESCRIPTION
## Summary
- MSYS2/Git Bash on Windows runners converts `/p:` to a Unix path, breaking `dotnet pack` for Plugins signing
- Changed `/p:PublicSign=false` and `/p:AssemblyOriginatorKeyFile=` to `-p:` syntax in `publish-nuget.yml`
- Unblocks Plugins-v3.0.0 NuGet publish (failed with MSB1008 during v1.0.0 release)

## Test plan
- [ ] Re-push Plugins-v3.0.0 tag after merge to verify `dotnet pack` succeeds with real SNK

🤖 Generated with [Claude Code](https://claude.com/claude-code)