### PR TITLE
feat(skill): /cleanup overhaul — classify, bulk-execute SAFE, discuss only AMBIGUOUS

### DIFF
--- a/.claude/skills/cleanup/REFERENCE.md
+++ b/.claude/skills/cleanup/REFERENCE.md
@@ -1,0 +1,235 @@
+# Cleanup — Reference
+
+Rationale, taxonomies, and worked templates for the `cleanup` skill. SKILL.md cites sections here by `§N`.
+
+## §1 — Framing rationale
+
+The earlier `cleanup` was too conservative: it stopped at `git branch --merged main`, leaving drift-merged, squash-shipped, superseded, and abandoned branches for the user to investigate. In a 2026-05-15 session the user redirected the skill six times before the work got done (retro at `.retros/2026-05-15-cleanup-session.md`). Once the user escalated to "dispatch parallel investigators", 14 of 16 ambiguous branches turned out to be safe deletes.
+
+This rewrite encodes that pattern as the default. The skill enumerates everything first, classifies in parallel, and only surfaces to the user (a) the SAFE batch in one approval and (b) genuinely undecidable items as per-item prompts. Reduces user back-and-forth from ~6 redirects to 1 bulk approval + up-to-5 per-item prompts.
+
+The single most important phrase: **"when in doubt, classify and act on the safe bucket — only surface what genuinely needs judgment."** Investigators bias toward DELETE-HIGH for clearly-shipped-elsewhere work and DISCUSS-LOW only when unsure.
+
+## §2 — Rule-filter table (SKILL.md §4)
+
+Apply in order; first match wins. Bypasses investigator dispatch.
+
+| Signal | Bucket |
+|--------|--------|
+| Branch is `main` | PROTECTED (root) |
+| Worktree path == current cleanup session's worktree | PROTECTED (current) |
+| Branch has an OPEN PR in `pr_by_branch` | PROTECTED (open PR) |
+| Branch is the head of an `isRunning: true` session's `cwd` worktree | PROTECTED (active session) |
+| Locked worktree, PID alive (or no PID in reason) | PROTECTED (locked) |
+| Branch in `git branch --merged main` AND `git log main..<branch>` non-empty | SAFE (merged) |
+| Branch in `--merged` AND `git log main..<branch>` empty | SAFE (not-started — 0 divergent commits) |
+| Branch's remote tracking ref was freshly pruned this run | SAFE (squash-merged via prune) |
+| Branch has a MERGED PR in `pr_by_branch` | SAFE (squash-merged via PR) |
+| All divergent commits touch only `.retros/**`, `.workflow/**`, `.claude/state/**` | SAFE (drift-merged via workflow artifacts) |
+| `release/*` AND tag-lineage check passes (tag in branch ancestry) | PROTECTED (shipped release) |
+| `release/*` AND tag-lineage check fails | AMBIGUOUS (release-lineage-fail) |
+| Otherwise | dispatch investigator (§3) |
+
+The workflow-artifact filter is the biggest false-positive remover from the retro: half the "active" branches in that session were active only because `.retros/.workflow` commits accumulated after the real work shipped.
+
+The release-lineage rule reflects: `release/v1.0.0` looked sacred but its commits were on a separate lineage from where `Cli-v1.0.0` actually shipped (the tag is on main; the branch tip is not in main's ancestry). Tags are the source of truth.
+
+## §3 — Investigator brief (SKILL.md §4)
+
+Dispatch all investigators in a single `Agent` message (Lane A, read-only). Issue them in parallel — the only place the skill runs agents concurrently. Sequential execution happens in step 8.
+
+Prompt template:
+
+> **Investigator brief for `<branch>`**
+>
+> Determine whether this branch's work has already shipped (cherry-picked, squash-merged under a different name, superseded by a later PR) or is genuinely active and unshipped.
+>
+> Return one structured block with all of:
+>
+> - `last_author_date` — `git log -1 --format=%ai <branch>`
+> - `divergent_commits` — count from `git log main..<branch> --oneline | wc -l`
+> - `divergent_loc` — `git diff main...<branch> --shortstat`
+> - `paths_touched` — `git log main..<branch> --name-only --pretty=format: | sort -u`
+> - `ships_elsewhere` — search `git log main --grep="<branch>"`, `gh pr list --search "head:<branch>"`, and `git log --all --grep="<branch-key-phrase>"`. Look for cherry-picks, squash merges, supersession.
+> - `summary` — 1–2 sentences describing what this branch is.
+> - `recommendation` — DELETE / KEEP / DISCUSS
+> - `confidence` — HIGH / LOW
+> - `rationale` — one sentence justifying the recommendation.
+>
+> Bias: when work clearly shipped elsewhere or the divergence is only workflow artifacts, **DELETE with HIGH**. When unsure, **DISCUSS with LOW** — do not guess. Verify "is this branch actually unshipped?" before recommending KEEP for branches with substantive code.
+
+The investigator MUST verify the ships-elsewhere claim with `git diff` evidence before returning DELETE — the 2026-05-15 retro caught a wrong mission brief because the calling agent skipped that step.
+
+## §4 — Bucketing rules (SKILL.md §5)
+
+| Source | Resulting bucket |
+|--------|-----------------|
+| Rule-filter PROTECTED | PROTECTED |
+| Rule-filter SAFE | SAFE |
+| Investigator `DELETE` + `HIGH` | SAFE |
+| Investigator `DELETE` + `LOW` | AMBIGUOUS |
+| Investigator `DISCUSS` | AMBIGUOUS |
+| Investigator `KEEP` | PROTECTED (active, leave alone) |
+| Release-lineage failure (no tag in ancestry) | AMBIGUOUS |
+| Investigator timeout / malformed return | AMBIGUOUS (LOW) |
+
+Never auto-SAFE a `release/*` branch — even if the investigator says DELETE-HIGH, route to AMBIGUOUS for a human eyeball.
+
+## §5 — Stale-lock detection (SKILL.md §5)
+
+Lock reasons look like `locked claude agent agent-xxx (pid 43216)`. Parse the PID; ambiguous reasons (no PID, no text) stay PROTECTED.
+
+PID-alive check:
+
+```bash
+# Windows
+powershell -NoProfile -Command "Get-Process -Id <pid> -ErrorAction SilentlyContinue | Select-Object Id, ProcessName"
+# Unix
+kill -0 <pid> 2>/dev/null && echo running || echo dead
+```
+
+Dead PID → `git worktree unlock <path>`, then re-bucket by §2. `--dry-run` records but does not unlock.
+
+## §6 — Zombie + daemon shutdown (SKILL.md §8)
+
+Dead Claude agent sessions leave bash/shell processes in `until ... sleep` loops polling for task output that will never arrive. They hold filesystem locks on the worktree directory, blocking `git worktree remove` and `rm -rf` with "Permission denied" / "Device or resource busy".
+
+Match the **full worktree path** (e.g., `.worktrees/profile-env-ux`), not just the dirname — avoids false matches on short names.
+
+```bash
+# Windows
+powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*<full-worktree-path>*' } | Select-Object ProcessId, Name, CommandLine"
+# Unix
+pgrep -af '<full-worktree-path>'
+```
+
+Report matches, then kill each (exclude the cleanup session's own PID):
+
+```bash
+# Windows
+taskkill /PID <pid> /F
+# Unix
+kill -9 <pid>
+```
+
+Wait 2 s after kill so file handles release before the removal command runs.
+
+**Daemon shutdown:** for each `*-session.json` file in the worktree (e.g., `tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json`):
+
+1. Read `daemonPort`, `daemonPid` from the JSON.
+2. `POST http://localhost:{port}/shutdown` (5 s timeout).
+3. On failure, kill `daemonPid` directly (`taskkill /PID {pid} /F` or `kill {pid}`).
+4. Delete the session file.
+
+## §7 — Remote-sweep classification (SKILL.md §10)
+
+For each remote branch (`git ls-remote --heads origin`, exclude `main` / default):
+
+| Signal | Classification |
+|--------|---------------|
+| Has MERGED PR in `pr_by_branch` | SAFE (remote-merged) |
+| Has CLOSED-without-merge PR AND no open issue references the branch name | SAFE (closed-no-ship) |
+| Tracked by a local branch in a `isRunning: true` session | PROTECTED (in flight) |
+| Has an OPEN PR | PROTECTED (open PR) |
+| `release/*` AND tag-lineage passes | PROTECTED (shipped release) |
+| `release/*` AND tag-lineage fails | AMBIGUOUS (release-lineage-fail — confirm before delete) |
+| No PR record AND last commit > 90 days old | AMBIGUOUS (stale-orphan) |
+| Otherwise | AMBIGUOUS (no signal) |
+
+Deletion command (one-at-a-time):
+
+```bash
+git push origin --delete <branch>
+```
+
+Remote-sweep gets its own bulk-approval prompt — it's a second batch, but still one prompt for many items, not per-item.
+
+## §8 — Final report
+
+```
+## Cleanup Report
+
+### Removed (worktrees)
+| Worktree | Branch | Reason | Forced? |
+
+### Deleted Branches (no worktree)
+- <branch> — <reason> (-d / -D)
+
+### Orphans Removed
+| Directory | Status |
+
+### Pruned Local Remote Refs
+- origin/<branch>
+
+### Remote Branches Deleted (push --delete)
+| Branch | Reason |
+
+### Rebased (active)
+| Worktree | Branch | Result |
+
+### Skipped / Protected
+| Item | Reason |
+
+### AMBIGUOUS — User Decisions
+| Item | Decision |
+
+### Stale Locks Recovered
+| Worktree | PID | Action |
+
+### Zombie Processes Killed
+| PID | Worktree | Process |
+
+### Mid-Rebase Aborted
+| Worktree | Phase (pre / post) |
+
+### Sessions Archived
+| Session ID | cwd | Last active |
+
+### Investigators
+- Dispatched: N
+- DELETE (HIGH): N | DELETE (LOW): N | KEEP: N | DISCUSS: N
+
+### Summary
+- Local removed: N worktrees, N branches
+- Remote deleted: N
+- Orphans: N removed, N failed
+- Stale locks: N recovered
+- Zombies killed: N
+- Rebased: N OK, N conflict
+- Sessions archived: N
+- Protected: N
+```
+
+Prefix the title with `[DRY RUN]` when no destructive command ran.
+
+## §9 — Error catalogue
+
+| Error | Recovery |
+|-------|----------|
+| `merge --ff-only` fails on main | STOP — report; do not force-reset |
+| `git remote prune origin` fails | Log warning; classification still works via `--merged` and PR cross-reference |
+| Mid-rebase found in pre-scan | `rebase --abort`, record, continue |
+| Investigator times out / returns malformed | Treat as DISCUSS-LOW → AMBIGUOUS |
+| Worktree removal fails (Permission denied) | Zombies already killed → log "partially removed", do not retry |
+| `branch -d` fails | Branch not actually merged — skip and log |
+| `branch -D` fails | Unexpected — log for manual investigation |
+| Rebase conflict | `rebase --abort`, record, continue |
+| Locked worktree (PID alive) | PROTECTED, skip |
+| Locked worktree (PID dead) | Unlock, reclassify, proceed |
+| Lock reason has no PID | PROTECTED (ambiguous lock), skip |
+| `rm -rf` orphan fails | Log as failed, continue |
+| `.worktrees/` directory absent | Skip orphan sweep |
+| Orphan is symlink/junction (Windows) | Remove link, do not follow target |
+| `gh` unavailable | Skip remote sweep; warn in report |
+| `mcp__ccd_session_mgmt__list_sessions` unavailable | Skip session-aware protection; warn |
+| `archive_session` rejected (subagent mode) | Surface to user; do not retry from a subagent |
+| Tag-lineage ambiguous (no matching tag) | Recommendation = DISCUSS → AMBIGUOUS |
+| Investigator says KEEP for a branch later found shipped | Surface in report — improvement signal for next retro |
+
+## §10 — Design constraints from the retro
+
+- The permission classifier consistently denies batched cleanup ops (parallel rebase, `branch -d <list>`, `rm -rf` even on empty dirs). All destructive phases must be one-at-a-time by default. Do not retry batched.
+- Mid-rebase states from prior cancelled batches accumulate silently. Pre- and post-scan both run; both abort any found.
+- `mcp__ccd_session_mgmt__archive_session` is unavailable in unsupervised (subagent) mode. Only the main `/cleanup` session can call it — not investigators.
+- The investigator pattern (Lane A, parallel, structured return) is the only agent dispatch in this skill. The executor phase remains sequential.
+- The skill is the natural home for session archival proposals — main-session, one bulk-approval prompt, one archive call per session.

--- a/.claude/skills/cleanup/REFERENCE.md
+++ b/.claude/skills/cleanup/REFERENCE.md
@@ -117,7 +117,7 @@ Wait 2 s after kill so file handles release before the removal command runs.
 **Daemon shutdown:** for each `*-session.json` file in the worktree (e.g., `tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json`):
 
 1. Read `daemonPort`, `daemonPid` from the JSON.
-2. `POST http://localhost:{port}/shutdown` (5 s timeout).
+2. `curl -X POST --max-time 5 http://localhost:{port}/shutdown`.
 3. On failure, kill `daemonPid` directly (`taskkill /PID {pid} /F` or `kill {pid}`).
 4. Delete the session file.
 

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -5,315 +5,117 @@ description: Clean up merged worktrees and branches, prune stale remotes, rebase
 
 # Cleanup
 
-Remove merged worktrees and branches, prune stale remote tracking refs, and rebase remaining active worktrees onto main.
+Enumerate everything in one pass, dispatch parallel investigators for divergent items, auto-classify into SAFE / AMBIGUOUS / PROTECTED, bulk-approve SAFE in ONE prompt, discuss only AMBIGUOUS, execute one-at-a-time.
 
-## When to Use
+**Design principle:** default action, not default discussion. Read `REFERENCE.md §1` for the framing.
 
-- Before starting new feature work
-- After a PR is merged
-- "Clean up my branches"
-- "Tidy up worktrees"
-- Periodic housekeeping
+Phases: PARSE → PULL+PRE-SCAN → GATHER → CLASSIFY → BUCKET → APPROVE-SAFE → DISCUSS-AMBIGUOUS → EXECUTE-LOCAL → REBASE+POST-SCAN → REMOTE-SWEEP → SESSION-ARCHIVE → REPORT.
 
-## Process
+## 1. Parse args
 
-### 1. Parse Arguments
+- `/cleanup` — all phases
+- `/cleanup --dry-run` — run reads + the bulk-approval prompt; skip destructive commands
 
-Check `$ARGUMENTS` for flags:
-
-- `/cleanup` (no args) — execute all phases
-- `/cleanup --dry-run` — preview what would be cleaned without acting
-
-If `--dry-run` is set, skip all destructive commands but still run all read-only commands to produce the preview report.
-
-### 2. Pull Latest Main
+## 2. Pull main + pre-scan mid-rebase
 
 ```bash
-git fetch origin main
-git checkout main
-git merge --ff-only origin/main
+git fetch origin main && git checkout main && git merge --ff-only origin/main
 ```
 
-If `merge --ff-only` fails, main has local commits not on origin. STOP and report — do not force-reset main.
+`--ff-only` fail → STOP, report. Do not force-reset.
 
-### 3. Prune Stale Remotes and Classify Branches
+**Pre-scan (AC-7):** for every worktree in `git worktree list --porcelain`, if `<path>/.git/rebase-merge` or `<path>/.git/rebase-apply` exists, run `git -C <path> rebase --abort`. Mid-rebase leftovers break this run if not cleared.
 
-Prune first so we know which remote branches were deleted (indicating merged PRs):
+## 3. Gather (single pass — AC-1)
 
-```bash
-git remote prune origin --dry-run   # capture what will be pruned (lines like "* [would prune] origin/feature/foo")
-```
-
-If `--dry-run` mode is **not** active, execute the actual prune:
+Run in parallel:
 
 ```bash
-git remote prune origin             # actually prune
-```
-
-If `--dry-run` mode **is** active, skip the actual prune — use the `--dry-run` output for classification only.
-
-Save the list of pruned refs (extract the ref name after `[would prune]`, e.g., `origin/feature/foo`) for squash-merge detection below.
-
-Now identify merged branches:
-
-```bash
-# Machine-parseable worktree list
 git worktree list --porcelain
-
-# Branches merged into main (excluding main itself)
-git branch --merged main | grep -v '^\*\?\s*main$'
+git branch --format='%(refname:short) %(committerdate:iso8601) %(upstream:short)'
+git branch --merged main --format='%(refname:short)'
+git remote prune origin --dry-run                       # squash signal
+git ls-remote --heads origin
+git tag --list --sort=-version:refname
+gh pr list --state all --limit 500 --json number,headRefName,state,mergedAt,closedAt
+gh issue list --state open --limit 500 --json number,title,body
 ```
 
-For each branch in the merged list, check for divergent commits:
+Then `mcp__ccd_session_mgmt__list_sessions` (AC-4). Build `pr_by_branch`, `tag_set`, session map. In non-dry-run, execute `git remote prune origin` so reads see cleaned state. `gh` unavailable → warn, skip step 10.
+
+## 4. Classify
+
+Apply rule filters first (cheap, no agent). Canonical mapping in `REFERENCE.md §2 "Rule-filter table"`.
+
+**Workflow-artifact filter (AC-3):**
 
 ```bash
-git log main..<branch> --oneline
+git log main..<branch> --name-only --pretty=format: | sort -u
 ```
 
-If this produces **no output**, the branch has zero commits beyond main — it was created for future work or was fast-forward merged. Remove it from the merged list and classify it as **"not started"** (to be skipped).
+If every non-empty path matches `^(\.retros/|\.workflow/|\.claude/state/)` → SAFE (drift-merged).
 
-**Squash-merge detection (freshly pruned only):** For each local branch (whether or not it has a worktree) that is NOT in the merged list **and NOT classified as "not started"**, check if `origin/<branch>` appears in the pruned refs list from the prune command above. If so, classify as **squash-merged**.
-
-**Do NOT infer squash-merge from a missing remote tracking ref alone.** A missing remote could mean the branch was pruned in a prior session, OR that the branch was never pushed (in-flight local work) — these are indistinguishable after the fact. Deleting in-flight work is catastrophic; leaving a stale branch is harmless. If a branch has no remote tracking ref and wasn't freshly pruned this run, classify as **active** and leave it alone.
-
-Squash-merged detection only fires for branches whose remote was pruned in *this* run's `git remote prune`. Branches whose remotes were pruned in a previous session without being cleaned up will stay around indefinitely — that's the safe trade-off. Treat squash-merged the same as merged for worktree removal, but track separately for branch deletion (step 5).
-
-Build five lists:
-- **Merged:** branches in the `--merged` list (after filtering) — with or without worktrees
-- **Squash-merged:** branches detected via the pruned-remote heuristic — with or without worktrees
-- **Active:** branches NOT merged, NOT squash-merged, NOT "not started"
-- **Not started:** branches removed from the merged list by the divergence check — report as skipped
-- **Locked worktrees:** worktrees with `locked` attribute in porcelain output — but check for **stale locks** first (see below)
-
-**Stale git lock detection:** For each locked worktree, extract the PID from the lock reason (e.g., `locked claude agent agent-xxx (pid 43216)`). If the lock reason has no PID or no reason text at all, the lock is ambiguous — classify as locked and skip it (do not unlock).
-
-When a PID is present, check whether it is still running:
+**Release tag-lineage (AC-6):** for `release/*`, derive candidate tag (`release/v1.0.0` → try `Cli-v1.0.0`, `Tui-v1.0.0`, `v1.0.0`):
 
 ```bash
-# Windows
-powershell -NoProfile -Command "Get-Process -Id <pid> -ErrorAction SilentlyContinue | Select-Object Id, ProcessName"
-
-# Unix
-kill -0 <pid> 2>/dev/null && echo "running" || echo "dead"
+git merge-base --is-ancestor <tag> <branch>
 ```
 
-If the PID is **dead**, the lock is stale. Unlock it and reclassify:
+Exit 0 = shipped = PROTECTED. Non-zero = NOT shipped = AMBIGUOUS. Never auto-SAFE a release branch.
+
+**Dispatch parallel investigators (AC-2)** for every branch with divergent commits not classified by rules. Issue all in a single `Agent` message (Lane A, read-only). Prompt template in `REFERENCE.md §3 "Investigator brief"`. Each returns `{last_author_date, divergent_commits, divergent_loc, paths_touched, ships_elsewhere, summary, recommendation, confidence, rationale}`. Collect before bucketing.
+
+## 5. Bucket
+
+Combine rule outputs + investigator returns into SAFE / AMBIGUOUS / PROTECTED. Full mapping in `REFERENCE.md §4 "Bucketing rules"`.
+
+**Stale-lock recovery before final bucketing:** parse PID from each locked worktree's reason; PID-alive check commands in `REFERENCE.md §5 "Stale-lock detection"`. Dead PID → `git worktree unlock <path>`, reclassify by rules. No PID in reason → PROTECTED. In `--dry-run`, record but do not unlock.
+
+## 6. Approve SAFE bulk (AC-10)
+
+ONE message: counts + SAFE list grouped by reason. Ask: **"Approve SAFE bucket?"** Options: `yes` / `no` / `show <branch>`. The only bulk prompt of the run.
+
+## 7. Discuss AMBIGUOUS
+
+Per item: branch + last-author-date + divergent-LOC + investigator summary + lean + one-sentence ask. Cap at 5; if more, re-dispatch investigators with sharper briefs (interaction-patterns §4).
+
+## 8. Execute LOCAL (one-at-a-time — AC-8)
+
+Permission classifier denies batched destructive ops. Process sequentially: never batch `branch -d`, parallel `rebase`, or `rm -rf` across paths.
+
+For each approved worktree (skip locked, skip main), in order:
+
+1. **Kill zombies** referencing the **full worktree path** (not just dirname). Commands in `REFERENCE.md §6 "Zombie + daemon shutdown"`. Wait 2 s.
+2. **Shut down daemons** — find `*-session.json` in the worktree, POST `/shutdown` to `daemonPort`, fall back to killing `daemonPid`, delete the session file.
+3. **Remove worktree:** `git worktree remove --force <path>`. NEVER remove main. Permission-denied after zombie kill → log "partially removed", do not retry.
+4. **Delete branch:** `git branch -d <branch>` for regular-merged; `git branch -D <branch>` for squash / drift / investigator-DELETE.
+5. **Orphan sweep:** list `.worktrees/*/`; for each not registered in step 3 porcelain output, guard against main path, kill zombies, `rm -rf`. Windows junctions: remove the link, do not follow target. Skip in `--dry-run`.
+6. **In-flight deregister** (for every removed branch): `python scripts/inflight-deregister.py --branch <branch>`, then once `python scripts/inflight-check.py --area scripts/ >/dev/null 2>&1 || true` to sweep stale registry entries.
+
+## 9. Rebase active + post-scan (AC-7)
+
+For each remaining active worktree: `git -C <path> rebase origin/main` sequentially. Conflict → `rebase --abort`, record, continue.
+
+**Post-scan:** re-check every worktree for `.git/rebase-merge` / `.git/rebase-apply`. Abort any found. Catches cancelled-mid-batch leftovers.
+
+## 10. Remote sweep (AC-5 + AC-6)
+
+Skip if `gh` unavailable. Classify each remote per `REFERENCE.md §7 "Remote-sweep classification"`. Present remote SAFE as a second bulk-approval prompt, then delete one-at-a-time:
 
 ```bash
-git worktree unlock <worktree-path>
+git push origin --delete <branch>
 ```
 
-After unlocking, re-evaluate the worktree's branch against the merged/squash-merged lists and move it to the appropriate category for removal. If `--dry-run`, report the stale lock but do not unlock.
+Remote AMBIGUOUS → per-item prompts. `release/*` failing tag-lineage are AMBIGUOUS by default.
 
-### 4. Remove Merged Worktrees
+## 11. Session archive batch (AC-4)
 
-Process worktrees **one at a time, sequentially** — do NOT run removals in parallel. A single failure in a parallel batch cancels all sibling calls.
+Select sessions where `isRunning: false` AND `cwd` not in `git worktree list`. Present batch: "Archive N stale sessions?" → yes/no. On approval, call `mcp__ccd_session_mgmt__archive_session` once per session. **Main-session only — do not delegate to a subagent** (the MCP tool rejects unsupervised mode). `--dry-run` lists only.
 
-For each merged or squash-merged worktree (not locked, not the main worktree):
+## 12. Report
 
-**Before removal, kill zombie shell processes and shut down daemons:**
+Use the template in `REFERENCE.md §8 "Final report"`. Prefix title with `[DRY RUN]` when applicable.
 
-**Zombie process detection:** Dead Claude agent sessions leave behind bash/shell processes stuck in `until ... sleep` loops polling for task output files that will never arrive. These hold filesystem locks on the worktree directory, causing `git worktree remove` and `rm -rf` to fail with "Permission denied" or "Device or resource busy."
+## Error handling
 
-For each worktree about to be removed, search for processes whose command line contains the **full worktree path** (e.g., `.worktrees/profile-env-ux`, not just `profile-env-ux`) to avoid false matches on short directory names:
-
-```bash
-# Windows — use the full relative or absolute path in the -like pattern
-powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*<full-worktree-path>*' } | Select-Object ProcessId, Name, CommandLine"
-
-# Unix
-pgrep -af '<full-worktree-path>'
-```
-
-Report the matched processes before killing. Kill any matching processes (exclude the current cleanup session's own PID). Wait 2 seconds after killing to allow file handles to release before attempting removal:
-
-```bash
-# Windows
-taskkill /PID <pid> /F
-
-# Unix
-kill -9 <pid>
-```
-
-**Daemon shutdown:**
-
-1. Search for `*-session.json` files in the worktree (e.g., `tests/PPDS.Tui.E2eTests/tools/.tui-verify-session.json`)
-2. For each session file found:
-   - Read `daemonPort` and `daemonPid` from the JSON
-   - Send `POST http://localhost:{port}/shutdown` (timeout 5s)
-   - If the HTTP request fails, kill the PID directly: `taskkill /PID {pid} /F` (Windows) or `kill {pid}` (Unix)
-   - Delete the session file
-3. Proceed with worktree removal after zombies and daemons are shut down
-
-```bash
-git worktree remove --force .worktrees/<name>
-```
-
-`--force` handles worktrees with uncommitted changes. Report each removal including whether force was needed.
-
-**Safety rules:**
-- NEVER remove the main worktree (the repo root) <!-- enforcement: T1 hook:worktree-safety -->
-- Skip locked worktrees — report them as skipped with reason
-- Report any removal failures and continue with the next worktree
-
-### 4b. Sweep Orphan Directories
-
-After removing merged worktrees, check for orphan directories — directories in `.worktrees/` that are not registered git worktrees (e.g., left behind when `git worktree remove` deregistered but failed to delete the directory).
-
-1. List all directories in `.worktrees/`:
-   ```bash
-   ls -d .worktrees/*/ 2>/dev/null
-   ```
-
-2. Compare against registered worktree paths from `git worktree list --porcelain` (already parsed in step 3). Extract the `worktree` lines to get the full path of each registered worktree.
-
-3. For each directory in `.worktrees/` that does NOT appear in the registered worktree list:
-   - **Guard:** Compare the directory's resolved absolute path against the main worktree path (the first `worktree` entry in `git worktree list --porcelain`). If they match, skip it — never remove the main worktree.
-   - **Kill zombie processes first:** Before attempting `rm -rf`, search for processes referencing the orphan's full path (same technique as step 4's zombie detection) and kill them. Wait 2 seconds after killing. Orphan directories are the most common place where zombie processes block cleanup.
-   - If `--dry-run`: add to orphan report, do NOT delete
-   - Otherwise: `rm -rf .worktrees/<name>`
-   - On Windows, if the orphan is a junction/symlink, remove the link itself — do not follow into the target directory
-
-4. If `rm -rf` fails (e.g., permission denied) even after killing zombies, log as failed in the report and continue with the next orphan.
-
-### 4c. Deregister In-Flight Entries
-
-For every branch that was removed (merged, squash-merged, or its
-worktree deleted), deregister its entry from the cross-session in-flight
-state file so sibling sessions stop seeing stale claims:
-
-```bash
-python scripts/inflight-deregister.py --branch <branch-name>
-```
-
-This is idempotent — sessions that were never registered (or already
-deregistered) succeed silently. Skip in `--dry-run` mode.
-
-Additionally, sweep stale entries (older than 24h with a missing local
-branch) by issuing a no-op check:
-
-```bash
-python scripts/inflight-check.py --area scripts/ >/dev/null 2>&1 || true
-```
-
-The pruning is a side-effect of `inflight-check` — running it ensures
-abandoned sessions do not accumulate in the registry forever.
-
-### 5. Delete Local Branches
-
-After worktrees are removed, delete their local branches:
-
-**Regular-merged branches** (detected by `--merged`):
-
-```bash
-git branch -d <branch-name>
-```
-
-Use `-d` as a safety check — git will refuse if the branch is not actually merged.
-
-**Squash-merged branches** (detected by pruned-remote heuristic):
-
-```bash
-git branch -D <branch-name>
-```
-
-Use `-D` because git cannot see squash-merge ancestry, so `-d` will always refuse. The pruned-remote heuristic provides a strong signal that the branch is safe to delete.
-
-If either command fails, log the error and continue.
-
-### 6. Rebase Active Worktrees
-
-Process worktrees **one at a time, sequentially** — do NOT run rebases in parallel. A single conflict in a parallel batch cancels all sibling calls.
-
-For each remaining (non-locked) active worktree:
-
-```bash
-git -C <worktree-path> rebase origin/main
-```
-
-If rebase produces conflicts:
-1. Run `git -C <worktree-path> rebase --abort` immediately
-2. Record the worktree as "rebase conflict" in the report
-3. Continue to the next worktree
-
-Do NOT leave any worktree in a mid-rebase state.
-
-### 7. Final Report
-
-Present a summary:
-
-```
-## Cleanup Report
-
-### Removed (merged)
-| Worktree | Branch | Merge Type | Forced? |
-|----------|--------|------------|---------|
-| .worktrees/foo | feature/foo | regular | No |
-| .worktrees/bar | feature/bar | squash (used -D) | Yes (uncommitted changes) |
-
-### Deleted Branches (no worktree)
-- feature/old-thing (regular → -d)
-- fix/stale-fix (squash → -D)
-
-### Orphans Removed
-| Directory | Status |
-|-----------|--------|
-| .worktrees/old-thing | Removed |
-| .worktrees/stale-dir | Failed (permission denied) |
-
-### Pruned Remote Refs
-- origin/feature/old-thing
-- origin/fix/stale-fix
-
-### Rebased (active)
-| Worktree | Branch | Result |
-|----------|--------|--------|
-| .worktrees/baz | feature/baz | OK |
-| .worktrees/qux | feature/qux | Conflict — aborted |
-
-### Skipped
-| Worktree | Branch | Reason |
-|----------|--------|--------|
-| .worktrees/wip | feature/wip | Locked |
-| .worktrees/prep | feature/prep | No divergent commits (not started) |
-
-### Stale Locks Recovered
-| Worktree | Branch | Lock PID | Action |
-|----------|--------|----------|--------|
-| .claude/worktrees/agent-xxx | docs/old-thing | 43216 (dead) | Unlocked → removed |
-
-### Zombie Processes Killed
-| PID | Worktree | Process |
-|-----|----------|---------|
-| 12345 | .worktrees/foo | bash.exe (stale until-loop) |
-
-### Summary
-- Removed: N worktrees (N regular, N squash-merged), N branches
-- Orphans: N removed, N failed
-- Stale locks: N recovered
-- Zombies killed: N processes
-- Pruned: N remote refs
-- Rebased: N OK, N conflicts
-- Skipped: N locked, N not started
-```
-
-If `--dry-run` was specified, prefix the report title with `[DRY RUN]` and note that no changes were made.
-
-## Error Handling
-
-| Error | Recovery |
-|-------|----------|
-| `merge --ff-only` fails on main | STOP — report that main has diverged, do not proceed |
-| `git remote prune origin` fails | Log warning, continue — classification will still work via `--merged` |
-| Worktree removal fails (Permission denied) | Kill zombie processes referencing the worktree (step 4 zombie detection), then retry once. If still failing, log as "partially removed — directory locked by another process" and continue. Do NOT retry more than once. |
-| Worktree removal fails (other) | Log error, continue with next worktree |
-| `branch -d` fails (regular-merged) | Log error — branch may not actually be merged, skip it |
-| `branch -D` fails (squash-merged) | Log error — unexpected, report for manual investigation |
-| Rebase conflict | `git rebase --abort`, record in report, continue |
-| Locked worktree (PID alive) | Skip with note in report |
-| Locked worktree (PID dead) | Unlock with `git worktree unlock`, reclassify, proceed with removal |
-| Not on main branch | `git checkout main` before starting |
-| Branch has no remote tracking ref and is not in `--merged` | Classify as active — no signal to determine merge status |
-| `rm -rf` fails on orphan directory (permission denied) | Log as failed in report, continue with next orphan |
-| `.worktrees/` directory doesn't exist | Skip orphan sweep — nothing to check |
-| Orphan is a symlink/junction (Windows) | Remove the link itself, do not follow into the target |
+Full recovery table in `REFERENCE.md §9 "Error catalogue"`.

--- a/.retros/2026-05-15-cleanup-overhaul-shipped.md
+++ b/.retros/2026-05-15-cleanup-overhaul-shipped.md
@@ -1,0 +1,43 @@
+# Retrospective — 2026-05-15 — cleanup-overhaul shipped
+
+**Branch:** `feat/cleanup-overhaul` (merged via PR #1090)
+**Scope:** implementation of findings #1, #2, #3, #5, #6, #7, #10 from `2026-05-15-cleanup-session.md`
+**Mode:** interactive (this retro: headless via pr-monitor)
+**Transcripts:** 2 in worktree (322-line implementation session + this 57-line retro)
+
+---
+
+## Pattern narrative
+
+This is a "shipped clean" retro. The prior `cleanup-session` retro produced 10 findings; this branch implemented the high-confidence skill-tier ones and merged as #1090 with no blockers. Mechanical extraction reports zero user corrections, zero tool failures, zero repeated commands, zero stop-hook events, and zero allowlist drift across the whole worktree. The implementation session (322 lines) had no free-text user messages — the work was driven entirely from spec + plan + the prior retro's recommendation table, which is exactly the workflow CLAUDE.md and the constitution prescribe.
+
+The carryover loop worked: a retro produced findings, the findings became a spec, the spec became a PR, the PR shipped. There is nothing to investigate further on this branch.
+
+## Findings
+
+| # | Issue | Recommendation | Confidence | Tier | Kind |
+|---|-------|---------------|------------|------|------|
+| 1 | None — clean ship | n/a | HIGH | — | — |
+
+## Carryover from prior retros
+
+The `.retros/summary.json` schema has only aggregate counters (no per-finding entries), so per-ID carryover tracking isn't available without parsing each summary markdown file. From `2026-05-15-cleanup-session.md` (10 findings):
+
+- **Likely shipped via PR #1090** (verify against the squash diff): findings #1 (parallel-investigator default), #2 (session-aware), #3 (workflow-artifact-only drift), #5 (mid-rebase pre/post scan), #6 (remote-cleanup advisory), #7 (session archival surfacing), #10 (investigator metadata in report).
+- **Likely still open**: finding #4 (permission classifier batch-op friction — needs setup-tier change, not skill-tier), finding #8 (`/start` mission-brief verification), finding #9 (`workflow-state.py init` --worktree-path flag).
+
+## Decisions
+
+- **DO NOW**: nothing. No user-facing actions, no PRs to file, no skills to patch — the planned work for this branch landed.
+- **DEFER**: the three likely-still-open findings above belong on the backlog *if* they aren't already covered by #1090's diff. Worth a single `gh issue list --search "permission classifier cleanup" --search "start mission brief" --search "workflow-state init worktree-path"` pass next session — not now.
+- **META**: `.retros/summary.json` schema mismatch — the retro skill's Phase 9 "append findings, increment total_retros, update rolling metrics" assumes a `findings: [...]` array and `rolling_metrics` dict, but the live file has only `findings_by_category` + `metrics`. Carryover analysis (Phase 2) silently degrades. Worth a backlog issue: align `scripts/retro_helpers.py` write path with the documented schema, or update SS5 to match what's actually written.
+
+## What worked
+
+- Findings → spec → PR loop closed without any rework
+- Implementation session ran with zero observable friction (mechanical signals all zero)
+- Single-commit branch, single PR, clean merge — exactly the shape the workflow targets
+
+## What didn't
+
+- Nothing in this session. The only friction is the schema-drift meta-finding above, which belongs to the retro skill itself, not this branch's work.

--- a/.retros/2026-05-15-cleanup-session.md
+++ b/.retros/2026-05-15-cleanup-session.md
@@ -1,0 +1,63 @@
+# Retrospective — 2026-05-15 — /cleanup session
+
+**Branch:** `claude/condescending-lamarr-52011f`
+**Scope:** one interactive session: /cleanup → /start → discussion → still-pending remote review
+**Transcript:** ~607 lines, 187 tool calls, 31 tool-result error hits
+**Mode:** interactive
+
+---
+
+## Pattern narrative
+
+This session started as a conservative `/cleanup` invocation and the user had to escalate scope twice to get the work they actually wanted. The skill (as written) only acts on branches that pass `git branch --merged main`, which captured 2 of 33 worktrees on first pass. Everything else looked "active" to the skill but was, in the user's mental model, "obviously stale work that already shipped via a different PR." The user's escalation phrases:
+
+1. "set a /goal and clean it all up" — forced the agent to expand scope beyond `--merged`
+2. "dispatch parallel investigators to review each of the branches" — forced per-branch investigation
+
+The parallel-investigator pattern (16 agents in one shot) worked brilliantly: 14 of 16 ambiguous branches turned out to be safe deletes (work already shipped via a different branch / superseded / abandoned). One was a release branch worth keeping. One required a deeper investigation that turned into a `/start` to finalize lingering work. **That investigator pattern is the right default; /cleanup just doesn't know about it.**
+
+Permission classifier was the second-biggest friction source: it denied empty-dir `rm -rf`/`rmdir`, batched branch deletions (had to retry one-at-a-time), batched rebases (left 4 worktrees mid-rebase when cancelled), and PowerShell process search. Each denial required a fallback path. Net: 187 tool calls where ~120 would have sufficed with looser scope or batch-permitted operations.
+
+`/start` worked smoothly as a "spawn a finalize-this-work agent" — but the mission brief the cleanup agent handed it was **factually wrong**: it claimed PR #1075 was a precursor when #1075 was actually the squash merge of every commit on the source branch. The spawned agent caught it, verified with `git diff`, and abandoned cleanly. Good outcome, but a red flag that the cleanup agent's "what is this branch?" analysis was incomplete despite running 16 investigators.
+
+Session-archival exploration (this session): `mcp__ccd_session_mgmt__archive_session` cannot be called from a subagent (unsupervised mode rejected) — it has to be invoked from the main session with user approval per call. Currently 2 active vs 5 archived sessions; only one active session (`peaceful-bartik-86c8cc`) had a stale cwd. Not a big backlog, but `/cleanup` could opportunistically surface candidates for archiving.
+
+---
+
+## Findings
+
+| # | Issue | Recommendation | Confidence | Tier |
+|---|-------|---------------|------------|------|
+| 1 | `/cleanup` is too conservative — only acts on `--merged` branches, leaves drift-merged / squash-shipped / superseded branches behind | Add a `--full` or `--investigate` mode that auto-dispatches parallel investigators for branches with N divergent commits and proposes deletions in a bulk-approval batch | HIGH | T2 skill |
+| 2 | `/cleanup` doesn't enumerate active sessions — user had to manually call out the live one | Call `list_sessions` (or read `.workflow/state.json` across worktrees) at start; treat sessions with `isRunning: true` as do-not-touch and surface them in the report | HIGH | T2 skill |
+| 3 | Workflow artifacts (`.retros/`, `.workflow/`, `.claude/state/`) on branches falsely register as "divergent commits" | When computing `git log main..<branch> --oneline`, also check paths via `git log main..<branch> --name-only`. If ALL divergent commits touch only `.retros/**`, `.workflow/**`, `.claude/state/**` → classify as drift-merged (treat like squash-merged) | HIGH | T2 skill |
+| 4 | Permission classifier blocks the cleanup skill's batched ops (rebase batch, branch-delete batch, orphan `rm -rf`, even `rmdir` on empty dirs) | Two options: (a) rewrite the skill to use only one-at-a-time patterns the classifier accepts; (b) add a cleanup-context permission set the user pre-approves at `/cleanup` invocation | MED | T2 skill+setup |
+| 5 | Mid-rebase states left behind when a parallel rebase batch is cancelled by classifier | Step 6 should pre-scan all worktrees for `.git/rebase-merge` / `.git/rebase-apply` and abort any found, both before and after the rebase loop | HIGH | T2 skill |
+| 6 | No remote cleanup at all — user only learned this by asking | Add a final read-only step that reports `gh api repos/:owner/:repo/branches` count vs local, with an explicit "no remote cleanup performed; run `git push origin --delete <branch>` if desired" message | HIGH | T2 skill |
+| 7 | Session archival not integrated | Add Step 8: call `list_sessions`, find sessions whose `cwd` isn't in `git worktree list` AND not `isRunning`, propose archiving as a single user-approval batch using `archive_session` | MED | T2 skill |
+| 8 | `/start` worked for "spawn finalize agent" use case but handed a factually wrong mission brief (PR #1075 already squash-merged the source branch) | Trust LLM for resume/source-branch handling — but require the calling agent to verify "is this branch actually unshipped?" before constructing the brief. Could be a checklist line in /start's "build launch prompt" step | MED | T3 |
+| 9 | `workflow-state.py init` writes to caller's CWD, not the new worktree's path — caused state file to land in the wrong worktree | Add `--worktree-path` flag to `workflow-state.py init` OR have `/start` step 5 `cd` into the new worktree before calling. The current code already runs from worktree dir per the skill, but the cleanup session ran it from the wrong dir | LOW (skill says "run from worktree directory" — the bug was the calling agent not following it) | T3 |
+| 10 | User had to keep asking "what's actually on this branch", "when did we last touch it", "did this ship elsewhere" — the cleanup report doesn't surface metadata | When investigators run (finding #1), have them return: last-author-date, PR-shipped-elsewhere check, divergent-LOC count. Put it in the report | HIGH | T2 skill |
+
+---
+
+## Top-3 prioritized recommendations
+
+1. **Bake the parallel-investigator pattern into `/cleanup`** (covers findings #1, #3, #10). Right now the skill stops at `--merged`. The user already wants the broader sweep; that's what we did manually after escalation. Make it the default for any branch with divergent commits, with a bulk-approval UX at the end. This is the single biggest UX gain.
+
+2. **Make `/cleanup` session-aware** (covers #2 + #7). Read active sessions at the start, exclude them from any destructive operation, and propose archive candidates at the end. The subagent restriction on `archive_session` is fine — main-session `/cleanup` is exactly where the prompt should land.
+
+3. **Pre/post-scan for mid-rebase states + remote-cleanup advisory** (covers #5 + #6). Both are small additions but high-value: #5 is a real bug today, #6 is a documentation/expectation gap.
+
+## What worked
+
+- Parallel-investigator pattern with bulk-approval UX — exactly the right shape for ambiguous branches
+- `/start` for spawning a finalize-this-work agent — clean handoff, the spawned agent caught the wrong premise
+- User's "set a /goal" framing — gave the agent permission to plan iteratively instead of stopping for confirmation each step
+- Force-removal of workflow-artifact-only dirty worktrees after explicit "no user code" verification
+
+## What didn't
+
+- Conservative default that needed two scope escalations
+- 31 tool-result errors, ~half from permission classifier (correctly cautious but cleanup is the *one* skill where it consistently misfires)
+- Wrong mission brief on the spawned /start session (recovered, but indicates the analysis depth needed to live in /cleanup itself)

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-15",
-  "total_retros": 15,
+  "last_updated": "2026-05-15T21:58:37.002779Z",
+  "total_retros": 16,
   "findings_by_category": {
     "external": [
       {
@@ -341,6 +341,10 @@
   "metrics": {
     "avg_fix_ratio": 0.724,
     "pipeline_success_rate": 0.388,
-    "avg_convergence_rounds": 2.281
+    "avg_convergence_rounds": 2.281,
+    "last_session_findings": 0,
+    "last_session_status": "shipped_clean",
+    "last_session_branch": "feat/cleanup-overhaul",
+    "last_session_pr": 1090
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Agent topology, decision UX, lane assignment: **`.claude/interaction-patterns.md
 - Throw raw exceptions from Application Services — wrap in `PpdsException` with an `ErrorCode`. <!-- enforcement: T2 hook:exception-wrap-check -->
 - Trust an agent research summary without reading the underlying code yourself. <!-- enforcement: T3 -->
 - Edit `PublicAPI.Unshipped.txt` during a rebase — accept `--theirs` and let it regenerate; manual edits produce phantom API-drift conflicts. <!-- since: PR#956 rationale --> <!-- enforcement: T3 escape-hatch: rebase-context detection too brittle for hook -->
+- Trust a `release/X` branch as the source of truth for what shipped as version X — verify with `git merge-base --is-ancestor <release-tag> <branch>`. Tags are authoritative; the branch tip may sit on a separate lineage. <!-- since: 2026-05-15 cleanup retro --> <!-- enforcement: T3 escape-hatch: only fires when reasoning about release history -->
 - Invoke `claude -p` or any Anthropic SDK without going through `scripts/claude_dispatch.py:spawn()`. <!-- enforcement: T2 hook:sdk-spend-warn -->
 
 ## ALWAYS <!-- enforcement: T3 not-a-directive -->


### PR DESCRIPTION
## Summary

- Rewrites `.claude/skills/cleanup/SKILL.md` around a 12-phase classification pipeline (GATHER → CLASSIFY → APPROVE-SAFE-BULK → DISCUSS-AMBIGUOUS → EXECUTE → REMOTE-SWEEP → REPORT). The skill now does the classification work the 2026-05-15 retro forced the user to do manually — reducing back-and-forth from ~6 redirects to 1 bulk approval + per-AMBIGUOUS prompts.
- Adds `.claude/skills/cleanup/REFERENCE.md` with the rule-filter table, investigator prompt template, bucketing rules, zombie/daemon commands, remote-sweep classification, final report shape, and error catalogue (two-file pattern; SKILL.md stays at 121 lines).
- Adds a NEVER rule to `CLAUDE.md`: do not trust `release/X` branches as the source of truth for what shipped — verify with `git merge-base --is-ancestor <release-tag> <branch>`. Tags are authoritative.

Closes #1090

## Rule change

**Context.** The pre-rewrite `cleanup` stopped at `git branch --merged main`, leaving drift-merged / squash-shipped / superseded / abandoned branches for manual investigation. The 2026-05-15 session (committed under `.retros/`) needed six user redirects before the work got done. Once the user escalated to "dispatch parallel investigators", 14 of 16 ambiguous branches turned out to be safe deletes — the user did the classification work the skill should have.

**Old rule.** `/cleanup` acts only on branches that pass `git branch --merged main`. Anything divergent gets surfaced for user investigation, one at a time.

**New rule.** `/cleanup` enumerates everything in one pass, dispatches parallel investigators (Lane A, single Agent dispatch) for any branch with divergent commits, and auto-classifies into SAFE / AMBIGUOUS / PROTECTED. Single bulk-approval prompt for the SAFE bucket. Per-item prompts only for AMBIGUOUS. Destructive ops run one-at-a-time. Remote sweep runs after local sweep. Stale sessions are archived in a single batch.

**Why.** Default action over default discussion when the skill can decide with high confidence. Reduces the user's role to bulk approval + adjudicating items the skill genuinely cannot classify. Bakes in the investigator pattern the retro proved works.

**Falsification.** A future `/cleanup` session that requires more than 1 SAFE-bucket approval + 5 AMBIGUOUS adjudications would revise this rule — either the bias is wrong, the workflow-artifact filter (AC-3) misses a class of divergence, or the investigator brief (`REFERENCE.md §3`) needs sharpening. Track via `/retro`.

## AC Coverage

| AC | Where |
|----|------|
| AC-1 single-pass GATHER | SKILL.md §3 |
| AC-2 parallel investigators with structured returns | SKILL.md §4 + REFERENCE.md §3 |
| AC-3 workflow-artifact-only filter (`.retros/`, `.workflow/`, `.claude/state/`) | SKILL.md §4 |
| AC-4 `list_sessions` integration + stale-session archive batch | SKILL.md §3 + §11 |
| AC-5 remote sweep with PR cross-reference, one-at-a-time delete | SKILL.md §10 + REFERENCE.md §7 |
| AC-6 `release/*` tag-lineage check via `git merge-base --is-ancestor` | SKILL.md §4 |
| AC-7 pre- and post-scan for `.git/rebase-merge` / `.git/rebase-apply` | SKILL.md §2 + §9 |
| AC-8 one-at-a-time destructive ops | SKILL.md §8 (explicit warning) |
| AC-9 release-branch NEVER rule | CLAUDE.md:17 |
| AC-10 single bulk-approval for SAFE; per-item for AMBIGUOUS only | SKILL.md §6 + §7 |

## Preserved safety properties

Porcelain parse, stale-lock detection with PID-alive check, zombie-process detection by full worktree path, daemon shutdown via `*-session.json`, orphan sweep with Windows junction/symlink handling, in-flight deregister, `branch -d` vs `-D` distinction, rebase-conflict abort, NEVER-remove-main guard.

## Test Plan

- [x] SKILL.md re-read end-to-end for phase ordering and ACs (manual)
- [x] `claudemd-line-cap.py` and `skill-line-cap.py` allowed the writes
- [x] `audit-enforcement.py --strict` PASS (9 T1 markers wired)
- [x] Workflow check 6: `cleanup/SKILL.md` cites `§1–§9` and all anchors exist in `REFERENCE.md`
- [x] Frontmatter parses (32/32 SKILL.md)
- [x] 22/22 hooks pass `echo '{}' | python <hook>` smoke
- [x] `settings.json` parses; every hook command exists on disk
- [x] No regressions in `verify-workflow.py` (2 failures confirmed pre-existing against stashed-to-main state)
- [ ] Next interactive `/cleanup` invocation will validate the new flow on a real workload (no automated tests for skills)

## Verification

- [x] /gates passed (markdown-only diff — code gates SKIP; Gate 7 enforcement-audit PASS)
- [x] /verify completed (surfaces: workflow)
- [ ] /qa — N/A for skill text changes (no product surface)
- [ ] /review — N/A (docs-only; bypass per pr.md §3 self-review clause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
