### PR TITLE
fix(metadata): surface publish requirement on Update*Async (#1009)

### DIFF
--- a/src/PPDS.Cli/Commands/Metadata/Choice/ChoiceCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Choice/ChoiceCommandGroup.cs
@@ -308,15 +308,27 @@ public static class ChoiceCommandGroup
 
             await authoringService.UpdateGlobalChoiceAsync(request, ct: cancellationToken);
 
+            // Global choices aren't entity-bound; suggest publish --all.
+            const string publishHint = "ppds publish --all";
+
             if (globalOptions.IsJsonMode)
             {
-                writer.WriteSuccess(new { name, updated = true, dryRun });
+                writer.WriteSuccess(new
+                {
+                    name,
+                    updated = true,
+                    dryRun,
+                    requiresPublish = !dryRun,
+                    publishHint = dryRun ? null : publishHint
+                });
+            }
+            else if (dryRun)
+            {
+                Console.Error.WriteLine("[Dry-Run] Validation passed. No changes persisted.");
             }
             else
             {
-                Console.Error.WriteLine(dryRun
-                    ? "[Dry-Run] Validation passed. No changes persisted."
-                    : $"Global choice '{name}' updated successfully.");
+                Console.Error.WriteLine($"Global choice '{name}' updated. Run '{publishHint}' to publish changes.");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/Column/ColumnCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Column/ColumnCommandGroup.cs
@@ -464,15 +464,27 @@ public static class ColumnCommandGroup
 
             await authoringService.UpdateColumnAsync(request, ct: cancellationToken);
 
+            var publishHint = $"ppds metadata publish {entity}";
+
             if (globalOptions.IsJsonMode)
             {
-                writer.WriteSuccess(new { entity, column, updated = true, dryRun });
+                writer.WriteSuccess(new
+                {
+                    entity,
+                    column,
+                    updated = true,
+                    dryRun,
+                    requiresPublish = !dryRun,
+                    publishHint = dryRun ? null : publishHint
+                });
+            }
+            else if (dryRun)
+            {
+                Console.Error.WriteLine("[Dry-Run] Validation passed. No changes persisted.");
             }
             else
             {
-                Console.Error.WriteLine(dryRun
-                    ? "[Dry-Run] Validation passed. No changes persisted."
-                    : $"Column '{column}' on '{entity}' updated successfully.");
+                Console.Error.WriteLine($"Column '{column}' on '{entity}' updated. Run '{publishHint}' to publish changes.");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
@@ -421,15 +421,27 @@ public static class RelationshipCommandGroup
 
             await authoringService.UpdateRelationshipAsync(request, ct: cancellationToken);
 
+            // Relationships span two entities; the request DTO doesn't carry them, so suggest publish --all.
+            const string publishHint = "ppds publish --all";
+
             if (globalOptions.IsJsonMode)
             {
-                writer.WriteSuccess(new { name, updated = true, dryRun });
+                writer.WriteSuccess(new
+                {
+                    name,
+                    updated = true,
+                    dryRun,
+                    requiresPublish = !dryRun,
+                    publishHint = dryRun ? null : publishHint
+                });
+            }
+            else if (dryRun)
+            {
+                Console.Error.WriteLine("[Dry-Run] Validation passed. No changes persisted.");
             }
             else
             {
-                Console.Error.WriteLine(dryRun
-                    ? "[Dry-Run] Validation passed. No changes persisted."
-                    : $"Relationship '{name}' updated successfully.");
+                Console.Error.WriteLine($"Relationship '{name}' updated. Run '{publishHint}' to publish changes.");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/Table/TableCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Table/TableCommandGroup.cs
@@ -304,15 +304,26 @@ public static class TableCommandGroup
 
             await authoringService.UpdateTableAsync(request, ct: cancellationToken);
 
+            var publishHint = $"ppds metadata publish {entity}";
+
             if (globalOptions.IsJsonMode)
             {
-                writer.WriteSuccess(new { entity, updated = true, dryRun });
+                writer.WriteSuccess(new
+                {
+                    entity,
+                    updated = true,
+                    dryRun,
+                    requiresPublish = !dryRun,
+                    publishHint = dryRun ? null : publishHint
+                });
+            }
+            else if (dryRun)
+            {
+                Console.Error.WriteLine("[Dry-Run] Validation passed. No changes persisted.");
             }
             else
             {
-                Console.Error.WriteLine(dryRun
-                    ? "[Dry-Run] Validation passed. No changes persisted."
-                    : $"Table '{entity}' updated successfully.");
+                Console.Error.WriteLine($"Table '{entity}' updated. Run '{publishHint}' to publish changes.");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.cs
@@ -1909,6 +1909,8 @@ public class RpcMethodHandler : IDisposable
                     Success = true,
                     LogicalName = entityLogicalName,
                     WasDryRun = dryRun,
+                    RequiresPublish = !dryRun,
+                    PublishHint = dryRun ? null : $"ppds metadata publish {entityLogicalName}",
                 };
             }
             catch (Authoring.MetadataValidationException ex)
@@ -2091,6 +2093,8 @@ public class RpcMethodHandler : IDisposable
                     Success = true,
                     LogicalName = columnLogicalName,
                     WasDryRun = dryRun,
+                    RequiresPublish = !dryRun,
+                    PublishHint = dryRun ? null : $"ppds metadata publish {entityLogicalName}",
                 };
             }
             catch (Authoring.MetadataValidationException ex)
@@ -8834,6 +8838,14 @@ public class MetadataAuthoringResponse
     [JsonPropertyName("validationMessages")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<ValidationMessageDto>? ValidationMessages { get; set; }
+
+    // Issue #1009: signal that the change needs to be published before consumers see it.
+    [JsonPropertyName("requiresPublish")]
+    public bool RequiresPublish { get; set; }
+
+    [JsonPropertyName("publishHint")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PublishHint { get; set; }
 }
 
 /// <summary>

--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -382,7 +382,7 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         _cacheProvider?.InvalidateEntity(request.EntityLogicalName);
 
-        reporter?.ReportInfo($"Column '{request.ColumnLogicalName}' updated on '{request.EntityLogicalName}'.");
+        reporter?.ReportInfo($"Column '{request.ColumnLogicalName}' updated on '{request.EntityLogicalName}'. Run 'ppds metadata publish {request.EntityLogicalName}' to publish changes.");
         _logger?.LogInformation("Updated column {Column} on {Entity}", request.ColumnLogicalName, request.EntityLogicalName);
     }
 

--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -215,7 +215,8 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         _cacheProvider?.InvalidateEntityList();
         _cacheProvider?.InvalidateEntity(request.EntityLogicalName);
 
-        reporter?.ReportInfo($"Table '{request.EntityLogicalName}' updated successfully.");
+        // Issue #1009: keep the message UI-agnostic. Surfaces format their own publish command.
+        reporter?.ReportInfo($"Table '{request.EntityLogicalName}' updated. Changes must be published to take effect.");
         _logger?.LogInformation("Updated table {Entity}", request.EntityLogicalName);
     }
 
