### PR TITLE
feat(cli): add schema compare command (#42)

### DIFF
--- a/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
+++ b/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
@@ -50,7 +50,7 @@ public static class CompareCommand
             "compare",
             "Compare schema between a data package and an environment, or between two environments. "
             + "Differences are classified by severity (Error / Warning / Info); the highest severity "
-            + "determines the exit code. Output format selectable via -f (Text / Json / Csv).")
+            + "determines the exit code. Supported output formats: Text (default), Json.")
         {
             DataOption, EnvOption, SourceOption, TargetOption, ProfileOption
         };
@@ -63,6 +63,15 @@ public static class CompareCommand
             var env = result.GetValue(EnvOption);
             var source = result.GetValue(SourceOption);
             var target = result.GetValue(TargetOption);
+            var format = result.GetValue(GlobalOptions.OutputFormat);
+
+            if (format == Commands.OutputFormat.Csv)
+            {
+                // CSV output is not implemented for schema compare. System-wide CSV
+                // support is tracked in #1078.
+                result.AddError("CSV output is not supported for 'schema compare'. Use --output-format Json or Text.");
+                return;
+            }
 
             var packageMode = data is not null || env is not null;
             var envMode = source is not null || target is not null;
@@ -279,15 +288,17 @@ public static class CompareCommand
 
     private static void WriteTextReport(SchemaCompareReport report)
     {
+        // Report body is data: per CLAUDE.md "stdout is for data", every report line
+        // goes to stdout. Progress/status messages elsewhere correctly stay on stderr.
         var s = report.Summary;
-        Console.Error.WriteLine();
-        Console.Error.WriteLine($"Schema comparison: {report.Source} → {report.Target}");
-        Console.Error.WriteLine($"  {s.Errors} error(s), {s.Warnings} warning(s), {s.Infos} info");
-        Console.Error.WriteLine();
+        Console.WriteLine();
+        Console.WriteLine($"Schema comparison: {report.Source} → {report.Target}");
+        Console.WriteLine($"  {s.Errors} error(s), {s.Warnings} warning(s), {s.Infos} info");
+        Console.WriteLine();
 
         if (report.Differences.Count == 0)
         {
-            Console.Error.WriteLine("No schema differences detected.");
+            Console.WriteLine("No schema differences detected.");
             return;
         }
 
@@ -295,12 +306,12 @@ public static class CompareCommand
             .GroupBy(d => d.Severity)
             .OrderByDescending(g => g.Key))
         {
-            Console.Error.WriteLine($"[{group.Key.ToString().ToUpperInvariant()}]");
+            Console.WriteLine($"[{group.Key.ToString().ToUpperInvariant()}]");
             foreach (var diff in group)
             {
-                Console.Error.WriteLine($"  {diff.Kind}: {diff.Message}");
+                Console.WriteLine($"  {diff.Kind}: {diff.Message}");
             }
-            Console.Error.WriteLine();
+            Console.WriteLine();
         }
     }
 }

--- a/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
+++ b/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
@@ -1,0 +1,304 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.Schema;
+using PPDS.Cli.Services.Schema.Models;
+using PPDS.Cli.Services.Schema.Snapshots;
+using PPDS.Dataverse.Metadata;
+using PPDS.Migration.Formats;
+
+namespace PPDS.Cli.Commands.Schema;
+
+/// <summary>
+/// <c>ppds schema compare</c> — diff a data package or environment against
+/// a target environment and report differences with severity classification.
+/// </summary>
+public static class CompareCommand
+{
+    private static readonly Option<FileInfo?> DataOption = new("--data")
+    {
+        Description = "Path to a data package zip whose schema should be compared against the target environment."
+    };
+
+    private static readonly Option<string?> EnvOption = new("--env")
+    {
+        Description = "Target environment - URL, friendly name, unique name, or ID. Used with --data."
+    };
+
+    private static readonly Option<string?> SourceOption = new("--source")
+    {
+        Description = "Source environment for env-to-env comparison."
+    };
+
+    private static readonly Option<string?> TargetOption = new("--target")
+    {
+        Description = "Target environment for env-to-env comparison."
+    };
+
+    private static readonly Option<string?> ProfileOption = new("--profile", "-p")
+    {
+        Description = "Authentication profile name (defaults to active profile)."
+    };
+
+    /// <summary>
+    /// Creates the <c>schema compare</c> command.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command(
+            "compare",
+            "Compare schema between a data package and an environment, or between two environments.")
+        {
+            DataOption, EnvOption, SourceOption, TargetOption, ProfileOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.Validators.Add(result =>
+        {
+            var data = result.GetValue(DataOption);
+            var env = result.GetValue(EnvOption);
+            var source = result.GetValue(SourceOption);
+            var target = result.GetValue(TargetOption);
+
+            var packageMode = data is not null || env is not null;
+            var envMode = source is not null || target is not null;
+
+            if (packageMode && envMode)
+            {
+                result.AddError("--data/--env cannot be combined with --source/--target.");
+                return;
+            }
+            if (!packageMode && !envMode)
+            {
+                result.AddError("Provide either (--data + --env) for package-vs-env, or (--source + --target) for env-vs-env.");
+                return;
+            }
+            if (packageMode && (data is null || env is null))
+            {
+                result.AddError("--data and --env must be supplied together.");
+            }
+            if (envMode && (source is null || target is null))
+            {
+                result.AddError("--source and --target must be supplied together.");
+            }
+        });
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var data = parseResult.GetValue(DataOption);
+            var env = parseResult.GetValue(EnvOption);
+            var source = parseResult.GetValue(SourceOption);
+            var target = parseResult.GetValue(TargetOption);
+            var profile = parseResult.GetValue(ProfileOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(data?.FullName, env, source, target, profile, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string? dataPath,
+        string? env,
+        string? sourceEnv,
+        string? targetEnv,
+        string? profile,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var writer = ServiceFactory.CreateOutputWriter(globalOptions);
+
+        try
+        {
+            SchemaSnapshot sourceSnapshot;
+            SchemaSnapshot targetSnapshot;
+            IReadOnlyList<string> targetExtraEntities;
+
+            Action<string>? progress = globalOptions.IsJsonMode
+                ? null
+                : msg => Console.Error.WriteLine(msg);
+
+            if (dataPath is not null && env is not null)
+            {
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.WriteLine($"Reading schema from data package: {dataPath}");
+                }
+                var packageLoader = new DataPackageSnapshotLoader(dataPath, new CmtSchemaReader());
+                sourceSnapshot = await packageLoader.LoadAsync(null, cancellationToken).ConfigureAwait(false);
+
+                await using var targetProvider = await ProfileServiceFactory.CreateFromProfileAsync(
+                    profile,
+                    env,
+                    globalOptions.Verbose,
+                    globalOptions.Debug,
+                    ProfileServiceFactory.DefaultDeviceCodeCallback,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                var targetMetadata = targetProvider.GetRequiredService<IMetadataQueryService>();
+                var targetConnInfo = targetProvider.GetRequiredService<ResolvedConnectionInfo>();
+
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.WriteLine($"Loading target schema from {targetConnInfo.EnvironmentUrl}...");
+                }
+
+                var entityFilter = sourceSnapshot.Entities.Select(e => e.LogicalName).ToList();
+                var targetLoader = new EnvironmentSnapshotLoader(targetMetadata, $"env:{targetConnInfo.EnvironmentUrl}", progress);
+                targetSnapshot = await targetLoader.LoadAsync(entityFilter, cancellationToken).ConfigureAwait(false);
+                targetExtraEntities = targetLoader.UnloadedEntities;
+
+                var service = targetProvider.GetRequiredService<ISchemaComparisonService>();
+                var report = BuildReport(service, sourceSnapshot, targetSnapshot, targetExtraEntities);
+                return EmitAndExit(writer, report, globalOptions);
+            }
+
+            // env-to-env mode (validator guarantees both are non-null)
+            var (sourceProvider, targetEnvProvider) = await ProfileServiceFactory.CreateForCopyAsync(
+                profile,
+                sourceProfile: null,
+                targetProfile: null,
+                sourceEnv: sourceEnv!,
+                targetEnv: targetEnv!,
+                verbose: globalOptions.Verbose,
+                debug: globalOptions.Debug,
+                deviceCodeCallback: ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            await using (sourceProvider)
+            await using (targetEnvProvider)
+            {
+                var sourceInfo = sourceProvider.GetRequiredService<ResolvedConnectionInfo>();
+                var targetInfo = targetEnvProvider.GetRequiredService<ResolvedConnectionInfo>();
+
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.WriteLine($"Loading source schema from {sourceInfo.EnvironmentUrl}...");
+                }
+                var sourceLoader = new EnvironmentSnapshotLoader(
+                    sourceProvider.GetRequiredService<IMetadataQueryService>(),
+                    $"env:{sourceInfo.EnvironmentUrl}",
+                    progress);
+                sourceSnapshot = await sourceLoader.LoadAsync(null, cancellationToken).ConfigureAwait(false);
+
+                if (!globalOptions.IsJsonMode)
+                {
+                    Console.Error.WriteLine($"Loading target schema from {targetInfo.EnvironmentUrl}...");
+                }
+                var entityFilter = sourceSnapshot.Entities.Select(e => e.LogicalName).ToList();
+                var targetLoader = new EnvironmentSnapshotLoader(
+                    targetEnvProvider.GetRequiredService<IMetadataQueryService>(),
+                    $"env:{targetInfo.EnvironmentUrl}",
+                    progress);
+                targetSnapshot = await targetLoader.LoadAsync(entityFilter, cancellationToken).ConfigureAwait(false);
+                targetExtraEntities = targetLoader.UnloadedEntities;
+
+                var service = sourceProvider.GetRequiredService<ISchemaComparisonService>();
+                var report = BuildReport(service, sourceSnapshot, targetSnapshot, targetExtraEntities);
+                return EmitAndExit(writer, report, globalOptions);
+            }
+        }
+        catch (Exception ex)
+        {
+            var error = ExceptionMapper.Map(ex, context: "comparing schemas", debug: globalOptions.Debug);
+            writer.WriteError(error);
+            return ExceptionMapper.ToExitCode(ex);
+        }
+    }
+
+    /// <summary>
+    /// Run the comparison and merge in <see cref="DiffKind.ExtraEntity"/> diffs for
+    /// entities the loader skipped via the source-driven filter. Without this merge,
+    /// the filter would mask the only AC-relevant "info" output.
+    /// </summary>
+    internal static SchemaCompareReport BuildReport(
+        ISchemaComparisonService service,
+        SchemaSnapshot source,
+        SchemaSnapshot target,
+        IReadOnlyList<string> targetExtraEntityNames)
+    {
+        var report = service.Compare(source, target);
+        if (targetExtraEntityNames.Count == 0)
+        {
+            return report;
+        }
+
+        var sourceNames = new HashSet<string>(
+            source.Entities.Select(e => e.LogicalName), StringComparer.OrdinalIgnoreCase);
+
+        var extras = targetExtraEntityNames
+            .Where(n => !sourceNames.Contains(n))
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .Select(n => new SchemaDifference
+            {
+                Severity = DiffSeverity.Info,
+                Kind = DiffKind.ExtraEntity,
+                Entity = n,
+                Message = $"Entity '{n}' exists in target but not in source."
+            });
+
+        var merged = report.Differences.Concat(extras).ToList();
+        return new SchemaCompareReport
+        {
+            Source = report.Source,
+            Target = report.Target,
+            ComparedAt = report.ComparedAt,
+            Differences = merged
+        };
+    }
+
+    private static int EmitAndExit(
+        PPDS.Cli.Infrastructure.Output.IOutputWriter writer,
+        SchemaCompareReport report,
+        GlobalOptionValues globalOptions)
+    {
+        if (globalOptions.IsJsonMode)
+        {
+            writer.WriteSuccess(report);
+        }
+        else
+        {
+            WriteTextReport(report);
+        }
+        return ExitCodeFor(report.HighestSeverity);
+    }
+
+    internal static int ExitCodeFor(DiffSeverity? highest) => highest switch
+    {
+        null => ExitCodes.Success,
+        DiffSeverity.Info => ExitCodes.Success,
+        DiffSeverity.Warning => ExitCodes.PartialSuccess,
+        DiffSeverity.Error => ExitCodes.ValidationError,
+        _ => ExitCodes.Success
+    };
+
+    private static void WriteTextReport(SchemaCompareReport report)
+    {
+        var s = report.Summary;
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"Schema comparison: {report.Source} → {report.Target}");
+        Console.Error.WriteLine($"  {s.Errors} error(s), {s.Warnings} warning(s), {s.Infos} info");
+        Console.Error.WriteLine();
+
+        if (report.Differences.Count == 0)
+        {
+            Console.Error.WriteLine("No schema differences detected.");
+            return;
+        }
+
+        foreach (var group in report.Differences
+            .GroupBy(d => d.Severity)
+            .OrderByDescending(g => g.Key))
+        {
+            Console.Error.WriteLine($"[{group.Key.ToString().ToUpperInvariant()}]");
+            foreach (var diff in group)
+            {
+                Console.Error.WriteLine($"  {diff.Kind}: {diff.Message}");
+            }
+            Console.Error.WriteLine();
+        }
+    }
+}

