### PR TITLE
fix(metadata): populate IntersectEntitySchemaName for M2M create (#1008)

### DIFF
--- a/.claude/state/in-flight-issues.json
+++ b/.claude/state/in-flight-issues.json
@@ -1,5 +1,19 @@
 {
   "version": 1,
-  "updated": "2026-04-26T23:40:58Z",
-  "open_work": []
+  "updated": "2026-05-11T13:58:21Z",
+  "open_work": [
+    {
+      "session_id": "8ebd3468",
+      "started": "2026-05-11T13:58:21Z",
+      "branch": "feat/m2m-relationship-create",
+      "worktree": ".worktrees/m2m-relationship-create",
+      "issues": [
+        1008
+      ],
+      "areas": [
+        "m2m-relationship-create"
+      ],
+      "intent": "Fix many-to-many relationship creation failing with missing IntersectEntitySchemaName field"
+    }
+  ]
 }

--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -522,12 +522,18 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         reporter?.ReportPhase("Creating N:N relationship", request.SchemaName);
 
+        // Dataverse's CreateManyToMany requires IntersectEntityName; default to the
+        // relationship schema name when the caller doesn't supply one explicitly.
+        var intersectEntityName = string.IsNullOrWhiteSpace(request.IntersectEntitySchemaName)
+            ? request.SchemaName
+            : request.IntersectEntitySchemaName;
+
         var relationship = new ManyToManyRelationshipMetadata
         {
             SchemaName = request.SchemaName,
             Entity1LogicalName = request.Entity1LogicalName,
             Entity2LogicalName = request.Entity2LogicalName,
-            IntersectEntityName = request.IntersectEntitySchemaName
+            IntersectEntityName = intersectEntityName
         };
 
         if (!string.IsNullOrEmpty(request.Entity1NavigationPropertyName))

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -328,6 +328,80 @@ public class MetadataAuthoringServiceTests
 
     #endregion
 
+    #region CreateManyToManyAsync
+
+    [Fact]
+    public async Task CreateManyToManyAsync_WhenIntersectEntitySchemaNameNotSet_DefaultsToSchemaName()
+    {
+        Microsoft.Xrm.Sdk.Messages.CreateManyToManyRequest? capturedRequest = null;
+
+        var response = new CreateManyToManyResponse();
+        response.Results["ManyToManyRelationshipId"] = Guid.NewGuid();
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is Microsoft.Xrm.Sdk.Messages.CreateManyToManyRequest cmm)
+                {
+                    capturedRequest = cmm;
+                    return Task.FromResult<OrganizationResponse>(response);
+                }
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var request = new PPDS.Dataverse.Metadata.Authoring.CreateManyToManyRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm"
+            // IntersectEntitySchemaName intentionally left unset — reproduces #1008
+        };
+
+        await _service.CreateManyToManyAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.ManyToManyRelationship.IntersectEntityName.Should().NotBeNullOrWhiteSpace(
+            "Dataverse rejects CreateManyToMany requests with a missing IntersectEntitySchemaName (#1008)");
+        capturedRequest.ManyToManyRelationship.IntersectEntityName.Should().Be("new_account_contact_mm");
+    }
+
+    [Fact]
+    public async Task CreateManyToManyAsync_WhenIntersectEntitySchemaNameSet_UsesProvidedValue()
+    {
+        Microsoft.Xrm.Sdk.Messages.CreateManyToManyRequest? capturedRequest = null;
+
+        var response = new CreateManyToManyResponse();
+        response.Results["ManyToManyRelationshipId"] = Guid.NewGuid();
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is Microsoft.Xrm.Sdk.Messages.CreateManyToManyRequest cmm)
+                {
+                    capturedRequest = cmm;
+                    return Task.FromResult<OrganizationResponse>(response);
+                }
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var request = new PPDS.Dataverse.Metadata.Authoring.CreateManyToManyRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            Entity1LogicalName = "account",
+            Entity2LogicalName = "contact",
+            SchemaName = "new_account_contact_mm",
+            IntersectEntitySchemaName = "new_custom_intersect"
+        };
+
+        await _service.CreateManyToManyAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.ManyToManyRelationship.IntersectEntityName.Should().Be("new_custom_intersect");
+    }
+
+    #endregion
+
     #region ReorderOptionsAsync
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix many-to-many relationship creation failing with `Required field 'IntersectEntitySchemaName' is missing for RequestName='CreateManyToMany'`.
- Service layer now defaults `IntersectEntityName` on the SDK `CreateManyToMany` request to the relationship `SchemaName` when callers don't supply `IntersectEntitySchemaName`. Fixes CLI / TUI / MCP M2M create flows from a single code path.

Closes #1008

## Test Plan
- [x] Regression test reproduces #1008: `CreateManyToManyAsync_WhenIntersectEntitySchemaNameNotSet_DefaultsToSchemaName` asserts the SDK request carries `IntersectEntityName == SchemaName` when the caller omits it.
- [x] Companion test pins the explicit-value path: `CreateManyToManyAsync_WhenIntersectEntitySchemaNameSet_UsesProvidedValue`.
- [x] Full `PPDS.Cli.Tests` suite: 3560/3560 passing on net8/9/10.
- [x] Solution build clean (0 errors).

## Verification
- [x] /gates passed
- [x] /verify completed (surface: cli — service-layer regression coverage; live-env smoke skipped because shakedown-safety hook correctly blocked the non-allowlisted env)
- [ ] /qa not run (bug fix with direct regression coverage)
- [ ] /review not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
