### PR TITLE
fix(workflow): pr_monitor Gemini-poll window too short — escalate on timeout (#1127)

### DIFF
--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -205,6 +205,15 @@ class _DirtyWorktreeOnReadyFlipError(Exception):
     """
 
 
+class _GeminiTimeoutError(Exception):
+    """Raised by _step_ready when Gemini never posted within GEMINI_MAX_WAIT.
+
+    Propagated up to run_monitor to trigger the #1088 escalation block and
+    return exit code 1, preventing _step_notify from firing a duplicate
+    notification after _notify_terminal already ran inside _step_ready.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
@@ -2077,6 +2086,17 @@ def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
         logger.close()
         return 1
 
+    except _GeminiTimeoutError:
+        result["status"] = "gemini-timeout"
+        write_result(worktree, result)
+        logger.log("monitor", "ABORT", reason="gemini_review_not_posted")
+        _notify_terminal(
+            worktree, pr_number, logger,
+            f"PR #{pr_number}: gemini_review_not_posted",
+        )
+        logger.close()
+        return 1
+
     except KeyboardInterrupt:
         result["status"] = "interrupted"
         write_result(worktree, result)
@@ -2222,14 +2242,10 @@ def _step_ready(worktree, pr_number, logger, result):
             result["ready_skip_reasons"] = reasons
             write_result(worktree, result)
             if "gemini_review_not_posted" in reasons:
-                # Gemini never posted within the poll window — fire the full
-                # escalation block (#1127/#1088): state marker + GitHub comment
-                # + label + platform notify so the operator sees a visible signal
-                # rather than a silent "ready=SKIPPED" with monitor COMPLETE.
-                _notify_terminal(
-                    worktree, pr_number, logger,
-                    f"PR #{pr_number}: gemini_review_not_posted",
-                )
+                # Raise so run_monitor's except block fires the #1088 escalation
+                # block and returns exit 1 — prevents _step_notify from issuing
+                # a duplicate notification after _notify_terminal runs (#1127).
+                raise _GeminiTimeoutError("gemini_review_not_posted")
             else:
                 # Other gate failures (CI not green, unreplied comments) — basic
                 # toast only; no escalation label since the monitor can still
@@ -2289,7 +2305,7 @@ def _step_ready(worktree, pr_number, logger, result):
         success = mark_pr_ready(worktree, pr_number, logger)
         mark_step(result, "ready", "done" if success else "error")
         write_result(worktree, result)
-    except (_DirtyWorktreeOnReadyFlipError, _UncommittedTriageError):
+    except (_DirtyWorktreeOnReadyFlipError, _UncommittedTriageError, _GeminiTimeoutError):
         raise  # propagate terminal-state errors to run_monitor
     except Exception as e:
         logger.log("ready", "EXCEPTION", error=str(e))

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -46,7 +46,7 @@ CI_MAX_WAIT = 1800          # 30 minutes max for CI (AC-125; bumped from 900 per
 CI_ESCALATION_THRESHOLD = 3       # consecutive no-check polls before escalation
 CI_ESCALATION_MIN_ELAPSED = 120   # seconds since first error before escalation
 GEMINI_POLL_INTERVAL = 30   # seconds between Gemini comment polls
-GEMINI_MAX_WAIT = 300       # 5 minutes max for Gemini
+GEMINI_MAX_WAIT = 1800      # 30 minutes max for Gemini (bumped from 300 per #1127)
 MAX_TRIAGE_ITERATIONS = 3   # max triage -> CI re-check cycles
 
 MAX_CI_FIX_ROUNDS = int(os.environ.get("PPDS_MAX_CI_FIX_ROUNDS", "3"))
@@ -63,6 +63,19 @@ def _resolve_ci_timeout_sec(flag_value):
         except ValueError:
             pass
     return CI_MAX_WAIT, "default"
+
+
+def _resolve_gemini_timeout_sec(flag_value):
+    """Return (effective_seconds, source) with flag > env > default precedence."""
+    if flag_value is not None:
+        return flag_value, "flag"
+    env_val = os.environ.get("PPDS_PR_MONITOR_GEMINI_TIMEOUT")
+    if env_val:
+        try:
+            return int(env_val), "env"
+        except ValueError:
+            pass
+    return GEMINI_MAX_WAIT, "default"
 
 
 KNOWN_FLAKE_PATTERNS = [
@@ -1646,7 +1659,7 @@ def _parse_github_repo(remote_url):
 
 
 def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
-                ci_timeout_source="default"):
+                ci_timeout_source="default", gemini_timeout_source="default"):
     """Main monitor loop — state-machine orchestrator (v9.1).
 
     Args:
@@ -1679,6 +1692,7 @@ def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
 
     logger.log("monitor", "START", pr=pr_number, resume=resume, pid=os.getpid())
     logger.log("monitor", "CI_TIMEOUT", ci_timeout_sec=CI_MAX_WAIT, source=ci_timeout_source)
+    logger.log("monitor", "GEMINI_TIMEOUT", gemini_timeout_sec=GEMINI_MAX_WAIT, source=gemini_timeout_source)
 
     ci_fix_rounds_used = 0
     triage_rounds_used = 0
@@ -2207,14 +2221,25 @@ def _step_ready(worktree, pr_number, logger, result):
             mark_step(result, "ready", "skipped")
             result["ready_skip_reasons"] = reasons
             write_result(worktree, result)
-            # Notify the user so they know the PR is still in draft.
-            # (Gemini review #3107696760 — use a message that explains why.)
-            msg = (f"PR #{pr_number} still in draft: "
-                   + ", ".join(reasons))
-            try:
-                run_notify(worktree, pr_number, logger, message=msg)
-            except Exception as e:  # noqa: BLE001
-                logger.log("ready", "NOTIFY_ERROR", error=str(e))
+            if "gemini_review_not_posted" in reasons:
+                # Gemini never posted within the poll window — fire the full
+                # escalation block (#1127/#1088): state marker + GitHub comment
+                # + label + platform notify so the operator sees a visible signal
+                # rather than a silent "ready=SKIPPED" with monitor COMPLETE.
+                _notify_terminal(
+                    worktree, pr_number, logger,
+                    f"PR #{pr_number}: gemini_review_not_posted",
+                )
+            else:
+                # Other gate failures (CI not green, unreplied comments) — basic
+                # toast only; no escalation label since the monitor can still
+                # recover those on a resume run.
+                msg = (f"PR #{pr_number} still in draft: "
+                       + ", ".join(reasons))
+                try:
+                    run_notify(worktree, pr_number, logger, message=msg)
+                except Exception as e:  # noqa: BLE001
+                    logger.log("ready", "NOTIFY_ERROR", error=str(e))
             return
 
         # Bug 4 / belt-and-suspenders: refuse rebase+ready-flip if the worktree
@@ -2321,11 +2346,18 @@ def main():
     parser.add_argument("--ci-timeout-sec", type=int, default=None,
                         help="CI polling timeout in seconds (default: 1800). "
                              "Env: PPDS_PR_MONITOR_CI_TIMEOUT. Flag takes precedence over env.")
+    parser.add_argument("--gemini-timeout-sec", type=int, default=None,
+                        help="Gemini review polling timeout in seconds (default: 1800). "
+                             "Env: PPDS_PR_MONITOR_GEMINI_TIMEOUT. Flag takes precedence over env.")
     args = parser.parse_args()
 
     global CI_MAX_WAIT
     ci_timeout_sec, ci_timeout_source = _resolve_ci_timeout_sec(args.ci_timeout_sec)
     CI_MAX_WAIT = ci_timeout_sec
+
+    global GEMINI_MAX_WAIT
+    gemini_timeout_sec, gemini_timeout_source = _resolve_gemini_timeout_sec(args.gemini_timeout_sec)
+    GEMINI_MAX_WAIT = gemini_timeout_sec
 
     worktree = str(Path(args.worktree).resolve())
 
@@ -2335,7 +2367,8 @@ def main():
         sys.exit(1)
 
     exit_code = run_monitor(worktree, args.pr, resume=args.resume, repo=args.repo,
-                            mode=args.mode, ci_timeout_source=ci_timeout_source)
+                            mode=args.mode, ci_timeout_source=ci_timeout_source,
+                            gemini_timeout_source=gemini_timeout_source)
     sys.exit(exit_code)
 
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -105,6 +105,7 @@ TERMINAL_STATES = (
     "stuck-uncommitted-triage",
     "stuck-dirty-worktree-on-ready-flip",
     "ci-timeout",
+    "gemini-timeout",
     "monitor-crash",
 )
 
@@ -210,7 +211,7 @@ class _GeminiTimeoutError(Exception):
 
     Propagated up to run_monitor to trigger the #1088 escalation block and
     return exit code 1, preventing _step_notify from firing a duplicate
-    notification after _notify_terminal already ran inside _step_ready.
+    notification after _notify_terminal runs in run_monitor's exception handler.
     """
 
 