--- a/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
+++ b/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
@@ -18,22 +18,22 @@ public static class CompareCommand
 {
     private static readonly Option<FileInfo?> DataOption = new("--data")
     {
-        Description = "Path to a data package zip whose schema should be compared against the target environment."
+        Description = "[Required with --environment] Path to a data package zip whose schema is compared against the target environment."
     };
 
-    private static readonly Option<string?> EnvOption = new("--env")
+    private static readonly Option<string?> EnvOption = new("--environment", "-e")
     {
-        Description = "Target environment - URL, friendly name, unique name, or ID. Used with --data."
+        Description = "[Required with --data] Target environment - URL, friendly name, unique name, or ID."
     };
 
-    private static readonly Option<string?> SourceOption = new("--source")
+    private static readonly Option<string?> SourceOption = new("--source-env", "-se")
     {
-        Description = "Source environment for env-to-env comparison."
+        Description = "[Required with --target-env] Source environment for env-to-env comparison."
     };
 
-    private static readonly Option<string?> TargetOption = new("--target")
+    private static readonly Option<string?> TargetOption = new("--target-env", "-te")
     {
-        Description = "Target environment for env-to-env comparison."
+        Description = "[Required with --source-env] Target environment for env-to-env comparison."
     };
 
     private static readonly Option<string?> ProfileOption = new("--profile", "-p")
@@ -48,7 +48,9 @@ public static class CompareCommand
     {
         var command = new Command(
             "compare",
-            "Compare schema between a data package and an environment, or between two environments.")
+            "Compare schema between a data package and an environment, or between two environments. "
+            + "Differences are classified by severity (Error / Warning / Info); the highest severity "
+            + "determines the exit code. Output format selectable via -f (Text / Json / Csv).")
         {
             DataOption, EnvOption, SourceOption, TargetOption, ProfileOption
         };
@@ -67,21 +69,21 @@ public static class CompareCommand
 
             if (packageMode && envMode)
             {
-                result.AddError("--data/--env cannot be combined with --source/--target.");
+                result.AddError("--data/--environment cannot be combined with --source-env/--target-env.");
                 return;
             }
             if (!packageMode && !envMode)
             {
-                result.AddError("Provide either (--data + --env) for package-vs-env, or (--source + --target) for env-vs-env.");
+                result.AddError("Provide either (--data + --environment) for package-vs-env, or (--source-env + --target-env) for env-vs-env.");
                 return;
             }
             if (packageMode && (data is null || env is null))
             {
-                result.AddError("--data and --env must be supplied together.");
+                result.AddError("--data and --environment must be supplied together.");
             }
             if (envMode && (source is null || target is null))
             {
-                result.AddError("--source and --target must be supplied together.");
+                result.AddError("--source-env and --target-env must be supplied together.");
             }
         });
 

