### PR TITLE
fix(workflow): bg-spawn autonomy — thread bypassPermissions through all spawn paths

### DIFF
--- a/.claude/hooks/pr-gate.py
+++ b/.claude/hooks/pr-gate.py
@@ -72,6 +72,16 @@ def _is_agent_context(cwd=None, env=None):
     normalized = cwd.replace("\\", "/")
     if "/.worktrees/" in normalized or "/.claude/worktrees/" in normalized:
         return True
+
+    # Also check CLAUDE_PROJECT_DIR — hook subprocess CWD may be the main
+    # repo root rather than the session worktree (covers nested bg-spawned
+    # worktrees at .worktrees/<outer>/worktree-<inner> and foreground
+    # .claude/worktrees/<name> sessions).
+    proj_dir = env.get("CLAUDE_PROJECT_DIR", "")
+    if proj_dir:
+        norm_proj = proj_dir.replace("\\", "/")
+        if "/.worktrees/" in norm_proj or "/.claude/worktrees/" in norm_proj:
+            return True
     return False
 
 

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,7 +1,12 @@
 {
   "schema_version": 1,
+<<<<<<< HEAD
   "last_updated": "2026-05-16",
   "total_retros": 18,
+=======
+  "last_updated": "2026-05-16T06:42:00Z",
+  "total_retros": 17,
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
   "findings_by_category": {
     "external": [
       {
@@ -133,18 +138,31 @@
       },
       {
         "date": "2026-05-16",
+<<<<<<< HEAD
         "branch": "feat/1098-prompt-template",
+=======
+        "branch": "fix/1067-bg-spawn-autonomy",
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
         "finding_id": "R-01"
       },
       {
         "date": "2026-05-16",
+<<<<<<< HEAD
         "branch": "feat/1098-prompt-template",
+=======
+        "branch": "fix/1067-bg-spawn-autonomy",
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
         "finding_id": "R-02"
       },
       {
         "date": "2026-05-16",
+<<<<<<< HEAD
         "branch": "feat/1098-prompt-template",
         "finding_id": "R-04"
+=======
+        "branch": "fix/1067-bg-spawn-autonomy",
+        "finding_id": "R-03"
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
       }
     ],
     "design": [
@@ -329,8 +347,13 @@
       },
       {
         "date": "2026-05-16",
+<<<<<<< HEAD
         "branch": "feat/1098-prompt-template",
         "finding_id": "R-03"
+=======
+        "branch": "fix/1067-bg-spawn-autonomy",
+        "finding_id": "R-04"
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
       }
     ],
     "setup": [
@@ -354,6 +377,11 @@
       {
         "date": "2026-04-26",
         "branch": "feat/monitor-autonomy",
+        "finding_id": "R-05"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "fix/1067-bg-spawn-autonomy",
         "finding_id": "R-05"
       }
     ],
@@ -381,6 +409,7 @@
     ]
   },
   "metrics": {
+<<<<<<< HEAD
     "avg_fix_ratio": 0.705,
     "pipeline_success_rate": 0.412,
     "avg_convergence_rounds": 2.206,
@@ -388,5 +417,14 @@
     "last_session_status": "shipped_clean",
     "last_session_branch": "feat/1098-prompt-template",
     "last_session_pr": 1116
+=======
+    "avg_fix_ratio": 0.724,
+    "pipeline_success_rate": 0.388,
+    "avg_convergence_rounds": 2.281,
+    "last_session_findings": 5,
+    "last_session_status": "in_flight_awaiting_gemini_post",
+    "last_session_branch": "fix/1067-bg-spawn-autonomy",
+    "last_session_pr": null
+>>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
   }
 }