@@ -2092,7 +2093,10 @@ def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
         logger.log("monitor", "ABORT", reason="gemini_review_not_posted")
         _notify_terminal(
             worktree, pr_number, logger,
-            f"PR #{pr_number}: gemini_review_not_posted",
+            _build_terminal_notification(
+                pr_number, "gemini-timeout", result,
+                ci_fix_rounds_used, triage_rounds_used, worktree
+            )
         )
         logger.close()
         return 1

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -510,6 +510,7 @@ class TestRepollCi:
              patch("pr_monitor.run_triage", return_value=[
                  {"id": 1, "action": "fixed", "description": "done", "commit": "abc"}
              ]), \
+             patch("pr_monitor._ready_flip_gates", return_value=(True, [])), \
              patch("pr_monitor.mark_pr_ready", return_value=True), \
              patch("pr_monitor.run_retro", return_value="done"), \
              patch("pr_monitor.run_notify"):
@@ -627,6 +628,7 @@ class TestResultJsonSchema:
 
         with patch("pr_monitor.poll_ci", return_value="pass"), \
              patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor._ready_flip_gates", return_value=(True, [])), \
              patch("pr_monitor.mark_pr_ready", return_value=True), \
              patch("pr_monitor.run_retro", return_value="done"), \
              patch("pr_monitor.run_notify"):
