### PR TITLE
chore(deps): split github-actions majors into individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # VS Code Extension (npm)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Add `update-types: [minor, patch]` to the `github-actions` group in `.github/dependabot.yml`
- Causes major-version bumps to fall out of the group and arrive as individual PRs

## Why
`.github/dependabot.yml` currently groups ALL github-actions updates (any update type) into a single weekly PR. When a major lands in the group, the PR mixes patch+minor+major bumps and cannot be auto-merged per `docs/MERGE-POLICY.md` Rule 1 (any major-version bump is a universal Group C exclusion).

This is exactly what happened in #1020: `actions/checkout` 4→6 + `actions/dependency-review-action` 4→5 + `actions/setup-python` 5→6 all bundled into one un-mergeable PR. Each major deserves individual evaluation.

After this lands, close #1020 — the next weekly dependabot run will produce:
- One grouped patch/minor PR (if any non-major updates exist)
- One individual PR per major bump

## Test plan
- [ ] CI passes
- [ ] Verify `.github/dependabot.yml` parses (dependabot will validate on next run)
- [ ] On next Monday's dependabot run, confirm majors arrive individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)