### PR TITLE
fix(workflow): post_replies cross-process dedup via get_unreplied_comments

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -795,9 +795,19 @@ _POSTED_REPLY_KEYS: "set[tuple]" = set()
 
 def _reply_body_for(item):
     """Mirror of triage_common.format_reply_body for pre-POST filtering."""
+    import re
     action = item.get("action", "unknown")
     description = item.get("description", "")
     commit_sha = item.get("commit")
+    # Strip "Already fixed/dismissed/addressed in commit <sha> \u2014 " prefix that
+    # triage agents sometimes emit, which would produce doubled phrasing like
+    # "Fixed in X \u2014 Already fixed in commit X \u2014 \u2026" (PR #1094 style nit).
+    description = re.sub(
+        r"^Already (?:fixed|dismissed|addressed) in commit \S+\s*\u2014\s*",
+        "",
+        description,
+        flags=re.IGNORECASE,
+    )
     if action == "fixed" and commit_sha:
         return f"Fixed in {commit_sha} \u2014 {description}"
     if action == "dismissed":
@@ -808,9 +818,12 @@ def _reply_body_for(item):
 def post_replies(worktree, pr_number, triage_results, logger):
     """Post threaded replies to Gemini review comments.
 
-    Applies two guards before delegating to _post_replies_common:
+    Applies three guards before delegating to _post_replies_common:
       1. Empty-body guard (meta-retro #1) — skip whitespace-only bodies.
       2. Dedupe on (pr, comment_id) (meta-retro #3; PR #864 hardening).
+      3. GitHub-side check via get_unreplied_comments (issue #1096) — skip
+         any comment_id that already has a threaded reply in GitHub's state,
+         preventing duplicates across monitor restarts or parallel actors.
 
     The dedupe key is recorded only after a successful POST event so
     transient failures (network, API timeout) don't permanently block
@@ -838,6 +851,19 @@ def post_replies(worktree, pr_number, triage_results, logger):
             _log_fn("SKIPPED_DUPLICATE", comment_id=comment_id, action=action)
             continue
         filtered.append(item)
+
+    if not filtered:
+        return
+
+    unreplied_ids = {c["id"] for c in get_unreplied_comments(worktree, pr_number)}
+    cross_process_filtered = []
+    for item in filtered:
+        cid = item.get("id")
+        if cid not in unreplied_ids:
+            _log_fn("SKIPPED_ALREADY_REPLIED", comment_id=cid, action=item.get("action", "unknown"))
+        else:
+            cross_process_filtered.append(item)
+    filtered = cross_process_filtered
 
     if not filtered:
         return

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from triage_common import (
     GEMINI_BOT_LOGIN,
+    UnrepliedQueryError,
     build_triage_prompt,
     get_repo_slug as _get_repo_slug,
     get_unreplied_comments,
@@ -855,15 +856,26 @@ def post_replies(worktree, pr_number, triage_results, logger):
     if not filtered:
         return
 
-    unreplied_ids = {c["id"] for c in get_unreplied_comments(worktree, pr_number, shakedown=bool(SHAKEDOWN))}
-    cross_process_filtered = []
-    for item in filtered:
-        cid = item.get("id")
-        if cid not in unreplied_ids:
-            _log_fn("SKIPPED_ALREADY_REPLIED", comment_id=cid, action=item.get("action", "unknown"))
-        else:
-            cross_process_filtered.append(item)
-    filtered = cross_process_filtered
+    # Fail-open on query error: if we can't ask GitHub whether replies exist,
+    # skip the cross-process filter rather than silently dropping every POST.
+    # In-process dedupe (above) + GitHub's own idempotency on reply threads
+    # remain as safety nets.
+    try:
+        unreplied = get_unreplied_comments(
+            worktree, pr_number, shakedown=bool(SHAKEDOWN),
+            raise_on_error=True,
+        )
+        unreplied_ids = {c["id"] for c in unreplied}
+        cross_process_filtered = []
+        for item in filtered:
+            cid = item.get("id")
+            if cid not in unreplied_ids:
+                _log_fn("SKIPPED_ALREADY_REPLIED", comment_id=cid, action=item.get("action", "unknown"))
+            else:
+                cross_process_filtered.append(item)
+        filtered = cross_process_filtered
+    except UnrepliedQueryError as e:
+        _log_fn("UNREPLIED_QUERY_FAILED_FAIL_OPEN", error=str(e)[:200])
 
     if not filtered:
         return

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -18,6 +18,7 @@ import argparse
 import atexit
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -795,13 +796,12 @@ _POSTED_REPLY_KEYS: "set[tuple]" = set()
 
 def _reply_body_for(item):
     """Mirror of triage_common.format_reply_body for pre-POST filtering."""
-    import re
     action = item.get("action", "unknown")
     description = item.get("description", "")
     commit_sha = item.get("commit")
     # Strip "Already fixed/dismissed/addressed in commit <sha> \u2014 " prefix that
     # triage agents sometimes emit, which would produce doubled phrasing like
-    # "Fixed in X \u2014 Already fixed in commit X \u2014 \u2026" (PR #1094 style nit).
+    # "Fixed in X \u2014 Already fixed in commit X \u2014 \u2026" (issue #1096 style nit).
     description = re.sub(
         r"^Already (?:fixed|dismissed|addressed) in commit \S+\s*\u2014\s*",
         "",
@@ -855,7 +855,7 @@ def post_replies(worktree, pr_number, triage_results, logger):
     if not filtered:
         return
 
-    unreplied_ids = {c["id"] for c in get_unreplied_comments(worktree, pr_number)}
+    unreplied_ids = {c["id"] for c in get_unreplied_comments(worktree, pr_number, shakedown=bool(SHAKEDOWN))}
     cross_process_filtered = []
     for item in filtered:
         cid = item.get("id")

--- a/scripts/test_pr_monitor.py
+++ b/scripts/test_pr_monitor.py
@@ -228,6 +228,26 @@ class TestPostRepliesDedup(unittest.TestCase):
         self.assertEqual(skipped[1].get("comment_id"), 3251204411)
         self.assertEqual(skipped[1].get("action"), "fixed")
 
+    def test_fail_open_when_unreplied_query_errors(self):
+        """Gemini #1121: GH query error → fail-open (still POST), don't silently skip all."""
+        import pr_monitor
+        from triage_common import UnrepliedQueryError
+
+        triage_results = [{"id": 3251204411, "action": "fixed",
+                           "description": "Fixed it", "commit": "abc123"}]
+        logger = _FakeLogger()
+
+        with patch("pr_monitor.get_unreplied_comments",
+                   side_effect=UnrepliedQueryError("gh api exited 1: boom")), \
+             patch("pr_monitor._post_replies_common") as mock_post:
+            pr_monitor.post_replies("/worktree", 1094, triage_results, logger)
+
+        mock_post.assert_called_once()
+        events = [e[0][1] for e in logger.entries]
+        self.assertIn("UNREPLIED_QUERY_FAILED_FAIL_OPEN", events)
+        self.assertNotIn("SKIPPED_ALREADY_REPLIED", events,
+                         "Must not silently drop replies on query error")
+
     def test_posts_when_comment_unreplied(self):
         """AC: comment_id X not yet replied on GitHub → POST proceeds as before."""
         import pr_monitor

