### PR TITLE
fix(extension): bump engines.vscode to ^1.116.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ppds data export --schema schema.xml --output data.zip
 | Component | Type | Install | Requirement |
 |-----------|------|---------|-------------|
 | **ppds** | CLI + TUI | `dotnet tool install -g PPDS.Cli` | .NET 8.0+ (Windows / macOS / Linux) |
-| **VS Code Extension** | IDE Extension | [Marketplace](https://marketplace.visualstudio.com/items?itemName=JoshSmithXRM.power-platform-developer-suite) | VS Code 1.109+ |
+| **VS Code Extension** | IDE Extension | [Marketplace](https://marketplace.visualstudio.com/items?itemName=JoshSmithXRM.power-platform-developer-suite) | VS Code 1.116+ |
 | **ppds-mcp-server** | MCP Server | `dotnet tool install -g PPDS.Mcp` | .NET 8.0+ |
 
 ### NuGet Libraries

--- a/docs/whats-new-v1.md
+++ b/docs/whats-new-v1.md
@@ -144,7 +144,7 @@ dotnet add package PPDS.Plugins
 
 - **.NET runtime** — .NET 8.0 or later (CLI, MCP, libraries). Plugins: .NET Framework 4.6.2 (Dataverse sandbox requirement).
 - **OS** — Windows, macOS, Linux.
-- **VS Code** — 1.109 or later.
+- **VS Code** — 1.116 or later.
 - **Node.js** — 20 or later (contributors only).
 
 ---

--- a/src/PPDS.Extension/package-lock.json
+++ b/src/PPDS.Extension/package-lock.json
@@ -30,7 +30,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.116.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -11,7 +11,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "AI",


### PR DESCRIPTION
## Summary
- Dependabot PR #852 bumped `@types/vscode` to `^1.116.0` but `engines.vscode` stayed at `^1.109.0`
- `vsce package` rejects this mismatch — blocks Extension v1.0.0 marketplace publish
- Bumps `engines.vscode` to `^1.116.0` in package.json and package-lock.json
- Updates VS Code version references in README and docs/whats-new-v1.md

## Test plan
- [ ] CI passes (build, typecheck, extension tests)
- [ ] After merge + retag: `gh workflow run extension-publish.yml --ref Extension-v1.0.0 -f dry_run=false -f channel=stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)