@@ -648,6 +650,7 @@ class TestResultJsonSchema:
 
         with patch("pr_monitor.poll_ci", return_value="pass"), \
              patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor._ready_flip_gates", return_value=(True, [])), \
              patch("pr_monitor.mark_pr_ready", return_value=True), \
              patch("pr_monitor.run_retro", return_value="done"), \
              patch("pr_monitor.run_notify"):
@@ -1009,7 +1012,7 @@ class TestReadyFlipGates:
         assert result["steps_completed"]["ready"]["status"] == "skipped"
 
     def test_ready_flip_skipped_when_no_gemini_review(self, tmp_path):
-        """No Gemini review means no flip and escalation block fires (#1127)."""
+        """No Gemini review raises _GeminiTimeoutError for escalation (#1127)."""
         wt = _make_worktree(tmp_path)
         logger = _make_logger(tmp_path)
         result = self._base_result(gemini_review_posted=False)
@@ -1017,16 +1020,14 @@ class TestReadyFlipGates:
         with patch("pr_monitor.get_unreplied_comments", return_value=[]), \
              patch("pr_monitor._rebase_source_branch") as mock_rebase, \
              patch("pr_monitor.mark_pr_ready") as mock_ready, \
-             patch("pr_monitor._notify_terminal") as mock_escalate, \
              patch("pr_monitor.run_notify") as mock_notify:
-            pr_monitor._step_ready(wt, 42, logger, result)
+            with pytest.raises(pr_monitor._GeminiTimeoutError):
+                pr_monitor._step_ready(wt, 42, logger, result)
 
         mock_rebase.assert_not_called()
         mock_ready.assert_not_called()
-        # Escalation fires for gemini_review_not_posted; basic notify does not.
-        mock_escalate.assert_called_once()
-        assert "gemini_review_not_posted" in mock_escalate.call_args[0][3]
         mock_notify.assert_not_called()
+        # State is written before the raise.
         assert result["steps_completed"]["ready"]["status"] == "skipped"
         assert "gemini_review_not_posted" in result["ready_skip_reasons"]
 

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -246,6 +246,37 @@ class TestCiTimeoutConfig:
         assert result == "pass"
 
 
+class TestGeminiTimeoutConfig:
+    """#1127: Gemini timeout is configurable via flag and env var."""
+
+    def test_default_is_1800(self):
+        """GEMINI_MAX_WAIT default is 1800 seconds (30 min)."""
+        assert pr_monitor.GEMINI_MAX_WAIT == 1800
+
+    def test_resolve_default_when_no_override(self):
+        """_resolve_gemini_timeout_sec returns (1800, 'default') with no flag or env."""
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_MONITOR_GEMINI_TIMEOUT"}
+        with patch.dict(os.environ, env, clear=True):
+            val, source = pr_monitor._resolve_gemini_timeout_sec(None)
+        assert val == 1800
+        assert source == "default"
+
+    def test_resolve_env_wins_over_default(self):
+        """_resolve_gemini_timeout_sec returns env value when flag is absent."""
+        with patch.dict(os.environ, {"PPDS_PR_MONITOR_GEMINI_TIMEOUT": "600"}):
+            val, source = pr_monitor._resolve_gemini_timeout_sec(None)
+        assert val == 600
+        assert source == "env"
+
+    def test_resolve_flag_wins_over_env(self):
+        """Flag value takes precedence over PPDS_PR_MONITOR_GEMINI_TIMEOUT env var."""
+        with patch.dict(os.environ, {"PPDS_PR_MONITOR_GEMINI_TIMEOUT": "600"}):
+            val, source = pr_monitor._resolve_gemini_timeout_sec(300)
+        assert val == 300
+        assert source == "flag"
+
+
 class TestTerminalNotifications:
     """Monitor fires run_notify on every terminal state (success + failures)."""
 
