### PR TITLE
fix(workflow): pr_monitor visible escalation — GitHub comment + notify when monitor exits non-clean

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1235,8 +1235,8 @@ def _add_escalation_label(worktree, pr_number, logger):
             cwd=worktree, capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=20,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.log("escalation", "LABEL_CREATE_ERROR", error=str(e))
     try:
         result = subprocess.run(
             ["gh", "pr", "edit", str(pr_number), "--add-label", _ESCALATION_LABEL],
@@ -1256,6 +1256,7 @@ def _set_terminal_state_marker(worktree, terminal_state, reason, logger):
     """Write pr_monitor.terminal_state marker to .workflow/state.json."""
     state_path = os.path.join(worktree, ".workflow", "state.json")
     try:
+        os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
         try:
             with open(state_path, "r", encoding="utf-8") as f:
                 state = json.load(f)
@@ -1265,7 +1266,6 @@ def _set_terminal_state_marker(worktree, terminal_state, reason, logger):
         pm["terminal_state"] = terminal_state
         pm["timestamp"] = _timestamp()
         pm["reason"] = (reason or "")[:500]
-        os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
         with open(state_path, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
             f.write("\n")
@@ -1285,6 +1285,9 @@ def _notify_terminal(worktree, pr_number, logger, message):
 
     All actions are fire-and-forget — failures are logged but never cascade.
     Also deregisters the worktree's branch from the in-flight registry (AC-178).
+
+    Clean-exit path uses _step_notify → run_notify directly and never reaches
+    this function, so no guard against clean-exit is needed here.
     """
     _deregister_inflight(worktree, logger)
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1173,20 +1173,148 @@ def _deregister_inflight(worktree, logger):
                    branch=branch, error=str(e))
 
 
+# ---------------------------------------------------------------------------
+# Escalation visibility block (#1088)
+# ---------------------------------------------------------------------------
+
+_ESCALATION_LOG_TAIL_LINES = 25
+_ESCALATION_LABEL = "status:monitor-escalated"
+
+
+def _read_log_tail(log_path, lines=_ESCALATION_LOG_TAIL_LINES):
+    """Return the last N lines of the monitor log as a string."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            all_lines = f.readlines()
+        return "".join(all_lines[-lines:])
+    except OSError:
+        return ""
+
+
+def _post_escalation_comment(worktree, pr_number, terminal_state, log_path, logger):
+    """Post a GitHub PR comment with reason + log tail on any non-clean exit."""
+    if SHAKEDOWN:
+        logger.log("escalation", "COMMENT_SKIPPED_SHAKEDOWN")
+        return
+    log_tail = _read_log_tail(log_path)
+    body = (
+        f":warning: **pr_monitor escalated: `{terminal_state}`**\n\n"
+        f"The background PR monitor exited non-cleanly. "
+        f"Operator attention is needed.\n\n"
+        f"<details><summary>Monitor log (last {_ESCALATION_LOG_TAIL_LINES} lines)"
+        f"</summary>\n\n```\n{log_tail.strip()}\n```\n</details>\n\n"
+        f"Log file: `.workflow/pr-monitor.log`"
+    )
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "comment", str(pr_number), "--body", body],
+            cwd=worktree, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=30,
+        )
+        logger.log("escalation", "COMMENT_POSTED",
+                   pr=pr_number, rc=result.returncode)
+        if result.returncode != 0:
+            logger.log("escalation", "COMMENT_ERROR",
+                       stderr=result.stderr.strip()[:200])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.log("escalation", "COMMENT_ERROR", error=str(e))
+
+
+def _add_escalation_label(worktree, pr_number, logger):
+    """Add 'status:monitor-escalated' label to the PR, creating it if needed."""
+    if SHAKEDOWN:
+        logger.log("escalation", "LABEL_SKIPPED_SHAKEDOWN")
+        return
+    # Create label if missing; --force updates it if it already exists.
+    try:
+        subprocess.run(
+            ["gh", "label", "create", _ESCALATION_LABEL,
+             "--color", "B60205",
+             "--description", "pr_monitor exited non-cleanly; operator attention needed",
+             "--force"],
+            cwd=worktree, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=20,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "edit", str(pr_number), "--add-label", _ESCALATION_LABEL],
+            cwd=worktree, capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=20,
+        )
+        logger.log("escalation", "LABEL_ADDED",
+                   pr=pr_number, label=_ESCALATION_LABEL, rc=result.returncode)
+        if result.returncode != 0:
+            logger.log("escalation", "LABEL_ERROR",
+                       stderr=result.stderr.strip()[:200])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.log("escalation", "LABEL_ERROR", error=str(e))
+
+
+def _set_terminal_state_marker(worktree, terminal_state, reason, logger):
+    """Write pr_monitor.terminal_state marker to .workflow/state.json."""
+    state_path = os.path.join(worktree, ".workflow", "state.json")
+    try:
+        try:
+            with open(state_path, "r", encoding="utf-8") as f:
+                state = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            state = {}
+        pm = state.setdefault("pr_monitor", {})
+        pm["terminal_state"] = terminal_state
+        pm["timestamp"] = _timestamp()
+        pm["reason"] = (reason or "")[:500]
+        os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+            f.write("\n")
+        logger.log("escalation", "STATE_MARKER_SET", terminal_state=terminal_state)
+    except OSError as e:
+        logger.log("escalation", "STATE_MARKER_ERROR", error=str(e))
+
+
 def _notify_terminal(worktree, pr_number, logger, message):
