### PR TITLE
feat(workflow): empirical shakedown gate + retro extractor fix + drift detector

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -60,10 +60,18 @@ Run non-LLM extractors via `scripts/retro_helpers.py`. NEVER use `grep` on JSONL
 python -c "
 import json, sys
 sys.path.insert(0, 'scripts')
-from retro_helpers import extract_transcript_signals, extract_enforcement_signals, discover_transcripts
+from retro_helpers import (
+    extract_transcript_signals, extract_enforcement_signals,
+    discover_transcripts, detect_allowlist_drift, write_drift_proposals,
+)
 for t in discover_transcripts('.'):
     print(json.dumps({'transcript': t, 'signals': extract_transcript_signals(t)}))
 print(json.dumps({'enforcement': extract_enforcement_signals('.workflow/state.json')}))
+# Post-/verify allowlist-drift: flags fix commits touching subprocess-spawning
+# files NOT in the shakedown allowlist. Proposals merge into retro-findings.json.
+proposals = detect_allowlist_drift()
+print(json.dumps({'allowlist_drift': proposals}))
+write_drift_proposals('.workflow/retro-findings.json', proposals)
 "
 ```
 

--- a/.claude/skills/verify/REFERENCE.md
+++ b/.claude/skills/verify/REFERENCE.md
@@ -1,0 +1,112 @@
+# Verify - REFERENCE
+
+Rationale and worked examples for `.claude/skills/verify/SKILL.md`. The
+procedure stays in SKILL.md; everything that doesn't change between
+sessions lives here.
+
+---
+
+## TUI Mode - worked example
+
+The TUI verifier wraps `@microsoft/tui-test` + `node-pty`. Full command
+reference: `@tui-verify` skill.
+
+```bash
+# Phase A: Build and launch
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
+
+# Phase B (MANDATORY when src/PPDS.Cli/Tui/ changes): interactive nav
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 28
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify.json
+
+# Phase C: Cleanup
+node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
+```
+
+---
+
+## Extension Mode - worked example
+
+Wraps `@playwright/test` + `@vscode/test-electron`. Full reference:
+`@ext-verify` skill.
+
+```bash
+# Phase A: Launch and screenshot
+node src/PPDS.Extension/tools/webview-cdp.mjs launch --build
+node src/PPDS.Extension/tools/webview-cdp.mjs command "PPDS: Data Explorer"
+node src/PPDS.Extension/tools/webview-cdp.mjs wait --ext "power-platform-developer-suite"
+node src/PPDS.Extension/tools/webview-cdp.mjs screenshot $TEMP/data-explorer.png
+node src/PPDS.Extension/tools/webview-cdp.mjs logs --channel "PPDS"
+
+# Phase B (MANDATORY when query/data/panel code changes): exercise a query
+node src/PPDS.Extension/tools/webview-cdp.mjs eval 'monaco.editor.getEditors()[0].setValue("SELECT TOP 5 name FROM account")'
+node src/PPDS.Extension/tools/webview-cdp.mjs click "#execute-btn" --ext "power-platform-developer-suite"
+node src/PPDS.Extension/tools/webview-cdp.mjs screenshot $TEMP/after-query.png
+
+# Phase C: Cleanup
+node src/PPDS.Extension/tools/webview-cdp.mjs close
+```
+
+Phase B trigger files: `SqlQueryService`, `RpcMethodHandler`, `QueryPanel`,
+`query-panel.ts`, anything under data rendering or panel interactions.
+
+---
+
+## Empirical shakedown gate - rationale
+
+PR #1051 Phase B shipped clean from `/verify` then took seven fix commits
+because `tests/conftest.py` auto-stubs `claude_dispatch.spawn`. Unit tests
+cannot regress what they cannot exercise. The shakedown gate spawns one
+real `claude --bg` session against a throwaway prompt and asserts exit 0,
+deliberately bypassing the stub.
+
+**Allowlist source of truth:** `scripts/_shakedown_allowlist.py`. Both the
+gate (`scripts/verify_shakedown.py`) and the post-`/verify` drift detector
+(`scripts/retro_helpers.py:detect_allowlist_drift`) read it. Adding a new
+subprocess-spawning wrapper is a one-line append.
+
+**Cost bound:** the helper defaults to a 5-minute timeout. The throwaway
+prompt is `"Reply with the word OK and stop."` so a healthy session
+finishes in seconds. The gate only runs when the diff touches the allowlist
+- typical PRs skip it entirely with one log line.
+
+**Pool discipline:** uses `claude_dispatch.spawn(mode="interactive", ...)`
+- subscription pool, never `-p`. The dispatcher emits the SDK-spend
+warning when callers pick `-p`, so accidentally regressing this surfaces
+in stderr.
+
+---
+
+## Report template
+
+```
+## Verification Results -- [component]
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Unit tests | PASS | 12/12 passing |
+| Daemon connection | PASS | PID 12345, uptime 30s |
+| Tree view state | PASS | 2 profiles, 3 environments |
+| Data Explorer open | PASS | Panel created |
+| SQL query execution | PASS | 5 rows returned |
+| Webview rendering | PASS | Query panel layout correct |
+
+### Verdict: PASS -- all checks green
+```
+
+---
+
+## Retro store schema (Check 7)
+
+If `.retros/summary.json` exists:
+- Parse as JSON
+- Required keys: `schema_version`, `last_updated`, `total_retros`,
+  `findings_by_category`, `metrics`
+- `schema_version == 1`
+
+Missing file passes (the store is optional until first retro).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -5,271 +5,138 @@ description: AI self-verification of implemented work across surfaces (extension
 
 # Verify
 
-AI self-verification of implemented work using MCP tools. Goes beyond unit tests to verify that code actually works in its runtime environment.
+AI self-verification of implemented work. Goes beyond unit tests to verify
+code actually works in its runtime environment.
 
 ## Usage
 
-`/verify` - Auto-detect component from recent changes
-`/verify cli` - Verify CLI command behavior
-`/verify tui` - Verify TUI rendering and interaction
-`/verify extension` - Verify VS Code extension behavior
-`/verify mcp` - Verify MCP server tools
+- `/verify` - auto-detect from recent changes
+- `/verify cli|tui|extension|mcp|workflow` - explicit mode
 
 ## Prerequisites
 
-Each mode requires specific MCP servers. If a prerequisite is missing, tell the user what to install and stop.
+| Mode | Required |
+|------|----------|
+| cli | Bash tool only |
+| tui | `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` (`@microsoft/tui-test`, `node-pty`) |
+| extension | `src/PPDS.Extension/tools/webview-cdp.mjs` (`@playwright/test`, `@vscode/test-electron`) |
+| mcp | `npx @modelcontextprotocol/inspector` |
 
-| Mode | Required MCPs / Tools |
-|------|----------------------|
-| cli | None (uses Bash tool directly) |
-| tui | `tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs` (uses `@microsoft/tui-test` + `node-pty`, both dev deps) |
-| extension | `src/PPDS.Extension/tools/webview-cdp.mjs` (uses @playwright/test + @vscode/test-electron, both dev deps) |
-| mcp | MCP Inspector CLI (`npx @modelcontextprotocol/inspector`) |
+If a prerequisite is missing, tell the user what to install and stop.
 
 ## Process
 
-### 1. Detect Component
+### 1. Detect component
 
-Based on $ARGUMENTS or recent changes:
-- `src/PPDS.Cli/Commands/` → CLI mode
-- `src/PPDS.Cli/Tui/` → TUI mode
-- `src/PPDS.Extension/` → Extension mode
-- `src/PPDS.Mcp/` → MCP mode
-- `.claude/` or `scripts/` → Workflow mode
-- No clear match → Ask user
+From `$ARGUMENTS` or recent changes:
+`src/PPDS.Cli/Commands/`->cli, `src/PPDS.Cli/Tui/`->tui,
+`src/PPDS.Extension/`->extension, `src/PPDS.Mcp/`->mcp,
+`.claude/`+`scripts/`->workflow. No match: ask.
 
-### 2. Run Unit Tests First
-
-Always run the relevant unit tests before interactive verification. If tests fail, fix them first — don't waste MCP verification cycles on broken code.
+### 2. Unit tests first
 
 - CLI/TUI: `dotnet test PPDS.sln --filter "Category!=Integration" -v q`
 - Extension: `npm run test --prefix src/PPDS.Extension`
 - MCP: `dotnet test --filter "FullyQualifiedName~Mcp" -v q`
 
-### 3. CLI Mode
+Don't waste interactive cycles on broken code.
 
-Run the CLI command and verify output:
+### 3. CLI mode
 
 ```bash
 dotnet build src/PPDS.Cli/PPDS.Cli.csproj -f net10.0
 .\src\PPDS.Cli\bin\Debug\net10.0\ppds.exe <command> <args>
 ```
+Verify exit 0, format correct, edge cases (empty/invalid/no-auth).
 
-Verify:
-- Command executes without error
-- Output format is correct (JSON where expected, table where expected)
-- Exit code is 0
-- Edge cases: empty input, invalid args, missing auth
+### 4. TUI mode
 
-### 4. TUI Mode
+See `REFERENCE.md` "TUI Mode - worked example" for the Phase A/B/C
+commands. Phase B is mandatory when changed files touch
+`src/PPDS.Cli/Tui/`. <!-- enforcement: T3 -->
 
-**Phase A: Build and Launch**
+### 5. Extension mode
 
-```bash
-# Build and launch TUI in PTY
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs launch --build
+See `REFERENCE.md` "Extension Mode - worked example" for Phase A/B/C
+commands. Phase B is mandatory when query/data/panel files change.
+<!-- enforcement: T3 -->
 