--- a/src/PPDS.Cli/Commands/Schema/SchemaCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Schema/SchemaCommandGroup.cs
@@ -1,0 +1,20 @@
+using System.CommandLine;
+
+namespace PPDS.Cli.Commands.Schema;
+
+/// <summary>
+/// <c>schema</c> command group — tooling for comparing Dataverse schemas
+/// between environments and data packages.
+/// </summary>
+public static class SchemaCommandGroup
+{
+    /// <summary>
+    /// Creates the <c>schema</c> command with all subcommands.
+    /// </summary>
+    public static Command Create()
+    {
+        var command = new Command("schema", "Compare Dataverse schemas across environments and data packages.");
+        command.Subcommands.Add(CompareCommand.Create());
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -10,6 +10,7 @@ using PPDS.Cli.Commands.Flows;
 using PPDS.Cli.Commands.ImportJobs;
 using PPDS.Cli.Commands.Internal;
 using PPDS.Cli.Commands.Metadata;
+using PPDS.Cli.Commands.Schema;
 using PPDS.Cli.Commands.Plugins;
 using PPDS.Cli.Commands.PluginTraces;
 using PPDS.Cli.Commands.CustomApis;
@@ -98,6 +99,7 @@ public static class Program
         rootCommand.Subcommands.Add(DataProvidersCommandGroup.Create());
         rootCommand.Subcommands.Add(DataSourcesCommandGroup.Create());
         rootCommand.Subcommands.Add(MetadataCommandGroup.Create());
+        rootCommand.Subcommands.Add(SchemaCommandGroup.Create());
         rootCommand.Subcommands.Add(QueryCommandGroup.Create());
         rootCommand.Subcommands.Add(SolutionsCommandGroup.Create());
         rootCommand.Subcommands.Add(ImportJobsCommandGroup.Create());

--- a/src/PPDS.Cli/Services/Schema/ISchemaComparisonService.cs
+++ b/src/PPDS.Cli/Services/Schema/ISchemaComparisonService.cs
@@ -1,0 +1,20 @@
+using PPDS.Cli.Services.Schema.Models;
+using PPDS.Cli.Services.Schema.Snapshots;
+
+namespace PPDS.Cli.Services.Schema;
+
+/// <summary>
+/// Application service that diffs two schema snapshots and produces a
+/// severity-categorized report.
+/// </summary>
+public interface ISchemaComparisonService
+{
+    /// <summary>
+    /// Compare a source snapshot against a target. The source is treated as the
+    /// "data being imported"; the target is the environment receiving it.
+    /// </summary>
+    /// <param name="source">Schema as it exists in the data package or source environment.</param>
+    /// <param name="target">Schema as it exists in the target environment.</param>
+    /// <returns>Report of differences, ordered deterministically.</returns>
+    SchemaCompareReport Compare(SchemaSnapshot source, SchemaSnapshot target);
+}

--- a/src/PPDS.Cli/Services/Schema/Models/DiffKind.cs
+++ b/src/PPDS.Cli/Services/Schema/Models/DiffKind.cs
@@ -1,0 +1,40 @@
+namespace PPDS.Cli.Services.Schema.Models;
+
+/// <summary>
+/// Categorical kind of schema difference detected by <see cref="SchemaComparisonService"/>.
+/// </summary>
+public enum DiffKind
+{
+    /// <summary>Entity exists in source but not in target.</summary>
+    MissingEntity,
+
+    /// <summary>Entity exists in target but not in source (non-breaking).</summary>
+    ExtraEntity,
+
+    /// <summary>Attribute exists in source but not in target.</summary>
+    MissingAttribute,
+
+    /// <summary>Attribute exists in target but not in source (non-breaking).</summary>
+    ExtraAttribute,
+
+    /// <summary>Attribute type changed between source and target.</summary>
+    TypeMismatch,
+
+    /// <summary>Required level became stricter in target (e.g. Optional → SystemRequired).</summary>
+    RequiredLevelStricter,
+
+    /// <summary>String length in target is smaller than source — truncation risk.</summary>
+    LengthShrunk,
+
+    /// <summary>Decimal precision in target is smaller than source — precision loss.</summary>
+    PrecisionLoss,
+
+    /// <summary>Source has option-set values not present in target.</summary>
+    MissingOptionValue,
+
+    /// <summary>Source lookup targets an entity that the target lookup does not allow.</summary>
+    LookupTargetMissing,
+
+    /// <summary>Relationship exists in source but not in target.</summary>
+    MissingRelationship
+}

--- a/src/PPDS.Cli/Services/Schema/Models/DiffSeverity.cs
+++ b/src/PPDS.Cli/Services/Schema/Models/DiffSeverity.cs
@@ -1,0 +1,16 @@
+namespace PPDS.Cli.Services.Schema.Models;
+
+/// <summary>
+/// Severity of a schema difference.
+/// </summary>
+public enum DiffSeverity
+{
+    /// <summary>Non-breaking difference (e.g. extra fields in target).</summary>
+    Info,
+
+    /// <summary>May cause data loss during import (truncation, missing option values).</summary>
+    Warning,
+
+    /// <summary>Will cause import to fail (missing required field, type mismatch).</summary>
+    Error
+}

--- a/src/PPDS.Cli/Services/Schema/Models/SchemaCompareReport.cs
+++ b/src/PPDS.Cli/Services/Schema/Models/SchemaCompareReport.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.Schema.Models;
+
+/// <summary>
+/// Report produced by comparing two <c>SchemaSnapshot</c> instances.
+/// </summary>
+public sealed class SchemaCompareReport
+{
+    /// <summary>Source descriptor (e.g. <c>data:path.zip</c> or <c>env:https://...</c>).</summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    /// <summary>Target descriptor.</summary>
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    /// <summary>UTC timestamp the comparison was produced.</summary>
+    [JsonPropertyName("comparedAt")]
+    public DateTime ComparedAt { get; init; } = DateTime.UtcNow;
+
+    /// <summary>All differences in deterministic order (entity, attribute, kind).</summary>
+    [JsonPropertyName("differences")]
+    public required IReadOnlyList<SchemaDifference> Differences { get; init; }
+
+    /// <summary>Summary counts.</summary>
+    [JsonPropertyName("summary")]
+    public SchemaCompareSummary Summary => new()
+    {
+        Errors = Differences.Count(d => d.Severity == DiffSeverity.Error),
+        Warnings = Differences.Count(d => d.Severity == DiffSeverity.Warning),
+        Infos = Differences.Count(d => d.Severity == DiffSeverity.Info),
+        Total = Differences.Count
+    };
+
+    /// <summary>Highest severity in the report, or <c>null</c> if no differences.</summary>
+    [JsonIgnore]
+    public DiffSeverity? HighestSeverity =>
+        Differences.Count == 0 ? null : Differences.Max(d => d.Severity);
+}
+
+/// <summary>Summary counts for a schema compare report.</summary>
+public sealed record SchemaCompareSummary
+{
+    /// <summary>Number of <see cref="DiffSeverity.Error"/> diffs.</summary>
+    [JsonPropertyName("errors")]
+    public int Errors { get; init; }
+
+    /// <summary>Number of <see cref="DiffSeverity.Warning"/> diffs.</summary>
+    [JsonPropertyName("warnings")]
+    public int Warnings { get; init; }
+
+    /// <summary>Number of <see cref="DiffSeverity.Info"/> diffs.</summary>
+    [JsonPropertyName("infos")]
+    public int Infos { get; init; }
+
+    /// <summary>Total diff count.</summary>
+    [JsonPropertyName("total")]
+    public int Total { get; init; }
+}

--- a/src/PPDS.Cli/Services/Schema/Models/SchemaDifference.cs
+++ b/src/PPDS.Cli/Services/Schema/Models/SchemaDifference.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace PPDS.Cli.Services.Schema.Models;
+
+/// <summary>
+/// A single schema difference between source and target snapshots.
+/// </summary>
+public sealed record SchemaDifference
+{
+    /// <summary>Severity classification.</summary>
+    [JsonPropertyName("severity")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required DiffSeverity Severity { get; init; }
+
+    /// <summary>Diff kind for programmatic handling.</summary>
+    [JsonPropertyName("kind")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public required DiffKind Kind { get; init; }
+
+    /// <summary>Entity logical name the diff applies to (null for cross-entity).</summary>
+    [JsonPropertyName("entity")]
+    public string? Entity { get; init; }
+
+    /// <summary>Attribute logical name the diff applies to (null when not attribute-scoped).</summary>
+    [JsonPropertyName("attribute")]
+    public string? Attribute { get; init; }
+
+    /// <summary>Human-readable description.</summary>
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    /// <summary>Source-side value (for type/length/precision diffs).</summary>
+    [JsonPropertyName("sourceValue")]
+    public string? SourceValue { get; init; }
+
+    /// <summary>Target-side value (for type/length/precision diffs).</summary>
+    [JsonPropertyName("targetValue")]
+    public string? TargetValue { get; init; }
+}

--- a/src/PPDS.Cli/Services/Schema/SchemaComparisonService.cs
+++ b/src/PPDS.Cli/Services/Schema/SchemaComparisonService.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PPDS.Cli.Services.Schema.Models;
+using PPDS.Cli.Services.Schema.Snapshots;
+
+namespace PPDS.Cli.Services.Schema;
+
+/// <summary>
+/// Pure, I/O-free implementation of <see cref="ISchemaComparisonService"/>.
+/// </summary>
+public sealed class SchemaComparisonService : ISchemaComparisonService
+{
+    private static readonly StringComparer NameComparer = StringComparer.OrdinalIgnoreCase;
+
+    // Required-level ordering: higher = stricter. Used to decide if target became more demanding.
+    private static readonly Dictionary<string, int> RequiredLevelRank = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["None"] = 0,
+        ["Recommended"] = 1,
+        ["ApplicationRequired"] = 2,
+        ["SystemRequired"] = 3
+    };
+
+    /// <inheritdoc />
+    public SchemaCompareReport Compare(SchemaSnapshot source, SchemaSnapshot target)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(target);
+
+        var diffs = new List<SchemaDifference>();
+
+        var targetEntities = target.Entities.ToDictionary(e => e.LogicalName, NameComparer);
+        var sourceEntities = source.Entities.ToDictionary(e => e.LogicalName, NameComparer);
+
+        foreach (var entity in source.Entities.OrderBy(e => e.LogicalName, NameComparer))
+        {
+            if (!targetEntities.TryGetValue(entity.LogicalName, out var targetEntity))
+            {
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = DiffSeverity.Error,
+                    Kind = DiffKind.MissingEntity,
+                    Entity = entity.LogicalName,
+                    Message = $"Entity '{entity.LogicalName}' exists in source but not in target."
+                });
+                continue;
+            }
+
+            CompareAttributes(entity, targetEntity, source.IncludesOptionSetValues && target.IncludesOptionSetValues, diffs);
+            CompareRelationships(entity, targetEntity, diffs);
+        }
+
+        // ExtraInTarget — entities present in target but not in source.
+        foreach (var entity in target.Entities.OrderBy(e => e.LogicalName, NameComparer))
+        {
+            if (!sourceEntities.ContainsKey(entity.LogicalName))
+            {
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = DiffSeverity.Info,
+                    Kind = DiffKind.ExtraEntity,
+                    Entity = entity.LogicalName,
+                    Message = $"Entity '{entity.LogicalName}' exists in target but not in source."
+                });
+            }
+        }
+
+        return new SchemaCompareReport
+        {
+            Source = source.Source,
+            Target = target.Source,
+            Differences = diffs
+        };
+    }
+
+    private static void CompareAttributes(
+        EntitySnapshot source,
+        EntitySnapshot target,
+        bool compareOptionSetValues,
+        List<SchemaDifference> diffs)
+    {
+        var targetAttrs = target.Attributes.ToDictionary(a => a.LogicalName, NameComparer);
+        var sourceAttrs = source.Attributes.ToDictionary(a => a.LogicalName, NameComparer);
+
+        foreach (var attr in source.Attributes.OrderBy(a => a.LogicalName, NameComparer))
+        {
+            if (!targetAttrs.TryGetValue(attr.LogicalName, out var targetAttr))
+            {
+                var isRequired =
+                    string.Equals(attr.RequiredLevel, "ApplicationRequired", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(attr.RequiredLevel, "SystemRequired", StringComparison.OrdinalIgnoreCase);
+
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = isRequired ? DiffSeverity.Error : DiffSeverity.Warning,
+                    Kind = DiffKind.MissingAttribute,
+                    Entity = source.LogicalName,
+                    Attribute = attr.LogicalName,
+                    Message = $"Attribute '{source.LogicalName}.{attr.LogicalName}' exists in source but not in target."
+                });
+                continue;
+            }
+
+            if (!string.Equals(attr.AttributeType, targetAttr.AttributeType, StringComparison.OrdinalIgnoreCase))
+            {
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = DiffSeverity.Error,
+                    Kind = DiffKind.TypeMismatch,
+                    Entity = source.LogicalName,
+                    Attribute = attr.LogicalName,
+                    Message = $"Attribute '{source.LogicalName}.{attr.LogicalName}' type changed: source='{attr.AttributeType}', target='{targetAttr.AttributeType}'.",
+                    SourceValue = attr.AttributeType,
+                    TargetValue = targetAttr.AttributeType
+                });
+                continue; // further comparisons would be apples-to-oranges
+            }
+
+            CompareRequiredLevel(source.LogicalName, attr, targetAttr, diffs);
+            CompareLength(source.LogicalName, attr, targetAttr, diffs);
+            ComparePrecision(source.LogicalName, attr, targetAttr, diffs);
+            CompareLookupTargets(source.LogicalName, attr, targetAttr, diffs);
+
+            if (compareOptionSetValues)
+            {
+                CompareOptionValues(source.LogicalName, attr, targetAttr, diffs);
+            }
+        }
+
+        foreach (var attr in target.Attributes.OrderBy(a => a.LogicalName, NameComparer))
+        {
+            if (!sourceAttrs.ContainsKey(attr.LogicalName))
+            {
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = DiffSeverity.Info,
+                    Kind = DiffKind.ExtraAttribute,
+                    Entity = target.LogicalName,
+                    Attribute = attr.LogicalName,
+                    Message = $"Attribute '{target.LogicalName}.{attr.LogicalName}' exists in target but not in source."
+                });
+            }
+        }
+    }
+
+    private static void CompareRequiredLevel(
+        string entity,
+        AttributeSnapshot source,
+        AttributeSnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        if (source.RequiredLevel is null || target.RequiredLevel is null)
+        {
+            return;
+        }
+
+        if (!RequiredLevelRank.TryGetValue(source.RequiredLevel, out var sourceRank) ||
+            !RequiredLevelRank.TryGetValue(target.RequiredLevel, out var targetRank))
+        {
+            return;
+        }
+
+        if (targetRank > sourceRank)
+        {
+            diffs.Add(new SchemaDifference
+            {
+                Severity = DiffSeverity.Error,
+                Kind = DiffKind.RequiredLevelStricter,
+                Entity = entity,
+                Attribute = source.LogicalName,
+                Message = $"Attribute '{entity}.{source.LogicalName}' required level is stricter in target: source='{source.RequiredLevel}', target='{target.RequiredLevel}'.",
+                SourceValue = source.RequiredLevel,
+                TargetValue = target.RequiredLevel
+            });
+        }
+    }
+
+    private static void CompareLength(
+        string entity,
+        AttributeSnapshot source,
+        AttributeSnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        if (source.MaxLength is { } sourceLen && target.MaxLength is { } targetLen && targetLen < sourceLen)
+        {
+            diffs.Add(new SchemaDifference
+            {
+                Severity = DiffSeverity.Warning,
+                Kind = DiffKind.LengthShrunk,
+                Entity = entity,
+                Attribute = source.LogicalName,
+                Message = $"Attribute '{entity}.{source.LogicalName}' max length shrunk: source={sourceLen}, target={targetLen}. Data may be truncated.",
+                SourceValue = sourceLen.ToString(),
+                TargetValue = targetLen.ToString()
+            });
+        }
+    }
+
+    private static void ComparePrecision(
+        string entity,
+        AttributeSnapshot source,
+        AttributeSnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        if (source.Precision is { } sourceP && target.Precision is { } targetP && targetP < sourceP)
+        {
+            diffs.Add(new SchemaDifference
+            {
+                Severity = DiffSeverity.Warning,
+                Kind = DiffKind.PrecisionLoss,
+                Entity = entity,
+                Attribute = source.LogicalName,
+                Message = $"Attribute '{entity}.{source.LogicalName}' precision reduced: source={sourceP}, target={targetP}. Precision may be lost.",
+                SourceValue = sourceP.ToString(),
+                TargetValue = targetP.ToString()
+            });
+        }
+    }
+
+    private static void CompareLookupTargets(
+        string entity,
+        AttributeSnapshot source,
+        AttributeSnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        if (source.LookupTargets is null || target.LookupTargets is null)
+        {
+            return;
+        }
+
+        var targetSet = new HashSet<string>(target.LookupTargets, NameComparer);
+        var missing = source.LookupTargets.Where(t => !targetSet.Contains(t)).ToList();
+        if (missing.Count == 0)
+        {
+            return;
+        }
+
+        diffs.Add(new SchemaDifference
+        {
+            Severity = DiffSeverity.Error,
+            Kind = DiffKind.LookupTargetMissing,
+            Entity = entity,
+            Attribute = source.LogicalName,
+            Message = $"Lookup '{entity}.{source.LogicalName}' targets missing in target: {string.Join(", ", missing)}.",
+            SourceValue = string.Join(",", source.LookupTargets),
+            TargetValue = string.Join(",", target.LookupTargets)
+        });
+    }
+
+    private static void CompareOptionValues(
+        string entity,
+        AttributeSnapshot source,
+        AttributeSnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        if (source.OptionValues is null || target.OptionValues is null)
+        {
+            return;
+        }
+
+        var targetSet = target.OptionValues.ToHashSet();
+        foreach (var value in source.OptionValues.Where(v => !targetSet.Contains(v)).OrderBy(v => v))
+        {
+            diffs.Add(new SchemaDifference
+            {
+                Severity = DiffSeverity.Warning,
+                Kind = DiffKind.MissingOptionValue,
+                Entity = entity,
+                Attribute = source.LogicalName,
+                Message = $"Option-set '{entity}.{source.LogicalName}' value {value} present in source but missing in target.",
+                SourceValue = value.ToString(),
+                TargetValue = null
+            });
+        }
+    }
+
+    private static void CompareRelationships(
+        EntitySnapshot source,
+        EntitySnapshot target,
+        List<SchemaDifference> diffs)
+    {
+        var targetRels = new HashSet<string>(target.Relationships.Select(r => r.SchemaName), NameComparer);
+        foreach (var rel in source.Relationships.OrderBy(r => r.SchemaName, NameComparer))
+        {
+            if (!targetRels.Contains(rel.SchemaName))
+            {
+                diffs.Add(new SchemaDifference
+                {
+                    Severity = DiffSeverity.Error,
+                    Kind = DiffKind.MissingRelationship,
+                    Entity = source.LogicalName,
+                    Message = $"Relationship '{rel.SchemaName}' ({rel.RelationshipType}) on '{source.LogicalName}' missing in target."
+                });
+            }
+        }
+    }
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/AttributeSnapshot.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/AttributeSnapshot.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>Snapshot of a single attribute.</summary>
+public sealed class AttributeSnapshot
+{
+    /// <summary>Logical name (e.g. <c>name</c>).</summary>
+    public required string LogicalName { get; init; }
+
+    /// <summary>
+    /// Normalized attribute type identifier (e.g. <c>string</c>, <c>integer</c>,
+    /// <c>lookup</c>, <c>picklist</c>, <c>datetime</c>, <c>decimal</c>).
+    /// </summary>
+    public required string AttributeType { get; init; }
+
+    /// <summary>
+    /// Required level — one of <c>None</c>, <c>Recommended</c>,
+    /// <c>ApplicationRequired</c>, <c>SystemRequired</c>. Null when unknown.
+    /// </summary>
+    public string? RequiredLevel { get; init; }
+
+    /// <summary>Maximum length for string types.</summary>
+    public int? MaxLength { get; init; }
+
+    /// <summary>Precision for decimal/money types.</summary>
+    public int? Precision { get; init; }
+
+    /// <summary>Allowed lookup targets, lowercase, for lookup attributes.</summary>
+    public IReadOnlyList<string>? LookupTargets { get; init; }
+
+    /// <summary>Option-set values for picklist attributes (null if unknown).</summary>
+    public IReadOnlyList<int>? OptionValues { get; init; }
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Migration.Formats;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>
+/// Builds a <see cref="SchemaSnapshot"/> from a CMT-format data package (zip
+/// containing <c>data_schema.xml</c> or <c>schema.xml</c>).
+/// </summary>
+/// <remarks>
+/// CMT schema files don't carry option-set values, so the resulting snapshot
+/// has <see cref="SchemaSnapshot.IncludesOptionSetValues"/> = false and any
+/// option-value diffs against it are suppressed by the comparison service.
+/// </remarks>
+public sealed class DataPackageSnapshotLoader : ISnapshotLoader
+{
+    private readonly string _packagePath;
+    private readonly ICmtSchemaReader _schemaReader;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="packagePath">Path to a CMT data package zip.</param>
+    /// <param name="schemaReader">Reader used to parse the embedded schema.xml.</param>
+    public DataPackageSnapshotLoader(string packagePath, ICmtSchemaReader schemaReader)
+    {
+        if (string.IsNullOrWhiteSpace(packagePath))
+        {
+            throw new ArgumentException("Package path must be provided.", nameof(packagePath));
+        }
+        _packagePath = packagePath;
+        _schemaReader = schemaReader ?? throw new ArgumentNullException(nameof(schemaReader));
+    }
+
+    /// <inheritdoc />
+    public async Task<SchemaSnapshot> LoadAsync(
+        IReadOnlyCollection<string>? entityFilter = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_packagePath))
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.FileNotFound,
+                $"Data package not found: {_packagePath}");
+        }
+
+        try
+        {
+            await using var fileStream = new FileStream(
+                _packagePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous);
+
+            using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read);
+
+            var schemaEntry = archive.GetEntry("data_schema.xml")
+                ?? archive.GetEntry("schema.xml");
+
+            if (schemaEntry is null)
+            {
+                throw new PpdsException(
+                    ErrorCodes.Validation.SchemaInvalid,
+                    "Data package does not contain a schema file (data_schema.xml or schema.xml).");
+            }
+
+            await using var schemaStream = schemaEntry.Open();
+            using var buffer = new MemoryStream();
+            await schemaStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            buffer.Position = 0;
+
+            var migrationSchema = await _schemaReader.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+
+            var entities = migrationSchema.Entities
+                .Where(e => entityFilter is null || entityFilter.Count == 0 ||
+                            entityFilter.Contains(e.LogicalName, StringComparer.OrdinalIgnoreCase))
+                .Select(e => new EntitySnapshot
+                {
+                    LogicalName = e.LogicalName,
+                    DisplayName = e.DisplayName,
+                    Attributes = e.Fields.Select(f => new AttributeSnapshot
+                    {
+                        LogicalName = f.LogicalName,
+                        AttributeType = string.IsNullOrEmpty(f.Type) ? "unknown" : f.Type.ToLowerInvariant(),
+                        RequiredLevel = f.IsRequired ? "ApplicationRequired" : "None",
+                        MaxLength = f.MaxLength,
+                        Precision = f.Precision,
+                        LookupTargets = string.IsNullOrEmpty(f.LookupEntity)
+                            ? null
+                            : new[] { f.LookupEntity!.ToLowerInvariant() }
+                    }).ToList(),
+                    Relationships = e.Relationships.Select(r => new RelationshipSnapshot
+                    {
+                        SchemaName = r.Name,
+                        RelationshipType = r.IsManyToMany ? "ManyToMany" : "OneToMany"
+                    }).ToList()
+                })
+                .ToList();
+
+            return new SchemaSnapshot
+            {
+                Source = $"data:{Path.GetFileName(_packagePath)}",
+                Entities = entities,
+                IncludesOptionSetValues = false
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException and not PpdsException)
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.SchemaInvalid,
+                $"Failed to read schema from data package: {ex.Message}",
+                ex);
+        }
+    }
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
@@ -69,15 +69,14 @@ public sealed class DataPackageSnapshotLoader : ISnapshotLoader
             }
 
             await using var schemaStream = schemaEntry.Open();