-    """Best-effort notification on any terminal non-success state.
+    """Best-effort notification + escalation visibility on any non-clean exit.
 
-    Wraps ``run_notify`` in a try/except so a notify failure cannot
-    cascade into the monitor's own error path. Keeps the user informed
-    when the monitor aborts (CI fail, CI timeout, exception) — previously
-    only the clean-success path fired a notification, so crashes were
-    invisible until the user happened to check the PR.
+    Four actions (AC from #1088):
+      1. Set pr_monitor.terminal_state marker in .workflow/state.json
+      2. Post GitHub PR comment with reason + log tail
+      3. Add 'status:monitor-escalated' label to the PR
+      4. Fire platform notification (toast)
 
-    Also deregisters the worktree's branch from the in-flight registry
-    (AC-178) so terminal states clean up automatically without waiting
-    for `gh pr merge` or manual `/cleanup`.
+    All actions are fire-and-forget — failures are logged but never cascade.
+    Also deregisters the worktree's branch from the in-flight registry (AC-178).
     """
     _deregister_inflight(worktree, logger)
+
+    # Parse terminal state from message first line ("PR #N: <terminal_state>")
+    terminal_state = "error"
+    first_line = (message or "").split("\n")[0]
+    if ": " in first_line:
+        terminal_state = first_line.split(": ", 1)[-1].strip()
+
+    log_path = os.path.join(worktree, ".workflow", "pr-monitor.log")
+
+    # Action 1: state marker
+    try:
+        _set_terminal_state_marker(worktree, terminal_state, message, logger)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Action 2: GitHub PR comment
+    try:
+        _post_escalation_comment(worktree, pr_number, terminal_state, log_path, logger)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Action 3: PR label
+    try:
+        _add_escalation_label(worktree, pr_number, logger)
+    except Exception:  # noqa: BLE001
+        pass
+
+    # Action 4: platform notification
     try:
         run_notify(worktree, pr_number, logger, message=message)
     except Exception as notify_err:  # noqa: BLE001 — best-effort

--- a/scripts/test_pr_monitor.py
+++ b/scripts/test_pr_monitor.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Unit tests for pr_monitor.py model routing.
+"""Unit tests for pr_monitor.py model routing and escalation visibility.
 
 Usage:
     python -m unittest scripts.test_pr_monitor
     python -m pytest scripts/test_pr_monitor.py
 """
 import io
+import json
 import os
 import sys
 import tempfile
@@ -294,6 +295,178 @@ class TestPostRepliesDedup(unittest.TestCase):
                 "description": "Updated the config file"}
         body = pr_monitor._reply_body_for(item)
         self.assertEqual(body, "Fixed in abc123 — Updated the config file")
+
+
+class TestEscalationVisibility(unittest.TestCase):
+    """#1088: non-clean exits must post comment + set state marker + add label + notify."""
+
+    def _make_fake_run(self, calls):
+        def _fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = ""
+            m.stderr = ""
+            return m
+        return _fake_run
+
+    def test_post_escalation_comment_calls_gh(self):
+        """_post_escalation_comment must invoke gh pr comment on non-clean exit."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            calls = []
+
+            with patch("pr_monitor.subprocess.run", side_effect=self._make_fake_run(calls)), \
+                 patch("pr_monitor.SHAKEDOWN", ""):
+                pr_monitor._post_escalation_comment(
+                    worktree, 42, "stuck-ci-fix-exhausted",
+                    os.path.join(worktree, ".workflow", "pr-monitor.log"),
+                    logger,
+                )
+
+            comment_calls = [c for c in calls if "comment" in c]
+            self.assertTrue(comment_calls,
+                            "gh pr comment must be invoked on non-clean exit")
+            self.assertTrue(
+                any("42" in c for c in comment_calls),
+                "gh pr comment must target the correct PR number"
+            )
+
+    def test_add_escalation_label_calls_gh(self):
+        """_add_escalation_label must add status:monitor-escalated label."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            calls = []
+
+            with patch("pr_monitor.subprocess.run", side_effect=self._make_fake_run(calls)), \
+                 patch("pr_monitor.SHAKEDOWN", ""):
+                pr_monitor._add_escalation_label(worktree, 42, logger)
+
+            add_label_calls = [c for c in calls if "--add-label" in c]
+            self.assertTrue(add_label_calls, "gh pr edit --add-label must be called")
+            self.assertTrue(
+                any("status:monitor-escalated" in " ".join(c) for c in add_label_calls),
+                "label 'status:monitor-escalated' must be added to the PR"
+            )
+
+    def test_set_terminal_state_marker_writes_state(self):
+        """_set_terminal_state_marker must write pr_monitor.terminal_state to state.json."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+
+            pr_monitor._set_terminal_state_marker(
+                worktree, "stuck-ci-fix-exhausted", "PR #42: stuck-ci-fix-exhausted", logger
+            )
+
+            state_path = os.path.join(worktree, ".workflow", "state.json")
+            self.assertTrue(os.path.exists(state_path), "state.json must be written")
+            with open(state_path, encoding="utf-8") as f:
+                state = json.load(f)
+            pm = state.get("pr_monitor", {})
+            self.assertEqual(pm.get("terminal_state"), "stuck-ci-fix-exhausted",
+                             "terminal_state must be recorded")
+            self.assertIn("timestamp", pm, "timestamp must be recorded")
+            self.assertIn("reason", pm, "reason must be recorded")
+
+    def test_set_terminal_state_marker_preserves_existing_state(self):
+        """_set_terminal_state_marker must not clobber existing state.json keys."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            state_path = os.path.join(worktree, ".workflow", "state.json")
+            # Write pre-existing state
+            with open(state_path, "w", encoding="utf-8") as f:
+                json.dump({"branch": "feat/test", "pr": {"url": "https://x"}}, f)
+
+            pr_monitor._set_terminal_state_marker(
+                worktree, "monitor-crash", "crash msg", logger
+            )
+
+            with open(state_path, encoding="utf-8") as f:
+                state = json.load(f)
+            self.assertEqual(state.get("branch"), "feat/test",
+                             "existing keys must be preserved")
+            self.assertEqual(state["pr_monitor"]["terminal_state"], "monitor-crash")
+
+    def test_notify_terminal_all_four_actions_fire(self):
+        """_notify_terminal must invoke all 4 escalation actions in order."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            actions = []
+
+            with patch("pr_monitor._deregister_inflight",
+                       side_effect=lambda *a, **k: None), \
+                 patch("pr_monitor._set_terminal_state_marker",
+                       side_effect=lambda *a, **k: actions.append("state_marker")), \
+                 patch("pr_monitor._post_escalation_comment",
+                       side_effect=lambda *a, **k: actions.append("comment")), \
+                 patch("pr_monitor._add_escalation_label",
+                       side_effect=lambda *a, **k: actions.append("label")), \
+                 patch("pr_monitor.run_notify",
+                       side_effect=lambda *a, **k: actions.append("notify")):
+                pr_monitor._notify_terminal(
+                    worktree, 42, logger,
+                    "PR #42: stuck-ci-fix-exhausted\n  CI: fail"
+                )
+
+        self.assertIn("state_marker", actions, "Action 1: state marker must be set")
+        self.assertIn("comment", actions, "Action 2: GitHub comment must be posted")
+        self.assertIn("label", actions, "Action 3: label must be added")
+        self.assertIn("notify", actions, "Action 4: platform notification must fire")
+
+    def test_clean_exit_no_escalation_comment(self):
+        """Clean exit path (_step_notify) must not invoke _post_escalation_comment."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            escalation_called = []
+
+            with patch("pr_monitor._post_escalation_comment",
+                       side_effect=lambda *a, **k: escalation_called.append(True)), \
+                 patch("pr_monitor.run_notify",
+                       side_effect=lambda *a, **k: None):
+                pr_monitor._step_notify(worktree, 42, logger, {"status": "ready"})
+
+            self.assertFalse(escalation_called,
+                             "Clean exit must not call _post_escalation_comment")
+
+    def test_escalation_skipped_in_shakedown(self):
+        """Escalation actions must be no-ops in shakedown mode."""
+        import pr_monitor
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+            logger = _FakeLogger()
+            calls = []
+
+            with patch("pr_monitor.subprocess.run",
+                       side_effect=self._make_fake_run(calls)), \
+                 patch("pr_monitor.SHAKEDOWN", "1"):
+                pr_monitor._post_escalation_comment(
+                    worktree, 42, "stuck-ci-fix-exhausted",
+                    os.path.join(worktree, ".workflow", "pr-monitor.log"),
+                    logger,
+                )
+                pr_monitor._add_escalation_label(worktree, 42, logger)
+
+            self.assertFalse(calls,
+                             "No gh calls must be made in shakedown mode")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds 4-action escalation visibility block to `pr_monitor.py` — fires on every non-clean exit (stuck-ci-fix-exhausted, ci-timeout, monitor-crash, etc.)
- Actions: (1) set `pr_monitor.terminal_state` marker in `.workflow/state.json`; (2) post GitHub PR comment with reason + last 25 log lines; (3) add `status:monitor-escalated` label (created if missing via `gh label create --force`); (4) fire platform notification via `run_notify`
- Clean exit path (`_step_notify → run_notify`) is untouched — no spurious escalation on successful monitor runs

Closes #1088

## Test Plan

- [x] `test_post_escalation_comment_calls_gh` — gh pr comment invoked on non-clean exit
- [x] `test_add_escalation_label_calls_gh` — status:monitor-escalated label added
- [x] `test_set_terminal_state_marker_writes_state` — state.json written with terminal_state + timestamp + reason
- [x] `test_set_terminal_state_marker_preserves_existing_state` — existing state.json keys not clobbered
- [x] `test_notify_terminal_all_four_actions_fire` — all 4 actions invoked by _notify_terminal
- [x] `test_clean_exit_no_escalation_comment` — clean exit path does not call _post_escalation_comment
- [x] `test_escalation_skipped_in_shakedown` — SHAKEDOWN mode suppresses all gh calls

## Verification

- [x] /gates passed (11 Python tests, dotnet build 0 errors)
- [x] Pre-PR self-review completed (2 concerns addressed: label-create logging + makedirs ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