-# Wait for TUI to render
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "PPDS" 15000
-
-# Read the title bar to confirm it loaded
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 0
-```
-
-**Phase B: Interactive Verification (MANDATORY for TUI rendering/interaction changes)** <!-- enforcement: T3 -->
-
-If changed files touch `src/PPDS.Cli/Tui/`, Phase B is NOT optional.
-
-```bash
-# Navigate to the relevant screen
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs key "tab"
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 2
-
-# Verify status bar content
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs text 28
-
-# Wait for expected screen title
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs wait "SQL Query" 5000
-
-# Dump terminal state for debugging if needed
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs screenshot $TEMP/tui-verify.json
-```
-
-**Phase C: Cleanup**
-
-```bash
-node tests/PPDS.Tui.E2eTests/tools/tui-verify.mjs close
-```
-
-See @tui-verify skill for full command reference and Terminal.Gui keyboard patterns.
-
-### 5. Extension Mode
-
-**Phase A: Functional Verification (ext-verify)**
-
-Launch VS Code with the extension and verify panels load:
-
-```bash
-# Build and launch (compiles extension + daemon)
-node src/PPDS.Extension/tools/webview-cdp.mjs launch --build
-
-# Open Data Explorer and wait for webview
-node src/PPDS.Extension/tools/webview-cdp.mjs command "PPDS: Data Explorer"
-node src/PPDS.Extension/tools/webview-cdp.mjs wait --ext "power-platform-developer-suite"
-
-# Screenshot to verify panel rendered correctly
-node src/PPDS.Extension/tools/webview-cdp.mjs screenshot $TEMP/data-explorer.png
-# LOOK at the screenshot — verify layout, no blank areas, controls visible
-
-# Check for runtime errors
-node src/PPDS.Extension/tools/webview-cdp.mjs logs
-node src/PPDS.Extension/tools/webview-cdp.mjs logs --channel "PPDS"
-```
-
-**Phase B: Interaction Verification (MANDATORY for query/data-display/panel-interaction changes)** <!-- enforcement: T3 -->
-
-If changed files touch query execution (`SqlQueryService`, `RpcMethodHandler`, `QueryPanel`, `query-panel.ts`), data rendering, or panel interactions, Phase B is NOT optional — you must execute at least one query and verify the results.
-
-```bash
-# Test query execution
-node src/PPDS.Extension/tools/webview-cdp.mjs eval 'monaco.editor.getEditors()[0].setValue("SELECT TOP 5 name FROM account")'
-node src/PPDS.Extension/tools/webview-cdp.mjs click "#execute-btn" --ext "power-platform-developer-suite"
-node src/PPDS.Extension/tools/webview-cdp.mjs screenshot $TEMP/after-query.png
-
-# Test Solutions Panel
-node src/PPDS.Extension/tools/webview-cdp.mjs command "PPDS: Solutions"
-node src/PPDS.Extension/tools/webview-cdp.mjs wait --ext "power-platform-developer-suite"
-node src/PPDS.Extension/tools/webview-cdp.mjs screenshot $TEMP/solutions.png
-```
-
-**Phase C: Cleanup**
-
-```bash
-node src/PPDS.Extension/tools/webview-cdp.mjs close
-```
-
-See @ext-verify skill for full command reference and common patterns.
-
-### 6. MCP Mode
-
-Use MCP Inspector CLI to test tools:
+### 6. MCP mode
 
 ```bash
 npx @modelcontextprotocol/inspector --cli --server "ppds-mcp-server"
 ```
+Per tool: valid->success shape; edge case->error handling; matches schema.
 
-For each tool:
-1. Call with valid input -> verify success response shape
-2. Call with edge case input -> verify error handling
-3. Verify response matches expected schema
+### 7. Workflow mode
 
-
-### 7. Workflow Mode
-
-Structural validation of process code (`.claude/` and `scripts/`).
-
-**Check 1: Python tests**
+**Check 1 - Python tests:**
 ```bash
 pytest tests/test_pipeline.py tests/test_workflow_state.py tests/test_protect_main_branch.py tests/test_session_stop_workflow.py -v
 ```
 
-**Check 2: Hook script tests**
-For each `.py` file in `.claude/hooks/` (excluding `_pathfix.py`):
+**Check 2 - Hook scripts:** for each `.py` in `.claude/hooks/` (except
+`_pathfix.py`): `echo '{}' | python .claude/hooks/{hook}.py`. Exit 0 or 2,
+never 1.
+
+**Check 3 - settings.json:** parses; every hook `command` exists on disk.
+
+**Check 4 - Skill frontmatter:** every `.claude/skills/*/SKILL.md` parses;
+`name` and `description` non-empty.
+
+**Check 5 - Agent frontmatter:** every `.claude/agents/*.md` parses;
+`tools` present; names in known set (`Read`, `Edit`, `Write`, `Glob`,
+`Grep`, `Bash`, `Agent`, `WebSearch`, `WebFetch`, `NotebookEdit`, and
+`Bash(pattern:*)`).
+
+**Check 6 - Skill file refs:** every referenced path exists.
+
+**Check 7 - Retro store schema:** see `REFERENCE.md` "Retro store schema".
+
+**Check 8 - Behavioral scenarios:** `python scripts/verify-workflow.py`;
+any failed scenario fails the check.
+
+**Check 9 - Empirical shakedown gate** <!-- enforcement: T2 hook:shakedown-gate -->
 ```bash
-echo '{}' | python .claude/hooks/{hook}.py
-# Expect exit 0 (allow) or exit 2 (block) — not a crash (exit 1)
+python scripts/verify_shakedown.py
 ```
+Allowlist source of truth: `scripts/_shakedown_allowlist.py`. When the
+diff touches any allowlisted file, spawn one real `claude --bg` against
+a throwaway prompt and assert exit 0; otherwise log a skip and exit 0.
+Subscription pool only (`claude --bg`), never `-p`. Rationale + how to
+add a wrapper: `REFERENCE.md` "Empirical shakedown gate". Exit codes:
+0=skipped/passed, 1=ran-and-failed, 2=setup error.
 
-**Check 3: settings.json validation**
-Parse `.claude/settings.json` as JSON. For each hook entry, verify the `command` path exists on disk.
-
-**Check 4: Skill frontmatter validation**
-For each `.claude/skills/*/SKILL.md`:
-- Parse YAML frontmatter (between `---` delimiters)
-- Verify `name` field present and non-empty
-- Verify `description` field present and non-empty
-
-**Check 5: Agent frontmatter validation**
-For each `.claude/agents/*.md`:
-- Parse YAML frontmatter
-- Verify `tools` list present
-- Verify each tool name is in the known valid set: `Read`, `Edit`, `Write`, `Glob`, `Grep`, `Bash`, `Agent`, `WebSearch`, `WebFetch`, `NotebookEdit` (and Bash with patterns like `Bash(git diff:*)`)
-
-**Check 6: Skill file references**
-Scan each skill markdown for file path patterns (relative paths starting with `./`, `../`, or absolute paths). Verify each referenced file exists.
-
-**Check 7: Retro store schema**
-If `.retros/summary.json` exists:
-- Parse as JSON
-- Verify required keys: `schema_version`, `last_updated`, `total_retros`, `findings_by_category`, `metrics`
-- Verify `schema_version == 1`
-If the file does not exist, this check passes (the store is optional until first retro).
-
-**Check 8: Behavioral scenario tests**
-```bash
-python scripts/verify-workflow.py
-```
-Runs behavioral scenarios against workflow hooks and state management. Parses JSON output from stdout; any failed scenario is a check failure.
-
-**Check 9: Workflow state write**
-On all checks passing:
-```bash
-python scripts/workflow-state.py set verify.workflow now
-python scripts/workflow-state.py set verify.workflow_commit_ref "$(git rev-parse HEAD)"
-```
+**Check 10 - State write:** on all checks passing,
+`python scripts/workflow-state.py set verify.workflow now` and
+`python scripts/workflow-state.py set verify.workflow_commit_ref "$(git rev-parse HEAD)"`.
 
 ### 8. Report
 
-Present structured results:
+See `REFERENCE.md` "Report template". Include actual values.
 
-```
-## Verification Results -- [component]
+## Workflow state
 
-| Check | Status | Details |
-|-------|--------|---------|
-| Unit tests | PASS | 12/12 passing |
-| Daemon connection | PASS | PID 12345, uptime 30s |
-| Tree view state | PASS | 2 profiles, 3 environments |
-| Data Explorer open | PASS | Panel created |
-| SQL query execution | PASS | 5 rows returned |
-| Webview rendering | PASS | Query panel layout correct |
-
-### Verdict: PASS -- all checks green
-```
-
-## Workflow State
-
-After verification passes for a surface (verdict is PASS), run:
-
+After PASS for a surface (`ext`/`tui`/`mcp`/`cli`/`workflow`):
 ```bash
 python scripts/workflow-state.py set verify.{surface} now
 python scripts/workflow-state.py set verify.{surface}_commit_ref "$(git rev-parse HEAD)"
 ```
 
-Surface key matches mode: `ext`, `tui`, `mcp`, `cli`. Example: `/verify extension` → `verify.ext`.
-Surface key `workflow`: `/verify workflow` → writes `verify.workflow` (structural validation for process code).
+## Workflow continuation - MANDATORY <!-- enforcement: T1 hook:session-stop-workflow -->
 
-## Workflow Continuation — MANDATORY <!-- enforcement: T1 hook:session-stop-workflow -->
+Verify is one step in the shipping pipeline, not the last one. Check
+`python scripts/workflow-state.py get phase`:
+- `implementing` -> return results to `/implement`.
+- otherwise -> proceed to `/pr` immediately. Pipeline is `/gates` ->
+  `/verify` -> `/pr`. Do not stop.
 
-Verify is ONE step in the shipping pipeline — not the last one.
-
-After verify passes, check whether `/implement` is driving the pipeline:
-
-```bash
-python scripts/workflow-state.py get phase
-```
-
-- **If phase is `implementing`:** return verify results to the `/implement` orchestrator. It manages the remaining pipeline steps.
-- **Otherwise (standalone invocation):** proceed to `/pr` immediately. Do NOT stop after reporting verification results. Do NOT wait for the user to tell you what to do next.
-
-  The shipping pipeline is `/gates` → `/verify` → `/pr`. You are at step 2. Proceed to step 3.
-
-Exception: if verify FAILS, stop and fix the failures first. Re-run `/verify` after fixing, then proceed to `/pr`.
+Exception: on FAIL, fix first, rerun `/verify`, then `/pr`.
 
 ## Rules
 
-1. **Unit tests first** -- always. Don't waste interactive cycles on broken code.
-2. **Screenshots for visual changes** -- if your change affects what users see, take a screenshot and look at it. See @ext-verify for what requires screenshots vs compile+test.
-3. **Report exact state** -- include actual values, not just pass/fail.
-4. **Prerequisites are hard gates** -- if MCP not configured, stop and say so.
-5. **Don't fix during verify** -- report problems, don't fix them. That's for /debug or /converge.
+1. Unit tests first.
+2. Screenshots for visual changes - look at them, don't just take them.
+3. Report actual values, not just pass/fail.
+4. Prerequisites are hard gates.
+5. Don't fix during verify - report problems for `/debug` or `/converge`.

--- a/scripts/_shakedown_allowlist.py
+++ b/scripts/_shakedown_allowlist.py
@@ -1,0 +1,30 @@
+"""Single source of truth for the empirical-shakedown allowlist.
+
+Files listed here spawn `claude` subprocesses. Touching any of them during
+a PR triggers `/verify`'s empirical-shakedown step (one real `claude --bg`
+against a throwaway target, exit 0 asserted) — see
+`.claude/skills/verify/SKILL.md`. The post-`/verify` drift detector in
+`scripts/retro_helpers.py` reads the same list to flag fix commits that
+touched subprocess-spawning files outside the allowlist.
+
+Paths are repo-relative, forward slashes. Add a new wrapper by appending a
+single line here; the gate and the detector both pick it up automatically.
+"""
+from __future__ import annotations
+
+SHAKEDOWN_ALLOWLIST: tuple[str, ...] = (
+    "scripts/claude_dispatch.py",
+    "scripts/pipeline.py",
+    "scripts/pr_monitor.py",
+    "scripts/triage_common.py",
+    "scripts/start-bg-spawn.py",
+)
+
+
+def _norm(p: str) -> str:
+    return p.replace("\\", "/").lstrip("./")
+
+
+def is_allowlisted(path: str) -> bool:
+    """Return True if *path* (any separator, optional ``./`` prefix) is in the allowlist."""
+    return _norm(path) in SHAKEDOWN_ALLOWLIST

--- a/scripts/claude_dispatch.py
+++ b/scripts/claude_dispatch.py
@@ -99,10 +99,20 @@ def _norm(p: str) -> str:
 _SLUG_CHAR_RE = re.compile(r"[^A-Za-z0-9-]")
 
 
+def derive_slug(cwd: str) -> str:
+    """Return Claude Code's per-project slug for ``cwd``.
+
+    Replaces every non-[A-Za-z0-9-] character with `-`. This is the same
+    encoding Claude Code uses for ``~/.claude/projects/<slug>/``. Other
+    PPDS scripts (e.g. retro transcript discovery) must call this helper
+    rather than re-deriving the rule.
+    """
+    return _SLUG_CHAR_RE.sub("-", cwd)
+
+
 def _derive_transcript_path(cwd: str, session_id: str) -> Path:
     """Return ~/.claude/projects/<slug>/<sessionId>.jsonl for the given cwd."""
-    slug = _SLUG_CHAR_RE.sub("-", cwd)
-    return Path(os.path.expanduser("~/.claude/projects")) / slug / f"{session_id}.jsonl"
+    return Path(os.path.expanduser("~/.claude/projects")) / derive_slug(cwd) / f"{session_id}.jsonl"
 
 
 def _parse_version(out: str) -> tuple[int, int, int]:

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -2,6 +2,15 @@
 
 import json
 import os
+import subprocess
+import sys
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from claude_dispatch import derive_slug
+from _shakedown_allowlist import SHAKEDOWN_ALLOWLIST, is_allowlisted
 
 
 def extract_transcript_signals(jsonl_path):
@@ -142,37 +151,197 @@ def extract_enforcement_signals(state_path):
 def _encode_project_dir(path):
     """Encode a filesystem path into the Claude Code project directory name.
 
-    Claude Code stores per-project data under ``~/.claude/projects/<encoded>``,
-    where ``<encoded>`` is the absolute path with ``:``, ``/``, ``\\``, and ``.``
-    replaced by ``-``.
+    Delegates to ``claude_dispatch.derive_slug`` so retro and the dispatcher
+    stay in lockstep — Claude Code replaces every non-[A-Za-z0-9-] character
+    with ``-``, not just ``:\\/.`` (the older retro rule missed underscores
+    and dropped transcripts on Windows usernames like ``josh_``).
     """
-    import re
-
-    path = os.path.abspath(path)
-    return re.sub(r"[:\\/.]", "-", path)
+    return derive_slug(os.path.abspath(path))
 
 
-def discover_transcripts(worktree_path):
-    """Find all transcript files (JSONL, logs) for *this* worktree only."""
+def discover_transcripts(worktree_path, since=None):
+    """Find transcript files (JSONL, logs) for *this* worktree only.
+
+    Args:
+        worktree_path: filesystem path of the worktree.
+        since: optional epoch-seconds floor; transcripts with ``st_mtime``
+            older than this value are skipped. Lets retro narrow noise from
+            unrelated sessions stored under the same project slug.
+    """
     transcripts = []
     # Pipeline stage logs
     stages_dir = os.path.join(worktree_path, ".workflow", "stages")
     if os.path.isdir(stages_dir):
         for f in os.listdir(stages_dir):
             if f.endswith(".jsonl"):
-                transcripts.append(os.path.join(stages_dir, f))
+                p = os.path.join(stages_dir, f)
+                if since is not None:
+                    try:
+                        if os.stat(p).st_mtime < since:
+                            continue
+                    except OSError:
+                        continue
+                transcripts.append(p)
     # Interactive session transcripts (Claude Code stores these)
     claude_dir = os.path.expanduser("~/.claude/projects")
     if os.path.isdir(claude_dir):
         encoded = _encode_project_dir(worktree_path)
-        for entry in os.listdir(claude_dir):
-            if entry != encoded:
-                continue
-            project_dir = os.path.join(claude_dir, entry)
-            if not os.path.isdir(project_dir):
-                continue
+        project_dir = os.path.join(claude_dir, encoded)
+        if os.path.isdir(project_dir):
             for root, _dirs, files in os.walk(project_dir):
                 for f in files:
-                    if f.endswith(".jsonl"):
-                        transcripts.append(os.path.join(root, f))
+                    if not f.endswith(".jsonl"):
+                        continue
+                    p = os.path.join(root, f)
+                    if since is not None:
+                        try:
+                            if os.stat(p).st_mtime < since:
+                                continue
+                        except OSError:
+                            continue
+                    transcripts.append(p)
     return transcripts
+
+
+def _git_log(args, cwd=None):
+    """Run ``git log`` and return stdout text, empty string on failure."""
+    try:
+        out = subprocess.run(
+            ["git", "log", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if out.returncode != 0:
+        return ""
+    return out.stdout
+
+
+def _commits_since_verify(cwd=None):
+    """Return commit SHAs (oldest -> newest) authored after the latest
+    ``/verify`` marker.
+
+    Heuristic: the marker is a commit whose subject matches ``/verify`` or
+    ``verify:``/``verify(``/``verify passed``. If no such commit is found,
+    return ``[]`` (the detector then has nothing to flag).
+    """
+    log = _git_log(["--reverse", "--format=%H%x09%s", "-n", "200"], cwd=cwd)
+    if not log:
+        return []
+    rows = [line.split("\t", 1) for line in log.splitlines() if "\t" in line]
+    verify_idx = None
+    markers = ("/verify", "verify:", "verify(", "verify passed", "verify ok")
+    for i, (_sha, subject) in enumerate(rows):
+        s = subject.lower()
+        if any(m in s for m in markers):
+            verify_idx = i
+    if verify_idx is None:
+        return []
+    return [sha for sha, _s in rows[verify_idx + 1:]]
+
+
+def _commit_subject(sha, cwd=None):
+    return _git_log(["-1", "--format=%s", sha], cwd=cwd).strip()
+
+
+def _commit_files(sha, cwd=None):
+    out = _git_log(["-1", "--name-only", "--format=", sha], cwd=cwd)
+    return [line.strip().replace("\\", "/") for line in out.splitlines() if line.strip()]
+
+
+_FIX_PREFIX_RE = ("fix", "bug", "hotfix", "patch", "revert")
+_SUBPROCESS_HINTS = ("subprocess", "claude_dispatch", "spawn", "popen", "claude --bg", "claude -p")
+
+
+def _looks_like_fix(subject):
+    s = subject.lower().lstrip()
+    return any(s.startswith(p) for p in _FIX_PREFIX_RE)
+
+
+def _spawns_subprocess(path, cwd=None):
+    """Heuristic: file imports subprocess or references claude_dispatch."""
+    try:
+        full = os.path.join(cwd or ".", path)
+        with open(full, "r", encoding="utf-8", errors="replace") as f:
+            head = f.read(8192)
+    except OSError:
+        return False
+    return any(h in head for h in _SUBPROCESS_HINTS)
+
+
+def detect_allowlist_drift(cwd=None, post_verify_commits=None):
+    """Return drift proposals for files touched by post-/verify fix commits.
+
+    A proposal is generated for any subprocess-spawning file NOT in the
+    shakedown allowlist that received >=1 fix commit after ``/verify``.
+    Each proposal carries the file path, the fix-commit count, and the
+    suggested allowlist line so a human can rubber-stamp the addition.
+
+    Args:
+        cwd: repository root; defaults to current working directory.
+        post_verify_commits: pre-computed list of commit SHAs to inspect
+            (testing seam). When ``None``, derived from ``git log``.
+
+    Returns:
+        list[dict]: ``[{"file": ..., "fix_count": N, "proposal": str,
+        "commits": [sha, ...]}]``.
+    """
+    if post_verify_commits is None:
+        post_verify_commits = _commits_since_verify(cwd=cwd)
+    if not post_verify_commits:
+        return []
+
+    file_to_commits = {}
+    for sha in post_verify_commits:
+        subject = _commit_subject(sha, cwd=cwd)
+        if not _looks_like_fix(subject):
+            continue
+        for path in _commit_files(sha, cwd=cwd):
+            if is_allowlisted(path):
+                continue
+            if not _spawns_subprocess(path, cwd=cwd):
+                continue
+            file_to_commits.setdefault(path, []).append(sha)
+
+    proposals = []
+    for path, shas in sorted(file_to_commits.items()):
+        count = len(shas)
+        proposals.append({
+            "file": path,
+            "fix_count": count,
+            "commits": shas,
+            "proposal": (
+                f"Add {path} to shakedown allowlist "
+                f"({count} post-/verify fix{'es' if count != 1 else ''} this PR)"
+            ),
+        })
+    return proposals
+
+
+def write_drift_proposals(findings_path, proposals):
+    """Merge *proposals* into ``.workflow/retro-findings.json``.
+
+    Schema (additive): root dict gains ``allowlist_drift`` key holding the
+    list of proposals. Other keys are preserved. Creates the file (and
+    parent dir) if missing. Returns the proposals list (echoed for caller
+    convenience). When *proposals* is empty, no file is created.
+    """
+    if not proposals:
+        return proposals
+    os.makedirs(os.path.dirname(os.path.abspath(findings_path)) or ".", exist_ok=True)
+    existing = {}
+    try:
+        with open(findings_path, "r", encoding="utf-8") as f:
+            existing = json.load(f) or {}
+    except (json.JSONDecodeError, OSError):
+        existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+    existing["allowlist_drift"] = proposals
+    with open(findings_path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return proposals

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -266,7 +266,7 @@ def _spawns_subprocess(path, cwd=None):
     try:
         full = os.path.join(cwd or ".", path)
         with open(full, "r", encoding="utf-8", errors="replace") as f:
-            head = f.read(8192)
+            head = f.read(8192).lower()
     except OSError:
         return False
     return any(h in head for h in _SUBPROCESS_HINTS)

--- a/scripts/verify_shakedown.py
+++ b/scripts/verify_shakedown.py
@@ -1,0 +1,146 @@
+"""Empirical shakedown gate for /verify.
+
+When the change set touches any file in ``SHAKEDOWN_ALLOWLIST`` (the
+subprocess-spawning wrappers — see ``scripts/_shakedown_allowlist.py``),
+spawn one real ``claude --bg`` session against a throwaway prompt and
+assert exit 0. This is the gate that PR #1051 Phase B exhibited: the
+auto-stubbed ``claude_dispatch.spawn`` in ``tests/conftest.py`` masked
+seven real failures, so the unit-test suite passed while the real
+boundary was broken. The shakedown deliberately exercises the real
+boundary — no patches, no stubs, real subprocess.
+
+Subscription pool only — uses ``claude --bg``, never ``-p``. Bounded by
+``--timeout`` (default 5 min) so the /verify runtime cost is capped.
+
+CLI:
+    python scripts/verify_shakedown.py [--base <ref>] [--timeout <sec>]
+
+Exit codes:
+    0  shakedown not required, or required and passed.
+    1  shakedown required and the spawned --bg session did not reach
+       state=done within the timeout.
+    2  setup error (cannot reach git, dispatcher import failed, etc.).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _shakedown_allowlist import SHAKEDOWN_ALLOWLIST, is_allowlisted
+
+DEFAULT_TIMEOUT_SEC = 300
+THROWAWAY_PROMPT = "Reply with the word OK and stop."
+
+
+def _changed_files(base: str | None) -> list[str]:
+    """Return repo-relative changed paths vs *base*.
+
+    Uses ``git diff --name-only <base>...HEAD`` when *base* is provided,
+    otherwise falls back to ``git status --porcelain`` (uncommitted work).
+    """
+    if base:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if out.returncode == 0:
+            return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+    out = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if out.returncode != 0:
+        return []
+    files = []
+    for line in out.stdout.splitlines():
+        # porcelain format: "XY path" or "XY orig -> new"
+        if len(line) < 4:
+            continue
+        rest = line[3:]
+        if " -> " in rest:
+            rest = rest.split(" -> ", 1)[1]
+        files.append(rest.strip().strip('"'))
+    return files
+
+
+def _detect_base() -> str | None:
+    """Guess the merge-base ref. Returns None when we cannot determine one."""
+    for ref in ("origin/main", "main"):
+        out = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            capture_output=True, text=True, timeout=10,
+        )
+        if out.returncode == 0:
+            return ref
+    return None
+
+
+def run_shakedown(timeout: float = DEFAULT_TIMEOUT_SEC) -> int:
+    """Spawn one ``claude --bg`` session, wait for done, return exit code."""
+    # Import lazily so --help / no-change-set paths don't require dispatcher.
+    import claude_dispatch  # noqa: E402
+
+    handle = claude_dispatch.spawn(
+        mode="interactive",
+        prompt=THROWAWAY_PROMPT,
+        caller="verify_shakedown",
+        name="verify-shakedown",
+        dangerous=True,
+    )
+    sys.stderr.write(
+        f"verify_shakedown: spawned claude --bg short={handle.short} "
+        f"(timeout={timeout}s)\n"
+    )
+    start = time.time()
+    rc = handle.wait(timeout=timeout)
+    elapsed = time.time() - start
+    sys.stderr.write(
+        f"verify_shakedown: claude --bg short={handle.short} "
+        f"exit={rc} elapsed={elapsed:.1f}s\n"
+    )
+    return rc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Empirical shakedown gate for /verify.")
+    parser.add_argument("--base", default=None,
+                        help="Git ref to diff against (default: auto-detect origin/main).")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SEC,
+                        help=f"Spawn timeout in seconds (default {DEFAULT_TIMEOUT_SEC}).")
+    parser.add_argument("--require", action="store_true",
+                        help="Force run even when no allowlist file changed.")
+    args = parser.parse_args(argv)
+
+    base = args.base if args.base else _detect_base()
+    changed = _changed_files(base)
+    touched = sorted({p for p in changed if is_allowlisted(p)})
+
+    if not touched and not args.require:
+        sys.stderr.write(
+            "verify_shakedown: skip — no allowlist file touched "
+            f"(allowlist={list(SHAKEDOWN_ALLOWLIST)}, base={base or 'unknown'})\n"
+        )
+        return 0
+
+    sys.stderr.write(
+        "verify_shakedown: run — allowlist files touched: "
+        f"{touched or ['(forced)']}\n"
+    )
+    try:
+        rc = run_shakedown(timeout=args.timeout)
+    except Exception as exc:  # noqa: BLE001 — gate must surface dispatcher errors
+        sys.stderr.write(f"verify_shakedown: setup error: {exc}\n")
+        return 2
+    return 0 if rc == 0 else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_retro_helpers.py
+++ b/tests/test_retro_helpers.py
@@ -122,3 +122,143 @@ class TestDiscoverTranscripts:
             transcripts = retro_helpers.discover_transcripts(worktree)
             assert any("mine.jsonl" in t for t in transcripts)
             assert not any("theirs.jsonl" in t for t in transcripts)
+
+    def test_encode_project_dir_uses_dispatch_slug_rule(self):
+        """_encode_project_dir matches claude_dispatch.derive_slug — every
+        non-[A-Za-z0-9-] character (including underscores and dots) becomes -."""
+        import retro_helpers
+        from claude_dispatch import derive_slug
+
+        # Real Windows-shaped path with an underscore in the username and a
+        # dot in `.worktrees` — both are dropped by the old regex but caught
+        # by the dispatcher's rule.
+        path = r"C:\Users\josh_\source\repos\ppdsw\ppds\.worktrees\workflow-gates"
+        encoded = retro_helpers._encode_project_dir(path)
+        # Underscore replaced
+        assert "_" not in encoded
+        # Matches the dispatcher's derivation (after abspath normalization)
+        assert encoded == derive_slug(os.path.abspath(path))
+
+    def test_discover_transcripts_since_filter(self, monkeypatch):
+        """discover_transcripts skips transcripts older than ``since`` mtime."""
+        import retro_helpers
+        with tempfile.TemporaryDirectory() as fake_home:
+            claude_projects = os.path.join(fake_home, ".claude", "projects")
+            worktree = os.path.join(fake_home, "my", "project")
+            os.makedirs(worktree)
+            encoded = retro_helpers._encode_project_dir(worktree)
+            project_dir = os.path.join(claude_projects, encoded)
+            os.makedirs(project_dir)
+
+            old = os.path.join(project_dir, "old.jsonl")
+            new = os.path.join(project_dir, "new.jsonl")
+            with open(old, "w") as f:
+                f.write("{}\n")
+            with open(new, "w") as f:
+                f.write("{}\n")
+            os.utime(old, (1_000_000, 1_000_000))
+            os.utime(new, (2_000_000, 2_000_000))
+
+            monkeypatch.setattr(
+                os.path, "expanduser",
+                lambda p: p.replace("~", fake_home),
+            )
+            transcripts = retro_helpers.discover_transcripts(worktree, since=1_500_000)
+            assert any("new.jsonl" in t for t in transcripts)
+            assert not any("old.jsonl" in t for t in transcripts)
+
+
+class TestAllowlistDriftDetector:
+    def _init_repo(self, tmpdir):
+        import subprocess
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        for cmd in (
+            ["git", "init", "-q", "-b", "main"],
+            ["git", "commit", "-q", "--allow-empty", "-m", "init"],
+        ):
+            subprocess.run(cmd, cwd=tmpdir, check=True, env=env)
+        return env
+
+    def _commit(self, tmpdir, env, subject, files):
+        import subprocess
+        for rel, content in files.items():
+            full = os.path.join(tmpdir, rel)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w", encoding="utf-8") as f:
+                f.write(content)
+            subprocess.run(["git", "add", rel], cwd=tmpdir, check=True, env=env)
+        subprocess.run(["git", "commit", "-q", "-m", subject], cwd=tmpdir, check=True, env=env)
+
+    def test_flags_post_verify_fix_on_subprocess_file(self):
+        """A fix-after-/verify commit touching a subprocess-spawning file
+        outside the allowlist produces a concrete proposal."""
+        import retro_helpers
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = self._init_repo(tmpdir)
+            # Pre-verify work (ignored)
+            self._commit(tmpdir, env, "feat: introduce foo",
+                         {"scripts/foo.py": "import subprocess\n"})
+            # The /verify marker
+            self._commit(tmpdir, env, "verify: workflow ok",
+                         {"docs/notes.md": "x\n"})
+            # Two post-verify fixes touching scripts/foo.py — must be flagged
+            self._commit(tmpdir, env, "fix: foo crash on Windows",
+                         {"scripts/foo.py": "import subprocess  # patched\n"})
+            self._commit(tmpdir, env, "fix(foo): error path",
+                         {"scripts/foo.py": "import subprocess  # patched2\n"})
+            # Post-verify fix touching an allowlisted file — must NOT be flagged
+            self._commit(tmpdir, env, "fix(dispatch): edge case",
+                         {"scripts/claude_dispatch.py": "import subprocess\n"})
+            # Post-verify fix touching a non-subprocess file — must NOT be flagged
+            self._commit(tmpdir, env, "fix: doc typo",
+                         {"docs/notes.md": "y\n"})
+
+            proposals = retro_helpers.detect_allowlist_drift(cwd=tmpdir)
+            flagged = [p["file"] for p in proposals]
+            assert "scripts/foo.py" in flagged
+            assert "scripts/claude_dispatch.py" not in flagged
+            assert "docs/notes.md" not in flagged
+            foo = next(p for p in proposals if p["file"] == "scripts/foo.py")
+            assert foo["fix_count"] == 2
+            assert "shakedown allowlist" in foo["proposal"]
+
+    def test_no_verify_marker_returns_empty(self):
+        """Detector is a no-op when no /verify commit appears in history."""
+        import retro_helpers
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = self._init_repo(tmpdir)
+            self._commit(tmpdir, env, "fix: thing",
+                         {"scripts/foo.py": "import subprocess\n"})
+            assert retro_helpers.detect_allowlist_drift(cwd=tmpdir) == []
+
+    def test_write_drift_proposals_merges_existing_findings(self):
+        """write_drift_proposals preserves prior keys in retro-findings.json."""
+        import retro_helpers
+        with tempfile.TemporaryDirectory() as tmpdir:
+            findings = os.path.join(tmpdir, ".workflow", "retro-findings.json")
+            os.makedirs(os.path.dirname(findings))
+            with open(findings, "w", encoding="utf-8") as f:
+                json.dump({"prior": [1, 2, 3]}, f)
+            proposals = [
+                {"file": "scripts/bar.py", "fix_count": 1, "commits": ["abc"],
+                 "proposal": "Add scripts/bar.py to shakedown allowlist (1 post-/verify fix this PR)"},
+            ]
+            retro_helpers.write_drift_proposals(findings, proposals)
+            with open(findings, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            assert data["prior"] == [1, 2, 3]
+            assert data["allowlist_drift"] == proposals
+
+    def test_write_drift_proposals_skips_empty(self):
+        """No file write when proposals list is empty."""
+        import retro_helpers
+        with tempfile.TemporaryDirectory() as tmpdir:
+            findings = os.path.join(tmpdir, ".workflow", "retro-findings.json")
+            retro_helpers.write_drift_proposals(findings, [])
+            assert not os.path.exists(findings)

--- a/tests/test_verify_shakedown.py
+++ b/tests/test_verify_shakedown.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for verify_shakedown gate (Sub-task C).
+
+These tests cover the *decision* layer — whether the gate decides to run
+the empirical spawn — without actually spawning a real claude process.
+The spawn itself is exercised by the conftest auto-stub.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest.mock as mock
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "scripts"))
+
+import verify_shakedown  # noqa: E402
+
+
+def _init_repo(tmpdir):
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmpdir, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "init"],
+        cwd=tmpdir, check=True, env=env,
+    )
+    return env
+
+
+def _touch_and_commit(tmpdir, env, files, subject):
+    for rel, content in files.items():
+        full = os.path.join(tmpdir, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as f:
+            f.write(content)
+        subprocess.run(["git", "add", rel], cwd=tmpdir, check=True, env=env)
+    subprocess.run(["git", "commit", "-q", "-m", subject], cwd=tmpdir, check=True, env=env)
+
+
+def test_skips_when_no_allowlist_file_changed(monkeypatch, capsys):
+    """No spawn when the diff misses every allowlist entry."""
+    monkeypatch.setattr(verify_shakedown, "_changed_files", lambda base: ["docs/readme.md", "src/foo.cs"])
+    monkeypatch.setattr(verify_shakedown, "_detect_base", lambda: "origin/main")
+    spawn = mock.MagicMock()
+    monkeypatch.setattr(verify_shakedown, "run_shakedown", spawn)
+
+    rc = verify_shakedown.main([])
+    assert rc == 0
+    spawn.assert_not_called()
+
+
+def test_runs_when_allowlist_file_changed(monkeypatch):
+    """Touching any allowlist entry triggers the spawn."""
+    monkeypatch.setattr(
+        verify_shakedown, "_changed_files",
+        lambda base: ["scripts/claude_dispatch.py", "tests/conftest.py"],
+    )
+    monkeypatch.setattr(verify_shakedown, "_detect_base", lambda: "origin/main")
+    spawn = mock.MagicMock(return_value=0)
+    monkeypatch.setattr(verify_shakedown, "run_shakedown", spawn)
+
+    rc = verify_shakedown.main([])
+    assert rc == 0
+    spawn.assert_called_once()
+
+
+def test_propagates_spawn_failure(monkeypatch):
+    """Non-zero spawn exit becomes gate failure (rc=1)."""
+    monkeypatch.setattr(verify_shakedown, "_changed_files", lambda base: ["scripts/pipeline.py"])
+    monkeypatch.setattr(verify_shakedown, "_detect_base", lambda: "origin/main")
+    monkeypatch.setattr(verify_shakedown, "run_shakedown", lambda timeout: 1)
+
+    rc = verify_shakedown.main([])
+    assert rc == 1
+
+
+def test_setup_error_surfaces_as_rc2(monkeypatch):
+    """Dispatcher import / spawn raising surfaces as a distinct exit code."""
+    monkeypatch.setattr(verify_shakedown, "_changed_files", lambda base: ["scripts/pipeline.py"])
+    monkeypatch.setattr(verify_shakedown, "_detect_base", lambda: "origin/main")
+
+    def boom(timeout):
+        raise RuntimeError("dispatcher unavailable")
+    monkeypatch.setattr(verify_shakedown, "run_shakedown", boom)
+
+    rc = verify_shakedown.main([])
+    assert rc == 2
+
+
+def test_changed_files_diff_path(monkeypatch):
+    """End-to-end: a real git repo where /verify diff includes an allowlist file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        env = _init_repo(tmpdir)
+        _touch_and_commit(
+            tmpdir, env,
+            {"scripts/claude_dispatch.py": "import subprocess\n"},
+            "feat: bring dispatcher in",
+        )
+        # Diff vs the empty initial commit
+        base = subprocess.run(
+            ["git", "rev-list", "--max-parents=0", "HEAD"],
+            cwd=tmpdir, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        # _changed_files uses `git diff <base>...HEAD`
+        files = []
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            cwd=tmpdir, capture_output=True, text=True, check=True,
+        )
+        files = [line.strip() for line in out.stdout.splitlines() if line.strip()]
+        assert "scripts/claude_dispatch.py" in files
+        # Verify the allowlist matcher agrees
+        from _shakedown_allowlist import is_allowlisted
+        assert is_allowlisted("scripts/claude_dispatch.py")


### PR DESCRIPTION
Closes #1054.

Three coupled workflow-tooling edits in one PR. Same narrative across all three: catch the class of bugs PR #1051 Phase B exhibited — seven fix commits landed after `/verify` passed because `tests/conftest.py` auto-stubs `claude_dispatch.spawn`, masking the only boundary that was actually wrong. See the PR #1051 retrospective rationale.

## Summary

- **Sub-task A (extractor fix)**: `scripts/retro_helpers.py:discover_transcripts` now reuses `claude_dispatch.derive_slug` (every non-`[A-Za-z0-9-]` -> `-`), matching Claude Code's actual `~/.claude/projects/<slug>/` layout on Windows. The old retro rule only replaced `:\/.` and dropped underscores like `josh_`, so every interactive retro silently returned `[]` transcripts. Adds an optional `since=<epoch>` mtime filter so retros can scope to a window.
- **Sub-task C (empirical shakedown gate)**: `.claude/skills/verify/SKILL.md` Check 9 invokes `scripts/verify_shakedown.py`. When the diff touches any file in `scripts/_shakedown_allowlist.py`, the helper spawns one real `claude --bg` session via `claude_dispatch.spawn(mode="interactive", ...)`, waits for `state=done`, asserts exit 0. Subscription pool only — never `-p`. Untouched diffs skip with a clear log line; runtime budget is 5 min. SKILL.md was refactored to fit the 150-line cap; verbose phase examples moved to a new `REFERENCE.md` sibling.
- **Sub-task B (drift detector)**: `scripts/retro_helpers.py:detect_allowlist_drift` walks post-`/verify` commits, flags fix-shaped subjects (`fix`/`bug`/`hotfix`/`patch`/`revert`) touching subprocess-spawning files NOT in `SHAKEDOWN_ALLOWLIST`, and `write_drift_proposals` merges proposals into `.workflow/retro-findings.json` under the new `allowlist_drift` key. Retro `SKILL.md` Phase 3 invokes both helpers so proposals materialize without manual prompting. Human still approves; the detector just makes the suggestion mechanical.

**Single source of truth:** `scripts/_shakedown_allowlist.py` — both the gate and the detector import `SHAKEDOWN_ALLOWLIST`. Adding a new wrapper is a one-line append.

## Allowlist

- `scripts/claude_dispatch.py`
- `scripts/pipeline.py`
- `scripts/pr_monitor.py`
- `scripts/triage_common.py`
- `scripts/start-bg-spawn.py`

## Test plan

- [x] `discover_transcripts()` returns >0 transcripts from this worktree on Windows (verified: 1 transcript found for the live session)
- [x] New tests in `tests/test_retro_helpers.py` and `tests/test_verify_shakedown.py` pass (18/18)
- [x] `python scripts/audit-enforcement.py --strict` — OK: 10 T1 markers wired
- [x] `python scripts/verify-workflow.py` — 9/9 behavioral scenarios pass
- [x] `python scripts/verify_shakedown.py --base origin/main` — real `claude --bg` exit 0 in 3.0s
- [x] `claude_dispatch` + dispatch routing test suite — 48/48 pass
- [x] Pre-existing main test failures (7) unrelated to this PR — confirmed against `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)