### PR TITLE
fix(metadata): populate IntersectEntitySchemaName for M:N relationship create (#1008)

### DIFF
--- a/specs/metadata-authoring.md
+++ b/specs/metadata-authoring.md
@@ -175,7 +175,7 @@ Task DeleteRelationshipAsync(DeleteRelationshipRequest request, IProgressReporte
 - `SolutionUniqueName` (required)
 - `Entity1LogicalName`, `Entity2LogicalName` (required)
 - `SchemaName` (required)
-- `IntersectEntitySchemaName`
+- `IntersectEntitySchemaName` — schema name of the auto-generated intersect (link) table that holds the M:N associations. Required by the Dataverse SDK message but optional on this DTO: when null/empty, the service defaults it to `SchemaName` (matches Power Apps Maker convention and the Microsoft Learn `CreateManyToManyRequest` sample). Override only when the relationship name and intersect-entity name must differ. Validated for publisher prefix alongside `SchemaName`, so dry-run catches mismatches.
 - `Entity1NavigationPropertyName`, `Entity2NavigationPropertyName`
 - `DryRun` (bool)
 
@@ -424,7 +424,7 @@ All MCP tools support `dryRun` parameter. All use `McpToolBase` with `CreateScop
 | AC-03 | `CreateTableAsync` with `DryRun=true` validates without executing SDK call | `MetadataAuthoringServiceTests.CreateTableAsync_DryRun_DoesNotCallSdk` | ✅ |
 | AC-04 | `CreateColumnAsync` creates columns of all supported types with type-specific properties (parameterized: String, Memo, Integer, BigInt, Decimal, Double, Money, Boolean, DateTime, Choice, Choices, Image, File) | `CreateColumnTypeTests.CreateColumn_{Type}_SetsTypeSpecificProperties` | ✅ |
 | AC-05 | `CreateOneToManyAsync` creates a 1:N relationship with lookup column and cascade configuration | `SchemaValidatorTests.ValidateCreateOneToManyRequest_ValidRequest_DoesNotThrow` | ✅ |
-| AC-06 | `CreateManyToManyAsync` creates an N:N relationship with intersect entity | `SchemaValidatorTests.ValidateCreateManyToManyRequest_ValidRequest_DoesNotThrow` | ✅ |
+| AC-06 | `CreateManyToManyAsync` creates an N:N relationship with intersect entity. `IntersectEntitySchemaName` is set on the SDK `CreateManyToManyRequest` (not the metadata) and defaults to `SchemaName` when caller omits it. Issue #1008. | `MetadataAuthoringServiceTests.CreateManyToManyAsync_OmittedIntersect_DefaultsToSchemaNameOnSdkRequest`, `MetadataAuthoringServiceTests.CreateManyToManyAsync_ExplicitIntersect_PassesThroughOnSdkRequest`, `SchemaValidatorTests.ValidateCreateManyToManyRequest_ResolvedIntersectMissing_ThrowsMissingRequiredField`, `MetadataRelationshipCreateE2ETests.CreateManyToMany_OmittedIntersect_DefaultsFromName_Succeeds` | ✅ |
 | AC-07 | `CreateGlobalChoiceAsync` creates a global option set with initial values | `CacheInvalidationTests.CreateGlobalChoice_InvalidatesGlobalOptionSets` | ✅ |
 | AC-08 | `AddOptionValueAsync` adds a value to an existing global or local option set | — | ❌ |
 | AC-09 | `CreateKeyAsync` creates an alternate key with specified attributes | `SchemaValidatorTests.ValidateCreateKeyRequest_OneAttribute_DoesNotThrow` | ✅ |

--- a/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
@@ -71,6 +71,11 @@ public static class RelationshipCommandGroup
             Description = "Display name of the lookup column (one-to-many only)"
         };
 
+        var intersectEntityOption = new Option<string?>("--intersect-entity")
+        {
+            Description = "Schema name of the intersect entity (many-to-many only). Defaults to --name."
+        };
+
         var cascadeDeleteOption = new Option<CascadeBehavior?>("--cascade-delete")
         {
             Description = "Cascade behavior for delete: Cascade, Active, NoCascade, RemoveLink, Restrict"
@@ -96,6 +101,7 @@ public static class RelationshipCommandGroup
             nameOption,
             lookupNameOption,
             lookupDisplayNameOption,
+            intersectEntityOption,
             cascadeDeleteOption,
             cascadeAssignOption,
             dryRunOption,
@@ -114,6 +120,7 @@ public static class RelationshipCommandGroup
             var name = parseResult.GetValue(nameOption)!;
             var lookupName = parseResult.GetValue(lookupNameOption);
             var lookupDisplayName = parseResult.GetValue(lookupDisplayNameOption);
+            var intersectEntity = parseResult.GetValue(intersectEntityOption);
             var cascadeDelete = parseResult.GetValue(cascadeDeleteOption);
             var cascadeAssign = parseResult.GetValue(cascadeAssignOption);
             var dryRun = parseResult.GetValue(dryRunOption);
@@ -123,7 +130,7 @@ public static class RelationshipCommandGroup
 
             return await ExecuteCreateAsync(
                 solution, from, to, type, name,
-                lookupName, lookupDisplayName,
+                lookupName, lookupDisplayName, intersectEntity,
                 cascadeDelete, cascadeAssign, dryRun,
                 profile, environment, globalOptions, cancellationToken);
         });
@@ -139,6 +146,7 @@ public static class RelationshipCommandGroup
         string name,
         string? lookupName,
         string? lookupDisplayName,
+        string? intersectEntity,
         CascadeBehavior? cascadeDelete,
         CascadeBehavior? cascadeAssign,
         bool dryRun,
@@ -189,6 +197,7 @@ public static class RelationshipCommandGroup
                     Entity1LogicalName = from,
                     Entity2LogicalName = to,
                     SchemaName = name,
+                    IntersectEntitySchemaName = intersectEntity,
                     DryRun = dryRun
                 };
 

--- a/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Relationship/RelationshipCommandGroup.cs
@@ -191,6 +191,13 @@ public static class RelationshipCommandGroup
 
             if (type == "many-to-many")
             {
+                if (!globalOptions.IsJsonMode &&
+                    (lookupName is not null || lookupDisplayName is not null ||
+                     cascadeDelete.HasValue || cascadeAssign.HasValue))
+                {
+                    Console.Error.WriteLine("Warning: --lookup-name, --lookup-display-name, --cascade-delete, and --cascade-assign apply to one-to-many only and are ignored for many-to-many.");
+                }
+
                 var request = new CreateManyToManyRequest
                 {
                     SolutionUniqueName = solution,
@@ -205,6 +212,11 @@ public static class RelationshipCommandGroup
             }
             else
             {
+                if (!globalOptions.IsJsonMode && intersectEntity is not null)
+                {
+                    Console.Error.WriteLine("Warning: --intersect-entity applies to many-to-many only and is ignored for one-to-many.");
+                }
+
                 var request = new CreateOneToManyRequest
                 {
                     SolutionUniqueName = solution,

--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -506,8 +506,16 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         reporter?.ReportPhase("Resolving publisher prefix");
         var prefix = await ResolvePublisherPrefixAsync(request.SolutionUniqueName, ct).ConfigureAwait(false);
 
+        // Default the intersect entity schema name to the relationship schema name when not supplied.
+        // Matches the Power Apps Maker / SDK sample convention where both names are the same string
+        // (Microsoft Learn: CreateManyToManyRequest). Done before validation so prefix checks see the
+        // resolved value and dry-run catches mismatches.
+        var intersectSchemaName = string.IsNullOrWhiteSpace(request.IntersectEntitySchemaName)
+            ? request.SchemaName
+            : request.IntersectEntitySchemaName;
+
         reporter?.ReportPhase("Validating");
-        _validator.ValidateCreateManyToManyRequest(request, prefix);
+        _validator.ValidateCreateManyToManyRequest(request, prefix, intersectSchemaName);
 
         if (request.DryRun)
         {
@@ -526,8 +534,7 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         {
             SchemaName = request.SchemaName,
             Entity1LogicalName = request.Entity1LogicalName,
-            Entity2LogicalName = request.Entity2LogicalName,
-            IntersectEntityName = request.IntersectEntitySchemaName
+            Entity2LogicalName = request.Entity2LogicalName
         };
 
         if (!string.IsNullOrEmpty(request.Entity1NavigationPropertyName))
@@ -538,7 +545,8 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         var sdkRequest = new SdkCreateManyToManyRequest
         {
             ManyToManyRelationship = relationship,
-            SolutionUniqueName = request.SolutionUniqueName
+            SolutionUniqueName = request.SolutionUniqueName,
+            IntersectEntitySchemaName = intersectSchemaName
         };
 
         await using var client = await _connectionPool.GetClientAsync(cancellationToken: ct).ConfigureAwait(false);

--- a/src/PPDS.Dataverse/Metadata/Authoring/CreateManyToManyRequest.cs
+++ b/src/PPDS.Dataverse/Metadata/Authoring/CreateManyToManyRequest.cs
@@ -17,7 +17,11 @@ public sealed class CreateManyToManyRequest
     /// <summary>Gets or sets the schema name for the relationship.</summary>
     public string SchemaName { get; set; } = "";
 
-    /// <summary>Gets or sets the schema name of the intersect entity.</summary>
+    /// <summary>
+    /// Gets or sets the schema name for the intersect entity that Dataverse will auto-create
+    /// to store many-to-many associations. If null or empty, defaults to <see cref="SchemaName"/>
+    /// (matches Power Apps Maker convention; see Microsoft Learn CreateManyToManyRequest sample).
+    /// </summary>
     public string? IntersectEntitySchemaName { get; set; }
 
     /// <summary>Gets or sets the navigation property name on Entity1.</summary>

--- a/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
+++ b/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
@@ -224,7 +224,7 @@ public sealed class SchemaValidator
         // The Dataverse CreateManyToManyRequest message requires IntersectEntitySchemaName.
         // The caller defaults it to SchemaName before validation; we re-validate the resolved value so
         // dry-run rejects a missing or malformed intersect name (which would otherwise only fail at execute time).
-        CollectIfInvalid(messages, () => ValidateRequiredString(resolvedIntersectSchemaName!, "IntersectEntitySchemaName"));
+        CollectIfInvalid(messages, () => ValidateRequiredString(resolvedIntersectSchemaName, "IntersectEntitySchemaName"));
         if (!string.IsNullOrWhiteSpace(resolvedIntersectSchemaName))
         {
             CollectIfInvalid(messages, () => ValidateSchemaName(resolvedIntersectSchemaName));

--- a/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
+++ b/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
@@ -199,7 +199,17 @@ public sealed class SchemaValidator
     /// <summary>
     /// Validates a <see cref="CreateManyToManyRequest"/>.
     /// </summary>
-    public void ValidateCreateManyToManyRequest(CreateManyToManyRequest request, string publisherPrefix)
+    /// <param name="request">The request to validate.</param>
+    /// <param name="publisherPrefix">The publisher prefix resolved from the target solution.</param>
+    /// <param name="resolvedIntersectSchemaName">
+    /// The intersect-entity schema name after caller-supplied defaulting (typically
+    /// <see cref="CreateManyToManyRequest.IntersectEntitySchemaName"/> falling back to
+    /// <see cref="CreateManyToManyRequest.SchemaName"/>). Required by the Dataverse SDK.
+    /// </param>
+    public void ValidateCreateManyToManyRequest(
+        CreateManyToManyRequest request,
+        string publisherPrefix,
+        string? resolvedIntersectSchemaName = null)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -210,6 +220,17 @@ public sealed class SchemaValidator
         CollectIfInvalid(messages, () => ValidateRequiredString(request.Entity2LogicalName, "Entity2LogicalName"));
         CollectIfInvalid(messages, () => ValidateSchemaName(request.SchemaName));
         CollectIfInvalid(messages, () => ValidatePrefix(request.SchemaName, publisherPrefix));
+
+        // The Dataverse CreateManyToManyRequest message requires IntersectEntitySchemaName.
+        // Callers may default it to SchemaName before validation; we re-validate the resolved value here so
+        // dry-run rejects a missing or malformed intersect name (which would otherwise only fail at execute time).
+        var intersect = resolvedIntersectSchemaName ?? request.IntersectEntitySchemaName;
+        CollectIfInvalid(messages, () => ValidateRequiredString(intersect!, "IntersectEntitySchemaName"));
+        if (!string.IsNullOrWhiteSpace(intersect))
+        {
+            CollectIfInvalid(messages, () => ValidateSchemaName(intersect));
+            CollectIfInvalid(messages, () => ValidatePrefix(intersect, publisherPrefix));
+        }
 
         ThrowIfErrors(messages);
     }

--- a/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
+++ b/src/PPDS.Dataverse/Metadata/Authoring/SchemaValidator.cs
@@ -209,7 +209,7 @@ public sealed class SchemaValidator
     public void ValidateCreateManyToManyRequest(
         CreateManyToManyRequest request,
         string publisherPrefix,
-        string? resolvedIntersectSchemaName = null)
+        string? resolvedIntersectSchemaName)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -222,14 +222,13 @@ public sealed class SchemaValidator
         CollectIfInvalid(messages, () => ValidatePrefix(request.SchemaName, publisherPrefix));
 
         // The Dataverse CreateManyToManyRequest message requires IntersectEntitySchemaName.
-        // Callers may default it to SchemaName before validation; we re-validate the resolved value here so
+        // The caller defaults it to SchemaName before validation; we re-validate the resolved value so
         // dry-run rejects a missing or malformed intersect name (which would otherwise only fail at execute time).
-        var intersect = resolvedIntersectSchemaName ?? request.IntersectEntitySchemaName;
-        CollectIfInvalid(messages, () => ValidateRequiredString(intersect!, "IntersectEntitySchemaName"));
-        if (!string.IsNullOrWhiteSpace(intersect))
+        CollectIfInvalid(messages, () => ValidateRequiredString(resolvedIntersectSchemaName!, "IntersectEntitySchemaName"));
+        if (!string.IsNullOrWhiteSpace(resolvedIntersectSchemaName))
         {
-            CollectIfInvalid(messages, () => ValidateSchemaName(intersect));
-            CollectIfInvalid(messages, () => ValidatePrefix(intersect, publisherPrefix));
+            CollectIfInvalid(messages, () => ValidateSchemaName(resolvedIntersectSchemaName));
+            CollectIfInvalid(messages, () => ValidatePrefix(resolvedIntersectSchemaName, publisherPrefix));
         }
 
         ThrowIfErrors(messages);

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -19,6 +19,8 @@ using PPDS.Dataverse.Pooling;
 using Xunit;
 using AuthoringUpdateRelationshipRequest = PPDS.Dataverse.Metadata.Authoring.UpdateRelationshipRequest;
 using AuthoringUpdateStateValueRequest = PPDS.Dataverse.Metadata.Authoring.UpdateStateValueRequest;
+using AuthoringCreateManyToManyRequest = PPDS.Dataverse.Metadata.Authoring.CreateManyToManyRequest;
+using SdkCreateManyToManyRequest = Microsoft.Xrm.Sdk.Messages.CreateManyToManyRequest;
 
 namespace PPDS.Cli.Tests.Services.Metadata.Authoring;
 
@@ -324,6 +326,94 @@ public class MetadataAuthoringServiceTests
         updatedRel!.CascadeConfiguration.Should().NotBeNull();
         updatedRel.CascadeConfiguration.Delete.Should().Be(CascadeType.Restrict);
         updatedRel.CascadeConfiguration.Assign.Should().Be(CascadeType.Cascade);
+    }
+
+    #endregion
+
+    #region CreateManyToManyAsync
+
+    [Fact]
+    public async Task CreateManyToManyAsync_OmittedIntersect_DefaultsToSchemaNameOnSdkRequest()
+    {
+        // Regression guard for issue #1008: previously the CLI never populated IntersectEntitySchemaName,
+        // and the service set it on the wrong field (ManyToManyRelationshipMetadata.IntersectEntityName)
+        // instead of the SDK request's IntersectEntitySchemaName, so every M:N create failed at execute time.
+        var response = new CreateManyToManyResponse();
+        response.Results["ManyToManyRelationshipId"] = Guid.NewGuid();
+
+        SdkCreateManyToManyRequest? capturedRequest = null;
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is SdkCreateManyToManyRequest m2m) capturedRequest = m2m;
+            })
+            .ReturnsAsync(response);
+
+        var request = new AuthoringCreateManyToManyRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm"
+            // IntersectEntitySchemaName intentionally omitted
+        };
+
+        await _service.CreateManyToManyAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.IntersectEntitySchemaName.Should().Be("new_account_contact_mm",
+            "the service must default IntersectEntitySchemaName to SchemaName when omitted (Power Apps Maker convention; required by the SDK)");
+    }
+
+    [Fact]
+    public async Task CreateManyToManyAsync_ExplicitIntersect_PassesThroughOnSdkRequest()
+    {
+        var response = new CreateManyToManyResponse();
+        response.Results["ManyToManyRelationshipId"] = Guid.NewGuid();
+
+        SdkCreateManyToManyRequest? capturedRequest = null;
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is SdkCreateManyToManyRequest m2m) capturedRequest = m2m;
+            })
+            .ReturnsAsync(response);
+
+        var request = new AuthoringCreateManyToManyRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm",
+            IntersectEntitySchemaName = "new_AccountContactLink"
+        };
+
+        await _service.CreateManyToManyAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.IntersectEntitySchemaName.Should().Be("new_AccountContactLink");
+        capturedRequest.ManyToManyRelationship.SchemaName.Should().Be("new_account_contact_mm",
+            "the relationship schema name and intersect entity schema name remain independently set when overridden");
+    }
+
+    [Fact]
+    public async Task CreateManyToManyAsync_DryRun_DoesNotCallSdk()
+    {
+        var request = new AuthoringCreateManyToManyRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm",
+            DryRun = true
+        };
+
+        var result = await _service.CreateManyToManyAsync(request);
+
+        result.WasDryRun.Should().BeTrue();
+        _client.Verify(
+            c => c.ExecuteAsync(It.IsAny<SdkCreateManyToManyRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     #endregion

--- a/tests/PPDS.Dataverse.Tests/Metadata/Authoring/SchemaValidatorTests.cs
+++ b/tests/PPDS.Dataverse.Tests/Metadata/Authoring/SchemaValidatorTests.cs
@@ -424,9 +424,46 @@ public class SchemaValidatorTests
             SchemaName = "new_account_contact_mm"
         };
 
-        var act = () => _validator.ValidateCreateManyToManyRequest(request, "new");
+        var act = () => _validator.ValidateCreateManyToManyRequest(request, "new", request.SchemaName);
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ValidateCreateManyToManyRequest_ResolvedIntersectMissing_ThrowsMissingRequiredField()
+    {
+        // Reproduces issue #1008: SDK rejects CreateManyToMany with missing IntersectEntitySchemaName.
+        // Validator must catch this at dry-run time, not let it leak through to the SDK.
+        var request = new CreateManyToManyRequest
+        {
+            SolutionUniqueName = "MySolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm"
+        };
+
+        var act = () => _validator.ValidateCreateManyToManyRequest(request, "new", resolvedIntersectSchemaName: "");
+
+        act.Should().Throw<MetadataValidationException>()
+            .Which.ValidationMessages.Should().Contain(m => m.Field == "IntersectEntitySchemaName");
+    }
+
+    [Fact]
+    public void ValidateCreateManyToManyRequest_IntersectPrefixMismatch_Throws()
+    {
+        var request = new CreateManyToManyRequest
+        {
+            SolutionUniqueName = "MySolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm",
+            IntersectEntitySchemaName = "other_account_contact_mm"
+        };
+
+        var act = () => _validator.ValidateCreateManyToManyRequest(request, "new", request.IntersectEntitySchemaName);
+
+        act.Should().Throw<MetadataValidationException>()
+            .Which.ValidationMessages.Should().Contain(m => m.Rule == MetadataErrorCodes.InvalidPrefix);
     }
 
     #endregion

--- a/tests/PPDS.LiveTests/Cli/MetadataRelationshipCreateE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/MetadataRelationshipCreateE2ETests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using PPDS.LiveTests.Infrastructure;
+
+namespace PPDS.LiveTests.Cli;
+
+/// <summary>
+/// E2E tests for `ppds metadata relationship create --type many-to-many`.
+/// Regression coverage for issue #1008: every M:N create in v1.1 failed with
+/// "Required field 'IntersectEntitySchemaName' is missing for RequestName='CreateManyToMany'"
+/// because the CLI never populated the field and the service set it on the wrong SDK object.
+///
+/// Skipped unless PPDS_TEST_SOLUTION and PPDS_TEST_PREFIX are set (alongside the standard
+/// client-secret env vars), since N:N creation requires writing into a real custom solution.
+/// </summary>
+public class MetadataRelationshipCreateE2ETests : CliE2ETestBase
+{
+    private static string Solution => Environment.GetEnvironmentVariable("PPDS_TEST_SOLUTION")!;
+    private static string Prefix => Environment.GetEnvironmentVariable("PPDS_TEST_PREFIX")!;
+
+    [CliE2EWithSolution]
+    public async Task CreateManyToMany_OmittedIntersect_DefaultsFromName_Succeeds()
+    {
+        var profileName = GenerateTestProfileName();
+        await RunCliAsync(
+            "auth", "create",
+            "--name", profileName,
+            "--applicationId", Configuration.ApplicationId!,
+            "--clientSecret", Configuration.ClientSecret!,
+            "--tenant", Configuration.TenantId!,
+            "--environment", Configuration.DataverseUrl!);
+
+        await RunCliAsync("auth", "select", "--name", profileName);
+
+        // Account and contact are system entities present in every Dataverse env.
+        var schemaName = $"{Prefix}_acct_contact_{Guid.NewGuid():N}".Substring(0, 40);
+
+        try
+        {
+            var createResult = await RunCliAsync(
+                "metadata", "relationship", "create",
+                "--solution", Solution,
+                "--from", "account",
+                "--to", "contact",
+                "--type", "many-to-many",
+                "--name", schemaName);
+
+            createResult.ExitCode.Should().Be(0,
+                $"creating an N:N relationship without --intersect-entity must default it from --name; "
+                + $"StdOut: {createResult.StdOut}, StdErr: {createResult.StdErr}");
+            (createResult.StdOut + createResult.StdErr).Should().NotContain(
+                "IntersectEntitySchemaName",
+                "the SDK rejection from issue #1008 must not surface anywhere in output");
+        }
+        finally
+        {
+            // Best-effort cleanup; ignore exit code so a partial success still tears down.
+            await RunCliAsync(
+                "metadata", "relationship", "delete",
+                "--solution", Solution,
+                "--name", schemaName,
+                "--force");
+        }
+    }
+}

--- a/tests/PPDS.LiveTests/Cli/MetadataRelationshipCreateE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/MetadataRelationshipCreateE2ETests.cs
@@ -32,7 +32,8 @@ public class MetadataRelationshipCreateE2ETests : CliE2ETestBase
         await RunCliAsync("auth", "select", "--name", profileName);
 
         // Account and contact are system entities present in every Dataverse env.
-        var schemaName = $"{Prefix}_acct_contact_{Guid.NewGuid():N}".Substring(0, 40);
+        var rawName = $"{Prefix}_acct_contact_{Guid.NewGuid():N}";
+        var schemaName = rawName[..Math.Min(40, rawName.Length)];
 
         try
         {

--- a/tests/PPDS.LiveTests/Infrastructure/SkipIfNoCredentialsAttribute.cs
+++ b/tests/PPDS.LiveTests/Infrastructure/SkipIfNoCredentialsAttribute.cs
@@ -162,3 +162,43 @@ public sealed class CliE2EWithCredentialsAttribute : FactAttribute
     }
 }
 
+/// <summary>
+/// Fact attribute for CLI E2E tests that mutate solution-scoped metadata. Requires client secret
+/// credentials, .NET 8.0, and a configured target solution and publisher prefix
+/// (PPDS_TEST_SOLUTION, PPDS_TEST_PREFIX). Use for tests that create custom tables, columns,
+/// relationships, etc., where the schema name must satisfy a publisher prefix.
+/// </summary>
+public sealed class CliE2EWithSolutionAttribute : FactAttribute
+{
+    private static readonly LiveTestConfiguration Configuration = new();
+
+    /// <summary>
+    /// Initializes a new instance that skips when prerequisites are missing.
+    /// </summary>
+    public CliE2EWithSolutionAttribute()
+    {
+        if (!IsNet8Runtime())
+        {
+            Skip = "CLI E2E tests only run on .NET 8.0 (CLI is spawned with --framework net8.0, making other TFMs redundant).";
+        }
+        else if (!Configuration.HasClientSecretCredentials)
+        {
+            Skip = "Client secret credentials not configured. Set DATAVERSE_URL, PPDS_TEST_APP_ID, PPDS_TEST_CLIENT_SECRET, and PPDS_TEST_TENANT_ID.";
+        }
+        else if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PPDS_TEST_SOLUTION"))
+                 || string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("PPDS_TEST_PREFIX")))
+        {
+            Skip = "Solution-scoped E2E test requires PPDS_TEST_SOLUTION (target unmanaged solution unique name) and PPDS_TEST_PREFIX (publisher customization prefix, e.g., 'new' or 'hsl').";
+        }
+    }
+
+    private static bool IsNet8Runtime()
+    {
+#if NET8_0
+        return true;
+#else
+        return false;
+#endif
+    }
+}
+


### PR DESCRIPTION
## Summary
- Populate `IntersectEntitySchemaName` on the SDK `CreateManyToManyRequest` (was incorrectly set on `ManyToManyRelationshipMetadata.IntersectEntityName` instead, and never set from the CLI). Default to `SchemaName` when caller omits, per Microsoft Learn convention.
- Add optional `--intersect-entity` flag for the rare case where the intersect entity name must differ from the relationship schema name. Emit stderr warnings when off-type flags are passed (e.g., `--lookup-name` with `--type many-to-many`).
- Tighten `SchemaValidator.ValidateCreateManyToManyRequest` to require the resolved intersect name and validate its publisher prefix, so `--dry-run` catches the failure that previously slipped through to execute time.

Closes #1008

## Test Plan
- [x] Repro confirmed against `PPDS Demo - Dev` on `fix/1008-m2m-intersect-name` HEAD before fix: `Required field 'IntersectEntitySchemaName' is missing for RequestName='CreateManyToMany'`
- [x] After fix, default-intersect path: `ppds metadata relationship create --solution DevTechAIDemo --from account --to contact --type many-to-many --name hsl_acct_contact_<guid>` exits 0; relationship created and deleted successfully.
- [x] After fix, override path: same with `--intersect-entity hsl_OverrideLink_<guid>` exits 0; relationship created and deleted successfully.
- [x] After fix, validator path: dry-run with prefix-mismatched `--intersect-entity` exits 8 with `Schema name '...' must start with publisher prefix 'hsl_'` (regression that previously slipped through).
- [x] Off-type flag warnings fire on stderr (`--intersect-entity` on 1:N; `--lookup-name`/`--cascade-*` on N:N).
- [x] New unit tests:
  - `MetadataAuthoringServiceTests.CreateManyToManyAsync_OmittedIntersect_DefaultsToSchemaNameOnSdkRequest`
  - `MetadataAuthoringServiceTests.CreateManyToManyAsync_ExplicitIntersect_PassesThroughOnSdkRequest`
  - `MetadataAuthoringServiceTests.CreateManyToManyAsync_DryRun_DoesNotCallSdk`
  - `SchemaValidatorTests.ValidateCreateManyToManyRequest_ResolvedIntersectMissing_ThrowsMissingRequiredField`
  - `SchemaValidatorTests.ValidateCreateManyToManyRequest_IntersectPrefixMismatch_Throws`
- [x] New live test (opt-in via `PPDS_TEST_SOLUTION` + `PPDS_TEST_PREFIX`): `MetadataRelationshipCreateE2ETests.CreateManyToMany_OmittedIntersect_DefaultsFromName_Succeeds`.
- [x] Spec `specs/metadata-authoring.md` AC-06 updated to reference the new regression-guard tests.

## Verification
- [x] /gates passed (5938 unit tests across .NET 8/9/10; enforcement audit OK)
- [x] /verify cli completed against `PPDS Demo - Dev` (3 cases: default intersect, override, prefix-mismatch dry-run)

## Notes for Reviewer
- Sibling worktree `fix/1009-column-update-publish` touches the same service file (`DataverseMetadataAuthoringService.cs`) but a different method (`UpdateColumnAsync`). No textual overlap with this PR's `CreateManyToManyAsync` changes; whichever merges first, the other rebases mechanically.
- Workflow gap surfaced during this fix: v1.1 shipped a 100%-broken `metadata relationship create --type many-to-many` without ever exercising it against a real env. The `/verify cli` step in this branch's pipeline now does exercise it. A separate follow-up issue should add a pre-release checklist requiring `/verify cli` against a live env for every metadata-authoring command — out of scope for this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
