### PR TITLE
fix(metadata): send fresh AttributeMetadata for column update (#1009)

### DIFF
--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -351,25 +351,30 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         reporter?.ReportPhase("Updating column", request.ColumnLogicalName);
 
-        if (request.DisplayName != null)
-            existingAttr.DisplayName = new Label(request.DisplayName, 1033);
-        if (request.Description != null)
-            existingAttr.Description = new Label(request.Description, 1033);
-        if (request.RequiredLevel != null)
-            existingAttr.RequiredLevel = new AttributeRequiredLevelManagedProperty(ParseRequiredLevel(request.RequiredLevel));
-        if (request.IsAuditEnabled.HasValue)
-            existingAttr.IsAuditEnabled = new BooleanManagedProperty(request.IsAuditEnabled.Value);
-        if (request.IsSecured.HasValue)
-            existingAttr.IsSecured = request.IsSecured.Value;
-        if (request.IsValidForAdvancedFind.HasValue)
-            existingAttr.IsValidForAdvancedFind = new BooleanManagedProperty(request.IsValidForAdvancedFind.Value);
+        // #1009: re-sending the retrieved AttributeMetadata silently drops RequiredLevel
+        // changes on the wire. Build a fresh, minimal attribute of the same SDK type
+        // and copy only the fields the caller explicitly asked to change.
+        var updateAttr = CreateUpdateAttribute(existingAttr);
 
-        ApplyTypeSpecificUpdates(existingAttr, request);
+        if (request.DisplayName != null)
+            updateAttr.DisplayName = new Label(request.DisplayName, 1033);
+        if (request.Description != null)
+            updateAttr.Description = new Label(request.Description, 1033);
+        if (request.RequiredLevel != null)
+            updateAttr.RequiredLevel = new AttributeRequiredLevelManagedProperty(ParseRequiredLevel(request.RequiredLevel));
+        if (request.IsAuditEnabled.HasValue)
+            updateAttr.IsAuditEnabled = new BooleanManagedProperty(request.IsAuditEnabled.Value);
+        if (request.IsSecured.HasValue)
+            updateAttr.IsSecured = request.IsSecured.Value;
+        if (request.IsValidForAdvancedFind.HasValue)
+            updateAttr.IsValidForAdvancedFind = new BooleanManagedProperty(request.IsValidForAdvancedFind.Value);
+
+        ApplyTypeSpecificUpdates(updateAttr, request);
 
         var sdkRequest = new UpdateAttributeRequest
         {
             EntityName = request.EntityLogicalName,
-            Attribute = existingAttr,
+            Attribute = updateAttr,
             SolutionUniqueName = request.SolutionUniqueName
         };
 
@@ -1291,6 +1296,35 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         return attr;
     }
 
+    private static AttributeMetadata CreateUpdateAttribute(AttributeMetadata existingAttr)
+    {
+        AttributeMetadata fresh = existingAttr switch
+        {
+            StringAttributeMetadata => new StringAttributeMetadata(),
+            MemoAttributeMetadata => new MemoAttributeMetadata(),
+            IntegerAttributeMetadata => new IntegerAttributeMetadata(),
+            BigIntAttributeMetadata => new BigIntAttributeMetadata(),
+            DecimalAttributeMetadata => new DecimalAttributeMetadata(),
+            DoubleAttributeMetadata => new DoubleAttributeMetadata(),
+            MoneyAttributeMetadata => new MoneyAttributeMetadata(),
+            BooleanAttributeMetadata => new BooleanAttributeMetadata(),
+            DateTimeAttributeMetadata => new DateTimeAttributeMetadata(),
+            MultiSelectPicklistAttributeMetadata => new MultiSelectPicklistAttributeMetadata(),
+            PicklistAttributeMetadata => new PicklistAttributeMetadata(),
+            ImageAttributeMetadata => new ImageAttributeMetadata(),
+            FileAttributeMetadata => new FileAttributeMetadata(),
+            LookupAttributeMetadata => new LookupAttributeMetadata(),
+            _ => throw new MetadataValidationException(
+                MetadataErrorCodes.InvalidConstraint,
+                $"Unsupported attribute type for update: {existingAttr.GetType().Name}",
+                "ColumnType")
+        };
+
+        fresh.LogicalName = existingAttr.LogicalName;
+        fresh.SchemaName = existingAttr.SchemaName;
+        return fresh;
+    }
+
     private static void ApplyTypeSpecificUpdates(AttributeMetadata attr, UpdateColumnRequest request)
     {
         switch (attr)
@@ -1322,6 +1356,9 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
                 if (request.MinValue.HasValue) moneyAttr.MinValue = request.MinValue.Value;
                 if (request.MaxValue.HasValue) moneyAttr.MaxValue = request.MaxValue.Value;
                 if (request.Precision.HasValue) moneyAttr.Precision = request.Precision.Value;
+                break;
+            case DateTimeAttributeMetadata dtAttr:
+                if (request.Format != null) dtAttr.Format = ParseDateTimeFormat(request.Format);
                 break;
         }
     }

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -277,6 +277,101 @@ public class MetadataAuthoringServiceTests
         capturedRequest!.Attribute.RequiredLevel!.Value.Should().Be(AttributeRequiredLevel.ApplicationRequired);
     }
 
