### PR TITLE
fix(hooks): use $CLAUDE_PROJECT_DIR in hook commands (re-fix of #907)

### DIFF
--- a/.claude/hooks/settings-json-guard.py
+++ b/.claude/hooks/settings-json-guard.py
@@ -99,8 +99,13 @@ def _check_write(content: str, project_dir: str) -> list[str]:
 
         hook_file = m.group(1)
 
-        # Resolve relative to project root.
-        full_path = os.path.normpath(os.path.join(project_dir, hook_file))
+        # Expand $CLAUDE_PROJECT_DIR / ${CLAUDE_PROJECT_DIR} against the
+        # resolved project_dir so the new absolute hook form validates.
+        expanded = hook_file.replace("${CLAUDE_PROJECT_DIR}", project_dir)
+        expanded = expanded.replace("$CLAUDE_PROJECT_DIR", project_dir)
+
+        # Resolve relative to project root (no-op if already absolute).
+        full_path = os.path.normpath(os.path.join(project_dir, expanded))
         if not os.path.exists(full_path):
             errors.append(
                 f"Hook command references a file that does not exist: {hook_file!r}\n"

--- a/.claude/hooks/settings-json-guard.py
+++ b/.claude/hooks/settings-json-guard.py
@@ -101,6 +101,9 @@ def _check_write(content: str, project_dir: str) -> list[str]:
 
         # Expand $CLAUDE_PROJECT_DIR / ${CLAUDE_PROJECT_DIR} against the
         # resolved project_dir so the new absolute hook form validates.
+        # Order matters: brace form first, otherwise the second replace
+        # would consume `$CLAUDE_PROJECT_DIR` inside `${CLAUDE_PROJECT_DIR}`
+        # and leave a stray `{}`.
         expanded = hook_file.replace("${CLAUDE_PROJECT_DIR}", project_dir)
         expanded = expanded.replace("$CLAUDE_PROJECT_DIR", project_dir)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -219,7 +219,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/protect-main-branch.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-main-branch.py\"",
             "timeout": 5
           }
         ]
@@ -229,7 +229,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/protect-main-branch.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-main-branch.py\"",
             "timeout": 5
           }
         ]
@@ -239,7 +239,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/snk-protect.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/snk-protect.py\"",
             "timeout": 5
           }
         ]
@@ -249,7 +249,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/snk-protect.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/snk-protect.py\"",
             "timeout": 5
           }
         ]
@@ -259,7 +259,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/claudemd-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/claudemd-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -269,7 +269,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/claudemd-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/claudemd-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -279,7 +279,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/pre-commit-validate.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-validate.py\"",
             "timeout": 120
           }
         ]
@@ -289,7 +289,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/pr-gate.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-gate.py\"",
             "timeout": 30
           }
         ]
@@ -299,7 +299,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/checkout-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/checkout-guard.py\"",
             "timeout": 5
           }
         ]
@@ -309,7 +309,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/review-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/review-guard.py\"",
             "timeout": 5
           }
         ]
@@ -319,7 +319,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -329,7 +329,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -339,7 +339,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -349,7 +349,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -359,7 +359,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -369,7 +369,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/rm-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/rm-guard.py\"",
             "timeout": 5
           }
         ]
@@ -379,7 +379,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/shakedown-safety.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/shakedown-safety.py\"",
             "timeout": 10
           }
         ]
@@ -389,7 +389,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/skill-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -399,7 +399,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/skill-line-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/skill-line-cap.py\"",
             "timeout": 5
           }
         ]
@@ -409,7 +409,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/retro-html-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/retro-html-guard.py\"",
             "timeout": 5
           }
         ]
@@ -419,7 +419,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/worktree-safety.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-safety.py\"",
             "timeout": 5
           }
         ]
@@ -429,7 +429,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/taskcreate-cap.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/taskcreate-cap.py\"",
             "timeout": 5
           }
         ]
@@ -439,7 +439,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 5
           }
         ]
@@ -449,7 +449,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 5
           }
         ]
@@ -459,7 +459,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 5
           }
         ]
@@ -469,7 +469,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/settings-json-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/settings-json-guard.py\"",
             "timeout": 5
           }
         ]
@@ -479,7 +479,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/settings-json-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/settings-json-guard.py\"",
             "timeout": 5
           }
         ]
@@ -491,7 +491,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/post-commit-state.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-commit-state.py\"",
             "timeout": 10
           }
         ]
@@ -501,7 +501,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/worktree-safety.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-safety.py\"",
             "timeout": 5
           }
         ]
@@ -511,7 +511,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 10
           }
         ]
@@ -521,7 +521,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 10
           }
         ]
@@ -531,7 +531,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/debug-first.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/debug-first.py\"",
             "timeout": 10
           }
         ]
@@ -541,7 +541,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/inflight-auto-deregister.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/inflight-auto-deregister.py\"",
             "timeout": 15
           }
         ]
@@ -551,7 +551,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/inflight-auto-deregister.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/inflight-auto-deregister.py\"",
             "timeout": 15
           }
         ]
@@ -561,7 +561,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/inflight-auto-deregister.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/inflight-auto-deregister.py\"",
             "timeout": 15
           }
         ]
