### PR TITLE
feat(migration): JSON data export format alongside CMT XML

### DIFF
--- a/src/PPDS.Cli/Commands/Data/ExportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ExportCommand.cs
@@ -87,6 +87,12 @@ public static class ExportCommand
             DefaultValueFactory = _ => OutputFormat.Text
         };
 
+        var dataFormatOption = new Option<ExportDataFormat>("--format")
+        {
+            Description = "Data export format: cmt (CMT-compatible XML ZIP) or json (PPDS-native JSON)",
+            DefaultValueFactory = _ => ExportDataFormat.Cmt
+        };
+
         var verboseOption = new Option<bool>("--verbose", "-v")
         {
             Description = "Enable verbose logging output",
@@ -110,6 +116,7 @@ public static class ExportCommand
             pageParallelOption,
             pageParallelThresholdOption,
             outputFormatOption,
+            dataFormatOption,
             verboseOption,
             debugOption
         };
@@ -125,13 +132,14 @@ public static class ExportCommand
             var pageParallel = parseResult.GetValue(pageParallelOption);
             var pageParallelThreshold = parseResult.GetValue(pageParallelThresholdOption);
             var outputFormat = parseResult.GetValue(outputFormatOption);
+            var dataFormat = parseResult.GetValue(dataFormatOption);
             var verbose = parseResult.GetValue(verboseOption);
             var debug = parseResult.GetValue(debugOption);
 
             return await ExecuteAsync(
                 profile, environment, schema, output, parallel, batchSize,
                 pageParallel, pageParallelThreshold,
-                outputFormat, verbose, debug, cancellationToken);
+                outputFormat, dataFormat, verbose, debug, cancellationToken);
         });
 
         return command;
@@ -147,6 +155,7 @@ public static class ExportCommand
         int pageParallel,
         int pageParallelThreshold,
         OutputFormat outputFormat,
+        ExportDataFormat dataFormat,
         bool verbose,
         bool debug,
         CancellationToken cancellationToken)
@@ -177,7 +186,8 @@ public static class ExportCommand
                 DegreeOfParallelism = parallel,
                 PageSize = batchSize,
                 PageLevelParallelism = pageParallel,
-                PageLevelParallelismThreshold = pageParallelThreshold
+                PageLevelParallelismThreshold = pageParallelThreshold,
+                Format = dataFormat
             };
 
             var result = await exporter.ExportAsync(

--- a/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/PPDS.Migration/DependencyInjection/ServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ namespace PPDS.Migration.DependencyInjection
             services.AddTransient<ICmtSchemaWriter, CmtSchemaWriter>();
             services.AddTransient<ICmtDataReader, CmtDataReader>();
             services.AddTransient<ICmtDataWriter, CmtDataWriter>();
+            services.AddTransient<IJsonDataWriter, JsonDataWriter>();
 
             // Schema generation
             services.AddTransient<ISchemaGenerator, DataverseSchemaGenerator>();

--- a/src/PPDS.Migration/Export/ExportDataFormat.cs
+++ b/src/PPDS.Migration/Export/ExportDataFormat.cs
@@ -1,0 +1,19 @@
+namespace PPDS.Migration.Export
+{
+    /// <summary>
+    /// Serialization format for exported migration data.
+    /// </summary>
+    public enum ExportDataFormat
+    {
+        /// <summary>
+        /// Configuration Migration Tool (CMT) ZIP archive: data.xml + data_schema.xml.
+        /// Drop-in compatible with Microsoft's existing CMT tooling.
+        /// </summary>
+        Cmt,
+
+        /// <summary>
+        /// PPDS-native JSON document. Single file. Modern tooling (jq, JSON Schema, APIs).
+        /// </summary>
+        Json
+    }
+}

--- a/src/PPDS.Migration/Export/ExportOptions.cs
+++ b/src/PPDS.Migration/Export/ExportOptions.cs
@@ -45,5 +45,11 @@ namespace PPDS.Migration.Export
         /// Default: 5000
         /// </summary>
         public int PageLevelParallelismThreshold { get; set; } = 5000;
+
+        /// <summary>
+        /// Gets or sets the serialization format for the exported data.
+        /// Default: <see cref="ExportDataFormat.Cmt"/> (CMT-compatible XML ZIP).
+        /// </summary>
+        public ExportDataFormat Format { get; set; } = ExportDataFormat.Cmt;
     }
 }

--- a/src/PPDS.Migration/Export/ParallelExporter.cs
+++ b/src/PPDS.Migration/Export/ParallelExporter.cs
@@ -30,6 +30,7 @@ namespace PPDS.Migration.Export
         private readonly IDataverseConnectionPool _connectionPool;
         private readonly ICmtSchemaReader _schemaReader;
         private readonly ICmtDataWriter _dataWriter;
+        private readonly IJsonDataWriter? _jsonDataWriter;
         private readonly FileColumnTransferHelper? _fileTransferHelper;
         private readonly ExportOptions _defaultOptions;
         private readonly ILogger<ParallelExporter>? _logger;
@@ -56,7 +57,8 @@ namespace PPDS.Migration.Export
         /// </summary>
         /// <param name="connectionPool">The connection pool.</param>
         /// <param name="schemaReader">The schema reader.</param>