@@ -382,7 +383,8 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         _cacheProvider?.InvalidateEntity(request.EntityLogicalName);
 
-        reporter?.ReportInfo($"Column '{request.ColumnLogicalName}' updated on '{request.EntityLogicalName}'. Run 'ppds metadata publish {request.EntityLogicalName}' to publish changes.");
+        // Issue #1009: keep the message UI-agnostic. Surfaces format their own publish command.
+        reporter?.ReportInfo($"Column '{request.ColumnLogicalName}' updated on '{request.EntityLogicalName}'. Changes must be published to take effect.");
         _logger?.LogInformation("Updated column {Column} on {Entity}", request.ColumnLogicalName, request.EntityLogicalName);
     }
 
@@ -627,7 +629,7 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         // invalidate all entity caches to ensure stale relationship data is cleared.
         _cacheProvider?.InvalidateAll();
 
-        reporter?.ReportInfo($"Relationship '{request.SchemaName}' updated.");
+        reporter?.ReportInfo($"Relationship '{request.SchemaName}' updated. Changes must be published to take effect.");
         _logger?.LogInformation("Updated relationship {SchemaName}", request.SchemaName);
     }
 
@@ -786,7 +788,7 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         _cacheProvider?.InvalidateGlobalOptionSets();
 
-        reporter?.ReportInfo($"Global choice '{request.Name}' updated.");
+        reporter?.ReportInfo($"Global choice '{request.Name}' updated. Changes must be published to take effect.");
         _logger?.LogInformation("Updated global choice {Name}", request.Name);
     }
 

