### PR TITLE
chore(settings): disable picasso plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "enabledPlugins": {
     "superpowers@claude-plugins-official": false,
-    "procode-toolkit@procode-toolkit": false
+    "picasso@picasso": false
   },
   "safety": {
     "shakedown_safe_envs": [


### PR DESCRIPTION
## Summary
- Replace `procode-toolkit@procode-toolkit` with `picasso@picasso` in `.claude/settings.json` `enabledPlugins`, explicitly opting picasso out for this repo.
- One-line settings change; no source, hooks, skills, or agents touched.

## Test Plan
- [x] `settings.json` parses as JSON; `enabledPlugins` resolves to `{superpowers: false, picasso: false}`.
- [x] All hook command paths referenced in `settings.json` exist on disk.
- [x] No `procode-toolkit` references remain in `.claude/` (excluding transient `state/in-flight-issues.json` session entry).

## Verification
- [x] `/gates` passed (only Gate 7 enforcement audit applied — no .cs/.ts/.css/TUI changes; all other gates SKIP)
- [x] `/verify workflow` passed (JSON valid, hook paths resolve; pre-existing pytest/scenario failures on `main` baseline are out of scope)
- [ ] `/qa` skipped (settings-only change with no surface behavior to validate)
- [ ] `/review` skipped (`--no-self-review` — single-line plugin rename qualifies as trivially small per `/pr` skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