-        /// <param name="dataWriter">The data writer.</param>
+        /// <param name="dataWriter">The CMT XML data writer.</param>
+        /// <param name="jsonDataWriter">The JSON data writer (used when <see cref="ExportOptions.Format"/> is <see cref="ExportDataFormat.Json"/>).</param>
         /// <param name="fileTransferHelper">Optional file column transfer helper for downloading file data.</param>
         /// <param name="migrationOptions">Migration options from DI.</param>
         /// <param name="logger">The logger.</param>
@@ -64,11 +66,13 @@ namespace PPDS.Migration.Export
             IDataverseConnectionPool connectionPool,
             ICmtSchemaReader schemaReader,
             ICmtDataWriter dataWriter,
+            IJsonDataWriter? jsonDataWriter = null,
             FileColumnTransferHelper? fileTransferHelper = null,
             IOptions<MigrationOptions>? migrationOptions = null,
             ILogger<ParallelExporter>? logger = null)
             : this(connectionPool, schemaReader, dataWriter)
         {
+            _jsonDataWriter = jsonDataWriter;
             _fileTransferHelper = fileTransferHelper;
             _defaultOptions = migrationOptions?.Value.Export ?? new ExportOptions();
             _logger = logger;
@@ -220,7 +224,20 @@ namespace PPDS.Migration.Export
                     ExportedAt = DateTime.UtcNow
                 };
 