--- a/scripts/claude_dispatch.py
+++ b/scripts/claude_dispatch.py
@@ -461,11 +461,15 @@ def spawn(
         agent: Optional --agent value (headless mode).
         model: Optional --model value (headless mode).
         cwd: Working directory for the subprocess.
-        dangerous: If True, adds --dangerously-skip-permissions (unattended only).
+        dangerous: If True, adds --dangerously-skip-permissions to the
+            interactive ``claude --bg`` invocation (unattended daemons only).
+            Ignored in headless mode — ``claude -p`` has no permission dialog.
+            Mutually exclusive with ``permission_mode``.
         permission_mode: Optional value passed as ``--permission-mode <value>``
             to the interactive ``claude --bg`` invocation (e.g.
             ``"bypassPermissions"``). Ignored in headless mode — ``claude -p``
             has no permission dialog. When None, the flag is omitted.
+            Mutually exclusive with ``dangerous``.
         stage_log: Required for mode=headless. Streamed stdout path; also
             read back by output().
         env: Optional env mapping (defaults to os.environ).
@@ -477,6 +481,11 @@ def spawn(
         raise DispatchError(f"invalid mode: {mode!r}")
     if not caller:
         raise DispatchError("spawn() requires a non-empty caller string")
+    if dangerous and permission_mode:
+        raise DispatchError(
+            "spawn() received both dangerous=True and permission_mode="
+            f"{permission_mode!r} — these are mutually exclusive"
+        )
     require_min_version()
     cwd_str = str(Path(cwd).resolve()) if cwd else str(Path(".").resolve())
 

--- a/scripts/claude_dispatch.py
+++ b/scripts/claude_dispatch.py
@@ -444,6 +444,7 @@ def spawn(
     model: Optional[str] = None,
     cwd: Union[str, Path] = ".",
     dangerous: bool = False,
+    permission_mode: Optional[str] = None,
     stage_log: Optional[Union[str, Path]] = None,
     env: Optional[Mapping[str, str]] = None,
     jobs_dir: Optional[Path] = None,
@@ -461,6 +462,10 @@ def spawn(
         model: Optional --model value (headless mode).
         cwd: Working directory for the subprocess.
         dangerous: If True, adds --dangerously-skip-permissions (unattended only).
+        permission_mode: Optional value passed as ``--permission-mode <value>``
+            to the interactive ``claude --bg`` invocation (e.g.
+            ``"bypassPermissions"``). Ignored in headless mode — ``claude -p``
+            has no permission dialog. When None, the flag is omitted.
         stage_log: Required for mode=headless. Streamed stdout path; also
             read back by output().
         env: Optional env mapping (defaults to os.environ).
@@ -512,6 +517,8 @@ def spawn(
     if not NAME_RE.match(name):
         raise DispatchError(f"invalid --name value: {name!r}")
     argv = ["claude", "--bg", "--name", name]
+    if permission_mode:
+        argv.extend(["--permission-mode", permission_mode])
     if dangerous:
         argv.append("--dangerously-skip-permissions")
     argv.extend(["--", prompt])

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -555,7 +555,7 @@ def run_triage(worktree, pr_number, comments, logger, mode=None):
             agent="gemini-triage",
             model="haiku",
             cwd=worktree,
-            dangerous=True,
+            permission_mode="bypassPermissions",
             stage_log=stage_jsonl_path,
             env=env,
         )
@@ -995,7 +995,7 @@ def run_retro(worktree, logger, mode=None):
             name="retro",
             model="sonnet",
             cwd=worktree,
-            dangerous=True,
+            permission_mode="bypassPermissions",
             stage_log=stage_jsonl_path,
             env=env,
         )

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -500,9 +500,9 @@ def dispatch_subagent(profile_name, payload, *, model="sonnet", worktree=".",
          because interactive mode silently drops ``--agent`` (see #1086).
       3. The JSON payload under a clear ``=== PAYLOAD ===`` marker.
 
-    ``dangerous=True`` is passed to ``spawn`` because the subprocess is fully
-    automated — permission prompts here would surface as ``BlockedSessionError``
-    with no operator to respond.
+    ``permission_mode="bypassPermissions"`` is passed to ``spawn`` because the
+    subprocess is fully automated — permission prompts here would surface as
+    ``BlockedSessionError`` with no operator to respond.
 
     Args:
         profile_name: agent profile name (matches .claude/agents/<name>.md).
@@ -557,7 +557,7 @@ def dispatch_subagent(profile_name, payload, *, model="sonnet", worktree=".",
                 agent=profile_name,
                 model=model,
                 cwd=worktree,
-                dangerous=True,
+                permission_mode="bypassPermissions",
                 stage_log=stage_log,
             )
         except claude_dispatch.DispatchError as e:

--- a/specs/fix-1067-bg-spawn-autonomy.md
+++ b/specs/fix-1067-bg-spawn-autonomy.md
@@ -1,0 +1,123 @@
+# bg-spawn Autonomy — `--permission-mode bypassPermissions` across all spawn paths
+
+**Spec version:** 1.1  
+**Issue:** #1067 (epic #1066 Phase 1a)  
+**Code:** `scripts/claude_dispatch.py`, `scripts/start-bg-spawn.py`, `scripts/pr_monitor.py`, `scripts/triage_common.py`, `.claude/skills/start/SKILL.md`, `.claude/hooks/pr-gate.py`
+
+---
+
+## Background
+
+Supervisor-worker autonomy (epic #1066) requires background sessions to run without operator permission prompts. Claude Code exposes `--permission-mode bypassPermissions` for this purpose. PR #1075 added opt-in `permission_mode` to `start-bg-spawn.spawn()`. This spec covers the remaining delta: plumbing the parameter through `claude_dispatch.spawn()`, updating all bg-dispatch call sites, and fixing two related pr-gate hook detection gaps.
+
+---
+
+## Problem Statements
+
+### P-1: `claude_dispatch.spawn()` cannot express `--permission-mode`
+
+`spawn()` has a `dangerous=True` escape hatch that emits `--dangerously-skip-permissions`. It does not expose `--permission-mode <mode>`. Sub-agents dispatched via `run_triage`, `run_retro`, and `dispatch_subagent` cannot receive `bypassPermissions` and will pause at permission prompts, surfacing as `BlockedSessionError` with no operator to respond.
+
+### P-2: `/start` skill spawns workers without `bypassPermissions`
+
+The `/start` SKILL.md step 6c invokes `start-bg-spawn.py` without `--permission-mode bypassPermissions`. Workers spawned by `/start` pause at the first permission prompt.
+
+### P-3: pr-gate hook misses two agent-context patterns
+
+`_is_agent_context()` uses `os.getcwd()` to detect worktree context. Claude Code invokes hook subprocesses with CWD = main repo root; the session's actual working directory lives in `CLAUDE_PROJECT_DIR`. Two patterns fail to be detected:
+
+**P-3a — Nested bg-spawned worktrees (primary issue scope):** A bg session in `.worktrees/<outer>` spawns a sub-agent whose worktree is `.worktrees/<outer>/worktree-<inner>`. The hook process CWD is the main repo root; `CLAUDE_PROJECT_DIR` is the nested path (which contains `/.worktrees/`). Without checking `CLAUDE_PROJECT_DIR`, `_is_agent_context()` returns False.
+
+**P-3b — Foreground sessions in `.claude/worktrees/<name>` (observed in PR #1095):** Same root cause; `CLAUDE_PROJECT_DIR` contains `/.claude/worktrees/` but `os.getcwd()` is the main repo root. Observed when a foreground Claude Code session in `.claude/worktrees/peaceful-bartik-86c8cc` ran raw `gh pr create` and was not blocked.
+
+Both gaps are fixed by the same one-line change: also check `CLAUDE_PROJECT_DIR` in `_is_agent_context()`.
+
+---
+
+## Acceptance Criteria
+
+| AC | Description | Test |
+|----|-------------|------|
+| AC-01 | `claude_dispatch.spawn()` accepts a `permission_mode: Optional[str]` keyword parameter | `tests/scripts/test_claude_dispatch.py::test_spawn_permission_mode_threaded` |
+| AC-02 | When `permission_mode` is non-None, `--permission-mode <value>` appears in the `claude --bg` argv before `--` | `tests/scripts/test_claude_dispatch.py::test_spawn_permission_mode_threaded` |
+| AC-03 | When `permission_mode` is None (default), `--permission-mode` does NOT appear in the argv | `tests/scripts/test_claude_dispatch.py::test_spawn_permission_mode_absent_when_none` |
+| AC-04 | `claude_dispatch.spawn()` `dangerous` parameter continues to work unchanged (backward compat) | `tests/scripts/test_claude_dispatch.py::test_spawn_dangerous_still_works` |
+| AC-05 | `pr_monitor.run_triage` spawns with `permission_mode='bypassPermissions'` | `tests/test_pr_monitor.py::test_run_triage_uses_bypassPermissions` |
+| AC-06 | `pr_monitor.run_retro` spawns with `permission_mode='bypassPermissions'` | `tests/test_pr_monitor.py::test_run_retro_uses_bypassPermissions` |
+| AC-07 | `triage_common.dispatch_subagent` spawns with `permission_mode='bypassPermissions'` | `tests/test_triage_common.py::test_dispatch_subagent_uses_bypassPermissions` |
+| AC-08 | `/start` SKILL.md step 6c includes `--permission-mode bypassPermissions` in the `start-bg-spawn.py` invocation | `tests/scripts/test_start_skill_text.py::test_start_skill_spawn_includes_permission_mode` |
+| AC-09 | `_is_agent_context()` returns True when `CLAUDE_PROJECT_DIR` contains `/.claude/worktrees/` even if `os.getcwd()` does not (P-3b) | `tests/hooks/test_pr_gate_agent_enforcement.py::test_is_agent_context[project_dir_claude_worktrees]` |
+| AC-10 | `_is_agent_context()` returns True when `CLAUDE_PROJECT_DIR` contains `/.worktrees/` even if `os.getcwd()` does not (P-3a/P-3b shared) | `tests/hooks/test_pr_gate_agent_enforcement.py::test_is_agent_context[project_dir_worktrees]` |
+| AC-11 | `_is_agent_context()` returns True when `CLAUDE_PROJECT_DIR` is a nested-bg-worktree path `.worktrees/<outer>/worktree-<inner>` and `os.getcwd()` is the main repo root (P-3a primary scope) | `tests/hooks/test_pr_gate_agent_enforcement.py::test_is_agent_context[nested_bg_worktree]` |
+| AC-12 | Foreground session in `.claude/worktrees/<name>`: hook called with CWD=main-root, `CLAUDE_PROJECT_DIR`=worktree → blocked with exit 2 when no `/pr` skill marker | `tests/hooks/test_pr_gate_agent_enforcement.py::test_foreground_worktree_via_project_dir_blocked` |
+| AC-13 | `PPDS_PR_GATE_HUMAN=1` override continues to suppress agent enforcement even when `CLAUDE_PROJECT_DIR` is a worktree path | `tests/hooks/test_pr_gate_agent_enforcement.py::test_human_override_beats_project_dir` |
+| AC-14 | **Smoke test (manual QA):** A worker spawned by `/start` with `bypassPermissions` completes `/implement → /gates → /verify → /pr` end-to-end without any operator permission prompts and without bypassing PR creation via raw `gh pr create` | Manual — verify via `/shakedown workflow` or a real throwaway worktree after pipeline passes |
+
+---
+
+## Design
+
+### D-1: `claude_dispatch.spawn()` — add `permission_mode` parameter
+
+Add `permission_mode: Optional[str] = None` to the interactive-mode code path only (headless sessions use the `-p` API which does not accept `--permission-mode`). Insert the flag before `--` in argv construction:
+
+```python
+argv = ["claude", "--bg", "--name", name]
+if permission_mode:
+    argv.extend(["--permission-mode", permission_mode])
+if dangerous:
+    argv.append("--dangerously-skip-permissions")
+argv.extend(["--", prompt])
+```
+
+`dangerous` is kept for backward compatibility. No caller should need both simultaneously, but there is no validation error if both are passed.
+
+### D-2: Update `pr_monitor.run_triage` and `run_retro`
+
+Both call `claude_dispatch.spawn(dangerous=True, ...)`. Change to `permission_mode='bypassPermissions'` and remove `dangerous=True`. These are fully-automated sessions where permission prompts surface as `BlockedSessionError` with no operator to respond.
+
+### D-3: Update `triage_common.dispatch_subagent`
+
+Same as D-2: replace `dangerous=True` with `permission_mode='bypassPermissions'`.
+
+### D-4: `/start` skill step 6c
+
+Append `--permission-mode bypassPermissions` to the `start-bg-spawn.py` CLI invocation in SKILL.md:
+
+```bash
+python scripts/start-bg-spawn.py \
+  --worktree-abs "<worktree-absolute-path>" \
+  --branch "<branch>" \
+  --prompt-file "<temp-path>" \
+  --permission-mode bypassPermissions
+```
+
+### D-5: pr-gate `_is_agent_context()` — check `CLAUDE_PROJECT_DIR`
+
+Root cause (both P-3a and P-3b): Claude Code spawns hook subprocesses with CWD = main repo root, but sets `CLAUDE_PROJECT_DIR` to the session's actual working directory. The fix checks `CLAUDE_PROJECT_DIR` in addition to `os.getcwd()`:
+
+```python
+# Also check CLAUDE_PROJECT_DIR — hook subprocess CWD may be the main repo
+# root rather than the session worktree (covers nested bg-spawned worktrees
+# at .worktrees/<outer>/worktree-<inner> and foreground .claude/worktrees/<n>).
+proj_dir = (env if env is not None else os.environ).get("CLAUDE_PROJECT_DIR", "")
+if proj_dir:
+    norm_proj = proj_dir.replace("\\", "/")
+    if "/.worktrees/" in norm_proj or "/.claude/worktrees/" in norm_proj:
+        return True
+```
+
+This covers all three patterns in a single check:
+- `.worktrees/<name>` (existing pattern, now also via CLAUDE_PROJECT_DIR)
+- `.worktrees/<outer>/worktree-<inner>` (nested bg-worktree, P-3a — `/.worktrees/` matches the outer segment)
+- `.claude/worktrees/<name>` (foreground Claude Code worktrees, P-3b)
+
+The `env` parameter already exists on `_is_agent_context()`; the fix uses it consistently.
+
+---
+
+## Non-goals
+
+- Changing `dangerous=True` semantics or removing it — backward compat preserved.
+- Adding `permission_mode` to the headless (`-p`) path — headless sessions have no permission dialog.
+- Supervisor-worker topology (#1069) — separate epic phase.

--- a/tests/hooks/test_pr_gate_agent_enforcement.py
+++ b/tests/hooks/test_pr_gate_agent_enforcement.py
@@ -134,6 +134,40 @@ import pytest
     ("/home/j/ppds/.worktrees/toolbar-search-consistency", {"PPDS_PR_GATE_HUMAN": "1"}, False),
     # Non-agent .claude/worktrees/ (not just agent-* prefix)
     ("/home/j/ppds/.claude/worktrees/review-1234", {}, True),
+    # AC-09 (#1067): CLAUDE_PROJECT_DIR contains /.claude/worktrees/ and cwd
+    # is the main repo root (foreground worktree, P-3b pattern).
+    pytest.param(
+        "/home/j/ppds",
+        {"CLAUDE_PROJECT_DIR": "/home/j/ppds/.claude/worktrees/session-name"},
+        True,
+        id="project_dir_claude_worktrees",
+    ),
+    # AC-10 (#1067): CLAUDE_PROJECT_DIR contains /.worktrees/ and cwd is the
+    # main repo root (P-3a/P-3b shared root cause).
+    pytest.param(
+        "/home/j/ppds",
+        {"CLAUDE_PROJECT_DIR": "/home/j/ppds/.worktrees/feat-x"},
+        True,
+        id="project_dir_worktrees",
+    ),
+    # AC-11 (#1067): nested bg-worktree path
+    # .worktrees/<outer>/worktree-<inner> in CLAUDE_PROJECT_DIR while cwd is
+    # the main repo root (P-3a primary scope).
+    pytest.param(
+        "/home/j/ppds",
+        {"CLAUDE_PROJECT_DIR": "/home/j/ppds/.worktrees/feat-x/worktree-sub"},
+        True,
+        id="nested_bg_worktree",
+    ),
+    # AC-13 (#1067): PPDS_PR_GATE_HUMAN=1 override beats CLAUDE_PROJECT_DIR
+    # worktree signal.
+    pytest.param(
+        "/home/j/ppds",
+        {"CLAUDE_PROJECT_DIR": "/home/j/ppds/.worktrees/feat-x",
+         "PPDS_PR_GATE_HUMAN": "1"},
+        False,
+        id="human_override_beats_project_dir",
+    ),
 ])
 def test_is_agent_context(cwd, env, expected):
     assert hook._is_agent_context(cwd=cwd, env=env) is expected
@@ -254,6 +288,53 @@ class TestHumanUnaffected:
             env_extra={"PPDS_PR_GATE_HUMAN": "1"},
         )
         assert r.returncode == 0, r.stderr
+
+
+class TestForegroundWorktreeViaProjectDir:
+    """AC-12, AC-13 (#1067): hook subprocess CWD = main repo root,
+    CLAUDE_PROJECT_DIR = worktree. Without the CLAUDE_PROJECT_DIR check,
+    _is_agent_context() returns False and a foreground worktree session can
+    bypass `/pr` via raw `gh pr create`.
+    """
+
+    def test_foreground_worktree_via_project_dir_blocked(self, tmp_path):
+        """AC-12: CWD=main-root + CLAUDE_PROJECT_DIR=worktree + no /pr marker
+        → blocked with the agent-bypass message."""
+        main_path = tmp_path / "main"
+        main_path.mkdir()
+        _init_repo(main_path)
+        worktree = main_path / ".claude" / "worktrees" / "session-name"
+        worktree.mkdir(parents=True)
+
+        env = _clean_env()
+        env["CLAUDE_PROJECT_DIR"] = str(worktree)
+        payload = {"tool_name": "Bash",
+                   "tool_input": {"command": "gh pr create --draft"}}
+        r = _run([sys.executable, str(HOOK_PATH)], cwd=str(main_path),
+                 env=env, input_str=json.dumps(payload))
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" in r.stderr, r.stderr
+
+    def test_human_override_beats_project_dir(self, tmp_path):
+        """AC-13: PPDS_PR_GATE_HUMAN=1 forces human context even when
+        CLAUDE_PROJECT_DIR is a worktree path. The block message switches
+        to the generic 'No workflow state found' rather than agent bypass."""
+        main_path = tmp_path / "main"
+        main_path.mkdir()
+        _init_repo(main_path)
+        worktree = main_path / ".claude" / "worktrees" / "session-name"
+        worktree.mkdir(parents=True)
+
+        env = _clean_env()
+        env["CLAUDE_PROJECT_DIR"] = str(worktree)
+        env["PPDS_PR_GATE_HUMAN"] = "1"
+        payload = {"tool_name": "Bash",
+                   "tool_input": {"command": "gh pr create --draft"}}
+        r = _run([sys.executable, str(HOOK_PATH)], cwd=str(main_path),
+                 env=env, input_str=json.dumps(payload))
+        assert r.returncode == 2, r.stderr
+        assert "must go through the `/pr` skill" not in r.stderr, r.stderr
+        assert "No workflow state found" in r.stderr, r.stderr
 
 
 def test_non_pr_create_from_agent_passes(tmp_path):

--- a/tests/scripts/test_claude_dispatch.py
+++ b/tests/scripts/test_claude_dispatch.py
@@ -232,6 +232,81 @@ def test_dispatch_interactive_without_dangerous(monkeypatch, tmp_path):
     assert "--dangerously-skip-permissions" not in bg_call
 
 
+def test_spawn_permission_mode_threaded(monkeypatch, tmp_path):
+    """AC-01, AC-02: permission_mode='bypassPermissions' is threaded into the
+    `claude --bg` argv as `--permission-mode bypassPermissions` before `--`."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    _seed_state(jobs_dir, "abc12345", cwd=str(tmp_path))
+    captured = []
+
+    def fake_run(argv, **kw):
+        captured.append(list(argv))
+        if argv[:2] == ["claude", "--version"]:
+            return CompletedProcess(argv, 0, "2.1.141\n", "")
+        if argv[:2] == ["claude", "--bg"]:
+            return CompletedProcess(argv, 0, "backgrounded · abc12345\n", "")
+        return CompletedProcess(argv, 0, "", "")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    spawn(mode="interactive", prompt="x", caller="test", name="stage",
+          permission_mode="bypassPermissions",
+          cwd=str(tmp_path), jobs_dir=jobs_dir)
+    bg_call = [c for c in captured if c[:2] == ["claude", "--bg"]][0]
+    # Flag must appear and be paired with its value.
+    assert "--permission-mode" in bg_call
+    idx = bg_call.index("--permission-mode")
+    assert bg_call[idx + 1] == "bypassPermissions"
+    # Must appear before the `--` separator.
+    sep_idx = bg_call.index("--")
+    assert idx < sep_idx
+
+
+def test_spawn_permission_mode_absent_when_none(monkeypatch, tmp_path):
+    """AC-03: permission_mode=None (default) → flag absent from argv."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    _seed_state(jobs_dir, "abc12345", cwd=str(tmp_path))
+    captured = []
+
+    def fake_run(argv, **kw):
+        captured.append(list(argv))
+        if argv[:2] == ["claude", "--version"]:
+            return CompletedProcess(argv, 0, "2.1.141\n", "")
+        if argv[:2] == ["claude", "--bg"]:
+            return CompletedProcess(argv, 0, "backgrounded · abc12345\n", "")
+        return CompletedProcess(argv, 0, "", "")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    spawn(mode="interactive", prompt="x", caller="test", name="stage",
+          cwd=str(tmp_path), jobs_dir=jobs_dir)
+    bg_call = [c for c in captured if c[:2] == ["claude", "--bg"]][0]
+    assert "--permission-mode" not in bg_call
+
+
+def test_spawn_dangerous_still_works(monkeypatch, tmp_path):
+    """AC-04: existing dangerous=True keyword continues to emit
+    --dangerously-skip-permissions (backward compat)."""
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    _seed_state(jobs_dir, "abc12345", cwd=str(tmp_path))
+    captured = []
+
+    def fake_run(argv, **kw):
+        captured.append(list(argv))
+        if argv[:2] == ["claude", "--version"]:
+            return CompletedProcess(argv, 0, "2.1.141\n", "")
+        if argv[:2] == ["claude", "--bg"]:
+            return CompletedProcess(argv, 0, "backgrounded · abc12345\n", "")
+        return CompletedProcess(argv, 0, "", "")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    spawn(mode="interactive", prompt="x", caller="test", name="stage",
+          dangerous=True, cwd=str(tmp_path), jobs_dir=jobs_dir)
+    bg_call = [c for c in captured if c[:2] == ["claude", "--bg"]][0]
+    assert "--dangerously-skip-permissions" in bg_call
+
+
 def test_dispatch_interactive_requires_name(monkeypatch, tmp_path):
     _patch_min_version(monkeypatch)
     with pytest.raises(DispatchError):

--- a/tests/scripts/test_claude_dispatch.py
+++ b/tests/scripts/test_claude_dispatch.py
@@ -307,6 +307,16 @@ def test_spawn_dangerous_still_works(monkeypatch, tmp_path):
     assert "--dangerously-skip-permissions" in bg_call
 
 
+def test_spawn_rejects_dangerous_and_permission_mode_together(monkeypatch, tmp_path):
+    """dangerous=True and permission_mode are mutually exclusive — passing both
+    raises DispatchError before any subprocess invocation."""
+    _patch_min_version(monkeypatch)
+    with pytest.raises(DispatchError, match="mutually exclusive"):
+        spawn(mode="interactive", prompt="x", caller="t", name="stage",
+              dangerous=True, permission_mode="bypassPermissions",
+              cwd=str(tmp_path), jobs_dir=tmp_path)
+
+
 def test_dispatch_interactive_requires_name(monkeypatch, tmp_path):
     _patch_min_version(monkeypatch)
     with pytest.raises(DispatchError):

--- a/tests/scripts/test_claude_dispatch.py
+++ b/tests/scripts/test_claude_dispatch.py
@@ -360,6 +360,25 @@ def test_dispatch_headless_argv(monkeypatch, tmp_path):
     assert handle.transcript_path == stage_log
 
 
+def test_dispatch_headless_drops_permission_mode(monkeypatch, tmp_path):
+    """Headless (claude -p) has no permission dialog — permission_mode must be
+    silently dropped from the argv even when callers pass it (covers the
+    "Ignored in headless mode" docstring contract; #1067)."""
+    captured = []
+    _patch_headless(monkeypatch, captured)
+    spawn(
+        mode="headless",
+        prompt="hi",
+        caller="t",
+        permission_mode="bypassPermissions",
+        stage_log=tmp_path / "log.jsonl",
+        spend_log_path=tmp_path / "spend.jsonl",
+    )
+    argv = captured[0]["argv"]
+    assert "--permission-mode" not in argv
+    assert "bypassPermissions" not in argv
+
+
 def test_dispatch_headless_no_model_no_agent(monkeypatch, tmp_path):
     """When model/agent are omitted, the argv must not include them."""
     captured = []

--- a/tests/scripts/test_start_skill_text.py
+++ b/tests/scripts/test_start_skill_text.py
@@ -30,6 +30,30 @@ def test_step6_invokes_helper():
     )
 
 
+def test_start_skill_spawn_includes_permission_mode():
+    """AC-08 (#1067): the start-bg-spawn.py invocation in Step 6 must pass
+    --permission-mode bypassPermissions so worker sessions never strand at
+    permission prompts.
+
+    Without bypassPermissions, the very first permission prompt transitions
+    the daemon to state=blocked with no operator to respond — defeating the
+    autonomy guarantee of the /start skill.
+    """
+    step6 = _section("Step 6")
+    bash_blocks = re.findall(r"```bash\s+(.*?)```", step6, re.DOTALL)
+    spawn_block = next(
+        (b for b in bash_blocks if "python scripts/start-bg-spawn.py" in b),
+        None,
+    )
+    assert spawn_block is not None, "start-bg-spawn.py block not found in Step 6"
+    assert "--permission-mode" in spawn_block, (
+        "Step 6 start-bg-spawn.py invocation must pass --permission-mode"
+    )
+    assert "bypassPermissions" in spawn_block, (
+        "Step 6 start-bg-spawn.py invocation must pass bypassPermissions value"
+    )
+
+
 def test_step7_names_agent_view():
     """AC-09: Step 7 summary must reference Agent View."""
     step7 = _section("Step 7")

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -3131,9 +3131,16 @@ class TestPrMonitorLoudFailure:
                 assert "exited 7" in str(exc.value)
 
 
-class TestPrMonitorDangerousFlag:
-    def test_pr_monitor_passes_dangerous_true(self, tmp_path):
-        """AC-17 partial: run_triage passes dangerous=True to spawn."""
+class TestPrMonitorBypassPermissions:
+    """AC-05, AC-06 (#1067): pr_monitor must spawn with
+    permission_mode='bypassPermissions' instead of legacy dangerous=True.
+
+    Unattended bg sessions need bypassPermissions so permission prompts do not
+    transition the daemon to state=blocked with no operator to respond.
+    """
+
+    def test_run_triage_uses_bypassPermissions(self, tmp_path):
+        """AC-05: run_triage passes permission_mode='bypassPermissions'."""
         import pr_monitor
         import claude_dispatch
         from unittest.mock import patch, MagicMock
@@ -3160,11 +3167,13 @@ class TestPrMonitorDangerousFlag:
                                           [{"id": 1, "body": "x"}],
                                           logger, mode="interactive")
 
-        assert captured.get("dangerous") is True, \
-            "pr_monitor must pass dangerous=True (unattended daemon)"
+        assert captured.get("permission_mode") == "bypassPermissions", \
+            "run_triage must spawn with permission_mode='bypassPermissions'"
+        assert "dangerous" not in captured or not captured.get("dangerous"), \
+            "run_triage must not pass legacy dangerous=True"
 
-    def test_pr_monitor_retro_passes_dangerous_true(self, tmp_path):
-        """AC-17 partial: run_retro passes dangerous=True to spawn."""
+    def test_run_retro_uses_bypassPermissions(self, tmp_path):
+        """AC-06: run_retro passes permission_mode='bypassPermissions'."""
         import pr_monitor
         import claude_dispatch
         from unittest.mock import patch, MagicMock
@@ -3187,4 +3196,7 @@ class TestPrMonitorDangerousFlag:
             logger = MagicMock()
             pr_monitor.run_retro(str(tmp_path), logger, mode="interactive")
 
-        assert captured.get("dangerous") is True
+        assert captured.get("permission_mode") == "bypassPermissions", \
+            "run_retro must spawn with permission_mode='bypassPermissions'"
+        assert "dangerous" not in captured or not captured.get("dangerous"), \
+            "run_retro must not pass legacy dangerous=True"

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -533,8 +533,9 @@ def test_dispatch_subagent_both_modes(mode, tmp_path):
     assert captured["caller"] == "test.dispatch_subagent"
     assert captured["agent"] == "reviewer"
     assert captured["name"] == "reviewer"
-    # dangerous=True is required so permission prompts don't strand the session.
-    assert captured["dangerous"] is True
+    # permission_mode='bypassPermissions' is required (#1067) so permission
+    # prompts don't strand the unattended session as state=blocked.
+    assert captured["permission_mode"] == "bypassPermissions"
     # Prompt is wrapped: directive + profile section + payload section,
     # with the payload embedded as pretty-printed JSON.
     prompt = captured["prompt"]
@@ -619,6 +620,22 @@ def test_dispatch_subagent_dispatch_error_returns_error_shape(tmp_path):
                                    worktree=str(tmp_path), mode="interactive")
     assert result["exit_code"] == 2
     assert "nope" in result["stderr"]
+
+
+def test_dispatch_subagent_uses_bypassPermissions(tmp_path):
+    """AC-07 (#1067): dispatch_subagent spawns with
+    permission_mode='bypassPermissions' and not legacy dangerous=True."""
+    from triage_common import dispatch_subagent
+    import claude_dispatch
+    captured = {}
+    def fake_spawn(**kw):
+        captured.update(kw)
+        return _FakeHandle()
+    with patch.object(claude_dispatch, "spawn", fake_spawn):
+        dispatch_subagent(profile_name="p", payload={}, worktree=str(tmp_path),
+                          mode="interactive")
+    assert captured.get("permission_mode") == "bypassPermissions"
+    assert "dangerous" not in captured or not captured.get("dangerous")
 
 
 def test_dispatch_subagent_blocked_returns_loud_shape(tmp_path):


### PR DESCRIPTION
## Summary

- Plumb `permission_mode` through `claude_dispatch.spawn()` and update every bg-dispatch call site (`pr_monitor.run_triage`, `pr_monitor.run_retro`, `triage_common.dispatch_subagent`, `/start` skill step 6c) to use `permission_mode='bypassPermissions'` instead of legacy `dangerous=True`. Unattended bg sessions no longer strand at permission prompts as `state=blocked` with no operator.
- Fix the related `pr-gate.py` `_is_agent_context()` gap where foreground sessions in `.claude/worktrees/<name>` and nested bg-spawned worktrees were not detected as agent context — Claude Code spawns hook subprocesses with CWD=main-repo-root, so the check now also inspects `CLAUDE_PROJECT_DIR`.

Closes #1067

## Test Plan

- [x] `tests/scripts/test_claude_dispatch.py` — AC-01..04 + headless-drops-permission_mode regression
- [x] `tests/test_pr_monitor.py::TestPrMonitorBypassPermissions` — AC-05, AC-06
- [x] `tests/test_triage_common.py::test_dispatch_subagent_uses_bypassPermissions` — AC-07
- [x] `tests/scripts/test_start_skill_text.py::test_start_skill_spawn_includes_permission_mode` — AC-08
- [x] `tests/hooks/test_pr_gate_agent_enforcement.py` — AC-09..13 (4 new parametrize cases + `TestForegroundWorktreeViaProjectDir` e2e class)
- [ ] AC-14 (manual smoke — covered by future `/shakedown workflow` against a real throwaway worktree)

## Verification

- [x] `/gates` passed (245 tests, 14 pre-existing skips; enforcement audit clean)
- [x] `/verify workflow` completed (Python tests, hook exit codes, 9 behavioral scenarios, empirical shakedown via real `claude --bg` exit 0 in 3.5s)
- [x] `/qa` skipped (workflow-only diff per `pr-gate.py` policy)
- [x] `/review` completed — 0 critical / 2 important / 3 suggestions; one important addressed (headless-drops-permission_mode test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