-            using var buffer = new MemoryStream();
-            await schemaStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
-            buffer.Position = 0;
+            var migrationSchema = await _schemaReader.ReadAsync(schemaStream, cancellationToken).ConfigureAwait(false);
 
-            var migrationSchema = await _schemaReader.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            var filterSet = entityFilter is { Count: > 0 }
+                ? new HashSet<string>(entityFilter, StringComparer.OrdinalIgnoreCase)
+                : null;
 
             var entities = migrationSchema.Entities
-                .Where(e => entityFilter is null || entityFilter.Count == 0 ||
-                            entityFilter.Contains(e.LogicalName, StringComparer.OrdinalIgnoreCase))
+                .Where(e => filterSet is null || filterSet.Contains(e.LogicalName))
                 .Select(e => new EntitySnapshot
                 {
                     LogicalName = e.LogicalName,

--- a/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/DataPackageSnapshotLoader.cs
@@ -108,6 +108,13 @@ public sealed class DataPackageSnapshotLoader : ISnapshotLoader
                 IncludesOptionSetValues = false
             };
         }
+        catch (InvalidDataException ex)
+        {
+            throw new PpdsException(
+                ErrorCodes.Validation.SchemaInvalid,
+                $"Data package is not a valid zip archive: {_packagePath}",
+                ex);
+        }
         catch (Exception ex) when (ex is not OperationCanceledException and not PpdsException)
         {
             throw new PpdsException(

--- a/src/PPDS.Cli/Services/Schema/Snapshots/EntitySnapshot.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/EntitySnapshot.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>Snapshot of a single entity.</summary>
+public sealed class EntitySnapshot
+{
+    /// <summary>Logical name (e.g. <c>account</c>).</summary>
+    public required string LogicalName { get; init; }
+
+    /// <summary>Display name (e.g. <c>Account</c>).</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Attributes on the entity.</summary>
+    public required IReadOnlyList<AttributeSnapshot> Attributes { get; init; }
+
+    /// <summary>Relationships involving this entity (referencing side).</summary>
+    public required IReadOnlyList<RelationshipSnapshot> Relationships { get; init; }
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/EnvironmentSnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/EnvironmentSnapshotLoader.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Dataverse.Metadata;
+using PPDS.Dataverse.Metadata.Models;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>
+/// Builds a <see cref="SchemaSnapshot"/> from a live Dataverse environment via
+/// <see cref="IMetadataQueryService"/>.
+/// </summary>
+public sealed class EnvironmentSnapshotLoader : ISnapshotLoader
+{
+    private readonly IMetadataQueryService _metadata;
+    private readonly string _sourceDescriptor;
+    private readonly Action<string>? _progress;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    /// <param name="metadata">Metadata query service for the target environment.</param>
+    /// <param name="sourceDescriptor">Descriptor used in the report (e.g. <c>env:https://qa.crm.dynamics.com</c>).</param>
+    /// <param name="progress">Optional callback for per-entity progress messages.</param>
+    public EnvironmentSnapshotLoader(
+        IMetadataQueryService metadata,
+        string sourceDescriptor,
+        Action<string>? progress = null)
+    {
+        _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+        _sourceDescriptor = sourceDescriptor ?? throw new ArgumentNullException(nameof(sourceDescriptor));
+        _progress = progress;
+    }
+
+    /// <summary>
+    /// Logical names of entities that exist in the environment but are not loaded in
+    /// detail (i.e. filtered out by <c>entityFilter</c>). Populated after
+    /// <see cref="LoadAsync"/> returns. Empty when no filter was applied.
+    /// </summary>
+    public IReadOnlyList<string> UnloadedEntities { get; private set; } = Array.Empty<string>();
+
+    /// <inheritdoc />
+    public async Task<SchemaSnapshot> LoadAsync(
+        IReadOnlyCollection<string>? entityFilter = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var allEntities = await _metadata.GetEntitiesAsync(
+                customOnly: false,
+                filter: null,
+                includeIntersect: false,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            List<EntitySummary> selected;
+            if (entityFilter is { Count: > 0 })
+            {
+                var filterSet = new HashSet<string>(entityFilter, StringComparer.OrdinalIgnoreCase);
+                selected = allEntities.Where(e => filterSet.Contains(e.LogicalName)).ToList();
+                UnloadedEntities = allEntities.Where(e => !filterSet.Contains(e.LogicalName))
+                    .Select(e => e.LogicalName).ToList();
+            }
+            else
+            {
+                selected = allEntities.ToList();
+                UnloadedEntities = Array.Empty<string>();
+            }
+
+            var snapshots = new List<EntitySnapshot>(selected.Count);
+            var index = 0;
+            foreach (var summary in selected)
+            {
+                index++;
+                _progress?.Invoke($"  Loading entity {index}/{selected.Count}: {summary.LogicalName}");
+                cancellationToken.ThrowIfCancellationRequested();
+                var entity = await _metadata.GetEntityAsync(
+                    summary.LogicalName,
+                    includeAttributes: true,
+                    includeRelationships: true,
+                    includeKeys: false,
+                    includePrivileges: false,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                snapshots.Add(new EntitySnapshot
+                {
+                    LogicalName = entity.LogicalName,
+                    DisplayName = entity.DisplayName,
+                    Attributes = entity.Attributes.Select(a => new AttributeSnapshot
+                    {
+                        LogicalName = a.LogicalName,
+                        AttributeType = NormalizeType(a.AttributeType),
+                        RequiredLevel = a.RequiredLevel,
+                        MaxLength = a.MaxLength,
+                        Precision = a.Precision,
+                        LookupTargets = a.Targets?.Select(t => t.ToLowerInvariant()).ToList(),
+                        OptionValues = a.Options?.Select(o => o.Value).ToList()
+                    }).ToList(),
+                    Relationships = entity.OneToManyRelationships
+                        .Select(r => new RelationshipSnapshot
+                        {
+                            SchemaName = r.SchemaName,
+                            RelationshipType = "OneToMany",
+                            ReferencingEntity = r.ReferencingEntity,
+                            ReferencedEntity = r.ReferencedEntity
+                        })
+                        .Concat(entity.ManyToManyRelationships.Select(r => new RelationshipSnapshot
+                        {
+                            SchemaName = r.SchemaName,
+                            RelationshipType = "ManyToMany"
+                        }))
+                        .ToList()
+                });
+            }
+
+            return new SchemaSnapshot
+            {
+                Source = _sourceDescriptor,
+                Entities = snapshots,
+                IncludesOptionSetValues = true
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException and not PpdsException)
+        {
+            throw new PpdsException(
+                ErrorCodes.Operation.Internal,
+                $"Failed to load schema snapshot from environment: {ex.Message}",
+                ex);
+        }
+    }
+
+    private static string NormalizeType(string? type) =>
+        string.IsNullOrEmpty(type) ? "unknown" : type.ToLowerInvariant();
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/EnvironmentSnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/EnvironmentSnapshotLoader.cs
@@ -106,6 +106,13 @@ public sealed class EnvironmentSnapshotLoader : ISnapshotLoader
                             ReferencingEntity = r.ReferencingEntity,
                             ReferencedEntity = r.ReferencedEntity
                         })
+                        .Concat(entity.ManyToOneRelationships.Select(r => new RelationshipSnapshot
+                        {
+                            SchemaName = r.SchemaName,
+                            RelationshipType = "ManyToOne",
+                            ReferencingEntity = r.ReferencingEntity,
+                            ReferencedEntity = r.ReferencedEntity
+                        }))
                         .Concat(entity.ManyToManyRelationships.Select(r => new RelationshipSnapshot
                         {
                             SchemaName = r.SchemaName,

--- a/src/PPDS.Cli/Services/Schema/Snapshots/ISnapshotLoader.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/ISnapshotLoader.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>
+/// Loads a <see cref="SchemaSnapshot"/> from some backing source (live env, data package, ...).
+/// </summary>
+public interface ISnapshotLoader
+{
+    /// <summary>
+    /// Load the snapshot. <paramref name="entityFilter"/>, when non-null, restricts
+    /// the snapshot to the named entities (live-env loaders only — package loaders
+    /// always return all entities defined in the file).
+    /// </summary>
+    Task<SchemaSnapshot> LoadAsync(System.Collections.Generic.IReadOnlyCollection<string>? entityFilter = null, CancellationToken cancellationToken = default);
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/RelationshipSnapshot.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/RelationshipSnapshot.cs
@@ -1,0 +1,17 @@
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>Snapshot of a single relationship.</summary>
+public sealed class RelationshipSnapshot
+{
+    /// <summary>Schema name (e.g. <c>account_primary_contact</c>).</summary>
+    public required string SchemaName { get; init; }
+
+    /// <summary>Relationship type: <c>OneToMany</c>, <c>ManyToOne</c>, or <c>ManyToMany</c>.</summary>
+    public required string RelationshipType { get; init; }
+
+    /// <summary>Referencing (child) entity logical name. Null for many-to-many.</summary>
+    public string? ReferencingEntity { get; init; }
+
+    /// <summary>Referenced (parent) entity logical name. Null for many-to-many.</summary>
+    public string? ReferencedEntity { get; init; }
+}

--- a/src/PPDS.Cli/Services/Schema/Snapshots/SchemaSnapshot.cs
+++ b/src/PPDS.Cli/Services/Schema/Snapshots/SchemaSnapshot.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace PPDS.Cli.Services.Schema.Snapshots;
+
+/// <summary>
+/// Snapshot of a schema (entities + attributes + relationships) for use by
+/// <see cref="PPDS.Cli.Services.Schema.SchemaComparisonService"/>.
+/// </summary>
+/// <remarks>
+/// Decoupled from <c>EntityMetadataDto</c> and <c>MigrationSchema</c> so the
+/// comparison service is pure (no Dataverse / no CMT zip dependencies) and the
+/// same shape can be loaded from any source (live env, data package, future
+/// snapshot file format).
+/// </remarks>
+public sealed class SchemaSnapshot
+{
+    /// <summary>
+    /// Descriptor identifying where the snapshot came from
+    /// (e.g. <c>data:path.zip</c> or <c>env:https://...</c>).
+    /// </summary>
+    public required string Source { get; init; }
+
+    /// <summary>Entities included in the snapshot.</summary>
+    public required IReadOnlyList<EntitySnapshot> Entities { get; init; }
+
+    /// <summary>
+    /// Indicates whether the snapshot includes attribute-level option-set value lists.
+    /// Data packages don't carry option-set values, so option-set diffs are skipped
+    /// when either side reports <c>false</c>.
+    /// </summary>
+    public bool IncludesOptionSetValues { get; init; }
+}

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -20,6 +20,7 @@ using PPDS.Cli.Services.PluginTraces;
 using PPDS.Cli.Services.Profile;
 using PPDS.Cli.Services.Query;
 using PPDS.Cli.Services.Roles;
+using PPDS.Cli.Services.Schema;
 using PPDS.Cli.Services.SolutionComponents;
 using PPDS.Cli.Services.Solutions;
 using PPDS.Cli.Services.UpdateCheck;
@@ -92,6 +93,9 @@ public static class ServiceRegistration
 
         // Export services
         services.AddTransient<IExportService, ExportService>();
+
+        // Schema comparison — pure, stateless service (no Dataverse dependencies).
+        services.AddSingleton<ISchemaComparisonService, SchemaComparisonService>();
 
         // Plugin registration service - requires connection pool + shakedown guard
         services.AddTransient<IPluginRegistrationService>(sp =>

--- a/tests/PPDS.Cli.Tests/Services/Schema/DataPackageSnapshotLoaderTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Schema/DataPackageSnapshotLoaderTests.cs
@@ -1,0 +1,147 @@
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using FluentAssertions;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.Schema.Snapshots;
+using PPDS.Migration.Formats;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Schema;
+
+public class DataPackageSnapshotLoaderTests
+{
+    private const string SampleSchemaXml = """
+        <entities version="1.0">
+          <entity name="account" displayname="Account" etc="1">
+            <fields>
+              <field displayname="Name" name="name" type="string" maxlength="160" isrequired="true" />
+              <field displayname="Revenue" name="revenue" type="money" precision="2" />
+              <field displayname="Primary Contact" name="primarycontactid" type="lookup" lookupType="contact" />
+            </fields>
+            <relationships>
+              <relationship name="account_contacts" referencingEntity="contact" referencedEntity="account" />
+            </relationships>
+          </entity>
+          <entity name="contact" displayname="Contact" />
+        </entities>
+        """;
+
+    private static async Task<string> CreateZipAsync(string contents, string entryName)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"schema-test-{System.Guid.NewGuid():N}.zip");
+        await using (var fs = File.Create(path))
+        using (var zip = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            var entry = zip.CreateEntry(entryName);
+            await using var writer = new StreamWriter(entry.Open());
+            await writer.WriteAsync(contents);
+        }
+        return path;
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithDataSchemaXml_ReadsEntities()
+    {
+        var path = await CreateZipAsync(SampleSchemaXml, "data_schema.xml");
+        try
+        {
+            var loader = new DataPackageSnapshotLoader(path, new CmtSchemaReader());
+
+            var snapshot = await loader.LoadAsync();
+
+            snapshot.IncludesOptionSetValues.Should().BeFalse();
+            snapshot.Source.Should().StartWith("data:").And.EndWith(".zip");
+            snapshot.Entities.Should().HaveCount(2);
+
+            var account = snapshot.Entities.First(e => e.LogicalName == "account");
+            account.Attributes.Should().HaveCount(3);
+
+            var name = account.Attributes.First(a => a.LogicalName == "name");
+            name.AttributeType.Should().Be("string");
+            name.MaxLength.Should().Be(160);
+            name.RequiredLevel.Should().Be("ApplicationRequired");
+
+            var lookup = account.Attributes.First(a => a.LogicalName == "primarycontactid");
+            lookup.AttributeType.Should().Be("lookup");
+            lookup.LookupTargets.Should().NotBeNull();
+            // PPDS.Migration.Formats.CmtSchemaReader maps "lookupType" attribute to LookupEntity.
+
+            account.Relationships.Should().ContainSingle()
+                .Which.SchemaName.Should().Be("account_contacts");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_AcceptsLegacySchemaXmlEntryName()
+    {
+        var path = await CreateZipAsync(SampleSchemaXml, "schema.xml");
+        try
+        {
+            var loader = new DataPackageSnapshotLoader(path, new CmtSchemaReader());
+
+            var snapshot = await loader.LoadAsync();
+
+            snapshot.Entities.Should().HaveCount(2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_FileMissing_ThrowsPpdsExceptionWithFileNotFoundCode()
+    {
+        var loader = new DataPackageSnapshotLoader("Z:/does-not-exist.zip", new CmtSchemaReader());
+
+        var ex = await Assert.ThrowsAsync<PpdsException>(() => loader.LoadAsync());
+        ex.ErrorCode.Should().Be(ErrorCodes.Validation.FileNotFound);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ZipMissingSchemaEntry_ThrowsPpdsExceptionWithSchemaInvalid()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"schema-test-{System.Guid.NewGuid():N}.zip");
+        await using (var fs = File.Create(path))
+        using (var zip = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            zip.CreateEntry("readme.txt");
+        }
+
+        try
+        {
+            var loader = new DataPackageSnapshotLoader(path, new CmtSchemaReader());
+
+            var ex = await Assert.ThrowsAsync<PpdsException>(() => loader.LoadAsync());
+            ex.ErrorCode.Should().Be(ErrorCodes.Validation.SchemaInvalid);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithEntityFilter_RestrictsResult()
+    {
+        var path = await CreateZipAsync(SampleSchemaXml, "data_schema.xml");
+        try
+        {
+            var loader = new DataPackageSnapshotLoader(path, new CmtSchemaReader());
+
+            var snapshot = await loader.LoadAsync(entityFilter: new[] { "account" });
+
+            snapshot.Entities.Should().HaveCount(1)
+                .And.Subject.Single().LogicalName.Should().Be("account");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/Schema/EnvironmentSnapshotLoaderTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Schema/EnvironmentSnapshotLoaderTests.cs
@@ -134,4 +134,82 @@ public class EnvironmentSnapshotLoaderTests
         mock.Verify(m => m.GetEntityAsync("contact", It.IsAny<bool>(), It.IsAny<bool>(),
             It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task LoadAsync_IncludesOneToMany_ManyToOne_AndManyToMany_Relationships()
+    {
+        // Regression coverage for issue surfaced by /review on PR #1060:
+        // ManyToOneRelationships had been silently omitted from the snapshot, so
+        // package-vs-env compare could never detect ManyToOne drift and env-vs-env
+        // only caught it via the inverse OneToMany row. This test asserts all three
+        // relationship kinds appear in the snapshot's Relationships list.
+        var mock = new Mock<IMetadataQueryService>();
+        mock.Setup(m => m.GetEntitiesAsync(false, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Summary("account") });
+
+        mock.Setup(m => m.GetEntityAsync("account", true, true, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EntityMetadataDto
+            {
+                LogicalName = "account",
+                DisplayName = "Account",
+                SchemaName = "Account",
+                Attributes = new List<AttributeMetadataDto>(),
+                OneToManyRelationships = new List<RelationshipMetadataDto>
+                {
+                    new()
+                    {
+                        SchemaName = "account_contacts",
+                        RelationshipType = "OneToMany",
+                        ReferencedEntity = "account",
+                        ReferencedAttribute = "accountid",
+                        ReferencingEntity = "contact",
+                        ReferencingAttribute = "parentcustomerid"
+                    }
+                },
+                ManyToOneRelationships = new List<RelationshipMetadataDto>
+                {
+                    new()
+                    {
+                        SchemaName = "account_parentaccount",
+                        RelationshipType = "ManyToOne",
+                        ReferencedEntity = "account",
+                        ReferencedAttribute = "accountid",
+                        ReferencingEntity = "account",
+                        ReferencingAttribute = "parentaccountid"
+                    }
+                },
+                ManyToManyRelationships = new List<ManyToManyRelationshipDto>
+                {
+                    new()
+                    {
+                        SchemaName = "account_competitors",
+                        IntersectEntityName = "accountcompetitors",
+                        Entity1LogicalName = "account",
+                        Entity1IntersectAttribute = "accountid",
+                        Entity2LogicalName = "competitor",
+                        Entity2IntersectAttribute = "competitorid"
+                    }
+                }
+            });
+
+        var loader = new EnvironmentSnapshotLoader(mock.Object, "env:test");
+
+        var snapshot = await loader.LoadAsync();
+
+        var account = snapshot.Entities.Should().ContainSingle().Subject;
+        account.Relationships.Should().HaveCount(3);
+
+        var oneToMany = account.Relationships.Should().ContainSingle(r => r.RelationshipType == "OneToMany").Subject;
+        oneToMany.SchemaName.Should().Be("account_contacts");
+        oneToMany.ReferencingEntity.Should().Be("contact");
+        oneToMany.ReferencedEntity.Should().Be("account");
+
+        var manyToOne = account.Relationships.Should().ContainSingle(r => r.RelationshipType == "ManyToOne").Subject;
+        manyToOne.SchemaName.Should().Be("account_parentaccount");
+        manyToOne.ReferencingEntity.Should().Be("account");
+        manyToOne.ReferencedEntity.Should().Be("account");
+
+        var manyToMany = account.Relationships.Should().ContainSingle(r => r.RelationshipType == "ManyToMany").Subject;
+        manyToMany.SchemaName.Should().Be("account_competitors");
+    }
 }

--- a/tests/PPDS.Cli.Tests/Services/Schema/EnvironmentSnapshotLoaderTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Schema/EnvironmentSnapshotLoaderTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using PPDS.Cli.Services.Schema.Snapshots;
+using PPDS.Dataverse.Metadata;
+using PPDS.Dataverse.Metadata.Models;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Schema;
+
+public class EnvironmentSnapshotLoaderTests
+{
+    private static EntitySummary Summary(string logical) => new()
+    {
+        LogicalName = logical,
+        DisplayName = logical,
+        SchemaName = logical,
+        IsCustomEntity = false,
+        IsManaged = true
+    };
+
+    private static EntityMetadataDto BuildEntity(string logical, params AttributeMetadataDto[] attrs) => new()
+    {
+        LogicalName = logical,
+        DisplayName = logical,
+        SchemaName = logical,
+        Attributes = new List<AttributeMetadataDto>(attrs)
+    };
+
+    [Fact]
+    public async Task LoadAsync_BuildsSnapshotFromMetadataService()
+    {
+        var mock = new Mock<IMetadataQueryService>();
+        mock.Setup(m => m.GetEntitiesAsync(false, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Summary("account") });
+
+        mock.Setup(m => m.GetEntityAsync("account", true, true, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildEntity("account",
+                new AttributeMetadataDto
+                {
+                    LogicalName = "name",
+                    DisplayName = "Name",
+                    SchemaName = "Name",
+                    AttributeType = "String",
+                    RequiredLevel = "ApplicationRequired",
+                    MaxLength = 200
+                },
+                new AttributeMetadataDto
+                {
+                    LogicalName = "status",
+                    DisplayName = "Status",
+                    SchemaName = "Status",
+                    AttributeType = "Picklist",
+                    Options = new List<OptionValueDto>
+                    {
+                        new() { Value = 1, Label = "Active" },
+                        new() { Value = 2, Label = "Inactive" }
+                    }
+                }));
+
+        var loader = new EnvironmentSnapshotLoader(mock.Object, "env:https://example.crm.dynamics.com");
+
+        var snapshot = await loader.LoadAsync();
+
+        snapshot.IncludesOptionSetValues.Should().BeTrue();
+        snapshot.Source.Should().Be("env:https://example.crm.dynamics.com");
+
+        var account = snapshot.Entities.Should().ContainSingle().Subject;
+        account.LogicalName.Should().Be("account");
+
+        var name = account.Attributes.First(a => a.LogicalName == "name");
+        name.AttributeType.Should().Be("string"); // normalized to lowercase
+        name.RequiredLevel.Should().Be("ApplicationRequired");
+        name.MaxLength.Should().Be(200);
+
+        var status = account.Attributes.First(a => a.LogicalName == "status");
+        status.OptionValues.Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task LoadAsync_RecordsUnloadedEntities_WhenFilterApplied()
+    {
+        var mock = new Mock<IMetadataQueryService>();
+        mock.Setup(m => m.GetEntitiesAsync(false, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Summary("account"), Summary("contact"), Summary("lead") });
+
+        mock.Setup(m => m.GetEntityAsync(It.IsAny<string>(), true, true, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string name, bool _, bool __, bool ___, bool ____, CancellationToken _____) => BuildEntity(name));
+
+        var loader = new EnvironmentSnapshotLoader(mock.Object, "env:test");
+
+        await loader.LoadAsync(entityFilter: new[] { "account" });
+
+        loader.UnloadedEntities.Should().BeEquivalentTo(new[] { "contact", "lead" });
+    }
+
+    [Fact]
+    public async Task LoadAsync_InvokesProgressCallback_PerEntity()
+    {
+        var mock = new Mock<IMetadataQueryService>();
+        mock.Setup(m => m.GetEntitiesAsync(false, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Summary("account"), Summary("contact") });
+        mock.Setup(m => m.GetEntityAsync(It.IsAny<string>(), true, true, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string name, bool _, bool __, bool ___, bool ____, CancellationToken _____) => BuildEntity(name));
+
+        var messages = new List<string>();
+        var loader = new EnvironmentSnapshotLoader(mock.Object, "env:test", messages.Add);
+
+        await loader.LoadAsync();
+
+        messages.Should().HaveCount(2);
+        messages[0].Should().Contain("1/2").And.Contain("account");
+        messages[1].Should().Contain("2/2").And.Contain("contact");
+    }
+
+    [Fact]
+    public async Task LoadAsync_AppliesEntityFilter()
+    {
+        var mock = new Mock<IMetadataQueryService>();
+        mock.Setup(m => m.GetEntitiesAsync(false, null, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { Summary("account"), Summary("contact") });
+
+        mock.Setup(m => m.GetEntityAsync(It.IsAny<string>(), true, true, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string name, bool _, bool __, bool ___, bool ____, CancellationToken _____) => BuildEntity(name));
+
+        var loader = new EnvironmentSnapshotLoader(mock.Object, "env:test");
+
+        var snapshot = await loader.LoadAsync(entityFilter: new[] { "account" });
+
+        snapshot.Entities.Should().ContainSingle()
+            .Which.LogicalName.Should().Be("account");
+        mock.Verify(m => m.GetEntityAsync("contact", It.IsAny<bool>(), It.IsAny<bool>(),
+            It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/Schema/SchemaComparisonServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Schema/SchemaComparisonServiceTests.cs
@@ -1,0 +1,399 @@
+using System.Linq;
+using FluentAssertions;
+using PPDS.Cli.Services.Schema;
+using PPDS.Cli.Services.Schema.Models;
+using PPDS.Cli.Services.Schema.Snapshots;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Schema;
+
+public class SchemaComparisonServiceTests
+{
+    private readonly SchemaComparisonService _service = new();
+
+    private static SchemaSnapshot Snap(string name, params EntitySnapshot[] entities) =>
+        new() { Source = name, Entities = entities, IncludesOptionSetValues = true };
+
+    private static EntitySnapshot Entity(string name, params AttributeSnapshot[] attrs) =>
+        new()
+        {
+            LogicalName = name,
+            Attributes = attrs,
+            Relationships = System.Array.Empty<RelationshipSnapshot>()
+        };
+
+    private static EntitySnapshot EntityWithRels(string name, AttributeSnapshot[] attrs, RelationshipSnapshot[] rels) =>
+        new() { LogicalName = name, Attributes = attrs, Relationships = rels };
+
+    private static AttributeSnapshot Attr(
+        string name,
+        string type = "string",
+        string? requiredLevel = "None",
+        int? maxLength = null,
+        int? precision = null,
+        System.Collections.Generic.IReadOnlyList<string>? targets = null,
+        System.Collections.Generic.IReadOnlyList<int>? options = null) =>
+        new()
+        {
+            LogicalName = name,
+            AttributeType = type,
+            RequiredLevel = requiredLevel,
+            MaxLength = maxLength,
+            Precision = precision,
+            LookupTargets = targets,
+            OptionValues = options
+        };
+
+    [Fact]
+    public void Compare_IdenticalSnapshots_ProducesNoDifferences()
+    {
+        var src = Snap("a", Entity("account", Attr("name", "string", maxLength: 100)));
+        var tgt = Snap("b", Entity("account", Attr("name", "string", maxLength: 100)));
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences.Should().BeEmpty();
+        report.HighestSeverity.Should().BeNull();
+        report.Summary.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public void Compare_EntityMissingInTarget_ProducesError()
+    {
+        var src = Snap("a", Entity("account"), Entity("contact"));
+        var tgt = Snap("b", Entity("account"));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.MissingEntity).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+        diff.Entity.Should().Be("contact");
+        report.HighestSeverity.Should().Be(DiffSeverity.Error);
+    }
+
+    [Fact]
+    public void Compare_EntityExtraInTarget_ProducesInfo()
+    {
+        var src = Snap("a", Entity("account"));
+        var tgt = Snap("b", Entity("account"), Entity("contact"));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.ExtraEntity).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Info);
+        diff.Entity.Should().Be("contact");
+    }
+
+    [Fact]
+    public void Compare_MissingRequiredAttribute_ProducesError()
+    {
+        var src = Snap("a", Entity("account", Attr("name", "string", requiredLevel: "ApplicationRequired")));
+        var tgt = Snap("b", Entity("account"));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.MissingAttribute).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+        diff.Entity.Should().Be("account");
+        diff.Attribute.Should().Be("name");
+    }
+
+    [Fact]
+    public void Compare_MissingOptionalAttribute_ProducesWarning()
+    {
+        var src = Snap("a", Entity("account", Attr("nickname", "string", requiredLevel: "None")));
+        var tgt = Snap("b", Entity("account"));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.MissingAttribute).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Warning);
+    }
+
+    [Fact]
+    public void Compare_TypeMismatch_ProducesError()
+    {
+        var src = Snap("a", Entity("account", Attr("age", "integer")));
+        var tgt = Snap("b", Entity("account", Attr("age", "string")));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.TypeMismatch).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+        diff.SourceValue.Should().Be("integer");
+        diff.TargetValue.Should().Be("string");
+    }
+
+    [Fact]
+    public void Compare_StringLengthShrunk_ProducesWarning()
+    {
+        var src = Snap("a", Entity("account", Attr("name", "string", maxLength: 200)));
+        var tgt = Snap("b", Entity("account", Attr("name", "string", maxLength: 100)));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.LengthShrunk).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Warning);
+        diff.SourceValue.Should().Be("200");
+        diff.TargetValue.Should().Be("100");
+    }
+
+    [Fact]
+    public void Compare_StringLengthGrew_ProducesNoDifference()
+    {
+        // Negative case: target larger than source should NOT trigger a length diff.
+        var src = Snap("a", Entity("account", Attr("name", "string", maxLength: 100)));
+        var tgt = Snap("b", Entity("account", Attr("name", "string", maxLength: 200)));
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences.Should().NotContain(d => d.Kind == DiffKind.LengthShrunk);
+    }
+
+    [Fact]
+    public void Compare_PrecisionReduced_ProducesWarning()
+    {
+        var src = Snap("a", Entity("account", Attr("amount", "decimal", precision: 4)));
+        var tgt = Snap("b", Entity("account", Attr("amount", "decimal", precision: 2)));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.PrecisionLoss).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Warning);
+    }
+
+    [Fact]
+    public void Compare_RequiredLevelStricter_ProducesError()
+    {
+        var src = Snap("a", Entity("account", Attr("name", "string", requiredLevel: "None")));
+        var tgt = Snap("b", Entity("account", Attr("name", "string", requiredLevel: "ApplicationRequired")));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.RequiredLevelStricter).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+    }
+
+    [Fact]
+    public void Compare_RequiredLevelLooser_ProducesNoDifference()
+    {
+        var src = Snap("a", Entity("account", Attr("name", "string", requiredLevel: "ApplicationRequired")));
+        var tgt = Snap("b", Entity("account", Attr("name", "string", requiredLevel: "None")));
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences.Should().NotContain(d => d.Kind == DiffKind.RequiredLevelStricter);
+    }
+
+    [Fact]
+    public void Compare_LookupTargetMissingInTarget_ProducesError()
+    {
+        var src = Snap("a", Entity("account", Attr("customer", "lookup", targets: new[] { "contact", "lead" })));
+        var tgt = Snap("b", Entity("account", Attr("customer", "lookup", targets: new[] { "contact" })));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.LookupTargetMissing).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+        diff.Message.Should().Contain("lead");
+    }
+
+    [Fact]
+    public void Compare_MissingOptionValue_ProducesWarning()
+    {
+        var src = Snap("a", Entity("account", Attr("status", "picklist", options: new[] { 1, 2, 3 })));
+        var tgt = Snap("b", Entity("account", Attr("status", "picklist", options: new[] { 1, 2 })));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.MissingOptionValue).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Warning);
+        diff.SourceValue.Should().Be("3");
+    }
+
+    [Fact]
+    public void Compare_OptionValuesSkippedWhenSnapshotDoesNotCarryThem()
+    {
+        // Package mode: source carries no option values; should not emit MissingOptionValue.
+        var src = new SchemaSnapshot
+        {
+            Source = "data:x.zip",
+            Entities = new[] { Entity("account", Attr("status", "picklist")) },
+            IncludesOptionSetValues = false
+        };
+        var tgt = Snap("b", Entity("account", Attr("status", "picklist", options: new[] { 1, 2 })));
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences.Should().NotContain(d => d.Kind == DiffKind.MissingOptionValue);
+    }
+
+    [Fact]
+    public void Compare_RelationshipMissingInTarget_ProducesError()
+    {
+        var rel = new RelationshipSnapshot
+        {
+            SchemaName = "account_contacts",
+            RelationshipType = "OneToMany",
+            ReferencingEntity = "contact",
+            ReferencedEntity = "account"
+        };
+        var src = Snap("a", EntityWithRels("account", System.Array.Empty<AttributeSnapshot>(), new[] { rel }));
+        var tgt = Snap("b", Entity("account"));
+
+        var report = _service.Compare(src, tgt);
+
+        var diff = report.Differences.Should().ContainSingle(d => d.Kind == DiffKind.MissingRelationship).Subject;
+        diff.Severity.Should().Be(DiffSeverity.Error);
+        diff.Message.Should().Contain("account_contacts");
+    }
+
+    [Fact]
+    public void Compare_SummaryAndHighestSeverityReflectMixedDiffs()
+    {
+        var src = Snap("a",
+            Entity("account",
+                Attr("required", "string", requiredLevel: "ApplicationRequired", maxLength: 100),
+                Attr("optional", "string", requiredLevel: "None")),
+            Entity("contact"));
+        var tgt = Snap("b",
+            Entity("account",
+                Attr("required", "string", maxLength: 50),
+                Attr("optional", "string"),
+                Attr("extra", "string"))); // contact missing entirely
+
+        var report = _service.Compare(src, tgt);
+
+        report.Summary.Errors.Should().BeGreaterThan(0);
+        report.Summary.Warnings.Should().BeGreaterThan(0);
+        report.Summary.Infos.Should().BeGreaterThan(0);
+        report.HighestSeverity.Should().Be(DiffSeverity.Error);
+    }
+
+    [Fact]
+    public void Compare_NamesAreCaseInsensitive()
+    {
+        var src = Snap("a", Entity("Account", Attr("Name")));
+        var tgt = Snap("b", Entity("account", Attr("name")));
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Compare_DifferencesAreInDeterministicOrder()
+    {
+        var src = Snap("a",
+            Entity("zeta"),
+            Entity("alpha"),
+            Entity("beta"));
+        var tgt = Snap("b");
+
+        var report = _service.Compare(src, tgt);
+
+        report.Differences
+            .Where(d => d.Kind == DiffKind.MissingEntity)
+            .Select(d => d.Entity)
+            .Should().ContainInOrder("alpha", "beta", "zeta");
+    }
+}
+
+public class CompareCommandBuildReportTests
+{
+    [Fact]
+    public void BuildReport_AddsExtraEntityDiffs_ForUnloadedTargetEntities()
+    {
+        var service = new SchemaComparisonService();
+        var source = new SchemaSnapshot
+        {
+            Source = "data:p.zip",
+            Entities = new[]
+            {
+                new EntitySnapshot
+                {
+                    LogicalName = "account",
+                    Attributes = System.Array.Empty<AttributeSnapshot>(),
+                    Relationships = System.Array.Empty<RelationshipSnapshot>()
+                }
+            },
+            IncludesOptionSetValues = false
+        };
+        var target = new SchemaSnapshot
+        {
+            Source = "env:qa",
+            Entities = new[]
+            {
+                new EntitySnapshot
+                {
+                    LogicalName = "account",
+                    Attributes = System.Array.Empty<AttributeSnapshot>(),
+                    Relationships = System.Array.Empty<RelationshipSnapshot>()
+                }
+            },
+            IncludesOptionSetValues = true
+        };
+
+        var report = PPDS.Cli.Commands.Schema.CompareCommand.BuildReport(
+            service, source, target, new[] { "contact", "lead" });
+
+        report.Differences
+            .Where(d => d.Kind == DiffKind.ExtraEntity)
+            .Select(d => d.Entity)
+            .Should().BeEquivalentTo(new[] { "contact", "lead" });
+        report.Differences.Where(d => d.Kind == DiffKind.ExtraEntity)
+            .All(d => d.Severity == DiffSeverity.Info).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildReport_DoesNotDuplicateEntitiesThatExistInSource()
+    {
+        var service = new SchemaComparisonService();
+        var source = new SchemaSnapshot
+        {
+            Source = "a",
+            Entities = new[]
+            {
+                new EntitySnapshot
+                {
+                    LogicalName = "contact",
+                    Attributes = System.Array.Empty<AttributeSnapshot>(),
+                    Relationships = System.Array.Empty<RelationshipSnapshot>()
+                }
+            }
+        };
+        var target = new SchemaSnapshot
+        {
+            Source = "b",
+            Entities = new[]
+            {
+                new EntitySnapshot
+                {
+                    LogicalName = "contact",
+                    Attributes = System.Array.Empty<AttributeSnapshot>(),
+                    Relationships = System.Array.Empty<RelationshipSnapshot>()
+                }
+            }
+        };
+
+        // "contact" appears in unloaded list AND in source — should not produce ExtraEntity.
+        var report = PPDS.Cli.Commands.Schema.CompareCommand.BuildReport(
+            service, source, target, new[] { "contact" });
+
+        report.Differences.Where(d => d.Kind == DiffKind.ExtraEntity).Should().BeEmpty();
+    }
+}
+
+public class CompareCommandExitCodeTests
+{
+    [Theory]
+    [InlineData(null, 0)]                       // no diffs -> Success
+    [InlineData(DiffSeverity.Info, 0)]          // info -> Success
+    [InlineData(DiffSeverity.Warning, 1)]       // warning -> PartialSuccess
+    [InlineData(DiffSeverity.Error, 8)]         // error -> ValidationError
+    public void ExitCodeFor_MapsSeverityCorrectly(DiffSeverity? severity, int expected)
+    {
+        var actual = PPDS.Cli.Commands.Schema.CompareCommand.ExitCodeFor(severity);
+        actual.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- New `ppds schema compare` CLI command detects schema drift between a data package and a target environment, or between two live environments
- Severity-categorized report (Error / Warning / Info) with exit code reflecting highest severity (0 / 1 / 8) and JSON output for CI gates
- Pure, DI-registered `SchemaComparisonService` with a snapshot model decoupled from Dataverse/CMT types — single code path reusable from TUI/MCP/RPC later

## Commands
```
ppds schema compare --data data.zip --env target          # package vs env
ppds schema compare --source dev --target qa              # env vs env
ppds schema compare --data data.zip --env qa -f json      # CI gate mode
```

## Diff kinds
`MissingEntity` (Error) · `ExtraEntity` (Info) · `MissingAttribute` (Error/Warning based on required level) · `TypeMismatch` (Error) · `RequiredLevelStricter` (Error) · `LengthShrunk` (Warning) · `PrecisionLoss` (Warning) · `MissingOptionValue` (Warning) · `LookupTargetMissing` (Error) · `MissingRelationship` (Error)

## Acceptance Criteria (#42)
- [x] Compare exported data package schema against target environment
- [x] Compare two live environments directly
- [x] Generate report with severity-categorized differences
- [x] Exit code reflects highest severity (non-zero for errors)
- [x] Support JSON output for CI/CD integration

## Conventions followed
- Business logic in Application Services (`SchemaComparisonService`), commands stay thin
- All exceptions wrapped in `PpdsException` with structured `ErrorCode`
- CLI status to stderr; JSON output to stdout
- No changes to existing ImportService / ExportService internals — greenfield only

## Test plan
- [x] 33 new behavioral unit tests covering every diff kind, severity mapping, exit-code mapping, env-mode loader, package-mode zip loader (`data_schema.xml` and legacy `schema.xml` entry names), entity filter, progress callback, and `ExtraEntity` merge logic
- [x] Full solution build + full unit suite green across net8.0 / net9.0 / net10.0
- [x] CLI help, validator (mutex `--data/--source`, both-or-neither), and error path (`FileNotFound`) smoke-tested manually
- [ ] Live-env verification (requires real Dataverse target — author has not exercised against a live tenant; the snapshot loader is covered by mocked metadata-service tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)