@@ -572,7 +572,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/session-start-workflow.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-workflow.py\"",
             "timeout": 10
           }
         ]
@@ -584,7 +584,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/stop-hook-watchdog.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-hook-watchdog.py\"",
             "timeout": 5
           }
         ]
@@ -593,7 +593,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/session-stop-workflow.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-stop-workflow.py\"",
             "timeout": 30
           }
         ]
@@ -602,7 +602,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \".claude/hooks/shakedown-readonly-guard.py\"",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/shakedown-readonly-guard.py\"",
             "timeout": 10
           }
         ]

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -15,7 +15,6 @@ on:
       - '.claude/**'
       - 'tests/test_hook_paths.py'
       - 'tests/test_hooks.py'
-      - 'tests/test_hook_envelope.py'
       - '.github/workflows/workflow-tests.yml'
   push:
     branches:
@@ -24,7 +23,6 @@ on:
       - '.claude/**'
       - 'tests/test_hook_paths.py'
       - 'tests/test_hooks.py'
-      - 'tests/test_hook_envelope.py'
       - '.github/workflows/workflow-tests.yml'
   workflow_dispatch: {}
 
@@ -49,4 +47,4 @@ jobs:
         run: pip install pytest
 
       - name: Run hook-path regression tests
-        run: pytest tests/test_hook_paths.py tests/test_hooks.py tests/test_hook_envelope.py -v
+        run: pytest tests/test_hook_paths.py tests/test_hooks.py -v

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -1,0 +1,52 @@
+name: Workflow Tests
+
+# Runs the Python regression tests that protect `.claude/` workflow
+# infrastructure — hook command paths, settings-json-guard, hook envelopes.
+#
+# Existed before this workflow: `tests/test_hook_paths.py` (added by PR #907)
+# asserted every hook in `.claude/settings.json` uses `$CLAUDE_PROJECT_DIR/`.
+# It was correct and would have failed on PR #973, which silently regressed
+# all 39 entries back to bare-relative paths — but nothing in CI invoked it.
+# This workflow closes that gap so the regression can't happen a third time.
+
+on:
+  pull_request:
+    paths:
+      - '.claude/**'
+      - 'tests/test_hook_paths.py'
+      - 'tests/test_hooks.py'
+      - 'tests/test_hook_envelope.py'
+      - '.github/workflows/workflow-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude/**'
+      - 'tests/test_hook_paths.py'
+      - 'tests/test_hooks.py'
+      - 'tests/test_hook_envelope.py'
+      - '.github/workflows/workflow-tests.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-tests:
+    name: workflow-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run hook-path regression tests
+        run: pytest tests/test_hook_paths.py tests/test_hooks.py tests/test_hook_envelope.py -v

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -147,6 +147,29 @@ class TestWriteNonExistentFile:
         assert code == 2
 
 
+class TestWriteClaudeProjectDirForm:
+    """Hook must accept the $CLAUDE_PROJECT_DIR / ${CLAUDE_PROJECT_DIR} absolute form."""
+
+    def test_allows_claude_project_dir_form(self):
+        command = f'python "$CLAUDE_PROJECT_DIR/{_REAL_HOOK}"'
+        payload = _write_payload(".claude/settings.json", _settings_with_command(command))
+        code, _ = _run(payload)
+        assert code == 0
+
+    def test_allows_claude_project_dir_brace_form(self):
+        command = f'python "${{CLAUDE_PROJECT_DIR}}/{_REAL_HOOK}"'
+        payload = _write_payload(".claude/settings.json", _settings_with_command(command))
+        code, _ = _run(payload)
+        assert code == 0
+
+    def test_blocks_missing_file_with_claude_project_dir_prefix(self):
+        command = 'python "$CLAUDE_PROJECT_DIR/.claude/hooks/does-not-exist-xyz.py"'
+        payload = _write_payload(".claude/settings.json", _settings_with_command(command))
+        code, stderr = _run(payload)
+        assert code == 2
+        assert "does not exist" in stderr.lower()
+
+
 # ---------------------------------------------------------------------------
 # Edit tool — fragment validation (doubled pattern only)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Re-apply `$CLAUDE_PROJECT_DIR` prefix to all 39 hook commands in `.claude/settings.json` — PR #973 reintroduced the bare-relative `.claude/hooks/X.py` form that #907 originally fixed.
- Teach `.claude/hooks/settings-json-guard.py` to expand `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` during its Write-path existence check, so a future `Write` to settings.json doesn't false-block on the new absolute form.
- Cover the new expansion code path with 3 cases in `tests/test_hooks.py`.
- **NEW:** Wire `tests/test_hook_paths.py` (and `tests/test_hooks.py`) into CI via `.github/workflows/workflow-tests.yml`. This is the actual fix for the silent-regression class — see "CI gap" below.

## The bug

When the Bash tool's persistent shell cwd drifts (e.g., from a `cd src/<sub>` in an earlier call), every PreToolUse hook process inherits that cwd. The relative `python ".claude/hooks/X.py"` resolves against the wrong directory, Python exits code 2 ("No such file"), Claude Code interprets exit-2 as BLOCK, and all tool calls — including the recovery `cd <root>` — get blocked. Unrecoverable from inside the session; the only escape is `! cd <path>` typed by the user at the prompt.