--- a/src/PPDS.Extension/src/__tests__/integration/smokeTest.test.ts
+++ b/src/PPDS.Extension/src/__tests__/integration/smokeTest.test.ts
@@ -203,14 +203,11 @@ describe('Extension Smoke Tests', () => {
         vi.resetModules();
     });
 
-    // Cold import of extension.js pulls in the full module graph (commands, panels,
-    // services); after vi.resetModules() this can exceed vitest's 5s default. Subsequent
-    // tests in this file share the warmed cache and run quickly.
     it('exports activate and deactivate functions', async () => {
         const ext = await import('../../extension.js');
         expect(typeof ext.activate).toBe('function');
         expect(typeof ext.deactivate).toBe('function');
-    }, 30000);
+    });
 
     it('activate registers expected commands', async () => {
         const vscode = await import('vscode');

--- a/src/PPDS.Extension/src/__tests__/integration/smokeTest.test.ts
+++ b/src/PPDS.Extension/src/__tests__/integration/smokeTest.test.ts
@@ -203,11 +203,14 @@ describe('Extension Smoke Tests', () => {
         vi.resetModules();
     });
 
+    // Cold import of extension.js pulls in the full module graph (commands, panels,
+    // services); after vi.resetModules() this can exceed vitest's 5s default. Subsequent
+    // tests in this file share the warmed cache and run quickly.
     it('exports activate and deactivate functions', async () => {
         const ext = await import('../../extension.js');
         expect(typeof ext.activate).toBe('function');
         expect(typeof ext.deactivate).toBe('function');
-    });
+    }, 30000);
 
     it('activate registers expected commands', async () => {
         const vscode = await import('vscode');

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -453,6 +453,9 @@ export interface MetadataAuthoringResult {
     error?: string;
     errorCode?: string;
     validationMessages?: MetadataValidationMessageDto[];
+    // Issue #1009: signal that the change needs to be published before consumers see it.
+    requiresPublish?: boolean;
+    publishHint?: string;
 }
 
 export interface MetadataDeleteResult {

--- a/src/PPDS.Mcp/Tools/MetadataUpdateColumnTool.cs
+++ b/src/PPDS.Mcp/Tools/MetadataUpdateColumnTool.cs
@@ -72,7 +72,9 @@ public sealed class MetadataUpdateColumnTool : McpToolBase
             return new MetadataUpdateColumnResult
             {
                 Success = true,
-                WasDryRun = dryRun
+                WasDryRun = dryRun,
+                RequiresPublish = !dryRun,
+                PublishHint = dryRun ? null : $"ppds metadata publish {entityName}"
             };
         }
         catch (PpdsException ex)
@@ -100,4 +102,13 @@ public sealed class MetadataUpdateColumnResult
     /// <summary>Whether the operation was a dry run.</summary>
     [JsonPropertyName("wasDryRun")]
     public bool WasDryRun { get; set; }
+
+    // Issue #1009: schema changes are not visible to consumers until publish runs.
+    /// <summary>True when the change must be published before it takes effect.</summary>
+    [JsonPropertyName("requiresPublish")]
+    public bool RequiresPublish { get; set; }
+
+    /// <summary>CLI command the caller should run to publish the change, if any.</summary>
+    [JsonPropertyName("publishHint")]
+    public string? PublishHint { get; set; }
 }

--- a/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/MetadataAuthoringRpcTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/MetadataAuthoringRpcTests.cs
@@ -440,6 +440,35 @@ public class MetadataAuthoringRpcTests
         json.Should().NotContain("\"error\"");
         json.Should().NotContain("\"errorCode\"");
         json.Should().NotContain("\"validationMessages\"");
+        json.Should().NotContain("\"publishHint\"",
+            because: "publishHint is nullable and should be omitted when not set");
+        json.Should().Contain("\"requiresPublish\":false",
+            because: "requiresPublish is a non-nullable bool and serializes its default");
+    }
+
+    // Issue #1009: RPC consumers (Extension) need to know when a change requires
+    // publishing. The fields are additive so existing consumers are unaffected.
+    [Fact]
+    public void MetadataAuthoringResponse_WithPublishHint_SerializesCorrectly()
+    {
+        var response = new MetadataAuthoringResponse
+        {
+            Success = true,
+            LogicalName = "new_field",
+            WasDryRun = false,
+            RequiresPublish = true,
+            PublishHint = "ppds metadata publish account",
+        };
+
+        var json = JsonSerializer.Serialize(response, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<MetadataAuthoringResponse>(json, JsonOptions);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.RequiresPublish.Should().BeTrue();
+        deserialized.PublishHint.Should().Be("ppds metadata publish account");
+
+        json.Should().Contain("\"requiresPublish\":true");
+        json.Should().Contain("\"publishHint\":\"ppds metadata publish account\"");
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -376,8 +376,9 @@ public class MetadataAuthoringServiceTests
 
     // Issue #1009: UpdateColumnAsync executes UpdateAttributeRequest but never publishes,
     // so the change is invisible to consumers until something else publishes. Spec
-    // (metadata-authoring.md "Why no auto-publish?") forbids auto-publish, so the success
-    // message must explicitly tell the user to run publish.
+    // (metadata-authoring.md "Why no auto-publish?") forbids auto-publish, so the service
+    // success message must signal the publish requirement. The service stays UI-agnostic;
+    // surface-specific guidance (CLI command string) is added by each surface.
     [Fact]
     public async Task UpdateColumnAsync_SuccessMessage_TellsUserToPublish()
     {
@@ -393,27 +394,108 @@ public class MetadataAuthoringServiceTests
                 return Task.FromResult(new OrganizationResponse());
             });
 
+        var message = CaptureSingleInfoMessage(reporter =>
+            _service.UpdateColumnAsync(new UpdateColumnRequest
+            {
+                SolutionUniqueName = "TestSolution",
+                EntityLogicalName = "account",
+                ColumnLogicalName = "new_myfield",
+                RequiredLevel = "Required"
+            }, reporter));
+
+        message.Should().Contain("publish",
+            because: "users must know publish is required for the change to take effect (#1009)");
+        message.Should().NotContain("ppds ",
+            because: "the service is UI-agnostic and must not embed a CLI command string (F-4)");
+    }
+
+    [Fact]
+    public async Task UpdateTableAsync_SuccessMessage_TellsUserToPublish()
+    {
+        var message = CaptureSingleInfoMessage(reporter =>
+            _service.UpdateTableAsync(new UpdateTableRequest
+            {
+                SolutionUniqueName = "TestSolution",
+                EntityLogicalName = "account",
+                DisplayName = "Account"
+            }, reporter));
+
+        message.Should().Contain("publish",
+            because: "table updates carry the same silent-failure shape as #1009");
+        message.Should().NotContain("ppds ");
+    }
+
+    [Fact]
+    public async Task UpdateRelationshipAsync_SuccessMessage_TellsUserToPublish()
+    {
+        var existingRel = new OneToManyRelationshipMetadata
+        {
+            SchemaName = "new_account_contact",
+            CascadeConfiguration = new CascadeConfiguration()
+        };
+        var retrieveResponse = new RetrieveRelationshipResponse();
+        retrieveResponse.Results["RelationshipMetadata"] = existingRel;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is RetrieveRelationshipRequest)
+                    return Task.FromResult<OrganizationResponse>(retrieveResponse);
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var message = CaptureSingleInfoMessage(reporter =>
+            _service.UpdateRelationshipAsync(new AuthoringUpdateRelationshipRequest
+            {
+                SolutionUniqueName = "TestSolution",
+                SchemaName = "new_account_contact",
+                CascadeConfiguration = new CascadeConfigurationDto { Delete = CascadeBehavior.Restrict }
+            }, reporter));
+
+        message.Should().Contain("publish",
+            because: "relationship cascade changes aren't visible until publish");
+        message.Should().NotContain("ppds ");
+    }
+
+    [Fact]
+    public async Task UpdateGlobalChoiceAsync_SuccessMessage_TellsUserToPublish()
+    {
+        var existingOs = new OptionSetMetadata { Name = "new_priority" };
+        var retrieveResponse = new RetrieveOptionSetResponse();
+        retrieveResponse.Results["OptionSetMetadata"] = existingOs;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is RetrieveOptionSetRequest)
+                    return Task.FromResult<OrganizationResponse>(retrieveResponse);
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var message = CaptureSingleInfoMessage(reporter =>
+            _service.UpdateGlobalChoiceAsync(new UpdateGlobalChoiceRequest
+            {
+                SolutionUniqueName = "TestSolution",
+                Name = "new_priority",
+                DisplayName = "Priority"
+            }, reporter));
+
+        message.Should().Contain("publish",
+            because: "choice label changes aren't visible until publish");
+        message.Should().NotContain("ppds ");
+    }
+
+    private static string CaptureSingleInfoMessage(Func<IMetadataAuthoringProgressReporter, Task> act)
+    {
         var infoMessages = new System.Collections.Generic.List<string>();
         var reporter = new Mock<IMetadataAuthoringProgressReporter>();
         reporter.Setup(r => r.ReportInfo(It.IsAny<string>()))
             .Callback<string>(infoMessages.Add);
 
-        var request = new UpdateColumnRequest
-        {
-            SolutionUniqueName = "TestSolution",
-            EntityLogicalName = "account",
-            ColumnLogicalName = "new_myfield",
-            RequiredLevel = "Required"
-        };
-
-        await _service.UpdateColumnAsync(request, reporter.Object);
+        act(reporter.Object).GetAwaiter().GetResult();
 
         infoMessages.Should().ContainSingle();
-        var message = infoMessages[0];
-        message.Should().Contain("publish",
-            because: "users must know publish is required for the change to take effect (#1009)");
-        message.Should().Contain("ppds metadata publish account",
-            because: "the message should include the exact command to run");
+        return infoMessages[0];
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -374,6 +374,48 @@ public class MetadataAuthoringServiceTests
         dtAttr!.Format.Should().Be(DateTimeFormat.DateOnly);
     }
 
