### PR TITLE
fix(workflow): repair /retro mechanical extractor — zero-signal bug (#1097)

### DIFF
--- a/.claude/skills/retro/REFERENCE.md
+++ b/.claude/skills/retro/REFERENCE.md
@@ -94,7 +94,36 @@ Why mechanical extraction can be a subprocess but transcript judgment cannot:
 
 The hard rule: dispatch mechanical signal extraction (Python/subprocess) only; never dispatch LLM-based transcript judgment to a subagent. Agents previously reported "zero user corrections" when the user was furious because they were asked to *judge* what they had read instead of just extracting signals.
 
-## §7 - HTML artifact spec
+## §7 - Mechanical signal detector reference
+
+### Correction pattern taxonomy
+
+`extract_transcript_signals` matches two classes of corrections in user-typed text:
+
+| Class | Examples | Why included |
+|-------|---------|--------------|
+| Direct | `"no,"`, `"no "`, `"wrong"`, `"try again"`, `"that's not"`, `"not what i"` | Imperative corrections — operator says what was wrong |
+| Question-form | `"why "`, `"shouldn't "`, `"didn't you "`, `"weren't you supposed "`, `"isn't this "` | Interrogative corrections — operator asks why the wrong thing happened. PR #1095 example: *"why is the PR ready but the monitor hasn't been run?"* — missed by old detector |
+
+Both classes increment `user_corrections` and set `needs_manual_review: true`.
+
+### Escalation flags
+
+Written to `.workflow/retro-findings.json` via `write_session_flags`:
+
+| Flag | Trigger |
+|------|---------|
+| `needs_manual_review` | `user_corrections > 0` OR `tool_failures > 2` OR `repeated_commands > 3` OR `frustration_hits > 0` |
+| `signal_extractor_suspect` | All detector counts zero AND `tool_call_count > 50` — a non-trivial session with no signals is suspicious |
+
+### Tool failure detection
+
+Primary: `is_error: true` on a `tool_result` block inside a `user` event.
+Fallback: content-substring patterns — `"old_string not found"` (Edit), `"file not found"` / `"no such file"` (Read).
+
+Note: Claude Code transcripts carry tool results in `user`-type events (not `tool_result`-type events), and failures are signalled via `is_error: true`, not `"Exit code: N"` strings.
+
+## §8 - HTML artifact spec
 
 Pipeline retros write .workflow/retro-findings.json (machine-readable JSON). Interactive retros write .retros/YYYY-MM-DD-summary.md only. HTML artifacts (.retros/*.html) are reserved for tooling that consumes them - the retro-html-guard.py hook blocks HTML writes outside PPDS_PIPELINE=1. The conversation IS the analysis in interactive mode.
 

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -13,6 +13,36 @@ if _SCRIPTS_DIR not in sys.path:
 from claude_dispatch import derive_slug
 from _shakedown_allowlist import SHAKEDOWN_ALLOWLIST, is_allowlisted
 
+# Correction patterns: direct commands + question-form (per #1097 fix).
+# Question-form corrections often arrive as interrogatives rather than imperatives
+# ("why is the PR ready but the monitor hasn't been run?") and were previously missed.
+_CORRECTION_PATTERNS = [
+    "no,",
+    "no ",
+    "wrong",
+    "try again",
+    "that's not",
+    "thats not",
+    "not what i",
+    "why ",
+    "shouldn't ",
+    "didn't you ",
+    "weren't you supposed ",
+    "isn't this ",
+]
+
+_FRUSTRATION_PATTERNS = [
+    "wtf",
+    "ugh",
+    "dammit",
+    "come on",
+    "ffs",
+    "this is broken",
+    "this is wrong",
+    "why isn't",
+    "why can't",
+]
+
 
 def extract_transcript_signals(jsonl_path):
     """Extract structured signals from a JSONL transcript file."""
@@ -20,8 +50,10 @@ def extract_transcript_signals(jsonl_path):
         "user_corrections": [],
         "tool_failures": [],
         "repeated_commands": [],
+        "frustration_hits": [],
     }
     command_counts = {}
+    tool_call_count = 0
 
     try:
         with open(jsonl_path, "r", encoding="utf-8", errors="replace") as f:
@@ -36,80 +68,73 @@ def extract_transcript_signals(jsonl_path):
 
                 event_type = event.get("type")
 
-                # User messages — correction patterns
-                if event_type == "human":
+                # User messages — correction patterns AND tool results.
+                # Claude Code transcripts use "user", not "human" (bug #1097 fix 1).
+                if event_type == "user":
                     content = event.get("message", {}).get("content", "")
+
+                    # Extract text for correction/frustration matching (text blocks only)
                     if isinstance(content, list):
-                        content = " ".join(
+                        text = " ".join(
                             b.get("text", "")
                             for b in content
-                            if b.get("type") == "text"
+                            if isinstance(b, dict) and b.get("type") == "text"
                         )
-                    content_lower = content.lower().strip()
-                    correction_patterns = [
-                        "no,",
-                        "no ",
-                        "wrong",
-                        "try again",
-                        "that's not",
-                        "thats not",
-                        "not what i",
-                    ]
-                    if any(p in content_lower for p in correction_patterns):
+                    else:
+                        text = content if isinstance(content, str) else ""
+
+                    text_lower = text.lower().strip()
+                    if any(p in text_lower for p in _CORRECTION_PATTERNS):
                         signals["user_corrections"].append(
-                            {
-                                "text": content[:200],
-                                "pattern": "correction",
-                            }
+                            {"text": text[:200], "pattern": "correction"}
+                        )
+                    if any(p in text_lower for p in _FRUSTRATION_PATTERNS):
+                        signals["frustration_hits"].append(
+                            {"text": text[:200], "pattern": "frustration"}
                         )
 
-                # Tool results — failure patterns
-                if event_type == "tool_result" or (
-                    event_type == "assistant"
-                    and isinstance(event.get("message", {}).get("content"), list)
-                    and any(b.get("type") == "tool_result" for b in event["message"]["content"] if isinstance(b, dict))
-                ):
-                    if event_type == "assistant":
-                        content = event.get("message", {}).get("content", [])
-                    else:
-                        content = event.get("content", "")
-
-                    # Normalize: wrap string content into a list for uniform processing
-                    if isinstance(content, str):
-                        result_texts = [content] if content else []
-                    elif isinstance(content, list):
-                        result_texts = []
+                    # Tool result failure detection within user messages.
+                    # Primary signal: is_error: true on the result block (bug #1097 fix 2).
+                    # Fallback: content-substring patterns for non-error blocks.
+                    if isinstance(content, list):
                         for block in content:
-                            if isinstance(block, dict) and block.get("type") == "tool_result":
-                                rt = block.get("content", "")
-                                if isinstance(rt, str):
-                                    result_texts.append(rt)
-                    else:
-                        result_texts = []
+                            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                                continue
+                            result_content = block.get("content", "")
+                            if isinstance(result_content, list):
+                                result_text = " ".join(
+                                    b.get("text", "") for b in result_content
+                                    if isinstance(b, dict) and b.get("type") == "text"
+                                )
+                            elif isinstance(result_content, str):
+                                result_text = result_content
+                            else:
+                                result_text = ""
 
-                    for result_text in result_texts:
-                        if "Exit code:" in result_text and "Exit code: 0" not in result_text:
-                            signals["tool_failures"].append(
-                                {"tool": "Bash", "error": result_text[:200]}
-                            )
-                        if "file not found" in result_text.lower() or "no such file" in result_text.lower():
-                            signals["tool_failures"].append(
-                                {"tool": "Read", "error": result_text[:200]}
-                            )
-                        if "old_string not found" in result_text.lower():
-                            signals["tool_failures"].append(
-                                {"tool": "Edit", "error": result_text[:200]}
-                            )
+                            if block.get("is_error"):
+                                signals["tool_failures"].append(
+                                    {"tool": "Bash", "error": result_text[:200]}
+                                )
+                            else:
+                                result_lower = result_text.lower()
+                                if "file not found" in result_lower or "no such file" in result_lower:
+                                    signals["tool_failures"].append(
+                                        {"tool": "Read", "error": result_text[:200]}
+                                    )
+                                if "old_string not found" in result_lower:
+                                    signals["tool_failures"].append(
+                                        {"tool": "Edit", "error": result_text[:200]}
+                                    )
 
-                # Track commands for repetition detection
+                # Track tool calls for repetition detection and suspect-session heuristic
                 if event_type == "assistant":
                     msg_content = event.get("message", {}).get("content", [])
                     if isinstance(msg_content, list):
                         for block in msg_content:
-                            if (
-                                block.get("type") == "tool_use"
-                                and block.get("name") == "Bash"
-                            ):
+                            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                                continue
+                            tool_call_count += 1
+                            if block.get("name") == "Bash":
                                 cmd = block.get("input", {}).get("command", "")
                                 if cmd:
                                     command_counts[cmd] = (
@@ -127,6 +152,17 @@ def extract_transcript_signals(jsonl_path):
                     "count": count,
                 }
             )
+
+    # Escalation flags
+    u = len(signals["user_corrections"])
+    t = len(signals["tool_failures"])
+    r = len(signals["repeated_commands"])
+    f = len(signals["frustration_hits"])
+    signals["needs_manual_review"] = bool(u > 0 or t > 2 or r > 3 or f > 0)
+    # A non-trivial session (>50 tool calls) with zero signals across all detectors
+    # is suspicious — likely indicates the extractor missed something.
+    all_zero = u == 0 and t == 0 and r == 0 and f == 0
+    signals["signal_extractor_suspect"] = bool(all_zero and tool_call_count > 50)
 
     return signals
 
@@ -147,6 +183,29 @@ def extract_enforcement_signals(state_path):
     except (json.JSONDecodeError, OSError):
         pass
     return signals
+
+
+def write_session_flags(findings_path, flags):
+    """Merge escalation *flags* into ``.workflow/retro-findings.json``.
+
+    Writes ``needs_manual_review`` and ``signal_extractor_suspect`` (and any
+    other keys in *flags*) into the findings JSON. Creates the file (and
+    parent dir) if missing. Existing keys are preserved.
+    """
+    os.makedirs(os.path.dirname(os.path.abspath(findings_path)) or ".", exist_ok=True)
+    existing = {}
+    try:
+        with open(findings_path, "r", encoding="utf-8") as f:
+            existing = json.load(f) or {}
+    except (json.JSONDecodeError, OSError):
+        existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+    existing.update(flags)
+    with open(findings_path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return flags
 
 
 def _encode_project_dir(path):

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -114,6 +114,8 @@ def extract_transcript_signals(jsonl_path):
                                 tool_name = "Read"
                             elif "old_string not found" in result_lower:
                                 tool_name = "Edit"
+                            elif "exit code:" in result_lower:
+                                tool_name = "Bash"
 
                             if block.get("is_error") or tool_name != "unknown":
                                 signals["tool_failures"].append(

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -68,12 +68,10 @@ def extract_transcript_signals(jsonl_path):
 
                 event_type = event.get("type")
 
-                # User messages — correction patterns AND tool results.
                 # Claude Code transcripts use "user", not "human" (bug #1097 fix 1).
                 if event_type == "user":
                     content = event.get("message", {}).get("content", "")
 
-                    # Extract text for correction/frustration matching (text blocks only)
                     if isinstance(content, list):
                         text = " ".join(
                             b.get("text", "")
@@ -93,9 +91,8 @@ def extract_transcript_signals(jsonl_path):
                             {"text": text[:200], "pattern": "frustration"}
                         )
 
-                    # Tool result failure detection within user messages.
-                    # Primary signal: is_error: true on the result block (bug #1097 fix 2).
-                    # Fallback: content-substring patterns for non-error blocks.
+                    # is_error: true is the primary tool-failure signal (bug #1097 fix 2).
+                    # tool_result blocks live inside user events, not tool_result-type events.
                     if isinstance(content, list):
                         for block in content:
                             if not isinstance(block, dict) or block.get("type") != "tool_result":
@@ -113,7 +110,7 @@ def extract_transcript_signals(jsonl_path):
 
                             if block.get("is_error"):
                                 signals["tool_failures"].append(
-                                    {"tool": "Bash", "error": result_text[:200]}
+                                    {"tool": "unknown", "error": result_text[:200]}
                                 )
                             else:
                                 result_lower = result_text.lower()
@@ -126,7 +123,6 @@ def extract_transcript_signals(jsonl_path):
                                         {"tool": "Edit", "error": result_text[:200]}
                                     )
 
-                # Track tool calls for repetition detection and suspect-session heuristic
                 if event_type == "assistant":
                     msg_content = event.get("message", {}).get("content", [])
                     if isinstance(msg_content, list):
@@ -143,7 +139,6 @@ def extract_transcript_signals(jsonl_path):
     except OSError:
         pass
 
-    # Find repeated commands (3+)
     for cmd, count in command_counts.items():
         if count >= 3:
             signals["repeated_commands"].append(
@@ -153,7 +148,6 @@ def extract_transcript_signals(jsonl_path):
                 }
             )
 
-    # Escalation flags
     u = len(signals["user_corrections"])
     t = len(signals["tool_failures"])
     r = len(signals["repeated_commands"])
@@ -192,6 +186,8 @@ def write_session_flags(findings_path, flags):
     other keys in *flags*) into the findings JSON. Creates the file (and
     parent dir) if missing. Existing keys are preserved.
     """
+    if not flags:
+        return flags
     os.makedirs(os.path.dirname(os.path.abspath(findings_path)) or ".", exist_ok=True)
     existing = {}
     try:

--- a/scripts/retro_helpers.py
+++ b/scripts/retro_helpers.py
@@ -108,20 +108,17 @@ def extract_transcript_signals(jsonl_path):
                             else:
                                 result_text = ""
 
-                            if block.get("is_error"):
+                            result_lower = result_text.lower()
+                            tool_name = "unknown"
+                            if "file not found" in result_lower or "no such file" in result_lower:
+                                tool_name = "Read"
+                            elif "old_string not found" in result_lower:
+                                tool_name = "Edit"
+
+                            if block.get("is_error") or tool_name != "unknown":
                                 signals["tool_failures"].append(
-                                    {"tool": "unknown", "error": result_text[:200]}
+                                    {"tool": tool_name, "error": result_text[:200]}
                                 )
-                            else:
-                                result_lower = result_text.lower()
-                                if "file not found" in result_lower or "no such file" in result_lower:
-                                    signals["tool_failures"].append(
-                                        {"tool": "Read", "error": result_text[:200]}
-                                    )
-                                if "old_string not found" in result_lower:
-                                    signals["tool_failures"].append(
-                                        {"tool": "Edit", "error": result_text[:200]}
-                                    )
 
                 if event_type == "assistant":
                     msg_content = event.get("message", {}).get("content", [])

--- a/scripts/test_retro_helpers.py
+++ b/scripts/test_retro_helpers.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Unit tests for retro_helpers.py signal extraction.
+
+Fixture snippets approximate the PR #1094 and PR #1095 transcript shapes
+that the old extractor silently missed due to three bugs:
+  1. event_type "human" instead of "user"
+  2. "Exit code:" string matching instead of is_error: true
+  3. Missing question-form correction patterns
+
+Usage:
+    python scripts/test_retro_helpers.py
+    python -m pytest scripts/test_retro_helpers.py
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from retro_helpers import extract_transcript_signals, write_session_flags
+
+# ---------------------------------------------------------------------------
+# Shared fixture events
+# ---------------------------------------------------------------------------
+
+# PR #1095: operator question-form correction in a "user" event
+_PR1095_OPERATOR_CORRECTION = {
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": (
+            "why is the PR ready but the monitor hasn't been run? "
+            "gemini comments were not responded to."
+        ),
+    },
+}
+
+# PR #1094: tool failure signalled by is_error: true (not "Exit code:")
+_PR1094_TOOL_FAILURE_IS_ERROR = {
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_abc",
+                "content": "Error: pr_monitor PID 38784 already running; duplicate POST detected",
+                "is_error": True,
+            }
+        ],
+    },
+}
+
+# Old "human" event type — the extractor must NOT match this (regression guard)
+_HUMAN_TYPE_CORRECTION = {
+    "type": "human",
+    "message": {
+        "role": "user",
+        "content": "no, wrong, try again",
+    },
+}
+
+# Plain direct correction in a "user" event
+_DIRECT_CORRECTION = {
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": "no, that's not right — try the other branch",
+    },
+}
+
+# Edit tool failure via content substring (no is_error flag)
+_EDIT_FAILURE_SUBSTRING = {
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_def",
+                "content": "Error: old_string not found in scripts/pipeline.py",
+                "is_error": False,
+            }
+        ],
+    },
+}
+
+# Read tool failure via content substring (no is_error flag)
+_READ_FAILURE_SUBSTRING = {
+    "type": "user",
+    "message": {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_ghi",
+                "content": "Error: file not found: .workflow/state.json",
+                "is_error": False,
+            }
+        ],
+    },
+}
+
+# Assistant bash tool-use (for tool_call_count and repetition tracking)
+_BASH_TOOL_USE = {
+    "type": "assistant",
+    "message": {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "Bash",
+                "input": {"command": "git status"},
+            }
+        ],
+    },
+}
+
+# Assistant non-Bash tool-use (counts toward tool_call_count but not commands)
+_READ_TOOL_USE = {
+    "type": "assistant",
+    "message": {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_2",
+                "name": "Read",
+                "input": {"file_path": "/some/file.py"},
+            }
+        ],
+    },
+}
+
+
+def _run_on_events(events):
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as f:
+        for e in events:
+            f.write(json.dumps(e) + "\n")
+        path = f.name
+    try:
+        return extract_transcript_signals(path)
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: event_type "user" (not "human")
+# ---------------------------------------------------------------------------
+
+class TestEventTypeFix(unittest.TestCase):
+
+    def test_user_type_direct_correction_detected(self):
+        """Direct correction in a 'user' event is extracted."""
+        sigs = _run_on_events([_DIRECT_CORRECTION])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+        self.assertIn("no,", sigs["user_corrections"][0]["text"])
+
+    def test_human_type_event_silently_ignored(self):
+        """'human' event type (wrong) does not produce corrections — regression guard."""
+        sigs = _run_on_events([_HUMAN_TYPE_CORRECTION])
+        self.assertEqual(len(sigs["user_corrections"]), 0)
+
+    def test_user_type_list_content_correction(self):
+        """Correction in a list-content 'user' event (mixed text + tool_result) is detected."""
+        event = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "no, wrong approach"},
+                    {"type": "tool_result", "tool_use_id": "x", "content": "ok"},
+                ],
+            },
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: is_error: true detection
+# ---------------------------------------------------------------------------
+
+class TestToolFailureFix(unittest.TestCase):
+
+    def test_is_error_true_flagged(self):
+        """tool_result blocks with is_error: true are flagged as tool failures (PR #1094 fixture)."""
+        sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR])
+        self.assertEqual(len(sigs["tool_failures"]), 1)
+        self.assertIn("38784", sigs["tool_failures"][0]["error"])
+
+    def test_is_error_false_clean_result_not_flagged(self):
+        """tool_result with is_error: false and clean content is not flagged."""
+        event = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_ok",
+                        "content": "main branch up to date",
+                        "is_error": False,
+                    }
+                ],
+            },
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["tool_failures"]), 0)
+
+    def test_edit_failure_via_content_substring(self):
+        """tool_result without is_error but with 'old_string not found' content is flagged."""
+        sigs = _run_on_events([_EDIT_FAILURE_SUBSTRING])
+        self.assertEqual(len(sigs["tool_failures"]), 1)
+        self.assertEqual(sigs["tool_failures"][0]["tool"], "Edit")
+
+    def test_read_failure_via_content_substring(self):
+        """tool_result without is_error but with 'file not found' content is flagged."""
+        sigs = _run_on_events([_READ_FAILURE_SUBSTRING])
+        self.assertEqual(len(sigs["tool_failures"]), 1)
+        self.assertEqual(sigs["tool_failures"][0]["tool"], "Read")
+
+    def test_multiple_is_error_failures_all_captured(self):
+        """Multiple is_error: true blocks in one session are all captured."""
+        sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR, _PR1094_TOOL_FAILURE_IS_ERROR])
+        self.assertEqual(len(sigs["tool_failures"]), 2)
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: question-form correction patterns
+# ---------------------------------------------------------------------------
+
+class TestQuestionFormCorrections(unittest.TestCase):
+
+    def test_pr1095_operator_correction_detected(self):
+        """Question-form correction from PR #1095 ('why is the PR ready...') is detected."""
+        sigs = _run_on_events([_PR1095_OPERATOR_CORRECTION])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+    def test_why_prefix_triggers_correction(self):
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "why didn't you run the tests first?"},
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+    def test_shouldnt_prefix_triggers_correction(self):
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "shouldn't you have checked the logs?"},
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+    def test_didnt_you_prefix_triggers_correction(self):
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "didn't you already push that branch?"},
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+    def test_werent_you_supposed_triggers_correction(self):
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "weren't you supposed to wait for review?"},
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+    def test_isnt_this_triggers_correction(self):
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "isn't this the wrong file to edit?"},
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["user_corrections"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# Escalation flags
+# ---------------------------------------------------------------------------
+
+class TestEscalationFlags(unittest.TestCase):
+
+    def test_needs_manual_review_on_user_correction(self):
+        """needs_manual_review is True when user_corrections > 0."""
+        sigs = _run_on_events([_DIRECT_CORRECTION])
+        self.assertTrue(sigs["needs_manual_review"])
+
+    def test_needs_manual_review_on_tool_failures_above_threshold(self):
+        """needs_manual_review is True when tool_failures > 2."""
+        sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR] * 3)
+        self.assertTrue(sigs["needs_manual_review"])
+
+    def test_needs_manual_review_on_repeated_commands_above_threshold(self):
+        """needs_manual_review is True when >3 distinct commands are each repeated 3+ times."""
+        def _cmd(c):
+            return {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "tool_use", "id": "t", "name": "Bash", "input": {"command": c}}],
+                },
+            }
+        events = []
+        for cmd in ["git status", "git log", "git diff", "ls -la"]:
+            events.extend([_cmd(cmd)] * 3)
+        sigs = _run_on_events(events)
+        self.assertTrue(sigs["needs_manual_review"])
+
+    def test_needs_manual_review_false_on_clean_session(self):
+        """needs_manual_review is False when all signals are empty."""
+        sigs = _run_on_events([_READ_TOOL_USE])
+        self.assertFalse(sigs["needs_manual_review"])
+
+    def test_signal_extractor_suspect_on_heavy_clean_session(self):
+        """signal_extractor_suspect fires when >50 tool calls produce zero signals.
+
+        Uses Read tool calls (non-Bash) so the command-repetition detector stays quiet.
+        """
+        sigs = _run_on_events([_READ_TOOL_USE] * 51)
+        self.assertTrue(sigs["signal_extractor_suspect"])
+
+    def test_signal_extractor_suspect_false_when_signals_present(self):
+        """signal_extractor_suspect does not fire when at least one signal exists."""
+        sigs = _run_on_events([_READ_TOOL_USE] * 51 + [_DIRECT_CORRECTION])
+        self.assertFalse(sigs["signal_extractor_suspect"])
+
+    def test_signal_extractor_suspect_false_below_threshold(self):
+        """signal_extractor_suspect does not fire on small clean sessions."""
+        sigs = _run_on_events([_BASH_TOOL_USE] * 5)
+        self.assertFalse(sigs["signal_extractor_suspect"])
+
+    def test_both_flags_in_return_value(self):
+        """Both escalation flags are always present in the return value."""
+        sigs = _run_on_events([])
+        self.assertIn("needs_manual_review", sigs)
+        self.assertIn("signal_extractor_suspect", sigs)
+
+
+# ---------------------------------------------------------------------------
+# Repeated command detection
+# ---------------------------------------------------------------------------
+
+class TestRepeatedCommands(unittest.TestCase):
+
+    def test_command_3_times_flagged(self):
+        sigs = _run_on_events([_BASH_TOOL_USE] * 3)
+        self.assertEqual(len(sigs["repeated_commands"]), 1)
+        self.assertEqual(sigs["repeated_commands"][0]["count"], 3)
+
+    def test_command_2_times_not_flagged(self):
+        sigs = _run_on_events([_BASH_TOOL_USE] * 2)
+        self.assertEqual(len(sigs["repeated_commands"]), 0)
+
+    def test_empty_transcript_all_empty(self):
+        sigs = _run_on_events([])
+        self.assertEqual(sigs["user_corrections"], [])
+        self.assertEqual(sigs["tool_failures"], [])
+        self.assertEqual(sigs["repeated_commands"], [])
+        self.assertFalse(sigs["needs_manual_review"])
+        self.assertFalse(sigs["signal_extractor_suspect"])
+
+
+# ---------------------------------------------------------------------------
+# write_session_flags
+# ---------------------------------------------------------------------------
+
+class TestWriteSessionFlags(unittest.TestCase):
+
+    def test_creates_file_with_flags(self):
+        """write_session_flags creates retro-findings.json with escalation flags."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "retro-findings.json")
+            write_session_flags(path, {"needs_manual_review": True, "signal_extractor_suspect": False})
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        self.assertTrue(data["needs_manual_review"])
+        self.assertFalse(data["signal_extractor_suspect"])
+
+    def test_preserves_existing_keys(self):
+        """write_session_flags preserves existing keys like allowlist_drift."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "retro-findings.json")
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({"allowlist_drift": [{"file": "x.py"}]}, f)
+            write_session_flags(path, {"needs_manual_review": True})
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        self.assertIn("allowlist_drift", data)
+        self.assertTrue(data["needs_manual_review"])
+
+    def test_creates_parent_dir_if_missing(self):
+        """write_session_flags creates the parent directory if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "subdir", "retro-findings.json")
+            write_session_flags(path, {"needs_manual_review": False})
+            self.assertTrue(os.path.exists(path))
+
+    def test_overwrites_stale_flags(self):
+        """write_session_flags overwrites a previously written flag value."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "retro-findings.json")
+            write_session_flags(path, {"needs_manual_review": False})
+            write_session_flags(path, {"needs_manual_review": True})
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        self.assertTrue(data["needs_manual_review"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_retro_helpers.py
+++ b/scripts/test_retro_helpers.py
@@ -192,6 +192,7 @@ class TestToolFailureFix(unittest.TestCase):
         sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR])
         self.assertEqual(len(sigs["tool_failures"]), 1)
         self.assertIn("38784", sigs["tool_failures"][0]["error"])
+        self.assertEqual(sigs["tool_failures"][0]["tool"], "unknown")
 
     def test_is_error_false_clean_result_not_flagged(self):
         """tool_result with is_error: false and clean content is not flagged."""
@@ -313,6 +314,16 @@ class TestEscalationFlags(unittest.TestCase):
             events.extend([_cmd(cmd)] * 3)
         sigs = _run_on_events(events)
         self.assertTrue(sigs["needs_manual_review"])
+
+    def test_frustration_hits_content_captured(self):
+        """frustration_hits list contains the matched text when a frustration pattern fires."""
+        event = {
+            "type": "user",
+            "message": {"role": "user", "content": "wtf why isn't this working"},
+        }
+        sigs = _run_on_events([event])
+        self.assertGreaterEqual(len(sigs["frustration_hits"]), 1)
+        self.assertIn("wtf", sigs["frustration_hits"][0]["text"])
 
     def test_needs_manual_review_false_on_clean_session(self):
         """needs_manual_review is False when all signals are empty."""

--- a/scripts/test_retro_helpers.py
+++ b/scripts/test_retro_helpers.py
@@ -230,6 +230,26 @@ class TestToolFailureFix(unittest.TestCase):
         sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR, _PR1094_TOOL_FAILURE_IS_ERROR])
         self.assertEqual(len(sigs["tool_failures"]), 2)
 
+    def test_is_error_true_with_identifiable_content_attributes_tool(self):
+        """is_error: true with content matching a known tool marker attributes to that tool, not 'unknown'."""
+        event = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_jkl",
+                        "content": "old_string not found in scripts/pipeline.py",
+                        "is_error": True,
+                    }
+                ],
+            },
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["tool_failures"]), 1)
+        self.assertEqual(sigs["tool_failures"][0]["tool"], "Edit")
+
 
 # ---------------------------------------------------------------------------
 # Bug 3: question-form correction patterns

--- a/scripts/test_retro_helpers.py
+++ b/scripts/test_retro_helpers.py
@@ -230,6 +230,26 @@ class TestToolFailureFix(unittest.TestCase):
         sigs = _run_on_events([_PR1094_TOOL_FAILURE_IS_ERROR, _PR1094_TOOL_FAILURE_IS_ERROR])
         self.assertEqual(len(sigs["tool_failures"]), 2)
 
+    def test_bash_failure_attributed_via_exit_code(self):
+        """tool_result with 'Exit code:' content is attributed to Bash."""
+        event = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_bash",
+                        "content": "stderr: command failed\nExit code: 1",
+                        "is_error": True,
+                    }
+                ],
+            },
+        }
+        sigs = _run_on_events([event])
+        self.assertEqual(len(sigs["tool_failures"]), 1)
+        self.assertEqual(sigs["tool_failures"][0]["tool"], "Bash")
+
     def test_is_error_true_with_identifiable_content_attributes_tool(self):
         """is_error: true with content matching a known tool marker attributes to that tool, not 'unknown'."""
         event = {


### PR DESCRIPTION
## Summary

- Fix three bugs in `extract_transcript_signals` that caused every auto-retro to report zero signals: wrong event type (`"human"` → `"user"`), broken tool-failure detection (`"Exit code:"` string → `is_error: true`), and missing question-form correction patterns
- Add `needs_manual_review` and `signal_extractor_suspect` escalation flags to `retro-findings.json` so downstream supervisor logic (epic #1066) has trustworthy signals
- Add `write_session_flags()` helper and 30 fixture-based unit tests

Closes #1097

## Test Plan

- [x] `python scripts/test_retro_helpers.py` — 30/30 pass
- [x] Fixture events derived from PR #1094 and PR #1095 transcripts that the old extractor missed
- [x] Regression guard: `_HUMAN_TYPE_CORRECTION` fixture verifies old event type produces zero signals
- [x] `python scripts/audit-enforcement.py --strict` — PASS

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [ ] /qa completed (not applicable — pure Python mechanical extractor, no interactive surface)
- [ ] /review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
