### PR TITLE
docs(workflow): adopt Agent View as PPDS observability layer (#1026)

### DIFF
--- a/.claude/interaction-patterns.md
+++ b/.claude/interaction-patterns.md
@@ -124,6 +124,25 @@ To change a rule in this document:
 3. Open a PR with a `## Rule change` section per §7.
 4. Main-session judgment (not subagent) decides.
 
+## 9. Agent View — multi-session observability
+
+Anthropic's Agent View (May 2026) is PPDS's multi-session observability surface. Each Claude Code session shows as one row across CLI, desktop, IDE, claude.ai/code, and Slack.
+
+**Source of truth.** `scripts/pipeline.py` owns ship-stage status — `/gates`, `/verify`, `/pr` succeed or fail there. Agent View row state is **informational** and does NOT map 1:1 to pipeline stages.
+
+**Agent View states (informational only):** `working`, `waiting`, `completed`, `failed`, `idle`, `stopped`. None imply a pipeline-stage outcome. Consult `.workflow/state.json` and `gh pr view` for ship readiness; an Agent View row showing `completed` only means the session terminated, not that the PR is green.
+
+**Official surfaces for this team:**
+- **CLI** — primary control plane; same surface where `/gates`, `/verify`, `/pr` live.
+- **claude.ai/code** — primary multi-session dashboard.
+- **Slack** — optional, monitoring only; not authoritative.
+
+Desktop and IDE surfaces remain available but are not the team baseline.
+
+**In-session vs multi-session.** The CLAUDE.md ≤3 `TaskCreate` cap is per session. Agent View imposes no cap on the number of concurrent sessions; each session independently obeys ≤3.
+
+**Rationale (per §7 — decision records).** Agent View is observability over Claude Code background jobs, not a stage executor. Pipeline.py owns ship semantics; conflating row state with stage state would create two sources of truth. See epic #1025 (Decision §1) and #1026.
+
 ## References
 
 - `.plans/2026-04-19-retro-flow.md` — retro flow diagram (gitignored, local only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Agent topology, decision UX, lane assignment: **`.claude/interaction-patterns.md
 - Accept `IProgressReporter` for any operation likely to exceed 1 second. <!-- enforcement: T3 -->
 - Complete the shipping pipeline: `/gates` → `/verify` → `/pr`. Never stop after `/gates` or `/verify` — the work is not done until `/pr` creates the pull request. <!-- enforcement: T1 hook:session-stop-workflow -->
 - On `scripts/pipeline.py` failure, recover via `python scripts/pipeline.py --resume` (or `--from <stage>`) or sequential `/gates` → `/verify` → `/pr` — never ad-hoc parallel debug. <!-- since: PR#956 rationale --> <!-- enforcement: T3 escape-hatch: cannot detect omission of --resume flag -->
-- Hard cap on simultaneous background TaskCreate jobs: ≤3. If a 4th is needed, stop and ask. <!-- since: PR#956 rationale --> <!-- enforcement: T1 hook:taskcreate-cap -->
+- Hard cap on in-session simultaneous TaskCreate jobs: ≤3. Multi-session orchestration via Agent View has no cap, but each session independently obeys ≤3. If a 4th in-session job is needed, stop and ask. <!-- since: PR#956 rationale; PR#1026 in-session scoping --> <!-- enforcement: T1 hook:taskcreate-cap -->
 - For any test/build failure, invoke `/debug` first; do not hypothesize without evidence. <!-- since: PR#956 rationale --> <!-- enforcement: T1 hook:debug-first -->
 
 ## Testing


### PR DESCRIPTION
## Summary

- Documents Anthropic's **Agent View** (May 2026) as PPDS's multi-session observability layer, with `pipeline.py` retained as the single source of truth for ship-stage status.
- Clarifies the CLAUDE.md ≤3 `TaskCreate` cap as **in-session only** — Agent View imposes no cap on concurrent sessions, but each session independently obeys ≤3.
- Picks team-supported surfaces (CLI + claude.ai/code; Slack optional). No code changes; this is Option A from epic #1025.

Closes #1026
Closes #1025 (epic — Managed Agents `/qa` pilot sub-issues #1027–#1031 closed wontfix: no org Anthropic API key for the `managed-agents-2026-04-01` beta; epic done-criteria branch (b) — Option A only)

## Rule change

**Context.** Anthropic's Agent View ships as a multi-session dashboard (CLI / desktop / IDE / claude.ai/code / Slack) and could plausibly be read as a stage executor or as a separate concurrency budget. Without explicit scoping, two failure modes were predicted:

1. Treating Agent View row state (`working / waiting / completed / failed / idle / stopped`) as a substitute for `pipeline.py` stage status — re-introducing the two-source-of-truth drift the workflow-state machinery was built to prevent.
2. Reading the ≤3 `TaskCreate` cap as a *global* concurrency cap across sessions, blocking legitimate multi-session orchestration; OR reading it as session-scoped without writing it down, letting it drift to no cap at all.

**Old rule → new rule.**

- **CLAUDE.md / ≤3 `TaskCreate` cap.** Old: "Hard cap on simultaneous background TaskCreate jobs: ≤3." New: "Hard cap on **in-session** simultaneous TaskCreate jobs: ≤3. Multi-session orchestration via Agent View has no cap, but each session independently obeys ≤3."
- **interaction-patterns.md (new §9).** No prior rule. New rule: `pipeline.py` is the source of truth for ship-stage status; Agent View states are informational and do NOT map 1:1 to pipeline stages; CLI + claude.ai/code are the team-supported surfaces.

**Why.** Pipeline.py owns `/gates`, `/verify`, `/pr` outcomes and writes `.workflow/state.json` — these are the contract the pre-PR hook reads. Agent View is observability *over* Claude Code background jobs, not a stage executor. Per §7 (Decision records — how rules evolve), the rule belongs in the durable surface (CLAUDE.md + interaction-patterns.md) rather than discovered situationally.

**Falsification.** This rule should be revised if:

- A future Agent View revision exposes a hook surface that can write authoritatively to `.workflow/state.json` (collapsing the two-source-of-truth concern), or
- `/retro` finds that sessions are systematically being held back by independent ≤3 caps even though the workload is genuinely parallelizable (suggesting the cap should be promoted or relaxed at the orchestration layer), or
- The team picks a different official-surface set (e.g., desktop instead of claude.ai/code).

## Test Plan

- [x] CLAUDE.md line cap respected (34 / 100 lines).
- [x] `[claude-md-reviewed: 2026-05-13]` marker present in commit.
- [x] `claudemd-gate.sh` pre-commit hook passed.
- [x] `claudemd-marker.sh` commit-msg hook passed.
- [x] `python scripts/audit-enforcement.py --strict` passes (11 T1 markers, all hooks wired).
- [x] `python scripts/verify-workflow.py` — 7/9 scenarios pass; the 2 failures (`commit-ref-validation`, `workflow-only-no-qa`) reproduce on the clean baseline (no diff) and are unrelated to this docs change.

## Verification

- [x] /gates passed (docs-only — no .NET / TS / CSS gates applicable; enforcement audit green)
- [x] /verify completed (surface: workflow — structural)
- [ ] /qa — not applicable (docs-only diff)
- [ ] /review — Gemini posts on PR open

Part of epic #1025. Companion PR for #1027 (Managed Agents /qa pilot spec) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