+    // Issue #1009: UpdateColumnAsync executes UpdateAttributeRequest but never publishes,
+    // so the change is invisible to consumers until something else publishes. Spec
+    // (metadata-authoring.md "Why no auto-publish?") forbids auto-publish, so the success
+    // message must explicitly tell the user to run publish.
+    [Fact]
+    public async Task UpdateColumnAsync_SuccessMessage_TellsUserToPublish()
+    {
+        var existingAttr = new StringAttributeMetadata { LogicalName = "new_myfield", MaxLength = 100 };
+        var retrieveResponse = new RetrieveAttributeResponse();
+        retrieveResponse.Results["AttributeMetadata"] = existingAttr;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is RetrieveAttributeRequest)
+                    return Task.FromResult<OrganizationResponse>(retrieveResponse);
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var infoMessages = new System.Collections.Generic.List<string>();
+        var reporter = new Mock<IMetadataAuthoringProgressReporter>();
+        reporter.Setup(r => r.ReportInfo(It.IsAny<string>()))
+            .Callback<string>(infoMessages.Add);
+
+        var request = new UpdateColumnRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            EntityLogicalName = "account",
+            ColumnLogicalName = "new_myfield",
+            RequiredLevel = "Required"
+        };
+
+        await _service.UpdateColumnAsync(request, reporter.Object);
+
+        infoMessages.Should().ContainSingle();
+        var message = infoMessages[0];
+        message.Should().Contain("publish",
+            because: "users must know publish is required for the change to take effect (#1009)");
+        message.Should().Contain("ppds metadata publish account",
+            because: "the message should include the exact command to run");
+    }
+
     #endregion
 
     #region UpdateRelationshipAsync

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -394,7 +394,7 @@ public class MetadataAuthoringServiceTests
                 return Task.FromResult(new OrganizationResponse());
             });
 