-                await _dataWriter.WriteAsync(migrationData, outputPath, progress, cancellationToken).ConfigureAwait(false);
+                if (options.Format == ExportDataFormat.Json)
+                {
+                    if (_jsonDataWriter == null)
+                    {
+                        throw new InvalidOperationException(
+                            "JSON export format requested but no IJsonDataWriter is registered. " +
+                            "Register PPDS.Migration via AddDataverseMigration() so the JSON writer is available.");
+                    }
+                    await _jsonDataWriter.WriteAsync(migrationData, outputPath, progress, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await _dataWriter.WriteAsync(migrationData, outputPath, progress, cancellationToken).ConfigureAwait(false);
+                }
 
                 stopwatch.Stop();
 

--- a/src/PPDS.Migration/Formats/IJsonDataWriter.cs
+++ b/src/PPDS.Migration/Formats/IJsonDataWriter.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Formats
+{
+    /// <summary>
+    /// Writes migration data to a PPDS-native JSON document.
+    /// </summary>
+    public interface IJsonDataWriter
+    {
+        /// <summary>
+        /// Writes migration data to a JSON file at the given path.
+        /// </summary>
+        Task WriteAsync(MigrationData data, string path, IProgressReporter? progress = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Writes migration data to a stream as a JSON document.
+        /// </summary>
+        Task WriteAsync(MigrationData data, Stream stream, IProgressReporter? progress = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/PPDS.Migration/Formats/JsonDataWriter.cs
+++ b/src/PPDS.Migration/Formats/JsonDataWriter.cs
@@ -272,6 +272,14 @@ namespace PPDS.Migration.Formats
                 return;
             }
 
+            // Linked-entity attributes from FetchXML joins arrive wrapped in AliasedValue.
+            // Unwrap so the serialized JSON shows the underlying field value, not the wrapper.
+            if (value is AliasedValue aliased)
+            {
+                if (aliased.Value == null) return;
+                value = aliased.Value;
+            }
+
             writer.WritePropertyName(name);
             writer.WriteStartObject();
 

--- a/src/PPDS.Migration/Formats/JsonDataWriter.cs
+++ b/src/PPDS.Migration/Formats/JsonDataWriter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -98,7 +97,7 @@ namespace PPDS.Migration.Formats
             writer.WriteStartObject();
             writer.WriteString("$schema", SchemaUri);
             writer.WriteString("formatVersion", FormatVersion);
-            writer.WriteString("exportedAt", data.ExportedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+            writer.WriteString("exportedAt", data.ExportedAt.ToUniversalTime());
             if (!string.IsNullOrEmpty(data.SourceEnvironment))
             {
                 writer.WriteString("sourceEnvironment", data.SourceEnvironment);
@@ -127,7 +126,10 @@ namespace PPDS.Migration.Formats
                 writer.WriteString("displayName", entity.DisplayName);
                 writer.WriteString("primaryIdField", entity.PrimaryIdField);
                 writer.WriteString("primaryNameField", entity.PrimaryNameField);
-                writer.WriteNumber("objectTypeCode", entity.ObjectTypeCode ?? 0);
+                if (entity.ObjectTypeCode.HasValue)
+                {
+                    writer.WriteNumber("objectTypeCode", entity.ObjectTypeCode.Value);
+                }
                 writer.WriteBoolean("disablePlugins", entity.DisablePlugins);
 
                 writer.WritePropertyName("fields");
@@ -252,7 +254,7 @@ namespace PPDS.Migration.Formats
         private static void WriteRecord(Utf8JsonWriter writer, Entity record)
         {
             writer.WriteStartObject();
-            writer.WriteString("id", record.Id.ToString());
+            writer.WriteString("id", record.Id);
 
             writer.WritePropertyName("fields");
             writer.WriteStartObject();
@@ -286,7 +288,7 @@ namespace PPDS.Migration.Formats
             switch (value)
             {
                 case EntityReference er:
-                    writer.WriteString("value", er.Id.ToString());
+                    writer.WriteString("value", er.Id);
                     writer.WriteString("lookupEntity", er.LogicalName);
                     if (!string.IsNullOrEmpty(er.Name))
                     {
@@ -303,9 +305,7 @@ namespace PPDS.Migration.Formats
                     break;
 
                 case DateTime dt:
-                    writer.WriteString(
-                        "value",
-                        dt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+                    writer.WriteString("value", dt.ToUniversalTime());
                     break;
 
                 case bool b:
@@ -313,7 +313,7 @@ namespace PPDS.Migration.Formats
                     break;
 
                 case Guid g:
-                    writer.WriteString("value", g.ToString());
+                    writer.WriteString("value", g);
                     break;
 
                 case int i:
@@ -358,7 +358,7 @@ namespace PPDS.Migration.Formats
         {
             writer.WriteStartObject();
             writer.WriteString("relationshipName", m2m.RelationshipName);
-            writer.WriteString("sourceId", m2m.SourceId.ToString());
+            writer.WriteString("sourceId", m2m.SourceId);
             writer.WriteString("targetEntityName", m2m.TargetEntityName);
             writer.WriteString("targetEntityPrimaryKey", m2m.TargetEntityPrimaryKey);
 
@@ -366,7 +366,7 @@ namespace PPDS.Migration.Formats
             writer.WriteStartArray();
             foreach (var targetId in m2m.TargetIds)
             {
-                writer.WriteStringValue(targetId.ToString());
+                writer.WriteStringValue(targetId);
             }
             writer.WriteEndArray();
 

--- a/src/PPDS.Migration/Formats/JsonDataWriter.cs
+++ b/src/PPDS.Migration/Formats/JsonDataWriter.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Models;
+using PPDS.Migration.Progress;
+
+namespace PPDS.Migration.Formats
+{
+    /// <summary>
+    /// Writes migration data as a PPDS-native JSON document.
+    /// </summary>
+    /// <remarks>
+    /// JSON structure mirrors the CMT XML payload (schema + per-entity records + m2m relationships)
+    /// so consumers can build a 1:1 mental model between the two formats.
+    /// File-column binary data is not serialized in JSON v1 (single-file output) — when present,
+    /// a warning is emitted and binaries are skipped. Round-tripping file columns is out of scope
+    /// for v1; use CMT format if file data must round-trip.
+    /// </remarks>
+    public class JsonDataWriter : IJsonDataWriter
+    {
+        /// <summary>
+        /// Current JSON export format version. Bump on breaking schema changes.
+        /// </summary>
+        public const string FormatVersion = "1.0";
+
+        /// <summary>
+        /// $schema URI for the JSON export document.
+        /// </summary>
+        public const string SchemaUri = "https://ppds.dev/schemas/data-export/v1.json";
+
+        private readonly ILogger<JsonDataWriter>? _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonDataWriter"/> class.
+        /// </summary>
+        public JsonDataWriter()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonDataWriter"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        public JsonDataWriter(ILogger<JsonDataWriter> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task WriteAsync(MigrationData data, string path, IProgressReporter? progress = null, CancellationToken cancellationToken = default)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+
+            _logger?.LogInformation("Writing JSON export to {Path}", path);
+
+#if NET8_0_OR_GREATER
+            await using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous);
+#else
+            using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous);
+#endif
+            await WriteAsync(data, stream, progress, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task WriteAsync(MigrationData data, Stream stream, IProgressReporter? progress = null, CancellationToken cancellationToken = default)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+
+            progress ??= IProgressReporter.Silent;
+
+            if (data.FileData.Count > 0)
+            {
+                progress.Report(new ProgressEventArgs
+                {
+                    Phase = MigrationPhase.Exporting,
+                    Message = "Warning: file column binary data is not included in JSON export (use --format cmt for file-column round-trip)."
+                });
+                _logger?.LogWarning("File column data present but JSON format does not serialize binaries — skipping {Count} entity group(s).", data.FileData.Count);
+            }
+
+            var writerOptions = new JsonWriterOptions
+            {
+                Indented = true,
+                SkipValidation = false
+            };
+
+            await using var writer = new Utf8JsonWriter(stream, writerOptions);
+
+            writer.WriteStartObject();
+            writer.WriteString("$schema", SchemaUri);
+            writer.WriteString("formatVersion", FormatVersion);
+            writer.WriteString("exportedAt", data.ExportedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+            if (!string.IsNullOrEmpty(data.SourceEnvironment))
+            {
+                writer.WriteString("sourceEnvironment", data.SourceEnvironment);
+            }
+
+            WriteSchema(writer, data.Schema);
+            await WriteEntitiesAsync(writer, data, progress, cancellationToken).ConfigureAwait(false);
+
+            writer.WriteEndObject();
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger?.LogInformation("Wrote {RecordCount} total records to JSON", data.TotalRecordCount);
+        }
+
+        private static void WriteSchema(Utf8JsonWriter writer, MigrationSchema schema)
+        {
+            writer.WritePropertyName("schema");
+            writer.WriteStartObject();
+            writer.WritePropertyName("entities");
+            writer.WriteStartArray();
+
+            foreach (var entity in schema.Entities)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("logicalName", entity.LogicalName);
+                writer.WriteString("displayName", entity.DisplayName);
+                writer.WriteString("primaryIdField", entity.PrimaryIdField);
+                writer.WriteString("primaryNameField", entity.PrimaryNameField);
+                writer.WriteNumber("objectTypeCode", entity.ObjectTypeCode ?? 0);
+                writer.WriteBoolean("disablePlugins", entity.DisablePlugins);
+
+                writer.WritePropertyName("fields");
+                writer.WriteStartArray();
+                foreach (var field in entity.Fields)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("logicalName", field.LogicalName);
+                    writer.WriteString("displayName", field.DisplayName);
+                    writer.WriteString("type", field.Type);
+                    if (field.IsPrimaryKey)
+                    {
+                        writer.WriteBoolean("isPrimaryKey", true);
+                    }
+                    if (!string.IsNullOrEmpty(field.LookupEntity))
+                    {
+                        writer.WriteString("lookupType", field.LookupEntity);
+                    }
+                    if (field.MaxFileSizeKB.HasValue)
+                    {
+                        writer.WriteNumber("maxFileSizeKB", field.MaxFileSizeKB.Value);
+                    }
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+
+                if (entity.Relationships.Count > 0)
+                {
+                    writer.WritePropertyName("relationships");
+                    writer.WriteStartArray();
+                    foreach (var rel in entity.Relationships)
+                    {
+                        writer.WriteStartObject();
+                        writer.WriteString("name", rel.Name);
+                        writer.WriteBoolean("manyToMany", rel.IsManyToMany);
+                        if (rel.IsReflexive)
+                        {
+                            writer.WriteBoolean("isReflexive", true);
+                        }
+                        if (rel.IsManyToMany)
+                        {
+                            if (!string.IsNullOrEmpty(rel.Entity2))
+                            {
+                                writer.WriteString("m2mTargetEntity", rel.Entity2);
+                            }
+                            if (!string.IsNullOrEmpty(rel.TargetEntityPrimaryKey))
+                            {
+                                writer.WriteString("m2mTargetEntityPrimaryKey", rel.TargetEntityPrimaryKey);
+                            }
+                        }
+                        else if (!string.IsNullOrEmpty(rel.Entity2))
+                        {
+                            writer.WriteString("relatedEntityName", rel.Entity2);
+                        }
+                        writer.WriteEndObject();
+                    }
+                    writer.WriteEndArray();
+                }
+
+                if (!string.IsNullOrEmpty(entity.FetchXmlFilter))
+                {
+                    writer.WriteString("filter", entity.FetchXmlFilter);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private async Task WriteEntitiesAsync(
+            Utf8JsonWriter writer,
+            MigrationData data,
+            IProgressReporter progress,
+            CancellationToken cancellationToken)
+        {
+            writer.WritePropertyName("entities");
+            writer.WriteStartArray();
+
+            foreach (var (entityName, records) in data.EntityData)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var entitySchema = data.Schema.Entities.FirstOrDefault(e => e.LogicalName == entityName);
+                var displayName = entitySchema?.DisplayName ?? entityName;
+
+                writer.WriteStartObject();
+                writer.WriteString("logicalName", entityName);
+                writer.WriteString("displayName", displayName);
+
+                writer.WritePropertyName("records");
+                writer.WriteStartArray();
+                foreach (var record in records)
+                {
+                    WriteRecord(writer, record);
+                }
+                writer.WriteEndArray();
+
+                writer.WritePropertyName("m2mRelationships");
+                writer.WriteStartArray();
+                if (data.RelationshipData.TryGetValue(entityName, out var m2mList))
+                {
+                    foreach (var m2m in m2mList)
+                    {
+                        WriteM2MRelationship(writer, m2m);
+                    }
+                }
+                writer.WriteEndArray();
+
+                writer.WriteEndObject();
+
+                if (writer.BytesPending > 65536)
+                {
+                    await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static void WriteRecord(Utf8JsonWriter writer, Entity record)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", record.Id.ToString());
+
+            writer.WritePropertyName("fields");
+            writer.WriteStartObject();
+            foreach (var attribute in record.Attributes)
+            {
+                WriteField(writer, attribute.Key, attribute.Value);
+            }
+            writer.WriteEndObject();
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteField(Utf8JsonWriter writer, string name, object? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            writer.WritePropertyName(name);
+            writer.WriteStartObject();
+
+            switch (value)
+            {
+                case EntityReference er:
+                    writer.WriteString("value", er.Id.ToString());
+                    writer.WriteString("lookupEntity", er.LogicalName);
+                    if (!string.IsNullOrEmpty(er.Name))
+                    {
+                        writer.WriteString("lookupName", er.Name);
+                    }
+                    break;
+
+                case OptionSetValue osv:
+                    writer.WriteNumber("value", osv.Value);
+                    break;
+
+                case Money m:
+                    writer.WriteNumber("value", m.Value);
+                    break;
+
+                case DateTime dt:
+                    writer.WriteString(
+                        "value",
+                        dt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+                    break;
+
+                case bool b:
+                    writer.WriteBoolean("value", b);
+                    break;
+
+                case Guid g:
+                    writer.WriteString("value", g.ToString());
+                    break;
+
+                case int i:
+                    writer.WriteNumber("value", i);
+                    break;
+
+                case long l:
+                    writer.WriteNumber("value", l);
+                    break;
+
+                case decimal d:
+                    writer.WriteNumber("value", d);
+                    break;
+
+                case double dbl:
+                    writer.WriteNumber("value", dbl);
+                    break;
+
+                case float f:
+                    writer.WriteNumber("value", f);
+                    break;
+
+                case string s:
+                    writer.WriteString("value", s);
+                    break;
+
+                case FileColumnValue fcv:
+                    writer.WriteString("value", fcv.FilePath);
+                    writer.WriteString("fileName", fcv.FileName);
+                    writer.WriteString("mimeType", fcv.MimeType);
+                    break;
+
+                default:
+                    writer.WriteString("value", value.ToString() ?? string.Empty);
+                    break;
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static void WriteM2MRelationship(Utf8JsonWriter writer, ManyToManyRelationshipData m2m)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("relationshipName", m2m.RelationshipName);
+            writer.WriteString("sourceId", m2m.SourceId.ToString());
+            writer.WriteString("targetEntityName", m2m.TargetEntityName);
+            writer.WriteString("targetEntityPrimaryKey", m2m.TargetEntityPrimaryKey);
+
+            writer.WritePropertyName("targetIds");
+            writer.WriteStartArray();
+            foreach (var targetId in m2m.TargetIds)
+            {
+                writer.WriteStringValue(targetId.ToString());
+            }
+            writer.WriteEndArray();
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
+++ b/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
@@ -76,7 +76,7 @@ public class JsonDataWriterTests
 
         root.GetProperty("$schema").GetString().Should().Be(JsonDataWriter.SchemaUri);
         root.GetProperty("formatVersion").GetString().Should().Be(JsonDataWriter.FormatVersion);
-        root.GetProperty("exportedAt").GetString().Should().Be("2026-05-14T12:00:00.0000000Z");
+        root.GetProperty("exportedAt").GetString().Should().Be("2026-05-14T12:00:00Z");
     }
 
     [Fact]
@@ -297,7 +297,7 @@ public class JsonDataWriterTests
             .GetProperty("createdon")
             .GetProperty("value").GetString();
 
-        value.Should().Be("2026-01-15T10:30:00.0000000Z");
+        value.Should().Be("2026-01-15T10:30:00Z");
     }
 
     [Fact]

--- a/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
+++ b/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
@@ -408,6 +408,24 @@ public class JsonDataWriterTests
     }
 
     [Fact]
+    public async Task WriteAsync_AliasedValue_UnwrapsToInnerValue()
+    {
+        // Linked-entity attributes from FetchXML joins arrive as AliasedValue wrappers.
+        var entity = new Entity("account", Guid.NewGuid());
+        entity["contact.fullname"] = new AliasedValue("contact", "fullname", "Jane Doe");
+
+        var data = BuildSingleEntityData(entity, "account");
+
+        using var doc = await WriteAndParseAsync(data);
+        var field = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("contact.fullname");
+
+        field.GetProperty("value").GetString().Should().Be("Jane Doe");
+    }
+
+    [Fact]
     public async Task WriteAsync_EntityWithNoM2M_EmitsEmptyArray()
     {
         var entity = new Entity("account", Guid.NewGuid());

--- a/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
+++ b/tests/PPDS.Migration.Tests/Formats/JsonDataWriterTests.cs
@@ -1,0 +1,500 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using PPDS.Migration.Formats;
+using PPDS.Migration.Models;
+using Xunit;
+
+// ReSharper disable UseObjectOrCollectionInitializer
+
+namespace PPDS.Migration.Tests.Formats;
+
+public class JsonDataWriterTests
+{
+    private static async Task<JsonDocument> WriteAndParseAsync(MigrationData data)
+    {
+        var writer = new JsonDataWriter();
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThrowsWhenDataIsNull()
+    {
+        var writer = new JsonDataWriter();
+
+        var act = async () => await writer.WriteAsync(null!, "output.json");
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThrowsWhenPathIsNull()
+    {
+        var writer = new JsonDataWriter();
+        var data = new MigrationData();
+
+        var act = async () => await writer.WriteAsync(data, (string)null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThrowsWhenPathIsEmpty()
+    {
+        var writer = new JsonDataWriter();
+        var data = new MigrationData();
+
+        var act = async () => await writer.WriteAsync(data, string.Empty);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThrowsWhenStreamIsNull()
+    {
+        var writer = new JsonDataWriter();
+        var data = new MigrationData();
+
+        var act = async () => await writer.WriteAsync(data, (Stream)null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task WriteAsync_Envelope_IncludesSchemaAndFormatVersion()
+    {
+        var data = new MigrationData
+        {
+            ExportedAt = new DateTime(2026, 5, 14, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var root = doc.RootElement;
+
+        root.GetProperty("$schema").GetString().Should().Be(JsonDataWriter.SchemaUri);
+        root.GetProperty("formatVersion").GetString().Should().Be(JsonDataWriter.FormatVersion);
+        root.GetProperty("exportedAt").GetString().Should().Be("2026-05-14T12:00:00.0000000Z");
+    }
+
+    [Fact]
+    public async Task WriteAsync_SourceEnvironment_IncludedWhenSet()
+    {
+        var data = new MigrationData
+        {
+            SourceEnvironment = "https://contoso.crm.dynamics.com"
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+
+        doc.RootElement.GetProperty("sourceEnvironment").GetString()
+            .Should().Be("https://contoso.crm.dynamics.com");
+    }
+
+    [Fact]
+    public async Task WriteAsync_SourceEnvironment_OmittedWhenNull()
+    {
+        var data = new MigrationData();
+
+        using var doc = await WriteAndParseAsync(data);
+
+        doc.RootElement.TryGetProperty("sourceEnvironment", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WriteAsync_Schema_IncludesEntityMetadataAndFields()
+    {
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema
+                    {
+                        LogicalName = "account",
+                        DisplayName = "Account",
+                        PrimaryIdField = "accountid",
+                        PrimaryNameField = "name",
+                        ObjectTypeCode = 1,
+                        Fields = new List<FieldSchema>
+                        {
+                            new FieldSchema { LogicalName = "accountid", DisplayName = "Account", Type = "guid", IsPrimaryKey = true },
+                            new FieldSchema { LogicalName = "name", DisplayName = "Name", Type = "string" },
+                            new FieldSchema { LogicalName = "primarycontactid", DisplayName = "Primary Contact", Type = "lookup", LookupEntity = "contact" }
+                        }
+                    }
+                }
+            }
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var entity = doc.RootElement.GetProperty("schema").GetProperty("entities")[0];
+
+        entity.GetProperty("logicalName").GetString().Should().Be("account");
+        entity.GetProperty("displayName").GetString().Should().Be("Account");
+        entity.GetProperty("primaryIdField").GetString().Should().Be("accountid");
+        entity.GetProperty("primaryNameField").GetString().Should().Be("name");
+        entity.GetProperty("objectTypeCode").GetInt32().Should().Be(1);
+        entity.GetProperty("disablePlugins").GetBoolean().Should().BeFalse();
+
+        var fields = entity.GetProperty("fields").EnumerateArray().ToList();
+        fields.Should().HaveCount(3);
+
+        var idField = fields.First(f => f.GetProperty("logicalName").GetString() == "accountid");
+        idField.GetProperty("isPrimaryKey").GetBoolean().Should().BeTrue();
+
+        var lookupField = fields.First(f => f.GetProperty("logicalName").GetString() == "primarycontactid");
+        lookupField.GetProperty("lookupType").GetString().Should().Be("contact");
+    }
+
+    [Fact]
+    public async Task WriteAsync_Schema_IncludesRelationshipsWhenPresent()
+    {
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema
+                    {
+                        LogicalName = "team",
+                        DisplayName = "Team",
+                        PrimaryIdField = "teamid",
+                        Relationships = new List<RelationshipSchema>
+                        {
+                            new RelationshipSchema
+                            {
+                                Name = "teamroles",
+                                IsManyToMany = true,
+                                Entity1 = "team",
+                                Entity2 = "role",
+                                TargetEntityPrimaryKey = "roleid"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var rels = doc.RootElement.GetProperty("schema").GetProperty("entities")[0]
+            .GetProperty("relationships").EnumerateArray().ToList();
+
+        rels.Should().HaveCount(1);
+        var rel = rels[0];
+        rel.GetProperty("name").GetString().Should().Be("teamroles");
+        rel.GetProperty("manyToMany").GetBoolean().Should().BeTrue();
+        rel.GetProperty("m2mTargetEntity").GetString().Should().Be("role");
+        rel.GetProperty("m2mTargetEntityPrimaryKey").GetString().Should().Be("roleid");
+    }
+
+    [Fact]
+    public async Task WriteAsync_Schema_OmitsRelationshipsWhenEmpty()
+    {
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema { LogicalName = "account", DisplayName = "Account", PrimaryIdField = "accountid" }
+                }
+            }
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var entity = doc.RootElement.GetProperty("schema").GetProperty("entities")[0];
+
+        entity.TryGetProperty("relationships", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WriteAsync_Record_EmitsIdAndFields()
+    {
+        var recordId = Guid.NewGuid();
+        var entity = new Entity("account", recordId);
+        entity["name"] = "Acme Corp";
+
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema { LogicalName = "account", DisplayName = "Account", PrimaryIdField = "accountid" }
+                }
+            },
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { "account", new List<Entity> { entity } }
+            }
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var entityNode = doc.RootElement.GetProperty("entities")[0];
+
+        entityNode.GetProperty("logicalName").GetString().Should().Be("account");
+        var record = entityNode.GetProperty("records")[0];
+        record.GetProperty("id").GetString().Should().Be(recordId.ToString());
+        record.GetProperty("fields").GetProperty("name").GetProperty("value").GetString().Should().Be("Acme Corp");
+    }
+
+    [Fact]
+    public async Task WriteAsync_EntityReference_IncludesLookupMetadata()
+    {
+        var contactId = Guid.NewGuid();
+        var entity = new Entity("account", Guid.NewGuid());
+        entity["primarycontactid"] = new EntityReference("contact", contactId) { Name = "John Doe" };
+
+        var data = BuildSingleEntityData(entity, "account");
+
+        using var doc = await WriteAndParseAsync(data);
+        var field = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("primarycontactid");
+
+        field.GetProperty("value").GetString().Should().Be(contactId.ToString());
+        field.GetProperty("lookupEntity").GetString().Should().Be("contact");
+        field.GetProperty("lookupName").GetString().Should().Be("John Doe");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WriteAsync_BooleanValue_EmitsJsonBoolean(bool value)
+    {
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["boolfield"] = value;
+
+        var data = BuildSingleEntityData(entity, "testentity");
+
+        using var doc = await WriteAndParseAsync(data);
+        var field = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("boolfield");
+
+        field.GetProperty("value").GetBoolean().Should().Be(value);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DateTimeValue_EmitsIso8601Utc()
+    {
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["createdon"] = new DateTime(2026, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+
+        var data = BuildSingleEntityData(entity, "testentity");
+
+        using var doc = await WriteAndParseAsync(data);
+        var value = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("createdon")
+            .GetProperty("value").GetString();
+
+        value.Should().Be("2026-01-15T10:30:00.0000000Z");
+    }
+
+    [Fact]
+    public async Task WriteAsync_OptionSetValue_EmitsNumeric()
+    {
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["statuscode"] = new OptionSetValue(7);
+
+        var data = BuildSingleEntityData(entity, "testentity");
+
+        using var doc = await WriteAndParseAsync(data);
+        var value = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("statuscode")
+            .GetProperty("value").GetInt32();
+
+        value.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task WriteAsync_MoneyValue_EmitsNumeric()
+    {
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["revenue"] = new Money(1234.56m);
+
+        var data = BuildSingleEntityData(entity, "testentity");
+
+        using var doc = await WriteAndParseAsync(data);
+        var value = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields")
+            .GetProperty("revenue")
+            .GetProperty("value").GetDecimal();
+
+        value.Should().Be(1234.56m);
+    }
+
+    [Fact]
+    public async Task WriteAsync_NullFieldValue_IsOmitted()
+    {
+        var entity = new Entity("testentity", Guid.NewGuid());
+        entity["name"] = "Set";
+        entity["nullable"] = null;
+
+        var data = BuildSingleEntityData(entity, "testentity");
+
+        using var doc = await WriteAndParseAsync(data);
+        var fields = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("records")[0]
+            .GetProperty("fields");
+
+        fields.TryGetProperty("name", out _).Should().BeTrue();
+        fields.TryGetProperty("nullable", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WriteAsync_M2MRelationships_EmittedPerSourceRecord()
+    {
+        var sourceId = Guid.NewGuid();
+        var target1 = Guid.NewGuid();
+        var target2 = Guid.NewGuid();
+
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema { LogicalName = "team", DisplayName = "Team", PrimaryIdField = "teamid" }
+                }
+            },
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { "team", new List<Entity>() }
+            },
+            RelationshipData = new Dictionary<string, IReadOnlyList<ManyToManyRelationshipData>>
+            {
+                {
+                    "team", new List<ManyToManyRelationshipData>
+                    {
+                        new ManyToManyRelationshipData
+                        {
+                            RelationshipName = "teamroles",
+                            SourceEntityName = "team",
+                            SourceId = sourceId,
+                            TargetEntityName = "role",
+                            TargetEntityPrimaryKey = "roleid",
+                            TargetIds = new List<Guid> { target1, target2 }
+                        }
+                    }
+                }
+            }
+        };
+
+        using var doc = await WriteAndParseAsync(data);
+        var m2m = doc.RootElement.GetProperty("entities")[0]
+            .GetProperty("m2mRelationships")[0];
+
+        m2m.GetProperty("relationshipName").GetString().Should().Be("teamroles");
+        m2m.GetProperty("sourceId").GetString().Should().Be(sourceId.ToString());
+        m2m.GetProperty("targetEntityName").GetString().Should().Be("role");
+        m2m.GetProperty("targetEntityPrimaryKey").GetString().Should().Be("roleid");
+
+        var targets = m2m.GetProperty("targetIds").EnumerateArray()
+            .Select(t => t.GetString()!).ToList();
+        targets.Should().BeEquivalentTo(new[] { target1.ToString(), target2.ToString() });
+    }
+
+    [Fact]
+    public async Task WriteAsync_EntityWithNoM2M_EmitsEmptyArray()
+    {
+        var entity = new Entity("account", Guid.NewGuid());
+        var data = BuildSingleEntityData(entity, "account");
+
+        using var doc = await WriteAndParseAsync(data);
+        var m2mArray = doc.RootElement.GetProperty("entities")[0].GetProperty("m2mRelationships");
+
+        m2mArray.ValueKind.Should().Be(JsonValueKind.Array);
+        m2mArray.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WriteAsync_EmitsValidJson()
+    {
+        var entity = new Entity("account", Guid.NewGuid());
+        entity["name"] = "Acme \"Inc\" \n\t<special>";
+        var data = BuildSingleEntityData(entity, "account");
+
+        var writer = new JsonDataWriter();
+        using var stream = new MemoryStream();
+        await writer.WriteAsync(data, stream);
+        stream.Position = 0;
+
+        // If output is invalid JSON, parse throws.
+        var parse = async () =>
+        {
+            using var doc = await JsonDocument.ParseAsync(stream);
+            return doc.RootElement.GetProperty("entities").GetArrayLength();
+        };
+
+        await parse.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task WriteAsync_FileDataPresent_EmitsWarningAndSkipsBinaries()
+    {
+        var entity = new Entity("account", Guid.NewGuid());
+        var data = new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema { LogicalName = "account", DisplayName = "Account", PrimaryIdField = "accountid" }
+                }
+            },
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { "account", new List<Entity> { entity } }
+            },
+            FileData = new Dictionary<string, IReadOnlyList<FileColumnData>>
+            {
+                {
+                    "account", new List<FileColumnData>
+                    {
+                        new FileColumnData { RecordId = entity.Id, FieldName = "doc", FileName = "a.pdf", MimeType = "application/pdf", Data = new byte[] { 1, 2, 3 } }
+                    }
+                }
+            }
+        };
+
+        // The writer must not throw and must produce valid JSON. (Binary data has nowhere to go in single-file JSON.)
+        using var doc = await WriteAndParseAsync(data);
+        doc.RootElement.GetProperty("entities").GetArrayLength().Should().Be(1);
+    }
+
+    private static MigrationData BuildSingleEntityData(Entity entity, string logicalName)
+    {
+        return new MigrationData
+        {
+            Schema = new MigrationSchema
+            {
+                Entities = new List<EntitySchema>
+                {
+                    new EntitySchema
+                    {
+                        LogicalName = logicalName,
+                        DisplayName = logicalName,
+                        PrimaryIdField = $"{logicalName}id"
+                    }
+                }
+            },
+            EntityData = new Dictionary<string, IReadOnlyList<Entity>>
+            {
+                { logicalName, new List<Entity> { entity } }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Add `--format json` flag to `ppds data export` — emits a single-file PPDS-native JSON document alongside the existing CMT XML ZIP (default).
- Format selection lives in the Application Service (`ParallelExporter`), wired through a new `IJsonDataWriter` abstraction so future formats are pluggable without further CLI changes.
- JSON structure mirrors the CMT XML payload (schema metadata, per-entity records with typed field values, M2M associations) — 1:1 mental model between formats. Versioned with `$schema` + `formatVersion: "1.0"`.

Closes #147

## Changes
- `ExportDataFormat` enum (`Cmt`, `Json`) on `ExportOptions.Format` (default `Cmt`)
- `IJsonDataWriter` + `JsonDataWriter` using `Utf8JsonWriter` streaming (periodic flush at 64 KiB to keep memory bounded for large exports)
- `ParallelExporter` ctor takes optional `IJsonDataWriter` and routes to the right writer based on `options.Format`
- `JsonDataWriter` registered in `AddDataverseMigration()` DI extension
- CLI: `--format <cmt|json>` option on `data export`, default `cmt`
- 23 unit tests covering envelope, schema, records, typed values (bool / DateTime ISO 8601 UTC / `OptionSetValue` / `Money` / `EntityReference` / `AliasedValue` unwrap), null elision, M2M, file-data warning path, and valid-JSON escaping

## Scope / Out of Scope
- File-column binaries are not serialized in JSON v1 (single-file output; binaries have nowhere to live). The writer emits a warning and skips them. Use CMT format if file columns must round-trip.
- Round-trip / import-from-JSON is explicitly out of scope per issue — focus is correct export.
- Byte arrays, `EntityCollection` (party lists) currently fall through `value.ToString()` — same gap as `CmtDataWriter`; can be addressed as parity work later.

## Test Plan
- [x] `dotnet build PPDS.sln` — 0 errors
- [x] `dotnet test PPDS.sln --filter "Category!=Integration"` — 14,200+ tests across net8.0 / net9.0 / net10.0, all green
- [x] `dotnet test tests/PPDS.Migration.Tests/PPDS.Migration.Tests.csproj --filter "FullyQualifiedName~JsonDataWriterTests"` — 23/23 pass
- [x] CLI `--help` shows `--format <Cmt|Json>` with `[default: Cmt]`
- [x] CLI rejects invalid format values with a parser error suggesting `Cmt`/`Json`
- [x] Default behavior (no flag) unchanged — existing CMT consumers unaffected

## Verification
- [x] /gates passed (build, tests, enforcement audit)
- [x] /verify cli passed (build, flag wiring, parser rejection)
- [x] Pre-PR self-review run; AliasedValue gap surfaced and fixed in follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