This bricked two sessions in the `fix-1006-trace-filter` worktree on 2026-05-13 (sessions c0f57f7b + 733266ed); the second sat for ~2500 message lines repeatedly asking the user to `! cd` the shell before being interrupted.

## CI gap (regression-prevention story)

The reason this fix needs a *third* iteration:

| PR | Date | What happened |
|---|---|---|
| **#907** | 2026-04-24 | Original fix: converted hook commands to `$CLAUDE_PROJECT_DIR/.claude/hooks/...`. Added `tests/test_hook_paths.py` to assert no bare-relative paths slip back in. |
| **#973** | 2026-04-26 | "hook-over-skill enforcement redesign v9.0" added 6 new hook entries and reverted all 39 entries (originals + new) to bare-relative paths. **`tests/test_hook_paths.py` ran red against `main` from that day on — but nothing in CI invoked it**, so the regression sailed through review and merge. |
| #1035 (this PR) | 2026-05-13 | Re-apply the path fix + **wire the existing test into CI** so silent regressions can't recur. |

**Why CI didn't catch #973's regression:** I scanned `.github/workflows/*.yml`; the only `pytest` invocations are `pytest tests/extension_listing/` in `extension-publish.yml` and `marketplace-listing-gate.yml`. No workflow runs `pytest tests/test_hook_paths.py` or `pytest tests/` broadly. The test was correct, present, and dormant.

This PR adds `.github/workflows/workflow-tests.yml` — runs on PRs and pushes to main that touch `.claude/**` or the test files, invokes `pytest tests/test_hook_paths.py tests/test_hooks.py`. Mirrors the trigger style of `marketplace-listing-gate.yml`.

**Break-proof:** to confirm the new gate actually fires on the right tests, I pushed a synthetic regression on a throwaway branch (reverted one hook entry — `shakedown-safety.py` — to bare-relative form) and ran the workflow via `workflow_dispatch`. The workflow correctly went red on exactly the two regression assertions:

- `tests/test_hook_paths.py::test_hook_command_uses_absolute_path[python ".claude/hooks/shakedown-safety.py"]` — parametrized per-hook assertion caught the specific broken entry
- `tests/test_hook_paths.py::test_no_bare_relative_claude_hooks_path` — regex scan caught it independently

Failing run: https://github.com/joshsmithxrm/power-platform-developer-suite/actions/runs/25831500796 (2 failed, 54 passed). The throwaway branch `verify/workflow-tests-break-proof` has been deleted both locally and remote.

## Test Plan

- [x] Reproduced the failure mode live in this session (`cd src/PPDS.Cli`, then any Bash/Edit call fails with "Errno 2 No such file" against `src/PPDS.Cli/.claude/hooks/`).
- [x] After fix: Bash + Edit both succeed with cwd at `src/PPDS.Cli`.
- [x] `tests/test_hook_paths.py` passes after fix (40 parametrized + scan assertions).
- [x] `tests/test_hooks.py` — 16/16 pass including 3 new cases for `$CLAUDE_PROJECT_DIR` / `${CLAUDE_PROJECT_DIR}` expansion in the guard.
- [x] `scripts/audit-enforcement.py --strict` — 11 T1 markers, all hooks present and wired.
- [x] All 22 hook scripts smoke-tested with empty stdin `{}` — no crashes.
- [x] **`workflow-tests` CI job passes on this branch + verified it goes red on a synthetic regression (URL above).**

## Verification

- [x] `/gates` passed (Gate 7 enforcement audit; other gates SKIP for config-only diff)
- [x] `/verify` workflow surface passed
- [x] Pre-PR self-review run — F-1 (test coverage gap) and F-2 (str.replace order comment) addressed
- [x] **CI gate fires** on deliberately broken hook (run `25831500796`, conclusion `failure`)

## Out of scope (file as follow-ups)

- Recovering stranded #1006 work (`pluginTracesQuery.ts` + `.test.ts` uncommitted in `.worktrees/fix-1006-trace-filter`)
- T2 analyzer that flags bare `cd <subdir>` in Bash tool commands (preventive)
- Documenting the `! cd <path>` escape hatch in `specs/workflow-enforcement.md` or `CLAUDE.md`
- Pre-existing failures uncovered while verifying (NOT regressions; identical pre- and post-fix):
  - `tests/test_pipeline.py::TestFindDuplicateIssue` × 3 — `_find_duplicate_issue()` signature mismatch
  - `tests/test_workflow_state_bump.py` × 4 — expects `"non-integer"` in stderr, actual: `"is not an integer"`
  - `tests/test_hook_envelope.py::test_top_level_envelope_does_not_crash` — env-dependent (passes from worktree, fails on regular checkout) — *deliberately not included in `workflow-tests.yml` for that reason*
  - `scripts/verify-workflow.py` scenarios `commit-ref-validation` + `workflow-only-no-qa` — pr-gate `/qa`-bypass appears broken for workflow-only diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