-        var message = CaptureSingleInfoMessage(reporter =>
+        var message = await CaptureSingleInfoMessageAsync(reporter =>
             _service.UpdateColumnAsync(new UpdateColumnRequest
             {
                 SolutionUniqueName = "TestSolution",
@@ -412,7 +412,7 @@ public class MetadataAuthoringServiceTests
     [Fact]
     public async Task UpdateTableAsync_SuccessMessage_TellsUserToPublish()
     {
-        var message = CaptureSingleInfoMessage(reporter =>
+        var message = await CaptureSingleInfoMessageAsync(reporter =>
             _service.UpdateTableAsync(new UpdateTableRequest
             {
                 SolutionUniqueName = "TestSolution",
@@ -444,7 +444,7 @@ public class MetadataAuthoringServiceTests
                 return Task.FromResult(new OrganizationResponse());
             });
 
-        var message = CaptureSingleInfoMessage(reporter =>
+        var message = await CaptureSingleInfoMessageAsync(reporter =>
             _service.UpdateRelationshipAsync(new AuthoringUpdateRelationshipRequest
             {
                 SolutionUniqueName = "TestSolution",
@@ -472,7 +472,7 @@ public class MetadataAuthoringServiceTests
                 return Task.FromResult(new OrganizationResponse());
             });
 
-        var message = CaptureSingleInfoMessage(reporter =>
+        var message = await CaptureSingleInfoMessageAsync(reporter =>
             _service.UpdateGlobalChoiceAsync(new UpdateGlobalChoiceRequest
             {
                 SolutionUniqueName = "TestSolution",
@@ -485,14 +485,14 @@ public class MetadataAuthoringServiceTests
         message.Should().NotContain("ppds ");
     }
 
-    private static string CaptureSingleInfoMessage(Func<IMetadataAuthoringProgressReporter, Task> act)
+    private static async Task<string> CaptureSingleInfoMessageAsync(Func<IMetadataAuthoringProgressReporter, Task> act)
     {
         var infoMessages = new System.Collections.Generic.List<string>();
         var reporter = new Mock<IMetadataAuthoringProgressReporter>();
         reporter.Setup(r => r.ReportInfo(It.IsAny<string>()))
             .Callback<string>(infoMessages.Add);
 
-        act(reporter.Object).GetAwaiter().GetResult();
+        await act(reporter.Object);
 
         infoMessages.Should().ContainSingle();
         return infoMessages[0];


### PR DESCRIPTION
## Summary
- Surface publish requirement on metadata `Update*Async` commands so callers (CLI text, CLI JSON, MCP tools, Extension daemon) get a structured signal that changes need a publish step. The underlying bug for #1009 (RequiredLevel silently dropped) landed in #1022; this PR adds the publish-hint plumbing on top of that fix.
- Spec [`metadata-authoring.md` §"Why no auto-publish?"](../blob/main/specs/metadata-authoring.md) forbids auto-publish, so the fix is to surface the publish requirement, not hide it. Coverage extended to `UpdateColumnAsync`, `UpdateTableAsync`, `UpdateRelationshipAsync`, and `UpdateGlobalChoiceAsync` (same silent-success DX shape).
- Service messages stay UI-agnostic (`"Changes must be published to take effect."`); each surface formats its own publish hint. CLI/MCP/RPC carry structured `requiresPublish` + `publishHint` fields for programmatic consumers.

Related: #1009 (root-cause fix shipped in #1022).

## Test Plan
- [x] Regression test `UpdateColumnAsync_SuccessMessage_TellsUserToPublish` asserts the service emits a publish hint after update.
- [x] Parallel regression tests added for `UpdateTableAsync`, `UpdateRelationshipAsync`, `UpdateGlobalChoiceAsync`.
- [x] All four tests assert the literal `ppds ` CLI string is **absent** from service output (F-4 guard — service must stay UI-agnostic).
- [x] Existing `UpdateColumnAsync_ChangesRequiredLevel` (AC-26) still passes — request shape unchanged.
- [x] DTO round-trip tests cover `MetadataAuthoringResponse.RequiresPublish` + `PublishHint` (camelCase JSON, omitted when default).
- [x] Full unit suite green: 3568 PPDS.Cli tests + 152 MCP + all other suites.
- [x] CLI binary builds, `ppds metadata column update --help` parses, required-arg validation still triggers.

## Verification
- [x] `/gates` passed (build, 152/155 MCP + 3568/3568 CLI + all other suites, audit clean)
- [x] `/verify` cli — help output, validation paths, build green
- [x] `/verify` mcp — unit tests pass, structured `RequiresPublish`/`PublishHint` fields wired into `MetadataUpdateColumnResult`
- [x] Live Dataverse execution: not run (no auth available); covered by service-layer reporter assertions

## Notes for Reviewers
- The CLI `column update` message text changed from `"updated successfully."` to `"updated. Run '<cmd>' to publish changes."` — any console-output snapshot tests should be updated.
- JSON-mode output gained `requiresPublish` (bool) and `publishHint` (string|null) — additive, existing consumers unaffected.
- `MetadataUpdateColumnResult` (MCP) gained `RequiresPublish` and `PublishHint` properties — additive.
- TypeScript `MetadataAuthoringResult` (Extension daemon client) mirrors the new optional fields.
- Rebased on top of #1022 (real #1009 fix) and #1018 (M:N create fix); review feedback on `CaptureSingleInfoMessage` test helper addressed by converting it to `async Task<string> CaptureSingleInfoMessageAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)