--- a/scripts/test_pr_monitor.py
+++ b/scripts/test_pr_monitor.py
@@ -197,5 +197,84 @@ class TestTerminalDeregistersInflight(unittest.TestCase):
             self.assertIn("feat/test-branch", deregister_call)
 
 
+class TestPostRepliesDedup(unittest.TestCase):
+    """Issue #1096: post_replies must consult get_unreplied_comments before POSTing."""
+
+    def setUp(self):
+        import pr_monitor
+        pr_monitor._POSTED_REPLY_KEYS.clear()
+
+    def tearDown(self):
+        import pr_monitor
+        pr_monitor._POSTED_REPLY_KEYS.clear()
+
+    def test_skips_already_replied_comment(self):
+        """AC: comment_id X already replied on GitHub → no POST, logs SKIPPED_ALREADY_REPLIED."""
+        import pr_monitor
+
+        triage_results = [{"id": 3251204411, "action": "fixed",
+                           "description": "Fixed it", "commit": "abc123"}]
+        logger = _FakeLogger()
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=[]), \
+             patch("pr_monitor._post_replies_common") as mock_post:
+            pr_monitor.post_replies("/worktree", 1094, triage_results, logger)
+
+        mock_post.assert_not_called()
+        events = [e[0][1] for e in logger.entries]
+        self.assertIn("SKIPPED_ALREADY_REPLIED", events,
+                      "Must log SKIPPED_ALREADY_REPLIED when comment is already replied")
+        skipped = next(e for e in logger.entries if e[0][1] == "SKIPPED_ALREADY_REPLIED")
+        self.assertEqual(skipped[1].get("comment_id"), 3251204411)
+        self.assertEqual(skipped[1].get("action"), "fixed")
+
+    def test_posts_when_comment_unreplied(self):
+        """AC: comment_id X not yet replied on GitHub → POST proceeds as before."""
+        import pr_monitor
+
+        triage_results = [{"id": 3251204411, "action": "fixed",
+                           "description": "Fixed it", "commit": "abc123"}]
+        logger = _FakeLogger()
+        unreplied = [{"id": 3251204411, "user": "gemini-code-assist[bot]",
+                      "path": "file.py", "line": 10, "body": "Consider X"}]
+
+        with patch("pr_monitor.get_unreplied_comments", return_value=unreplied), \
+             patch("pr_monitor._post_replies_common") as mock_post:
+            pr_monitor.post_replies("/worktree", 1094, triage_results, logger)
+
+        mock_post.assert_called_once()
+        events = [e[0][1] for e in logger.entries]
+        self.assertNotIn("SKIPPED_ALREADY_REPLIED", events)
+
+    def test_reply_body_strips_already_fixed_prefix(self):
+        """Style nit #1096: 'Already fixed in commit X — …' prefix is stripped."""
+        import pr_monitor
+
+        item = {"action": "fixed", "commit": "eb19a01e6",
+                "description": "Already fixed in commit eb19a01e6 — REFERENCE.md line 120 already uses curl"}
+        body = pr_monitor._reply_body_for(item)
+        self.assertEqual(body, "Fixed in eb19a01e6 — REFERENCE.md line 120 already uses curl")
+        self.assertNotIn("Already fixed", body)
+
+    def test_reply_body_strips_already_dismissed_prefix(self):
+        """Style nit #1096: 'Already dismissed in commit X — …' prefix is stripped."""
+        import pr_monitor
+
+        item = {"action": "dismissed",
+                "description": "Already dismissed in commit abc123 — not applicable here"}
+        body = pr_monitor._reply_body_for(item)
+        self.assertEqual(body, "Not applicable — not applicable here")
+        self.assertNotIn("Already dismissed", body)
+
+    def test_reply_body_normal_description_unchanged(self):
+        """Descriptions without the prefix pass through unmodified."""
+        import pr_monitor
+
+        item = {"action": "fixed", "commit": "abc123",
+                "description": "Updated the config file"}
+        body = pr_monitor._reply_body_for(item)
+        self.assertEqual(body, "Fixed in abc123 — Updated the config file")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -5,6 +5,7 @@ delegate to these pure-ish functions instead of duplicating logic.
 """
 import json
 import os
+import re
 import subprocess
 import time
 from itertools import chain
@@ -403,6 +404,16 @@ def format_reply_body(item):
     action = item.get("action", "unknown")
     description = item.get("description", "")
     commit_sha = item.get("commit")
+
+    # Strip "Already fixed/dismissed/addressed in commit <sha> \u2014 " prefix that
+    # triage agents sometimes emit, which would produce doubled phrasing like
+    # "Fixed in X \u2014 Already fixed in commit X \u2014 \u2026" (issue #1096 style nit).
+    description = re.sub(
+        r"^Already (?:fixed|dismissed|addressed) in commit \S+\s*\u2014\s*",
+        "",
+        description,
+        flags=re.IGNORECASE,
+    )
 
     if action == "fixed" and commit_sha:
         return f"Fixed in {commit_sha} \u2014 {description}"

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -175,7 +175,18 @@ def poll_gemini_review(worktree, pr_number, pr_created_at,
     return [], "timeout"
 
 
-def get_unreplied_comments(worktree, pr_number, shakedown=False):
+class UnrepliedQueryError(Exception):
+    """Raised by get_unreplied_comments when the GitHub query fails.
+
+    Distinguishes a legitimate empty result (all bot comments replied)
+    from an error path (network, subprocess, JSON decode). Callers that
+    must avoid fail-closed silent-skips should pass raise_on_error=True
+    and handle this exception (typically fail-open).
+    """
+
+
+def get_unreplied_comments(worktree, pr_number, shakedown=False,
+                           raise_on_error=False):
     """Return Gemini + CodeQL inline comments with no threaded reply.
 
     Fetches all inline comments (pulls/comments endpoint) and identifies