+    // Regression for #1009: the retrieve-then-mutate pattern silently dropped the
+    // RequiredLevel change on the wire (the CLI reported success but Dataverse never
+    // applied the new value). The fix is to send a fresh, minimal AttributeMetadata
+    // of the same SDK type rather than the populated object returned by Retrieve.
+    [Fact]
+    public async Task UpdateColumnAsync_SendsFreshAttributeWithOnlyRequestedFields()
+    {
+        var existingAttr = new StringAttributeMetadata
+        {
+            LogicalName = "new_myfield",
+            SchemaName = "new_myfield",
+            MaxLength = 100,
+            DisplayName = new Label("Original Display", 1033),
+            Description = new Label("Original Description", 1033),
+            RequiredLevel = new AttributeRequiredLevelManagedProperty(AttributeRequiredLevel.None)
+        };
+        var retrieveResponse = new RetrieveAttributeResponse();
+        retrieveResponse.Results["AttributeMetadata"] = existingAttr;
+
+        UpdateAttributeRequest? capturedRequest = null;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is RetrieveAttributeRequest)
+                    return Task.FromResult<OrganizationResponse>(retrieveResponse);
+                if (req is UpdateAttributeRequest ua)
+                    capturedRequest = ua;
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var request = new UpdateColumnRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            EntityLogicalName = "account",
+            ColumnLogicalName = "new_myfield",
+            RequiredLevel = "Required"
+        };
+
+        await _service.UpdateColumnAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Attribute.Should().NotBeSameAs(existingAttr,
+            "retrieve-then-mutate doesn't reliably persist RequiredLevel — #1009");
+        capturedRequest.Attribute.Should().BeOfType<StringAttributeMetadata>();
+        capturedRequest.Attribute.LogicalName.Should().Be("new_myfield");
+        capturedRequest.Attribute.RequiredLevel!.Value.Should().Be(AttributeRequiredLevel.ApplicationRequired);
+        capturedRequest.Attribute.DisplayName.Should().BeNull(
+            "the caller did not request a DisplayName change, so it must not appear on the update payload");
+        capturedRequest.Attribute.Description.Should().BeNull(
+            "the caller did not request a Description change, so it must not appear on the update payload");
+    }
+
+    // Same silent-no-op class as #1009: --format on a DateTime column was being dropped
+    // because ApplyTypeSpecificUpdates had no DateTimeAttributeMetadata case.
+    [Fact]
+    public async Task UpdateColumnAsync_AppliesDateTimeFormatChange()
+    {
+        var existingAttr = new DateTimeAttributeMetadata
+        {
+            LogicalName = "new_eventdate",
+            SchemaName = "new_eventdate",
+            Format = DateTimeFormat.DateAndTime
+        };
+        var retrieveResponse = new RetrieveAttributeResponse();
+        retrieveResponse.Results["AttributeMetadata"] = existingAttr;
+
+        UpdateAttributeRequest? capturedRequest = null;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is RetrieveAttributeRequest)
+                    return Task.FromResult<OrganizationResponse>(retrieveResponse);
+                if (req is UpdateAttributeRequest ua)
+                    capturedRequest = ua;
+                return Task.FromResult(new OrganizationResponse());
+            });
+
+        var request = new UpdateColumnRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            EntityLogicalName = "account",
+            ColumnLogicalName = "new_eventdate",
+            Format = "dateonly"
+        };
+
+        await _service.UpdateColumnAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        var dtAttr = capturedRequest!.Attribute as DateTimeAttributeMetadata;
+        dtAttr.Should().NotBeNull();
+        dtAttr!.Format.Should().Be(DateTimeFormat.DateOnly);
+    }
+
     #endregion
 
     #region UpdateRelationshipAsync


### PR DESCRIPTION
## Summary
- `ppds metadata column update --required-level Required` was a silent no-op: the CLI reported "updated successfully" but the value never persisted in Dataverse.
- Root cause: `UpdateColumnAsync` retrieved the existing `AttributeMetadata` and re-sent the mutated instance via `UpdateAttributeRequest`. The Microsoft.Xrm.Sdk does not reliably honor `ManagedProperty` changes (like `RequiredLevel`) applied this way — every other field round-tripped unchanged while the new value was dropped.
- Fix: build a fresh `AttributeMetadata` of the same SDK subtype with only the caller's requested fields populated. Matches the pattern in Microsoft's `UpdateAttribute` samples.

Closes #1009

## Test Plan
- [x] `UpdateColumnAsync_SendsFreshAttributeWithOnlyRequestedFields` — fails on the retrieve-then-mutate code path, passes on the fix; asserts the captured `UpdateAttributeRequest.Attribute` is a new instance of the correct subtype with only `LogicalName` + `SchemaName` + `RequiredLevel` set.
- [x] `UpdateColumnAsync_ChangesRequiredLevel` — existing test still passes.
- [x] All 19 `MetadataAuthoringServiceTests` pass across net8/9/10.
- [ ] Live Dataverse verification — manual: run `ppds metadata column update -s <sol> -e <ent> -c <col> --required-level Required`, publish, confirm column shows Required in maker portal.

## Verification
- [x] `/gates` passed (build 0 errors, all CLI/Dataverse/Mcp tests pass; one pre-existing flaky `TuiStateStoreTests.ConcurrentSaves_DoNotCorrupt` Windows-fs race, unrelated, passes in isolation)
- [x] `/verify cli` — unit-test coverage (live run blocked by shakedown safety hook on current env; fix is pure service-layer refactor)
- [x] Pre-PR self-review — one CONCERN addressed (also copy `SchemaName` on the fresh attribute), others judged out-of-scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