@@ -630,7 +661,7 @@ class TestResultJsonSchema:
 
 
 class TestGeminiTimeout:
-    """AC-126: Gemini polling stops after GEMINI_MAX_WAIT (5 min).
+    """AC-126: Gemini polling stops after GEMINI_MAX_WAIT (30 min, bumped from 5 per #1127).
 
     Updated for v1-prelaunch retro item #3: poll_gemini_comments now
     delegates to triage_common.poll_gemini_review which polls 3 endpoints.
@@ -978,7 +1009,7 @@ class TestReadyFlipGates:
         assert result["steps_completed"]["ready"]["status"] == "skipped"
 
     def test_ready_flip_skipped_when_no_gemini_review(self, tmp_path):
-        """No Gemini review means no flip."""
+        """No Gemini review means no flip and escalation block fires (#1127)."""
         wt = _make_worktree(tmp_path)
         logger = _make_logger(tmp_path)
         result = self._base_result(gemini_review_posted=False)
@@ -986,11 +1017,16 @@ class TestReadyFlipGates:
         with patch("pr_monitor.get_unreplied_comments", return_value=[]), \
              patch("pr_monitor._rebase_source_branch") as mock_rebase, \
              patch("pr_monitor.mark_pr_ready") as mock_ready, \
-             patch("pr_monitor.run_notify"):
+             patch("pr_monitor._notify_terminal") as mock_escalate, \
+             patch("pr_monitor.run_notify") as mock_notify:
             pr_monitor._step_ready(wt, 42, logger, result)
 
         mock_rebase.assert_not_called()
         mock_ready.assert_not_called()
+        # Escalation fires for gemini_review_not_posted; basic notify does not.
+        mock_escalate.assert_called_once()
+        assert "gemini_review_not_posted" in mock_escalate.call_args[0][3]
+        mock_notify.assert_not_called()
         assert result["steps_completed"]["ready"]["status"] == "skipped"
         assert "gemini_review_not_posted" in result["ready_skip_reasons"]
 


### PR DESCRIPTION
## Summary

- **Option A**: Bumps `GEMINI_MAX_WAIT` from 300→1800s (30 min). Adds `--gemini-timeout-sec` flag and `PPDS_PR_MONITOR_GEMINI_TIMEOUT` env var with flag > env > default precedence, mirroring the `--ci-timeout-sec` pattern from #1089.
- **Option B**: On `gemini_review_not_posted` timeout, raises `_GeminiTimeoutError` (new exception class, propagated from `_step_ready` via the re-raise tuple). `run_monitor`'s except block fires the #1088 escalation block (state marker + GitHub comment + label + platform notify) and returns exit 1 — preventing the silent `SKIPPED_GATES / COMPLETE` path that was leaving PRs in draft indefinitely.
- Self-review caught a double-notification defect: `_notify_terminal` (called inside `_step_ready`) already fires `run_notify`, so `_step_notify` would have issued a second toast. The exception-based approach avoids this by never reaching Phase E's notify step.

## Test plan

- [ ] `tests/test_pr_monitor.py` — 122 passed, 14 skipped (no regressions)
- [ ] `TestGeminiTimeoutConfig` — new class: default=1800, env/flag precedence (4 tests)
- [ ] `test_ready_flip_skipped_when_no_gemini_review` — updated: asserts `_GeminiTimeoutError` raised, result written before raise
- [ ] Two integration-style tests updated to add `_ready_flip_gates` mock (their concern is CI re-poll / result schema, not the gate)
- [ ] AC verification for `fix-1122-subagent-hang.md` — 5/5 pass
- [ ] Enforcement audit — 7 T1 markers, all wired
- [ ] Shakedown gate — exit 0, 6s

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)