@@ -183,13 +194,18 @@ def get_unreplied_comments(worktree, pr_number, shakedown=False):
     that have no reply.  A reply is any comment whose in_reply_to_id matches
     the bot comment's id.
 
-    Returns: list of unreplied comment dicts, empty list on error or no comments.
+    Returns: list of unreplied comment dicts. On error: returns [] by default,
+    or raises UnrepliedQueryError if ``raise_on_error=True``. The raising
+    mode lets callers distinguish "all replied" from "query failed" so they
+    don't fail-closed (skip all replies) when GitHub is transiently unreachable.
     """
     if shakedown:
         return []
 
     repo = get_repo_slug(worktree, shakedown=shakedown)
     if not repo:
+        if raise_on_error:
+            raise UnrepliedQueryError("get_repo_slug returned None")
         return []
 
     try:
@@ -199,10 +215,17 @@ def get_unreplied_comments(worktree, pr_number, shakedown=False):
             cwd=worktree, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60,
         )
         if result.returncode != 0:
+            if raise_on_error:
+                raise UnrepliedQueryError(
+                    f"gh api exited {result.returncode}: "
+                    f"{(result.stderr or '')[:200]}")
             return []
         comments = _flatten_paginate_slurp(json.loads(result.stdout))
     except (subprocess.TimeoutExpired, FileNotFoundError,
-            json.JSONDecodeError, OSError):
+            json.JSONDecodeError, OSError) as e:
+        if raise_on_error:
+            raise UnrepliedQueryError(
+                f"{type(e).__name__}: {str(e)[:200]}") from e
         return []
 
     bot_usernames = {GEMINI_BOT_LOGIN, CODEQL_BOT_LOGIN}

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -864,7 +864,8 @@ class TestEmptyBodyReplyGuard:
             {"id": 202, "action": "noop", "description": "\t\n  "},
         ]
 
-        with patch("pr_monitor._post_replies_common") as mock_common:
+        with patch("pr_monitor._post_replies_common") as mock_common, \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]):
             pr_monitor.post_replies(wt, 42, items, logger)
 
         # All items had whitespace-only bodies — common POSTer never invoked.

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -838,7 +838,9 @@ class TestEmptyBodyReplyGuard:
              "description": "real fix"},  # real body
         ]
 
-        with patch("pr_monitor._post_replies_common") as mock_common:
+        with patch("pr_monitor._post_replies_common") as mock_common, \
+             patch("pr_monitor.get_unreplied_comments",
+                   return_value=[{"id": 102}]):
             pr_monitor.post_replies(wt, 42, items, logger)
 
         # _post_replies_common was called exactly once, with only the
@@ -1202,7 +1204,9 @@ class TestReplyDedupe:
                 log_fn("POSTED", comment_id=i["id"], action=i["action"])
 
         with patch("pr_monitor._post_replies_common",
-                   side_effect=fake_common) as mock_common:
+                   side_effect=fake_common) as mock_common, \
+             patch("pr_monitor.get_unreplied_comments",
+                   return_value=[{"id": 777}]):
             pr_monitor.post_replies(wt, 42, [item], logger)
             pr_monitor.post_replies(wt, 42, [item], logger)
 
@@ -1235,7 +1239,9 @@ class TestReplyDedupe:
                 log_fn("POSTED", comment_id=i["id"], action=i["action"])
 
         with patch("pr_monitor._post_replies_common",
-                   side_effect=fake_common) as mock_common:
+                   side_effect=fake_common) as mock_common, \
+             patch("pr_monitor.get_unreplied_comments",
+                   return_value=[{"id": 500}]):
             pr_monitor.post_replies(wt, 42, [item_fixed], logger)
             pr_monitor.post_replies(wt, 42, [item_dismissed], logger)
 
@@ -1270,7 +1276,9 @@ class TestReplyDedupe:
                 log_fn("POSTED", comment_id=i["id"], action=i["action"])
 
         with patch("pr_monitor._post_replies_common",
-                   side_effect=fail_once) as mock_common:
+                   side_effect=fail_once) as mock_common, \
+             patch("pr_monitor.get_unreplied_comments",
+                   return_value=[{"id": 999}]):
             pr_monitor.post_replies(wt, 42, [item], logger)
             # First call failed; key must not be in the dedupe set.
             assert (42, 999) not in pr_monitor._POSTED_REPLY_KEYS
@@ -1278,7 +1286,9 @@ class TestReplyDedupe:
 
         # Retry succeeds — common is invoked again, then key lands in the set.
         with patch("pr_monitor._post_replies_common",
-                   side_effect=succeed) as mock_common:
+                   side_effect=succeed) as mock_common, \
+             patch("pr_monitor.get_unreplied_comments",
+                   return_value=[{"id": 999}]):
             pr_monitor.post_replies(wt, 42, [item], logger)
             assert mock_common.call_count == 1
             assert (42, 999) in pr_monitor._POSTED_REPLY_KEYS

--- a/tests/test_triage_common.py
+++ b/tests/test_triage_common.py
@@ -201,6 +201,30 @@ class TestFormatReplyBody:
         })
         assert body == "patched"
 
+    def test_strips_already_fixed_prefix(self):
+        """issue #1096: avoid 'Fixed in X — Already fixed in commit X — …' doubling."""
+        body = format_reply_body({
+            "action": "fixed", "commit": "eb19a01e6",
+            "description": "Already fixed in commit eb19a01e6 — REFERENCE.md line 120",
+        })
+        assert body == "Fixed in eb19a01e6 — REFERENCE.md line 120"
+        assert "Already fixed" not in body
+
+    def test_strips_already_dismissed_prefix(self):
+        body = format_reply_body({
+            "action": "dismissed",
+            "description": "Already dismissed in commit abc123 — not applicable here",
+        })
+        assert body == "Not applicable — not applicable here"
+        assert "Already dismissed" not in body
+
+    def test_normal_description_unchanged(self):
+        body = format_reply_body({
+            "action": "fixed", "commit": "abc",
+            "description": "Updated the config file",
+        })
+        assert body == "Fixed in abc — Updated the config file"
+
 
 # ---------------------------------------------------------------------------
 # get_unreplied_comments (AC-139)


