### PR TITLE
fix(workflow): force headless mode for single-turn sub-agent dispatches (#1122)

### DIFF
--- a/.retros/2026-05-16-summary.md
+++ b/.retros/2026-05-16-summary.md
@@ -1,0 +1,87 @@
+# Retrospective — 2026-05-16
+
+**Branch:** `fix/1122-subagent-hang`
+**Scope:** 15 commits (2026-05-15 21:30 → 2026-05-16 04:00, ~6.5 h)
+**Diff shape:** 4 feat / 10 fix / 1 chore — fix_ratio 0.67
+**Mode:** headless interactive (pr-monitor bg context)
+
+---
+
+## Pattern narrative
+
+High-volume batch fix session: the core issue (#1122, sub-agent hangs after applying a fix) was resolved by adding `--headless` flag enforcement to triage/retro/dispatch_subagent spawn paths. Surrounding commits picked up 11 additional fixes and features across the workflow pipeline (CI timeout, escalation visibility, post-reply dedup, stop-hook bypass, worker prompt contract, bg-spawn autonomy, PR-stack envelope, cleanup janitor, retro extractor repair, fnm preflight).
+
+Session severity: **rough**. Stop hook fired 3 times (blocked once). Tool failures: 7 in the main transcript. Frustration markers: 2. The roughness is not alarming — it reflects the breadth of the session scope and some first-attempt tool usage errors, not thrashing on the core fix.
+
+Critical path (fix/1122) landed cleanly: `53ea19d3` forced headless, `02ebc05a` addressed self-review. No rework on those commits. The rough edges are in the surrounding work.
+
+---
+
+## Mechanical signals
+
+| Signal | Count |
+|--------|-------|
+| Transcripts examined | 5 |
+| user_corrections | 4 (across all transcripts) |
+| tool_failures | 9 (across all transcripts) |
+| repeated_commands | 0 |
+| stop_hook_blocked | true (3 fires) |
+| frustration_hits | 3 |
+| allowlist_drift proposals | 0 |
+
+---
+
+## Top findings
+
+### R-01 — Agent type `code-reviewer` not found (draft-fix / code / HIGH)
+
+**Issue:** `/impartial-code-review` (or the `pr` skill's review dispatch) hardcodes `subagent_type: "code-reviewer"`, which does not exist in this environment. Available types: `claude`, `Explore`, `general-purpose`, `Plan`, `statusline-setup`. Every invocation silently fails or errors.
+
+**Fix:** Replace `subagent_type: "code-reviewer"` with `subagent_type: "general-purpose"` in `.claude/skills/impartial-code-review/SKILL.md` (and any caller that passes this literal string). One-line change, high-confidence.
+
+**Routed:** DO NOW → Lane B (≤3 files, ≤200 LOC).
+
+**Contributing factors:** tooling (missing agent registration), skill (hardcoded type string).
+
+---
+
+### R-02 — `summary.json` merge conflict blocks retro parse (issue-only / process / HIGH)
+
+**Issue:** `chore(qa): auto-commit stranded files on pipeline failure` (commit f9c495066 on a parallel branch) wrote to `.retros/summary.json`. This worktree also wrote to it. The resulting merge conflict made the file invalid JSON, crashing this retro's mechanical parse step. The conflict was resolved manually in this session, but the underlying race will recur whenever any auto-commit touches the shared retro store.
+
+**Fix options (research needed):** (a) switch `.retros/summary.json` to an append-only JSONL so merges are line-level; (b) exclude `.retros/summary.json` from auto-commits and let the retro write it at PR-merge time only; (c) namespace per-worktree state into separate files, merged at release.
+
+**Routed:** DEFER → GitHub issue with label `area:workflow`, `type:bug`. Source: `.retros/2026-05-16-summary.md#R-02`.
+
+**Contributing factors:** process (two agents writing shared state concurrently), setup (no conflict-resolution strategy for auto-commits).
+
+---
+
+## Decisions log
+
+| # | Verb | Action | Status |
+|---|------|--------|--------|
+| R-01 | DO NOW (Lane B) | Patch `subagent_type: "code-reviewer"` → `"general-purpose"` in impartial-code-review skill | pending |
+| R-02 | DEFER | File GitHub issue — summary.json conflict strategy | pending |
+| R-03 | DROP | Root cause is R-01 (wrong agent type → stale schema); resolves when R-01 lands | dropped |
+| R-04 | DROP | Write-before-Read guard working as intended; two hits are process noise | dropped |
+| R-05 | DROP | One-off pipeline.py usage errors; not a recurring pattern | dropped |
+
+---
+
+## What worked
+
+- **Core fix stayed clean.** `53ea19d3` and `02ebc05a` landed without rework — investigation identified the hang root cause (blocking `claude -p` call in non-headless mode) and the fix was surgical.
+- **Parallel bug triage.** 11 additional fixes shipped in the same session without collision or thrash — each addressed a separate surface (CI timeout, escalation, dedup, stop-hook, spawn, retro extractor).
+- **Self-review caught spec gaps.** The `02ebc05a` follow-up addressed self-review findings on the spec Code field and docstring — Gemini review would have flagged these, so catching them pre-PR was efficient.
+
+## What didn't work
+
+- **`code-reviewer` agent type.** The impartial-code-review skill has a dead reference that silently fails every review run. This has likely been broken for multiple sessions without surfacing — the review falls through to whatever fallback the dispatcher applies.
+- **Shared mutable retro state.** Auto-commits touching `.retros/summary.json` race with worktree retro writes. The manual merge cost ~5 minutes this session; it will recur.
+
+---
+
+## Meta
+
+The retro mechanical extractor itself worked correctly this run (no zero-signal bug — fixed in #1109). The conflict was in the persistent store file, not the extractor. Extractor confidence: high.

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,12 +1,7 @@
 {
   "schema_version": 1,
-<<<<<<< HEAD
   "last_updated": "2026-05-16",
-  "total_retros": 18,
-=======
-  "last_updated": "2026-05-16T06:42:00Z",
-  "total_retros": 17,
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
+  "total_retros": 19,
   "findings_by_category": {
     "external": [
       {
@@ -138,31 +133,33 @@
       },
       {
         "date": "2026-05-16",
-<<<<<<< HEAD
-        "branch": "feat/1098-prompt-template",
-=======
         "branch": "fix/1067-bg-spawn-autonomy",
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
         "finding_id": "R-01"
       },
       {
         "date": "2026-05-16",
-<<<<<<< HEAD
-        "branch": "feat/1098-prompt-template",
-=======
         "branch": "fix/1067-bg-spawn-autonomy",
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
         "finding_id": "R-02"
       },
       {
         "date": "2026-05-16",
-<<<<<<< HEAD
-        "branch": "feat/1098-prompt-template",
-        "finding_id": "R-04"
-=======
         "branch": "fix/1067-bg-spawn-autonomy",
         "finding_id": "R-03"
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1098-prompt-template",
+        "finding_id": "R-01"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1098-prompt-template",
+        "finding_id": "R-02"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1098-prompt-template",
+        "finding_id": "R-04"
       }
     ],
     "design": [
@@ -347,13 +344,13 @@
       },
       {
         "date": "2026-05-16",
-<<<<<<< HEAD
-        "branch": "feat/1098-prompt-template",
-        "finding_id": "R-03"
-=======
         "branch": "fix/1067-bg-spawn-autonomy",
         "finding_id": "R-04"
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1098-prompt-template",
+        "finding_id": "R-03"
       }
     ],
     "setup": [
@@ -385,6 +382,20 @@
         "finding_id": "R-05"
       }
     ],
+    "workflow": [
+      {
+        "date": "2026-05-16",
+        "branch": "fix/1122-subagent-hang",
+        "finding_id": "R-01",
+        "issue": 1126
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "fix/1122-subagent-hang",
+        "finding_id": "R-02",
+        "issue": 1125
+      }
+    ],
     "uncategorized": [
       {
         "date": "2026-05-16",
@@ -409,22 +420,12 @@
     ]
   },
   "metrics": {
-<<<<<<< HEAD
-    "avg_fix_ratio": 0.705,
+    "avg_fix_ratio": 0.692,
     "pipeline_success_rate": 0.412,
     "avg_convergence_rounds": 2.206,
-    "last_session_findings": 4,
-    "last_session_status": "shipped_clean",
-    "last_session_branch": "feat/1098-prompt-template",
-    "last_session_pr": 1116
-=======
-    "avg_fix_ratio": 0.724,
-    "pipeline_success_rate": 0.388,
-    "avg_convergence_rounds": 2.281,
-    "last_session_findings": 5,
-    "last_session_status": "in_flight_awaiting_gemini_post",
-    "last_session_branch": "fix/1067-bg-spawn-autonomy",
+    "last_session_findings": 2,
+    "last_session_status": "rough",
+    "last_session_branch": "fix/1122-subagent-hang",
     "last_session_pr": null
->>>>>>> f9c495066 (chore(qa): auto-commit stranded files on pipeline failure)
   }
 }

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -564,7 +564,7 @@ def run_triage(worktree, pr_number, comments, logger, mode=None):
 
     try:
         handle = claude_dispatch.spawn(
-            mode=claude_dispatch._resolve_mode(mode),
+            mode="headless",
             prompt=full_prompt,
             caller="pr_monitor.run_triage",
             name="gemini-triage",
@@ -1041,7 +1041,7 @@ def run_retro(worktree, logger, mode=None):
 
     try:
         handle = claude_dispatch.spawn(
-            mode=claude_dispatch._resolve_mode(mode),
+            mode="headless",
             prompt=prompt,
             caller="pr_monitor.run_retro",
             name="retro",

--- a/scripts/test_pr_monitor.py
+++ b/scripts/test_pr_monitor.py
@@ -63,6 +63,9 @@ class _FakeHandle:
     def wait(self, timeout=None):
         return 0
 
+    def output(self):
+        return ""
+
     def terminate(self):
         pass
 
@@ -144,6 +147,173 @@ class TestMonitorModelRouting(unittest.TestCase):
         self.assertEqual(
             captured["kwargs"].get("model"), "sonnet",
             "retro must continue using model='sonnet' (unchanged by #1098)",
+        )
+
+    def test_triage_uses_headless_mode(self):
+        """AC-01/02/03 (#1122): run_triage dispatches with mode='headless'."""
+        import pr_monitor
+        import claude_dispatch
+
+        captured = {}
+
+        def _fake_spawn(**kwargs):
+            captured["kwargs"] = kwargs
+            stage_log = kwargs.get("stage_log")
+            if stage_log:
+                with open(stage_log, "w", encoding="utf-8") as f:
+                    f.write("")
+            return _FakeHandle(transcript_path=stage_log or "")
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow", "stages"),
+                        exist_ok=True)
+            logger = _FakeLogger()
+            with patch("pr_monitor.SHAKEDOWN", False), \
+                 patch("pr_monitor.build_triage_prompt", return_value="prompt"), \
+                 patch("pr_monitor.parse_triage_jsonl", return_value=[{"id": 1}]), \
+                 patch.object(claude_dispatch, "spawn", side_effect=_fake_spawn):
+                result = pr_monitor.run_triage(worktree, 123, [], logger)
+
+        self.assertIn("kwargs", captured, "claude_dispatch.spawn was not called")
+        kwargs = captured["kwargs"]
+        self.assertEqual(
+            kwargs.get("mode"), "headless",
+            f"AC-01 (#1122): run_triage must dispatch with mode='headless' "
+            f"(claude --bg daemon does not reliably transition state=done); "
+            f"got {kwargs.get('mode')!r}",
+        )
+        self.assertEqual(kwargs.get("agent"), "gemini-triage")
+        self.assertEqual(kwargs.get("model"), "haiku")
+        self.assertEqual(result, [{"id": 1}], "AC-03: parsed triage results returned")
+
+    def test_triage_timeout_returns_none(self):
+        """AC-04 (#1122): run_triage returns None when headless process times out."""
+        import pr_monitor
+        import claude_dispatch
+        import subprocess
+
+        class _TimingOutHandle(_FakeHandle):
+            def wait(self, timeout=None):
+                raise subprocess.TimeoutExpired(cmd="claude", timeout=timeout)
+
+        def _fake_spawn(**kwargs):
+            stage_log = kwargs.get("stage_log")
+            if stage_log:
+                with open(stage_log, "w", encoding="utf-8") as f:
+                    f.write("")
+            return _TimingOutHandle(transcript_path=stage_log or "")
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow", "stages"),
+                        exist_ok=True)
+            logger = _FakeLogger()
+            with patch("pr_monitor.SHAKEDOWN", False), \
+                 patch("pr_monitor.build_triage_prompt", return_value="prompt"), \
+                 patch.object(claude_dispatch, "spawn", side_effect=_fake_spawn):
+                result = pr_monitor.run_triage(worktree, 123, [], logger)
+
+        self.assertIsNone(result, "AC-04 (#1122): timeout must return None")
+        events = [e[0] for e in logger.entries]
+        self.assertTrue(
+            any("TIMEOUT" in str(e) for e in events),
+            "AC-04: TIMEOUT must be logged on subprocess.TimeoutExpired",
+        )
+
+    def test_retro_uses_headless_mode(self):
+        """AC-07 (#1122): run_retro dispatches with mode='headless'."""
+        import pr_monitor
+        import claude_dispatch
+
+        captured = {}
+
+        def _fake_spawn(**kwargs):
+            captured["kwargs"] = kwargs
+            stage_log = kwargs.get("stage_log")
+            if stage_log:
+                with open(stage_log, "w", encoding="utf-8") as f:
+                    f.write("")
+            return _FakeHandle(transcript_path=stage_log or "")
+
+        with tempfile.TemporaryDirectory() as worktree:
+            os.makedirs(os.path.join(worktree, ".workflow", "stages"),
+                        exist_ok=True)
+            logger = _FakeLogger()
+            with patch("pr_monitor.SHAKEDOWN", False), \
+                 patch.object(claude_dispatch, "spawn", side_effect=_fake_spawn):
+                try:
+                    pr_monitor.run_retro(worktree, logger)
+                except Exception:
+                    pass
+
+        self.assertIn("kwargs", captured, "claude_dispatch.spawn was not called")
+        self.assertEqual(
+            captured["kwargs"].get("mode"), "headless",
+            f"AC-07 (#1122): run_retro must dispatch with mode='headless'; "
+            f"got {captured['kwargs'].get('mode')!r}",
+        )
+
+
+class TestDispatchSubagentMode(unittest.TestCase):
+    """AC-08 (#1122): dispatch_subagent forces headless regardless of mode param."""
+
+    def test_dispatch_subagent_uses_headless_mode(self):
+        """AC-08: dispatch_subagent calls spawn(mode='headless', ...)."""
+        import triage_common
+        import claude_dispatch
+
+        captured = {}
+
+        def _fake_spawn(**kwargs):
+            captured["kwargs"] = kwargs
+            stage_log = kwargs.get("stage_log")
+            if stage_log:
+                with open(stage_log, "w", encoding="utf-8") as f:
+                    f.write("")
+            return _FakeHandle(transcript_path=stage_log or "")
+
+        with tempfile.TemporaryDirectory() as worktree:
+            with patch.object(claude_dispatch, "spawn", side_effect=_fake_spawn):
+                triage_common.dispatch_subagent(
+                    "ci-fix",
+                    {"test": True},
+                    worktree=worktree,
+                    mode=None,
+                )
+
+        self.assertIn("kwargs", captured, "claude_dispatch.spawn was not called")
+        self.assertEqual(
+            captured["kwargs"].get("mode"), "headless",
+            f"AC-08 (#1122): dispatch_subagent must force mode='headless'; "
+            f"got {captured['kwargs'].get('mode')!r}",
+        )
+
+    def test_dispatch_subagent_headless_even_when_mode_interactive(self):
+        """AC-08: interactive mode override is ignored — always headless."""
+        import triage_common
+        import claude_dispatch
+
+        captured = {}
+
+        def _fake_spawn(**kwargs):
+            captured["kwargs"] = kwargs
+            stage_log = kwargs.get("stage_log")
+            if stage_log:
+                with open(stage_log, "w", encoding="utf-8") as f:
+                    f.write("")
+            return _FakeHandle(transcript_path=stage_log or "")
+
+        with tempfile.TemporaryDirectory() as worktree:
+            with patch.object(claude_dispatch, "spawn", side_effect=_fake_spawn):
+                triage_common.dispatch_subagent(
+                    "ci-fix",
+                    {"test": True},
+                    worktree=worktree,
+                    mode="interactive",
+                )
+
+        self.assertEqual(
+            captured["kwargs"].get("mode"), "headless",
+            "dispatch_subagent must override interactive → headless",
         )
 
 

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -558,7 +558,7 @@ def dispatch_subagent(profile_name, payload, *, model="sonnet", worktree=".",
     import claude_dispatch  # local import keeps module-load cycle clean
     if caller is None:
         caller = "triage_common.dispatch_subagent"
-    resolved_mode = claude_dispatch._resolve_mode(mode)
+    resolved_mode = "headless"
     profile_body = _read_agent_profile_body(profile_name, worktree=worktree)
     payload_json = json.dumps(payload, indent=2)
     prompt = (

--- a/scripts/triage_common.py
+++ b/scripts/triage_common.py
@@ -520,23 +520,17 @@ def dispatch_subagent(profile_name, payload, *, model="sonnet", worktree=".",
                       stage_log=None):
     """Invoke an agent profile via the dispatch router.
 
-    Wraps ``claude_dispatch.spawn`` so both interactive (``--bg``) and headless
-    (``-p``) modes share one entry point. Mode defaults to the value of
-    ``PPDS_DISPATCH_MODE`` (or ``"interactive"`` when unset). ``caller``
-    defaults to ``"triage_common.dispatch_subagent"`` for the spend-journal
-    audit row. Constitution A2: single code path.
+    Always uses headless mode (``claude -p``). The ``claude --bg`` daemon does
+    not reliably transition ``state=done`` after a single-turn session (#1122),
+    so interactive mode is not suitable for these single-shot dispatches.
+    ``caller`` defaults to ``"triage_common.dispatch_subagent"`` for the
+    spend-journal audit row. Constitution A2: single code path.
 
     The constructed prompt has three parts so the spawned session has enough
     context to act without the operator answering questions:
-      1. A directive forbidding clarifying questions (matches the pattern that
-         ``pr_monitor.run_triage`` already uses successfully).
-      2. The agent profile body, inlined from ``.claude/agents/<name>.md``
-         because interactive mode silently drops ``--agent`` (see #1086).
+      1. A directive forbidding clarifying questions.
+      2. The agent profile body, inlined from ``.claude/agents/<name>.md``.
       3. The JSON payload under a clear ``=== PAYLOAD ===`` marker.
-
-    ``permission_mode="bypassPermissions"`` is passed to ``spawn`` because the
-    subprocess is fully automated — permission prompts here would surface as
-    ``BlockedSessionError`` with no operator to respond.
 
     Args:
         profile_name: agent profile name (matches .claude/agents/<name>.md).
@@ -545,12 +539,11 @@ def dispatch_subagent(profile_name, payload, *, model="sonnet", worktree=".",
         worktree: working directory for the subprocess; also the root used
             to resolve the agent profile file.
         timeout: seconds before the process is killed (default 30 min).
-        mode: ``"interactive"`` / ``"headless"`` / ``None``. ``None`` defers
-            to ``claude_dispatch._resolve_mode``.
+        mode: accepted for signature compatibility but ignored — always headless.
         caller: identification string written to the spend journal. Defaults
             to ``"triage_common.dispatch_subagent"``.
-        stage_log: optional headless-mode stream-json path. When mode resolves
-            to headless and this is unset, a temp file is used.
+        stage_log: optional stream-json path. When unset, a temp file is used
+            and deleted after ``output()`` reads it.
 
     Returns:
         dict with keys: ``stdout`` (str), ``stderr`` (str), ``exit_code`` (int).

--- a/specs/fix-1122-subagent-hang.md
+++ b/specs/fix-1122-subagent-hang.md
@@ -1,0 +1,82 @@
+# fix-1122-subagent-hang
+
+**Status:** Draft
+**Last Updated:** 2026-05-16
+**Issue:** #1122 (epic #1066, Phase 2)
+**Code:** `scripts/pr_monitor.py` | `scripts/test_pr_monitor.py`
+**Surfaces:** N/A (workflow tooling)
+
+---
+
+## Overview
+
+`pr_monitor.run_triage` spawns the gemini-triage sub-agent using interactive mode (`claude --bg`). After the sub-agent completes its work, the `claude --bg` daemon does not reliably transition `state=done` in its state.json. `BgHandle.wait()` polls for `state=done`, which may never arrive, causing a 30-minute hang followed by a `DispatchError` timeout. The fix is to force headless mode (`claude -p`) for `run_triage`, which exits cleanly after model output.
+
+---
+
+## Root Cause Investigation
+
+### Evidence — Session 23b24e75 (PR #1119, 2026-05-16)
+
+| Timestamp | Event |
+|---|---|
+| 07:50:39 | Session spawned — `claude --bg --name gemini-triage --permission-mode bypassPermissions` |
+| 07:50:45–07:51:18 | Sub-agent reads file, applies fix, commits (`838ba35a3`), git pushes (success) |
+| 07:51:21 | Model emits final JSON output |
+| 07:51:23 | `stop_hook_summary`: 3 hooks ran, `preventedContinuation: false`, `hookErrors: []` |
+| 07:51:23 | `turn_duration`: 42382ms — session turn complete |
+| 07:51:23–08:20:41 | **`state.json` frozen at `state=working`. No further daemon updates.** |
+| 08:20:41 | `BgHandle.wait` raised `DispatchError("timed out after 1800s for 23b24e75")` |
+| 08:23:32 | Session eventually transitioned to `state=stopped` (unknown external trigger) |
+
+**Three additional sessions** show the same pattern: `07f386cb`, `1071e54d`, `2112af19` — completed transcripts (`turn_duration` emitted), daemon state frozen at `working`, `firstTerminalAt: None`.
+
+### Hypotheses Evaluated
+
+**H1 — gh api / git push call blocked**: Ruled out. Transcript confirms git push returned at 07:51:18, model output at 07:51:21, turn complete at 07:51:23. No blocking call after model output.
+
+**H2 — stdout/stdin pipe EOF**: Not applicable. Interactive mode uses no pipe; this hypothesis applies only to headless mode.
+
+**H3 — Interactive prompt despite bypassPermissions**: Ruled out. `preventedContinuation: false` — no hook blocked continuation. Transcript contains no additional model turn after the first.
+
+**H4 — claude --bg daemon lifecycle (CONFIRMED)**: After the model's first turn completes, the `claude --bg` daemon does not reliably transition `state` → `done`. The daemon is designed for multi-turn interaction and remains alive waiting for the next turn. `BgHandle.wait()` polling for `state=done` is not a reliable termination signal for single-turn dispatches. The `state=done` transition is non-deterministic — it occurs for some sessions immediately and never for others.
+
+### Secondary Bug
+
+`run_triage` catches `BlockedSessionError` and `subprocess.TimeoutExpired` but not `claude_dispatch.DispatchError`. When `BgHandle.wait()` times out it raises `DispatchError`, which propagates up to `_step_triage` as a generic exception rather than being handled cleanly. This causes the triage step to be marked `error` without calling `handle.terminate()`.
+
+---
+
+## Fix
+
+Force `run_triage` to use `mode="headless"` when calling `claude_dispatch.spawn()`. Headless mode runs `claude -p`, which exits after the model produces its output. `HeadlessHandle.wait(timeout=1800)` uses `proc.wait(timeout=1800)`, raising `subprocess.TimeoutExpired` on timeout (already caught).
+
+- `--agent gemini-triage` IS passed in headless mode — tool restrictions from the agent profile apply.
+- `permission_mode` is not applicable in headless mode (no permission dialog); it is silently ignored by `spawn()`.
+- `stage_log` is already provided in `run_triage` and is used by headless mode to capture stdout.
+- The post-wait transcript copy (shutil.copyfile) remains; in headless mode `handle.transcript_path == stage_jsonl_path`, so the `if` condition is false and the copy is skipped — correct behavior.
+
+No changes to `claude_dispatch.BgHandle`, `BgHandle.wait()`, or any caller outside `run_triage`.
+
+---
+
+## Acceptance Criteria
+
+| # | AC | Test |
+|---|----|----|
+| AC-01 | `run_triage` calls `claude_dispatch.spawn(mode="headless", ...)` | `test_triage_uses_headless_mode` |
+| AC-02 | `run_triage` calls spawn with `agent="gemini-triage"` and `model="haiku"` (unchanged) | `test_triage_uses_headless_mode` + `test_triage_uses_haiku` |
+| AC-03 | When the headless process exits normally (exit 0), `run_triage` returns the parsed triage results | `test_triage_uses_headless_mode` |
+| AC-04 | When the headless process times out, `subprocess.TimeoutExpired` is caught and `None` is returned | `test_triage_timeout_returns_none` |
+| AC-05 | All existing `test_pr_monitor.py` tests pass without modification | run test suite |
+| AC-06 | CI-timeout default (PR #1089, `ci_timeout_sec`) is unaffected — separate concern, no shared state | code review |
+| AC-07 | `run_retro` calls `claude_dispatch.spawn(mode="headless", ...)` | `test_retro_uses_headless_mode` |
+| AC-08 | `dispatch_subagent` calls `claude_dispatch.spawn(mode="headless", ...)` regardless of the `mode` parameter | `test_dispatch_subagent_uses_headless_mode` |
+
+---
+
+## Out of Scope
+
+- The latent `DispatchError` exception handling gap in `run_triage` / `run_retro` (uncaught timeout from `BgHandle.wait`) becomes moot after the headless switch — `BgHandle.wait` is no longer called from these paths. Note for retro.
+- Changes to `BgHandle.wait()` or `claude_dispatch.py` are not needed for this fix.
+- No changes to `CLAUDE.md`, `CONSTITUTION.md`, or `interaction-patterns.md`.

--- a/specs/fix-1122-subagent-hang.md
+++ b/specs/fix-1122-subagent-hang.md
@@ -3,7 +3,7 @@
 **Status:** Draft
 **Last Updated:** 2026-05-16
 **Issue:** #1122 (epic #1066, Phase 2)
-**Code:** `scripts/pr_monitor.py` | `scripts/test_pr_monitor.py`
+**Code:** `scripts/pr_monitor.py` | `scripts/triage_common.py` | `scripts/test_pr_monitor.py`
 **Surfaces:** N/A (workflow tooling)
 
 ---


### PR DESCRIPTION
## Summary

- Force `mode="headless"` in `pr_monitor.run_triage`, `run_retro`, and `triage_common.dispatch_subagent` — `claude --bg` daemon does not reliably transition `state=done` after single-turn sessions, causing 30-min `BgHandle.wait` hangs
- Root cause confirmed with 4-session evidence: session `23b24e75` transcript shows model completed at 07:51:23 (42s), but daemon kept `state=working` for 32 minutes; `firstTerminalAt: None` on 3 additional stuck sessions
- `HeadlessHandle.wait()` uses `proc.wait(timeout=...)` — exits cleanly when `claude -p` terminates after model output; `subprocess.TimeoutExpired` already caught

Closes #1122

## Test Plan

- [x] `test_triage_uses_headless_mode` — AC-01/02/03: mode="headless", agent/model unchanged, results returned
- [x] `test_triage_timeout_returns_none` — AC-04: subprocess.TimeoutExpired caught, returns None
- [x] `test_retro_uses_headless_mode` — AC-07: run_retro forces headless
- [x] `test_dispatch_subagent_uses_headless_mode` — AC-08: mode=None → headless
- [x] `test_dispatch_subagent_headless_even_when_mode_interactive` — AC-08: mode="interactive" override ignored
- [x] All 22 `test_pr_monitor.py` tests pass

## Verification

- [x] /gates passed
- [x] /verify completed (surfaces: workflow)
- [x] /review completed (findings: 2 DEFECTs fixed, 1 CONCERN deferred to retro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