### PR DESCRIPTION
## Summary
- `post_replies` now calls `get_unreplied_comments` before POSTing, skipping any comment id that already has a threaded reply in GitHub's state — prevents duplicate replies across monitor restarts or parallel actors (issue #1096)
- `SKIPPED_ALREADY_REPLIED` is logged with `comment_id` and `action` when a skip occurs
- `format_reply_body` (canonical) and `_reply_body_for` (guard mirror) both strip the "Already fixed/dismissed/addressed in commit X — " prefix triage agents sometimes emit, preventing doubled phrasing like "Fixed in X — Already fixed in commit X — …"

Closes #1096

## Test Plan
- Unit: `TestPostRepliesDedup.test_skips_already_replied_comment` — id X already replied → no POST, logs SKIPPED_ALREADY_REPLIED
- Unit: `TestPostRepliesDedup.test_posts_when_comment_unreplied` — id X not replied → posts as before
- Unit: `TestPostRepliesDedup.test_reply_body_strips_already_fixed_prefix` — prefix stripped in guard mirror
- Unit: `TestFormatReplyBody.test_strips_already_fixed_prefix` — prefix stripped in canonical formatter (actual POST body)
- Existing `TestReplyDedupe` tests updated to mock `get_unreplied_comments` (previously passed by coincidence since API failure returned [] silently)

## Verification
- [x] /gates passed (9 script tests, 113 integration tests, enforcement audit)
- [x] /verify completed (surfaces: workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
