### PR TITLE
feat(workflow): supervisor pattern — goal_supervisor.py + /orchestrate skill

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: orchestrate
+description: Spawn N PR-stack workers from a pre-validated stack envelope, monitor them silently, and escalate only when a worker is blocked or fails. Use when a PR-stack JSON exists at .plans/<date>-<name>-stack.json and you want to run all entries in parallel without baby-sitting them. Workers are durable — supervisor crash does not prevent individual PRs from shipping.
+---
+
+# Orchestrate
+
+Drive an N-worker PR-stack run via `scripts/goal_supervisor.py`. The supervisor is a best-effort aggregation layer — workers ship PRs independently via `pipeline.py` + `pr_monitor.py`, so loss of the supervisor never blocks an individual PR notification.
+
+## When to Use
+
+Operator types `/orchestrate <path-to-stack-json>` after `/design` has produced a PR-stack envelope and the operator has reviewed the entries. Skip this skill for single-PR work; use `/implement` directly.
+
+## Process
+
+### Step 0: Readiness Gate
+
+```bash
+python scripts/supervisor_msg.py read --consume
+```
+
+Handle inbox kinds per `.claude/interaction-patterns.md`:
+- `abort` → stop, summarize reason, terminate.
+- `revise` → apply feedback before continuing.
+- `approve` / `note` / empty → proceed.
+
+```bash
+python scripts/workflow-state.py set phase orchestrating
+```
+
+### Step 1: Spawn Workers
+
+```bash
+python scripts/goal_supervisor.py spawn <stack-json-path>
+```
+
+The `spawn` subcommand:
+- Validates the stack envelope via `pr_stack.validate_envelope` — rejects wrong major version, missing fields, cycles.
+- Creates a worktree per entry under `.worktrees/<branch_suffix>/` via `scripts/worktree-create.py`.
+- Builds a worker prompt per entry from `WORKER_PROMPT_TEMPLATE` (pre-approved plan, skip `/design`, run `pipeline.py --spec --plan`, then launch `pr_monitor.py` in the background, then terminate after reading `.workflow/pr-monitor-result.json`).
+- Spawns each worker via `scripts/start-bg-spawn.py --permission-mode bypassPermissions --model sonnet`.
+- Delivers an initial inbox `note` to each worker via `scripts/supervisor_msg.py send`.
+- Persists `<supervisor_worktree>/.workflow/goal-envelope.json` (schema_version `1.1`) with each entry initialized to `goal_state="spawned"`.
+
+Stdout is one-line summary JSON `{"spawned": N, "envelope": "<path>", "entries": [...]}`. Progress and errors go to stderr (Constitution I1).
+
+Display a table to the operator: entry ID | title | worktree | session short | status.
+
+### Step 2: Schedule First Poll
+
+```
+ScheduleWakeup(delaySeconds=270, prompt=<poll-prompt-below>)
+```
+
+**270s is intentional** — the Anthropic prompt cache TTL is 300s. Polling every 270s keeps the supervisor's context cache warm; polling at 300s+ pays the cache-miss cost every cycle.
+
+**Poll prompt** (pass verbatim each wakeup so the loop survives compaction):
+
+```
+Supervisor poll: python scripts/goal_supervisor.py poll
+Read the JSON output and act:
+  - "all_merged" → PushNotification("All PRs merged: <summary>") and stop.
+  - "escalated" → PushNotification("Blocked worker: <entry_id>: <needs>")
+                   gh issue comment <issue_number> -b "<escalation text>"
+                   ScheduleWakeup(270s) to keep monitoring unblocked workers.
+  - "polling" → ScheduleWakeup(270s) with this same prompt.
+```
+
+### Step 3: Notification Behavior
+
+| Trigger | Action |
+|---------|--------|
+| `goal_state=all_merged` | `PushNotification(title="Supervisor: all merged", body="N PRs merged for <spec>")` then terminate the polling loop |
+| Entry `goal_state=blocked` | `PushNotification(title="Supervisor: worker blocked", body="<entry_id>: <blocked_needs>")` + `gh issue comment <issue_number> -b "<escalation text>"` + continue polling |
+| Entry `goal_state=error` | `PushNotification(title="Supervisor: worker error", body="<entry_id> session failed")` + continue polling |
+
+## Single-Signal Escalation Rule
+
+Escalation fires when **both** conditions hold simultaneously:
+- `state=blocked` (from the worker's `~/.claude/jobs/<short>/state.json`)
+- `needs != ""` (non-empty after `.strip()`)
+
+Empty `needs` (transient daemon flip) does NOT escalate. This mirrors `BgHandle.wait()` semantics in `claude_dispatch.py` and is the single contract between supervisor and worker — no other state combination triggers escalation.
+
+## Crash Tolerance
+
+The supervisor is best-effort and never load-bearing:
+
+1. **Workers are independent.** Each runs `pipeline.py` end-to-end in its own worktree. Loss of the supervisor does not stop any worker.
+2. **`pr_monitor` is the durable signal.** Each worker launches `scripts/pr_monitor.py` in the background after `pipeline.py` exits successfully. `pr_monitor` sends a `PushNotification` on PR merge regardless of supervisor health — the operator receives per-PR notifications even when the supervisor has crashed.
+3. **Resumption is best-effort.** The supervisor session ID is recorded in `goal-envelope.json` (`supervisor_session_id`). Operator may resume via `claude --resume <id>`; `ScheduleWakeup` re-fires on resume. No automatic resurrection.
+
+The supervisor adds aggregation value (single "all merged" notification, single "X blocked" escalation) but its absence does not block individual PRs from shipping or individual notifications from firing.
+
+## Termination
+
+The supervisor terminates the polling loop in exactly one case: `goal_state=all_merged`. Send the final `PushNotification("All PRs merged: ...")` and do not call `ScheduleWakeup` again. Escalated and polling states both keep the loop alive — the operator is expected to intervene on blocked workers while merged workers continue to ship.
+
+## Files
+
+- `scripts/goal_supervisor.py` — `spawn` / `poll` subcommands
+- `scripts/supervisor_msg.py` — inbox primitive (Supervisor → Worker `note`)
+- `scripts/start-bg-spawn.py` — worker spawn via `claude --bg`
+- `scripts/worktree-create.py` — per-entry worktree creation
+- `<supervisor_worktree>/.workflow/goal-envelope.json` — runtime state (v1.1)

--- a/.retros/summary.json
+++ b/.retros/summary.json
@@ -1,13 +1,18 @@
 {
   "schema_version": 1,
   "last_updated": "2026-05-16",
-  "total_retros": 19,
+  "total_retros": 21,
   "findings_by_category": {
     "external": [
       {
         "date": "2026-03-27",
         "branch": "feat/investigation-skill",
         "finding_id": "R-01"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1069-supervisor-pattern",
+        "finding_id": "F4"
       }
     ],
     "tooling": [
@@ -160,6 +165,21 @@
         "date": "2026-05-16",
         "branch": "feat/1098-prompt-template",
         "finding_id": "R-04"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1069-supervisor-pattern",
+        "finding_id": "F1"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1069-supervisor-pattern",
+        "finding_id": "F2"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1069-supervisor-pattern",
+        "finding_id": "F5"
       }
     ],
     "design": [
@@ -244,6 +264,11 @@
         "date": "2026-04-26",
         "branch": "feat/workflow-skill-redesign",
         "finding_id": "R-03"
+      },
+      {
+        "date": "2026-05-16",
+        "branch": "feat/1069-supervisor-pattern",
+        "finding_id": "F3"
       }
     ],
     "process": [
@@ -427,5 +452,12 @@
     "last_session_status": "rough",
     "last_session_branch": "fix/1122-subagent-hang",
     "last_session_pr": null
-  }
+  },
+  "notes": [
+    {
+      "date": "2026-05-16",
+      "branch": "feat/1069-supervisor-pattern",
+      "note": "Second consecutive failure-retro for the same root cause: gates verdict PASS + state.json gates.passed land correctly, but exit=-1 from STALL_TIMEOUT causes pipeline to misclassify the stage as failed. F1/F2 still open from prior retro at 10:36."
+    }
+  ]
 }

--- a/scripts/goal_supervisor.py
+++ b/scripts/goal_supervisor.py
@@ -536,7 +536,7 @@ def _evaluate_entry(
                 entry["goal_state"] = "error"
                 entry["error"] = "haiku predicate parse failure"
                 return
-            if verdict in VALID_ENTRY_GOAL_STATES:
+            if verdict in ("blocked", "working", "error"):
                 entry["goal_state"] = verdict
             elif verdict == "done":
                 # Haiku said done but no PR — treat as error.

--- a/scripts/goal_supervisor.py
+++ b/scripts/goal_supervisor.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Goal supervisor — spawn N PR-stack workers and poll their states.
+
+See specs/feat-1069-supervisor-pattern.md.
+
+The supervisor is best-effort: workers run pipeline.py end-to-end on their
+own and pr_monitor delivers the per-PR notification independently. The
+supervisor adds aggregate notification and silent monitoring on top of that
+durable substrate — its absence does not block individual PRs from
+shipping.
+
+Public API:
+    DEFAULT_POLL_INTERVAL: int        # seconds (270 — cache-warm)
+    SCHEMA_VERSION: str               # "1.1"
+    WORKER_PROMPT_TEMPLATE: str
+    HAIKU_PREDICATE_TEMPLATE: str
+    build_envelope_v11(stack_envelope, *, supervisor_worktree,
+                       poll_interval=DEFAULT_POLL_INTERVAL) -> dict
+    render_worker_prompt(entry, *, spec) -> str
+    render_haiku_prompt(*, entry_id, title, session_state, workflow_phase,
+                        pr_url, pr_state) -> str
+    spawn(stack_path, *, supervisor_worktree, poll_interval=270,
+          repo_root=None, subprocess_runner=None,
+          inbox_sender=None) -> dict
+    poll(*, supervisor_worktree, jobs_dir=None,
+         workflow_state_reader=None, gh_runner=None, haiku_runner=None,
+         clock=None) -> dict
+
+CLI:
+    python scripts/goal_supervisor.py spawn <stack-json-path>
+        [--supervisor-worktree <abs-path>] [--poll-interval <sec>]
+    python scripts/goal_supervisor.py poll
+        [--worktree <abs-path>]
+
+Constitution: I1 — stdout is JSON-only; progress, errors → stderr.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# Sibling-script imports (conftest.py and start-bg-spawn.py both prepend
+# scripts/ to sys.path; do the same here so direct CLI invocation works).
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import pr_stack  # noqa: E402  (validate_envelope accepts any "1." prefix)
+import supervisor_msg  # noqa: E402
+
+# claude_dispatch is imported lazily inside _default_haiku_runner so the
+# CLI smoke and most tests do not require its (heavier) module init.
+
+SCHEMA_VERSION = "1.1"
+DEFAULT_POLL_INTERVAL = 270
+JOBS_DIR = Path(os.path.expanduser("~/.claude/jobs"))
+
+ENVELOPE_RELATIVE_PATH = Path(".workflow") / "goal-envelope.json"
+
+VALID_ENTRY_GOAL_STATES = (
+    "pending",
+    "spawned",
+    "working",
+    "blocked",
+    "merged",
+    "error",
+)
+
+VALID_OVERALL_GOAL_STATES = (
+    "spawning",
+    "polling",
+    "all_merged",
+    "escalated",
+    "error",
+)
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+WORKER_PROMPT_TEMPLATE = """\
+Task brief — PR stack worker
+Entry: {id} — {title}
+Worktree: {worktree_path}
+Spec: {spec}
+Plan: {plan}
+Branch: feat/{branch_suffix}
+Issues: {issue_numbers}
+
+You are running in headless mode via the goal supervisor. Do not ask
+clarifying questions — make reasonable decisions and proceed.
+
+Workflow contract:
+1. Read CLAUDE.md, specs/CONSTITUTION.md, .claude/interaction-patterns.md.
+2. This worker has a pre-approved plan ({plan}). Skip /design.
+   Run `python scripts/pipeline.py --spec {spec} --plan {plan}` directly.
+   On failure: python scripts/pipeline.py --resume (or --from <stage>).
+3. After `python scripts/pipeline.py` exits successfully (pipeline includes
+   /pr internally): launch pr_monitor via Bash run_in_background=true:
+     python scripts/pr_monitor.py --worktree {worktree_path} --pr <PR-number>
+   Claude Code will re-engage you when pr_monitor exits.
+4. At re-engagement: read .workflow/pr-monitor-result.json and produce a final
+   summary covering actual PR state (ready / merged / escalated / error /
+   blocked). Terminate.
+
+Supervisor note (read first, before any other action):
+  python scripts/supervisor_msg.py read --consume
+Goal context: {title}. Plan at {plan}. Implement and ship — no design phase needed.
+"""
+
+HAIKU_PREDICATE_TEMPLATE = """\
+You are a one-turn evaluator. Assess this PR worker's completion state.
+
+Context:
+  entry_id: {entry_id}
+  title: {title}
+  session_state: {session_state}
+  workflow_phase: {workflow_phase}
+  pr_url: {pr_url}
+  pr_state: {pr_state}
+
+"session_state=done" means the Claude session exited. If pr_url is set and pr_state
+is MERGED, the worker is definitely done. If session_state=done but no pr_url exists,
+something likely went wrong.
+
+Reply with EXACTLY this JSON and nothing else:
+{{"verdict": "done|blocked|working|error", "confidence": "high|low", "reason": "<one sentence>"}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_worker_prompt(entry: dict, *, spec: str) -> str:
+    """Render the worker prompt for one stack entry.
+
+    Missing optional fields (issue_numbers) are rendered as an empty string
+    rather than KeyError, so tests with minimal entries succeed.
+    """
+    issue_numbers = entry.get("issue_numbers") or ""
+    if isinstance(issue_numbers, list):
+        issue_numbers = ", ".join(str(x) for x in issue_numbers)
+    return WORKER_PROMPT_TEMPLATE.format(
+        id=entry["id"],
+        title=entry["title"],
+        worktree_path=entry["worktree_path"],
+        spec=spec,
+        plan=entry["plan"],
+        branch_suffix=entry["branch_suffix"],
+        issue_numbers=issue_numbers,
+    )
+
+
+def render_haiku_prompt(
+    *,
+    entry_id: str,
+    title: str,
+    session_state: str,
+    workflow_phase: str,
+    pr_url: str,
+    pr_state: str,
+) -> str:
+    return HAIKU_PREDICATE_TEMPLATE.format(
+        entry_id=entry_id,
+        title=title,
+        session_state=session_state,
+        workflow_phase=workflow_phase,
+        pr_url=pr_url,
+        pr_state=pr_state,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Envelope construction
+# ---------------------------------------------------------------------------
+
+def build_envelope_v11(
+    stack_envelope: dict,
+    *,
+    supervisor_worktree: str,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    supervisor_session_id: str = "",
+) -> dict:
+    """Return a deep-merged v1.1 envelope ready for disk.
+
+    The input stack_envelope is expected to be a validated #1070-α envelope.
+    We bump schema_version to 1.1, add the runtime-state envelope fields,
+    and initialize each stack entry with goal_state="pending".
+    """
+    envelope: dict = json.loads(json.dumps(stack_envelope))  # cheap deep copy
+    envelope["schema_version"] = SCHEMA_VERSION
+    envelope["supervisor_worktree"] = str(supervisor_worktree)
+    envelope["goal_poll_interval_sec"] = int(poll_interval)
+    envelope["supervisor_session_id"] = supervisor_session_id
+    envelope["goal_state"] = "spawning"
+
+    for entry in envelope["stack"]:
+        entry.setdefault("goal_state", "pending")
+    return envelope
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers (injectable for tests)
+# ---------------------------------------------------------------------------
+
+def _default_subprocess_runner(cmd: list, *, cwd: Optional[str] = None,
+                               timeout: Optional[int] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _default_inbox_sender(worktree_path: str, message: str) -> None:
+    supervisor_msg.send(worktree_path, "note", message=message)
+
+
+def _default_gh_runner(pr_number: int) -> Optional[str]:
+    """Return PR state string (OPEN/MERGED/CLOSED) or None on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", str(pr_number),
+             "--json", "state", "--jq", ".state"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = (proc.stdout or "").strip()
+    return out or None
+
+
+def _default_haiku_runner(prompt: str) -> str:
+    """Return Haiku stdout (expected to be one-line JSON)."""
+    import claude_dispatch  # local — avoid hard dep at import time
+    handle = claude_dispatch.spawn(
+        mode="headless",
+        prompt=prompt,
+        caller="goal_supervisor",
+        model="haiku",
+    )
+    # HeadlessHandle.wait() returns exit code; output() returns stdout text.
+    handle.wait(timeout=120)
+    return handle.output() or ""
+
+
+def _default_workflow_state_reader(worktree_path: str) -> dict:
+    """Read <worktree>/.workflow/state.json — return {} on missing/invalid."""
+    p = Path(worktree_path) / ".workflow" / "state.json"
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _read_job_state(short: str, jobs_dir: Path) -> dict:
+    """Read ~/.claude/jobs/<short>/state.json — return {} on missing."""
+    p = jobs_dir / short / "state.json"
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# spawn
+# ---------------------------------------------------------------------------
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8",
+        dir=str(path.parent), suffix=".tmp", delete=False,
+    )
+    try:
+        json.dump(data, tmp, indent=2)
+        tmp.write("\n")
+        tmp.flush()
+        tmp.close()
+        os.replace(tmp.name, path)
+    except Exception:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+
+
+def _spawn_one_entry(
+    entry: dict,
+    *,
+    spec: str,
+    repo_root: str,
+    subprocess_runner: Callable,
+    inbox_sender: Callable,
+) -> None:
+    """Mutate entry in-place: create worktree, spawn worker, record fields.
+
+    On any failure, sets entry["goal_state"]="error" and entry["error"] with
+    the failure message; writes a stderr line. Always returns None.
+    """
+    branch_suffix = entry["branch_suffix"]
+    branch = f"feat/{branch_suffix}"
+
+    # 1. Create the worktree.
+    create_cmd = [
+        sys.executable, "scripts/worktree-create.py",
+        "--name", branch_suffix,
+        "--branch", branch,
+    ]
+    cp = subprocess_runner(create_cmd, cwd=repo_root, timeout=120)
+    if cp.returncode != 0:
+        msg = f"worktree-create failed for {entry['id']}: {(cp.stderr or '').strip()}"
+        print(msg, file=sys.stderr)
+        entry["goal_state"] = "error"
+        entry["error"] = msg
+        return
+
+    worktree_abs = os.path.abspath(os.path.join(repo_root, ".worktrees", branch_suffix))
+    entry["worktree_path"] = worktree_abs
+
+    # 2. Render the worker prompt and write to a temp file.
+    prompt_text = render_worker_prompt(entry, spec=spec)
+    prompt_dir = Path(repo_root) / ".workflow"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = None
+    try:
+        tf = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8",
+            dir=str(prompt_dir), prefix=f"worker-prompt-{branch_suffix}-",
+            suffix=".txt", delete=False,
+        )
+        tf.write(prompt_text)
+        tf.flush()
+        tf.close()
+        prompt_file = Path(tf.name)
+
+        # 3. Spawn the worker.
+        spawn_cmd = [
+            sys.executable, "scripts/start-bg-spawn.py",
+            "--worktree-abs", worktree_abs,
+            "--branch", branch,
+            "--prompt-file", str(prompt_file),
+            "--permission-mode", "bypassPermissions",
+            "--model", "sonnet",
+        ]
+        cp = subprocess_runner(spawn_cmd, cwd=repo_root, timeout=120)
+        if cp.returncode != 0:
+            msg = f"start-bg-spawn failed for {entry['id']}: {(cp.stderr or '').strip()}"
+            print(msg, file=sys.stderr)
+            entry["goal_state"] = "error"
+            entry["error"] = msg
+            return
+
+        try:
+            spawn_result = json.loads((cp.stdout or "").strip().splitlines()[-1])
+        except (json.JSONDecodeError, IndexError) as exc:
+            msg = f"start-bg-spawn output not JSON for {entry['id']}: {exc}"
+            print(msg, file=sys.stderr)
+            entry["goal_state"] = "error"
+            entry["error"] = msg
+            return
+
+        entry["session_short"] = spawn_result.get("short", "")
+        entry["session_id"] = spawn_result.get("sessionId", "")
+        entry["spawned_at"] = datetime.now(timezone.utc).isoformat()
+        entry["goal_state"] = "spawned"
+
+        # 4. Deliver the inbox note.
+        try:
+            inbox_sender(
+                worktree_abs,
+                f"Goal context: {entry['title']}. Plan at {entry['plan']}. "
+                f"Implement and ship — no design phase needed.",
+            )
+        except Exception as exc:  # noqa: BLE001 — surface but don't undo spawn
+            print(f"inbox note failed for {entry['id']}: {exc}", file=sys.stderr)
+    finally:
+        if prompt_file is not None and prompt_file.exists():
+            try:
+                prompt_file.unlink()
+            except OSError:
+                pass
+
+
+def spawn(
+    stack_path: str,
+    *,
+    supervisor_worktree: str,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    repo_root: Optional[str] = None,
+    subprocess_runner: Optional[Callable] = None,
+    inbox_sender: Optional[Callable] = None,
+) -> dict:
+    """Spawn N workers from stack.json, persist envelope, return summary.
+
+    Returns: {"spawned": N, "envelope": "<abs-path>", "entries": [...]}.
+    The summary is returned (not just printed) so callers and tests can
+    introspect without parsing stdout.
+    """
+    runner = subprocess_runner or _default_subprocess_runner
+    sender = inbox_sender or _default_inbox_sender
+
+    try:
+        stack_envelope = json.loads(Path(stack_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise FileNotFoundError(f"stack.json not readable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"stack.json invalid JSON: {exc}") from exc
+
+    # Reject obvious wrong-major envelopes before validate_envelope (which
+    # already enforces the "1." prefix) so we can produce a tailored AC-03
+    # error message.
+    sv = stack_envelope.get("schema_version")
+    if isinstance(sv, str) and not sv.startswith("1."):
+        raise ValueError(f"unsupported schema_version major: {sv!r}")
+
+    pr_stack.validate_envelope(stack_envelope)
+
+    if repo_root is None:
+        repo_root = str(Path(supervisor_worktree).resolve())
+
+    envelope = build_envelope_v11(
+        stack_envelope,
+        supervisor_worktree=supervisor_worktree,
+        poll_interval=poll_interval,
+    )
+
+    spec = envelope["spec"]
+    for entry in envelope["stack"]:
+        _spawn_one_entry(
+            entry,
+            spec=spec,
+            repo_root=repo_root,
+            subprocess_runner=runner,
+            inbox_sender=sender,
+        )
+
+    out_path = Path(supervisor_worktree) / ENVELOPE_RELATIVE_PATH
+    _atomic_write_json(out_path, envelope)
+
+    spawned_count = sum(1 for e in envelope["stack"] if e.get("goal_state") == "spawned")
+    return {
+        "spawned": spawned_count,
+        "envelope": str(out_path),
+        "entries": envelope["stack"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# poll
+# ---------------------------------------------------------------------------
+
+def _evaluate_entry(
+    entry: dict,
+    *,
+    jobs_dir: Path,
+    workflow_state_reader: Callable,
+    gh_runner: Callable,
+    haiku_runner: Callable,
+    now_iso: str,
+) -> None:
+    """Mutate entry in-place from the latest state snapshots."""
+    if entry.get("goal_state") == "merged":
+        return
+
+    short = entry.get("session_short", "")
+    job_state_data = _read_job_state(short, jobs_dir) if short else {}
+    session_state = (job_state_data.get("state") or "").strip()
+    needs = (job_state_data.get("needs") or "").strip()
+
+    workflow_data = workflow_state_reader(entry.get("worktree_path", "")) or {}
+    pr_url = workflow_data.get("pr", {}).get("url") if isinstance(workflow_data.get("pr"), dict) else workflow_data.get("pr_url")
+    pr_url = pr_url or ""
+    pr_number = entry.get("pr_number")
+    if pr_number is None:
+        pr_number = workflow_data.get("pr", {}).get("number") if isinstance(workflow_data.get("pr"), dict) else workflow_data.get("pr_number")
+    if pr_number is not None:
+        entry["pr_number"] = pr_number
+    if pr_url and not entry.get("pr_url"):
+        entry["pr_url"] = pr_url
+
+    entry["last_polled_at"] = now_iso
+
+    if session_state == "blocked" and needs:
+        entry["goal_state"] = "blocked"
+        entry["blocked_needs"] = needs
+        return
+
+    if session_state == "error":
+        entry["goal_state"] = "error"
+        return
+
+    if (session_state == "done") or entry.get("pr_url"):
+        pr_state = None
+        if entry.get("pr_number") is not None:
+            pr_state = gh_runner(int(entry["pr_number"]))
+        if pr_state:
+            entry["pr_state"] = pr_state
+            if pr_state == "MERGED":
+                entry["goal_state"] = "merged"
+                entry["merged_at"] = now_iso
+                return
+
+        if session_state == "done" and not entry.get("pr_url"):
+            # Ambiguous — ask Haiku.
+            prompt = render_haiku_prompt(
+                entry_id=entry.get("id", ""),
+                title=entry.get("title", ""),
+                session_state=session_state,
+                workflow_phase=str(workflow_data.get("phase") or ""),
+                pr_url=str(entry.get("pr_url") or ""),
+                pr_state=str(entry.get("pr_state") or ""),
+            )
+            try:
+                raw = haiku_runner(prompt) or ""
+                verdict_doc = json.loads(raw.strip())
+                verdict = str(verdict_doc.get("verdict") or "").lower()
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                entry["goal_state"] = "error"
+                entry["error"] = "haiku predicate parse failure"
+                return
+            if verdict in VALID_ENTRY_GOAL_STATES:
+                entry["goal_state"] = verdict
+            elif verdict == "done":
+                # Haiku said done but no PR — treat as error.
+                entry["goal_state"] = "error"
+                entry["error"] = "haiku verdict=done but no PR url"
+            else:
+                entry["goal_state"] = "error"
+                entry["error"] = f"haiku verdict unrecognized: {verdict!r}"
+            return
+
+        # session not done; pr_url present but not merged — keep working
+        entry["goal_state"] = "working"
+        return
+
+    if session_state in ("working", "done"):
+        entry["goal_state"] = "working"
+        return
+
+    # No usable session state — keep prior (or "spawned")
+    entry.setdefault("goal_state", "spawned")
+
+
+def _compute_overall_state(entries: list) -> str:
+    if all(e.get("goal_state") == "merged" for e in entries):
+        return "all_merged"
+    if any(e.get("goal_state") in ("blocked", "error") for e in entries):
+        return "escalated"
+    return "polling"
+
+
+def poll(
+    *,
+    supervisor_worktree: str,
+    jobs_dir: Optional[Path] = None,
+    workflow_state_reader: Optional[Callable] = None,
+    gh_runner: Optional[Callable] = None,
+    haiku_runner: Optional[Callable] = None,
+    clock: Optional[Callable[[], str]] = None,
+) -> dict:
+    """Re-read envelope, update entries, write back, return verdict dict."""
+    jobs_dir = jobs_dir or JOBS_DIR
+    workflow_state_reader = workflow_state_reader or _default_workflow_state_reader
+    gh_runner = gh_runner or _default_gh_runner
+    haiku_runner = haiku_runner or _default_haiku_runner
+    clock = clock or (lambda: datetime.now(timezone.utc).isoformat())
+
+    env_path = Path(supervisor_worktree) / ENVELOPE_RELATIVE_PATH
+    envelope = json.loads(env_path.read_text(encoding="utf-8"))
+
+    now_iso = clock()
+    for entry in envelope["stack"]:
+        _evaluate_entry(
+            entry,
+            jobs_dir=jobs_dir,
+            workflow_state_reader=workflow_state_reader,
+            gh_runner=gh_runner,
+            haiku_runner=haiku_runner,
+            now_iso=now_iso,
+        )
+
+    envelope["goal_state"] = _compute_overall_state(envelope["stack"])
+    _atomic_write_json(env_path, envelope)
+
+    verdict = {
+        "goal_state": envelope["goal_state"],
+        "entries": envelope["stack"],
+    }
+    return verdict
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _resolve_supervisor_worktree(arg: Optional[str]) -> str:
+    if arg:
+        return str(Path(arg).resolve())
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if proc.returncode == 0:
+            return proc.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return str(Path.cwd().resolve())
+
+
+def _cmd_spawn(args: argparse.Namespace) -> int:
+    supervisor_worktree = _resolve_supervisor_worktree(args.supervisor_worktree)
+    print(
+        f"goal_supervisor: spawn stack={args.stack_path} "
+        f"supervisor_worktree={supervisor_worktree} "
+        f"poll_interval={args.poll_interval}",
+        file=sys.stderr,
+    )
+    try:
+        summary = spawn(
+            args.stack_path,
+            supervisor_worktree=supervisor_worktree,
+            poll_interval=args.poll_interval,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"goal_supervisor: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump(summary, sys.stdout)
+    sys.stdout.write("\n")
+    if summary["spawned"] != len(summary["entries"]):
+        return 1
+    return 0
+
+
+def _cmd_poll(args: argparse.Namespace) -> int:
+    supervisor_worktree = _resolve_supervisor_worktree(args.worktree)
+    print(
+        f"goal_supervisor: poll supervisor_worktree={supervisor_worktree}",
+        file=sys.stderr,
+    )
+    try:
+        verdict = poll(supervisor_worktree=supervisor_worktree)
+    except (FileNotFoundError, OSError, json.JSONDecodeError) as exc:
+        print(f"goal_supervisor: {exc}", file=sys.stderr)
+        return 0  # spec §poll #6 — always exit 0; callers parse JSON
+    json.dump(verdict, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="goal_supervisor",
+        description="Goal supervisor for PR-stack workers (#1069).",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("spawn", help="Spawn N workers from stack.json")
+    sp.add_argument("stack_path")
+    sp.add_argument("--supervisor-worktree", default=None)
+    sp.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL)
+    sp.set_defaults(func=_cmd_spawn)
+
+    pl = sub.add_parser("poll", help="Poll worker states; print verdict JSON")
+    pl.add_argument("--worktree", default=None)
+    pl.set_defaults(func=_cmd_poll)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/goal_supervisor.py
+++ b/scripts/goal_supervisor.py
@@ -217,8 +217,10 @@ def _default_subprocess_runner(cmd: list, *, cwd: Optional[str] = None,
         cmd,
         cwd=cwd,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
+        check=True,
     )
 
 
@@ -230,13 +232,15 @@ def _default_gh_runner(pr_number: int) -> Optional[str]:
     """Return PR state string (OPEN/MERGED/CLOSED) or None on failure."""
     try:
         proc = subprocess.run(
-            ["gh", "pr", "view", str(pr_number),
+            ["gh", "pr", "view", "--", str(pr_number),
              "--json", "state", "--jq", ".state"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=True,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    if proc.returncode != 0:
+    except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
         return None
     out = (proc.stdout or "").strip()
     return out or None
@@ -245,15 +249,29 @@ def _default_gh_runner(pr_number: int) -> Optional[str]:
 def _default_haiku_runner(prompt: str) -> str:
     """Return Haiku stdout (expected to be one-line JSON)."""
     import claude_dispatch  # local — avoid hard dep at import time
-    handle = claude_dispatch.spawn(
-        mode="headless",
-        prompt=prompt,
-        caller="goal_supervisor",
-        model="haiku",
-    )
-    # HeadlessHandle.wait() returns exit code; output() returns stdout text.
-    handle.wait(timeout=120)
-    return handle.output() or ""
+    # Headless mode requires a stage_log path for the transcript.
+    tf = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+    log_path = tf.name
+    tf.close()
+    try:
+        handle = claude_dispatch.spawn(
+            mode="headless",
+            prompt=prompt,
+            caller="goal_supervisor",
+            model="haiku",
+            stage_log=log_path,
+        )
+        # HeadlessHandle.wait() returns exit code; output() returns stdout text.
+        handle.wait(timeout=120)
+        return handle.output() or ""
+    except Exception:
+        return ""
+    finally:
+        if os.path.exists(log_path):
+            try:
+                os.unlink(log_path)
+            except OSError:
+                pass
 
 
 def _default_workflow_state_reader(worktree_path: str) -> dict:
@@ -616,12 +634,15 @@ def _resolve_supervisor_worktree(arg: Optional[str]) -> str:
         return str(Path(arg).resolve())
     try:
         proc = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=5,
+            ["git", "-c", "core.quotePath=off", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=True,
         )
-        if proc.returncode == 0:
-            return proc.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return proc.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.CalledProcessError):
         pass
     return str(Path.cwd().resolve())
 

--- a/specs/feat-1069-supervisor-pattern.md
+++ b/specs/feat-1069-supervisor-pattern.md
@@ -1,0 +1,372 @@
+# Supervisor Pattern
+
+**Status:** Draft
+**Last Updated:** 2026-05-16
+**Code:** [scripts/goal_supervisor.py](../scripts/goal_supervisor.py) | [.claude/skills/orchestrate/](../.claude/skills/orchestrate/)
+**Surfaces:** N/A (workflow tooling)
+**Verification:** `python -m pytest tests/scripts/test_goal_supervisor.py -q`
+**Verification Max Iterations:** 5
+
+---
+
+## Overview
+
+The supervisor pattern allows one Claude session (the _supervisor_) to spawn N independent worker sessions from a PR-stack envelope, monitor them silently, and escalate only when a worker is blocked or fails. Workers are durable: each runs `pipeline.py` independently and `pr_monitor` ships individual PRs regardless of supervisor health. The supervisor is a best-effort aggregation layer — not a load-bearing dependency.
+
+### Goals
+
+- **Silent monitoring**: supervisor polls workers on a 270s cache-warm interval, producing no noise when things go well.
+- **Single-signal escalation**: one clear trigger per worker — `state=blocked AND needs != ""` — fires a `PushNotification` and GitHub comment. No false positives.
+- **Worker durability**: workers run `pipeline.py` independently; supervisor crash does not prevent PRs from shipping or individual notifications from firing.
+- **Schema forward-compatibility**: goal-envelope.json is a v1.1 additive extension of the #1070-α PR-stack schema; `validate_envelope` in `pr_stack.py` accepts it without changes.
+
+### Non-Goals
+
+- Supervisor-of-supervisor (infinite regress). Session resumption is best-effort via `claude --resume`.
+- Automatic retry of failed workers (operator intervenes after escalation).
+- Cross-repo or cross-branch stacks.
+- Real-time streaming of worker transcripts.
+
+---
+
+## Architecture
+
+```
+Operator
+   │ /orchestrate .plans/<date>-<name>-stack.json
+   ▼
+Supervisor Claude session (background, ScheduleWakeup loop)
+   │  goal_supervisor.py spawn <stack-json>
+   │  creates .workflow/goal-envelope.json (v1.1)
+   │  delivers inbox "note" per worker via supervisor_msg.py
+   │  spawns N interactive bg workers via claude_dispatch.spawn
+   │
+   ├──▶ Worker A (claude --bg, worktree .worktrees/pr-<id-a>)
+   │      runs /implement → /gates → /verify → /pr
+   │      pipeline.py ships PR independently
+   │      pr_monitor sends individual PR notification
+   │
+   ├──▶ Worker B (claude --bg, worktree .worktrees/pr-<id-b>)
+   │      same independent pipeline
+   │
+   └── ScheduleWakeup(270s) → poll loop
+            goal_supervisor.py poll
+            reads per-worker: state.json + .workflow/state.json + gh pr view
+            ambiguous states → Haiku evaluator (headless)
+            goal_state=blocked → PushNotification + gh issue comment
+            goal_state=all_merged → PushNotification, terminate loop
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| `scripts/goal_supervisor.py` | `spawn` subcommand: creates goal-envelope.json + spawns N workers; `poll` subcommand: checks worker states + updates envelope + prints verdict JSON |
+| `.workflow/goal-envelope.json` | Runtime state file; v1.1 extension of pr_stack envelope; lives in supervisor's worktree |
+| `.claude/skills/orchestrate/SKILL.md` | `/orchestrate` skill: reads stack.json → calls spawn → ScheduleWakeup loop → escalation + notification |
+| `scripts/supervisor_msg.py` | Delivers initial "note" inbox message per worker (from #1114) |
+| `scripts/claude_dispatch.py` | Worker spawn via `spawn(mode="interactive", permission_mode="bypassPermissions")` |
+| Haiku evaluator | Single-turn headless `claude_dispatch.spawn(mode="headless")` for ambiguous states only |
+
+### Dependencies
+
+- Requires: [specs/dispatch-routing.md](./dispatch-routing.md) — `BlockedSessionError`, `BgHandle.poll()`, headless dispatch
+- Extends: [specs/feat-1070-pr-stack-alpha.md](./feat-1070-pr-stack-alpha.md) — pr_stack envelope v1.1 (additive fields, same validator)
+- Uses: [specs/goal-driven-implement.md](./goal-driven-implement.md) — goal-loop conventions; `run_until_green` pattern
+
+---
+
+## Specification
+
+### goal-envelope.json Schema (v1.1)
+
+The goal-envelope.json is a superset of the #1070-α PR-stack envelope. All existing fields (`schema_version`, `spec`, `created_at`, `stack`, `justification`) are unchanged. The `schema_version` is bumped to `"1.1"` when writing. `validate_envelope` from `pr_stack.py` already accepts any `"1."` prefix, so no changes to the validator are required.
+
+**New envelope-level optional fields** (runtime state):
+
+```json
+{
+  "schema_version": "1.1",
+  "spec": "specs/...",
+  "created_at": "<ISO-8601>",
+  "stack": [ ... ],
+  "supervisor_session_id": "<uuid>",
+  "supervisor_worktree": "/abs/path/to/supervisor/worktree",
+  "goal_poll_interval_sec": 270,
+  "goal_state": "spawning | polling | all_merged | escalated | error"
+}
+```
+
+**New stack-entry optional fields** (runtime state per worker):
+
+```json
+{
+  "id": "pr-1",
+  "worktree_path": "/abs/path/.worktrees/pr-1",
+  "session_short": "a1b2c3d4",
+  "session_id": "<uuid>",
+  "spawned_at": "<ISO-8601>",
+  "goal_state": "pending | spawned | working | blocked | merged | error",
+  "blocked_needs": "<needs text when blocked>",
+  "pr_number": 1234,
+  "pr_url": "https://github.com/...",
+  "pr_state": "OPEN | MERGED | CLOSED",
+  "last_polled_at": "<ISO-8601>",
+  "merged_at": "<ISO-8601>"
+}
+```
+
+**Goal states (entry-level):**
+
+| State | Meaning |
+|-------|---------|
+| `pending` | Entry registered, worker not yet spawned |
+| `spawned` | `claude --bg` invoked, session starting |
+| `working` | Session state=working, no block |
+| `blocked` | `state=blocked AND needs != ""` — escalation fires |
+| `merged` | `gh pr view` returns state=MERGED |
+| `error` | Session state=error or unrecoverable |
+
+### goal_supervisor.py Design
+
+#### `spawn` subcommand
+
+```
+python scripts/goal_supervisor.py spawn <stack-json-path>
+                                        [--supervisor-worktree <abs-path>]
+                                        [--poll-interval <sec>]
+```
+
+1. Read and validate stack.json via `pr_stack.validate_envelope`.
+2. For each stack entry:
+   a. Compute `worktree_path` (`.worktrees/<entry.branch_suffix>` relative to repo root).
+   b. Create git worktree: `git worktree add <worktree_path> -b feat/<entry.branch_suffix>`.
+   c. Call `claude_dispatch.spawn(mode="interactive", name="worker-<id>", cwd=worktree_path, permission_mode="bypassPermissions", prompt=<worker_prompt>)`.
+   d. Record `session_short`, `session_id`, `worktree_path`, `spawned_at`, `goal_state="spawned"` on the entry.
+   e. Deliver initial inbox note via `supervisor_msg.send(worktree_path, "note", message=<goal_context>)`.
+3. Write goal-envelope.json (v1.1) to `<supervisor_worktree>/.workflow/goal-envelope.json`.
+4. Print spawn result JSON to stdout (`{"spawned": N, "envelope": "<path>", "entries": [...]}`).
+5. Write errors to stderr; exit 0 on success, exit 1 on any spawn failure (remaining entries still attempted; failed entries get `goal_state="error"`).
+
+**Worker prompt template:**
+```
+You are a PR stack worker for entry "{id}": {title}.
+Your worktree is at {worktree_path}. Your plan is at {plan}.
+Read your inbox first (python scripts/supervisor_msg.py read --consume).
+Then invoke /implement to start. After /pr completes, your work is done.
+Do not ask clarifying questions — make reasonable decisions and proceed.
+```
+
+#### `poll` subcommand
+
+```
+python scripts/goal_supervisor.py poll [--worktree <abs-path>]
+```
+
+1. Read `<supervisor_worktree>/.workflow/goal-envelope.json`.
+2. For each entry not already `merged`:
+   a. Read `~/.claude/jobs/<session_short>/state.json` → session state + needs.
+   b. Read `<worktree_path>/.workflow/state.json` → workflow phase + pr_url + pr_number.
+   c. If `session_state=blocked AND needs != ""` → set `goal_state="blocked"`, `blocked_needs=<needs>`.
+   d. If `session_state=done OR pr_url set`:
+      - Run `gh pr view <pr_number> --json state --jq .state` → pr_state.
+      - If MERGED → set `goal_state="merged"`, `merged_at=now`.
+      - If OPEN or CLOSED and session=done → invoke Haiku evaluator (§Haiku Predicate).
+   e. If `session_state=error` → set `goal_state="error"`.
+   f. Otherwise → `goal_state="working"` (or retain `spawned` if no change yet).
+   g. Update `last_polled_at`.
+3. Compute overall `goal_state`:
+   - All entries merged → `"all_merged"`.
+   - Any entry blocked or error → `"escalated"` (retain until resolved).
+   - Otherwise → `"polling"`.
+4. Write updated envelope to disk.
+5. Print verdict JSON to stdout:
+   ```json
+   {"goal_state": "all_merged|escalated|polling", "entries": [...]}
+   ```
+6. Write progress to stderr; exit 0 always (callers inspect the JSON).
+
+### Haiku Predicate Format
+
+Invoked only when a session reports `state=done` but no PR has been created yet (ambiguous: did /pr fail silently, or is /pr still pending?).
+
+**Template** (sent as headless prompt to Haiku via `claude_dispatch.spawn(mode="headless")`):
+
+```
+You are a one-turn evaluator. Assess this PR worker's completion state.
+
+Context:
+  entry_id: {entry_id}
+  title: {title}
+  session_state: {session_state}
+  workflow_phase: {workflow_phase}
+  pr_url: {pr_url}
+  pr_state: {pr_state}
+
+"session_state=done" means the Claude session exited. If pr_url is set and pr_state
+is MERGED, the worker is definitely done. If session_state=done but no pr_url exists,
+something likely went wrong.
+
+Reply with EXACTLY this JSON and nothing else:
+{"verdict": "done|blocked|working|error", "confidence": "high|low", "reason": "<one sentence>"}
+```
+
+Haiku result is parsed as JSON; `verdict` drives the entry's `goal_state`. On Haiku parse failure, treat as `goal_state="error"` and escalate.
+
+### /orchestrate Skill
+
+#### Step 0: Readiness gate
+
+`python scripts/supervisor_msg.py read --consume` — handle abort/revise per §inbox protocol.
+`python scripts/workflow-state.py set phase orchestrating`
+
+#### Step 1: Spawn workers
+
+```bash
+python scripts/goal_supervisor.py spawn <stack-json-path>
+```
+
+Display a table: entry ID | title | worktree | session short | status.
+
+#### Step 2: Schedule first poll
+
+`ScheduleWakeup(delaySeconds=270, prompt=<poll-prompt>)` — cache-warm interval.
+
+**Poll prompt** (passed verbatim each wakeup):
+```
+Supervisor poll: python scripts/goal_supervisor.py poll
+Read the JSON output and act:
+  - "all_merged" → PushNotification("All PRs merged: <summary>") and stop.
+  - "escalated" → PushNotification("Blocked worker: <entry_id>: <needs>")
+                   gh issue comment <issue_number> -b "<escalation text>"
+                   ScheduleWakeup(270s) to keep monitoring unblocked workers.
+  - "polling" → ScheduleWakeup(270s) with this same prompt.
+```
+
+#### Step 3: Notification behavior
+
+| Trigger | Action |
+|---------|--------|
+| `goal_state=all_merged` | `PushNotification(title="Supervisor: all merged", body="N PRs merged for <spec>")` + terminate |
+| Entry `goal_state=blocked` | `PushNotification(title="Supervisor: worker blocked", body="<entry_id>: <blocked_needs>")` + `gh issue comment` + continue polling |
+| Entry `goal_state=error` | `PushNotification(title="Supervisor: worker error", body="<entry_id> session failed")` + continue polling |
+
+### Escalation Rule (Single-Signal)
+
+Escalation fires when **both** conditions hold simultaneously:
+- `session_state == "blocked"`
+- `needs` field is non-empty after `.strip()`
+
+Empty `needs` (transient daemon flip) does NOT escalate. This mirrors the existing `BgHandle.wait()` semantics in `claude_dispatch.py`.
+
+### Supervisor Crash Tolerance
+
+The supervisor is a best-effort convenience layer (issue #1069 option 3+4):
+
+1. **Workers are independent**: each runs `pipeline.py` end-to-end in its own worktree. Loss of supervisor does not stop workers.
+2. **pr_monitor is the durable signal**: each worker's `pr_monitor` sends a `PushNotification` on PR merge. Operator receives individual notifications even without the supervisor.
+3. **Resumption is best-effort**: the supervisor session can be resumed via `claude --resume <supervisor_session_id>` (stored in `goal-envelope.json`). `ScheduleWakeup` re-fires on resume.
+
+This design means the supervisor adds aggregation value when healthy, but is never load-bearing.
+
+### supervisor_msg.py Usage
+
+| Direction | When | Kind | Content |
+|-----------|------|------|---------|
+| Supervisor → Worker | At spawn | `note` | Goal context: entry title, plan path, reminder to read inbox |
+| Supervisor → Worker | On abort decision | `abort` | Reason from escalation |
+| Worker → Supervisor | Not used | — | Workers do not write to supervisor inbox in this design |
+
+---
+
+## Forward Compatibility
+
+This spec amends [specs/feat-1070-pr-stack-alpha.md](./feat-1070-pr-stack-alpha.md) (per SL2 — specs are living documents) to add a "§Goal-Supervisor Extension (v1.1)" section documenting the runtime fields defined here. The `schema_version` bumps from `"1.0"` to `"1.1"`. The `validate_envelope` function already accepts any `"1."` prefix — no code changes needed to the existing validator.
+
+---
+
+## Acceptance Criteria
+
+| ID | Criterion | Test | Status |
+|----|-----------|------|--------|
+| AC-01 | `goal_supervisor.py spawn <valid-stack-json>` creates `<supervisor_worktree>/.workflow/goal-envelope.json` with `schema_version="1.1"` and all entries `goal_state="spawned"` | `TestGoalSupervisor.test_spawn_creates_envelope` | ❌ |
+| AC-02 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json fails `validate_envelope` | `TestGoalSupervisor.test_spawn_rejects_invalid_stack` | ❌ |
+| AC-03 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json has `schema_version` major != 1 | `TestGoalSupervisor.test_spawn_rejects_wrong_major` | ❌ |
+| AC-04 | `goal_supervisor.py poll` reads `goal-envelope.json`, updates `last_polled_at` for each non-merged entry, and writes the updated file | `TestGoalSupervisor.test_poll_updates_last_polled_at` | ❌ |
+| AC-05 | `goal_supervisor.py poll` sets overall `goal_state="all_merged"` and prints `{"goal_state": "all_merged"}` JSON to stdout when all entries have `goal_state="merged"` | `TestGoalSupervisor.test_poll_all_merged` | ❌ |
+| AC-06 | `goal_supervisor.py poll` sets entry `goal_state="blocked"` and `blocked_needs=<text>` when the worker's `state.json` has `state=blocked` and non-empty `needs` | `TestGoalSupervisor.test_poll_escalation_blocked` | ❌ |
+| AC-07 | `goal_supervisor.py poll` sets entry `goal_state="merged"` and `merged_at` when `gh pr view` returns `state=MERGED` | `TestGoalSupervisor.test_poll_merged_via_gh` | ❌ |
+| AC-08 | `goal_supervisor.py poll` sets entry `goal_state="error"` when the worker's `state.json` has `state=error` | `TestGoalSupervisor.test_poll_worker_error` | ❌ |
+| AC-09 | `goal_supervisor.py poll` does NOT escalate when `state=blocked` but `needs` is empty or whitespace-only | `TestGoalSupervisor.test_poll_no_escalation_empty_needs` | ❌ |
+| AC-10 | Haiku predicate template renders valid UTF-8 text containing the context fields; parsed Haiku response `{"verdict": "...", "confidence": "...", "reason": "..."}` drives entry `goal_state` | `TestGoalSupervisor.test_haiku_predicate_parses` | ❌ |
+| AC-11 | `goal_supervisor.py` writes all progress to stderr and all result JSON to stdout (Constitution I1) | `TestGoalSupervisor.test_stdout_discipline` | ❌ |
+| AC-12 | `goal_supervisor.py` uses stdlib only — no imports outside the stdlib or existing project scripts | `TestGoalSupervisor.test_no_extra_imports` | ❌ |
+| AC-13 | `pr_stack.validate_envelope` accepts a goal-envelope.json with `schema_version="1.1"` and v1.1 runtime fields without raising | `TestGoalSupervisorCompat.test_validate_v1_1_accepted` | ❌ |
+| AC-14 | `.claude/skills/orchestrate/SKILL.md` documents: spawn step calling `goal_supervisor.py spawn`, ScheduleWakeup at 270s, escalation via PushNotification + gh comment, termination when `all_merged` | `TestOrchestrateSkill.test_skill_documents_spawn` | ❌ |
+| AC-15 | `.claude/skills/orchestrate/SKILL.md` documents the single-signal escalation rule: `state=blocked AND needs != ""` | `TestOrchestrateSkill.test_skill_documents_escalation_rule` | ❌ |
+| AC-16 | `.claude/skills/orchestrate/SKILL.md` documents that workers are independent and the supervisor crash does not prevent individual PR notifications | `TestOrchestrateSkill.test_skill_documents_crash_tolerance` | ❌ |
+| AC-17 | Smoke: a goal-envelope.json with 2 entries both having `goal_state="merged"` drives `goal_supervisor.py poll` to output `{"goal_state": "all_merged"}` | `TestGoalSupervisor.test_smoke_two_entry_all_merged` | ❌ |
+| AC-18 | Smoke: a goal-envelope.json with 1 entry having `goal_state="blocked"` and `blocked_needs="fix the layout"` drives `goal_supervisor.py poll` to output `{"goal_state": "escalated"}` | `TestGoalSupervisor.test_smoke_one_blocked` | ❌ |
+
+Status key: ✅ covered by passing test · ⚠️ test exists but failing · ❌ no test yet · 🔲 not yet implemented
+
+### Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Worker worktree does not exist | Entry `goal_state="error"`, stderr message, poll continues |
+| state.json missing (worker just spawned) | Treat as `goal_state="spawned"`, no escalation |
+| `gh pr view` fails (no PR yet) | Retry on next poll; no escalation |
+| Haiku evaluator parse failure | Set `goal_state="error"`, escalate |
+| All workers error | `goal_state="escalated"`, no ScheduleWakeup scheduled (terminate) |
+
+---
+
+## Design Decisions
+
+### Why 270s poll interval?
+
+**Context:** Anthropic prompt cache has a 5-minute (300s) TTL. Sleeping past 300s means the next wakeup reads the full conversation context uncached — slower and more expensive.
+
+**Decision:** 270s — stays inside the cache window. Each poll costs a warm-cache read; the supervisor can run for hours without compounding cache misses.
+
+**Alternatives considered:**
+- 60s: too frequent; burns cache 5x per cache window for nothing.
+- 300s+: pays the cache miss every time. Wrong side of the TTL cliff.
+- 1800s: appropriate for fully idle waits, but supervisors are actively checking worker state.
+
+### Why options 3+4 for crash tolerance?
+
+**Context:** Issue comment surfaced the "what if supervisor crashes?" question. Four options presented.
+
+**Decision:** Option 3 (workers notify independently via pr_monitor) + Option 4 (accept supervisor as best-effort) is the right composition. Each worker runs `pipeline.py` and `pr_monitor` as a fully self-contained unit. The supervisor adds aggregated notification, not durable orchestration.
+
+**Alternatives considered:**
+- Option 1 (supervisor resumable): requires storing `supervisor_session_id` in `goal-envelope.json` (we do) and operator knows to run `claude --resume <id>`. This is a free win — we already store the ID.
+- Option 2 (watchdog hook): adds complexity for a component that is explicitly best-effort.
+
+### Why Haiku for ambiguous states only?
+
+**Context:** Most worker states are unambiguous (blocked=clear escalation, merged=clear done). Haiku adds latency and cost.
+
+**Decision:** Only invoke Haiku when `session_state=done` but no PR URL is present. This is the one genuinely ambiguous case — did /pr fail silently, or is /pr still running?
+
+**Alternatives considered:**
+- Always use Haiku for every state check: wastes tokens on obvious cases.
+- Never use Haiku: miss the ambiguous session=done/no-PR case.
+
+---
+
+## Related Specs
+
+- [feat-1070-pr-stack-alpha.md](./feat-1070-pr-stack-alpha.md) — canonical PR-stack envelope schema (v1.0 → v1.1 extended here)
+- [dispatch-routing.md](./dispatch-routing.md) — worker spawn via `claude_dispatch.spawn`, `BlockedSessionError` semantics
+- [goal-driven-implement.md](./goal-driven-implement.md) — goal-loop conventions followed by workers
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-16 | Initial spec — Phase 2 capstone of epic #1066 |

--- a/specs/feat-1069-supervisor-pattern.md
+++ b/specs/feat-1069-supervisor-pattern.md
@@ -316,25 +316,25 @@ This spec amends [specs/feat-1070-pr-stack-alpha.md](./feat-1070-pr-stack-alpha.
 
 | ID | Criterion | Test | Status |
 |----|-----------|------|--------|
-| AC-01 | `goal_supervisor.py spawn <valid-stack-json>` creates `<supervisor_worktree>/.workflow/goal-envelope.json` with `schema_version="1.1"` and all entries `goal_state="spawned"` | `TestGoalSupervisor.test_spawn_creates_envelope` | ❌ |
-| AC-02 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json fails `validate_envelope` | `TestGoalSupervisor.test_spawn_rejects_invalid_stack` | ❌ |
-| AC-03 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json has `schema_version` major != 1 | `TestGoalSupervisor.test_spawn_rejects_wrong_major` | ❌ |
-| AC-04 | `goal_supervisor.py poll` reads `goal-envelope.json`, updates `last_polled_at` for each non-merged entry, and writes the updated file | `TestGoalSupervisor.test_poll_updates_last_polled_at` | ❌ |
-| AC-05 | `goal_supervisor.py poll` sets overall `goal_state="all_merged"` and prints `{"goal_state": "all_merged"}` JSON to stdout when all entries have `goal_state="merged"` | `TestGoalSupervisor.test_poll_all_merged` | ❌ |
-| AC-06 | `goal_supervisor.py poll` sets entry `goal_state="blocked"` and `blocked_needs=<text>` when the worker's `state.json` has `state=blocked` and non-empty `needs` | `TestGoalSupervisor.test_poll_escalation_blocked` | ❌ |
-| AC-07 | `goal_supervisor.py poll` sets entry `goal_state="merged"` and `merged_at` when `gh pr view` returns `state=MERGED` | `TestGoalSupervisor.test_poll_merged_via_gh` | ❌ |
-| AC-08 | `goal_supervisor.py poll` sets entry `goal_state="error"` when the worker's `state.json` has `state=error` | `TestGoalSupervisor.test_poll_worker_error` | ❌ |
-| AC-09 | `goal_supervisor.py poll` does NOT escalate when `state=blocked` but `needs` is empty or whitespace-only | `TestGoalSupervisor.test_poll_no_escalation_empty_needs` | ❌ |
-| AC-10 | Haiku predicate template renders valid UTF-8 text containing the context fields; parsed Haiku response `{"verdict": "...", "confidence": "...", "reason": "..."}` drives entry `goal_state` | `TestGoalSupervisor.test_haiku_predicate_parses` | ❌ |
-| AC-11 | `goal_supervisor.py` writes all progress to stderr and all result JSON to stdout (Constitution I1) | `TestGoalSupervisor.test_stdout_discipline` | ❌ |
-| AC-12 | `goal_supervisor.py` uses stdlib only — no imports outside the stdlib or existing project scripts | `TestGoalSupervisor.test_no_extra_imports` | ❌ |
-| AC-13 | `pr_stack.validate_envelope` accepts a goal-envelope.json with `schema_version="1.1"` and v1.1 runtime fields without raising | `TestGoalSupervisorCompat.test_validate_v1_1_accepted` | ❌ |
-| AC-14 | `.claude/skills/orchestrate/SKILL.md` documents: spawn step calling `goal_supervisor.py spawn`, ScheduleWakeup at 270s, escalation via PushNotification + gh comment, termination when `all_merged` | `TestOrchestrateSkill.test_skill_documents_spawn` | ❌ |
-| AC-15 | `.claude/skills/orchestrate/SKILL.md` documents the single-signal escalation rule: `state=blocked AND needs != ""` | `TestOrchestrateSkill.test_skill_documents_escalation_rule` | ❌ |
-| AC-16 | `.claude/skills/orchestrate/SKILL.md` documents that workers are independent and the supervisor crash does not prevent individual PR notifications | `TestOrchestrateSkill.test_skill_documents_crash_tolerance` | ❌ |
-| AC-17 | Smoke: a goal-envelope.json with 2 entries both having `goal_state="merged"` drives `goal_supervisor.py poll` to output `{"goal_state": "all_merged"}` | `TestGoalSupervisor.test_smoke_two_entry_all_merged` | ❌ |
-| AC-18 | Smoke: a goal-envelope.json with 1 entry having `goal_state="blocked"` and `blocked_needs="fix the layout"` drives `goal_supervisor.py poll` to output `{"goal_state": "escalated"}` | `TestGoalSupervisor.test_smoke_one_blocked` | ❌ |
-| AC-19 | Worker prompt template contains all workflow contract elements: (a) skip-design note referencing the pre-approved plan, (b) `pipeline.py --spec --plan` invocation, (c) `--resume` fallback, (d) `pr_monitor.py` via Bash `run_in_background=true`, (e) re-engagement reads `.workflow/pr-monitor-result.json` and terminates | `TestGoalSupervisor.test_worker_prompt_contains_workflow_contract` | ❌ |
+| AC-01 | `goal_supervisor.py spawn <valid-stack-json>` creates `<supervisor_worktree>/.workflow/goal-envelope.json` with `schema_version="1.1"` and all entries `goal_state="spawned"` | `test_goal_supervisor.test_spawn_creates_envelope` | ✅ |
+| AC-02 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json fails `validate_envelope` | `test_goal_supervisor.test_spawn_rejects_invalid_stack` + `test_cli_spawn_invalid_stack_exits_1` | ✅ |
+| AC-03 | `goal_supervisor.py spawn` exits 1 with stderr message when stack.json has `schema_version` major != 1 | `test_goal_supervisor.test_spawn_rejects_wrong_major` | ✅ |
+| AC-04 | `goal_supervisor.py poll` reads `goal-envelope.json`, updates `last_polled_at` for each non-merged entry, and writes the updated file | `test_goal_supervisor.test_poll_updates_last_polled_at` | ✅ |
+| AC-05 | `goal_supervisor.py poll` sets overall `goal_state="all_merged"` and prints `{"goal_state": "all_merged"}` JSON to stdout when all entries have `goal_state="merged"` | `test_goal_supervisor.test_poll_all_merged` | ✅ |
+| AC-06 | `goal_supervisor.py poll` sets entry `goal_state="blocked"` and `blocked_needs=<text>` when the worker's `state.json` has `state=blocked` and non-empty `needs` | `test_goal_supervisor.test_poll_escalation_blocked` | ✅ |
+| AC-07 | `goal_supervisor.py poll` sets entry `goal_state="merged"` and `merged_at` when `gh pr view` returns `state=MERGED` | `test_goal_supervisor.test_poll_merged_via_gh` | ✅ |
+| AC-08 | `goal_supervisor.py poll` sets entry `goal_state="error"` when the worker's `state.json` has `state=error` | `test_goal_supervisor.test_poll_worker_error` | ✅ |
+| AC-09 | `goal_supervisor.py poll` does NOT escalate when `state=blocked` but `needs` is empty or whitespace-only | `test_goal_supervisor.test_poll_no_escalation_empty_needs` | ✅ |
+| AC-10 | Haiku predicate template renders valid UTF-8 text containing the context fields; parsed Haiku response `{"verdict": "...", "confidence": "...", "reason": "..."}` drives entry `goal_state` | `test_goal_supervisor.test_haiku_predicate_parses` + `test_haiku_parse_failure_marks_error` | ✅ |
+| AC-11 | `goal_supervisor.py` writes all progress to stderr and all result JSON to stdout (Constitution I1) | `test_goal_supervisor.test_stdout_discipline` | ✅ |
+| AC-12 | `goal_supervisor.py` uses stdlib only — no imports outside the stdlib or existing project scripts | `test_goal_supervisor.test_no_extra_imports` | ✅ |
+| AC-13 | `pr_stack.validate_envelope` accepts a goal-envelope.json with `schema_version="1.1"` and v1.1 runtime fields without raising | `test_goal_supervisor.TestGoalSupervisorCompat.test_validate_v1_1_accepted` | ✅ |
+| AC-14 | `.claude/skills/orchestrate/SKILL.md` documents: spawn step calling `goal_supervisor.py spawn`, ScheduleWakeup at 270s, escalation via PushNotification + gh comment, termination when `all_merged` | `test_goal_supervisor.TestOrchestrateSkill.test_skill_documents_spawn` | ✅ |
+| AC-15 | `.claude/skills/orchestrate/SKILL.md` documents the single-signal escalation rule: `state=blocked AND needs != ""` | `test_goal_supervisor.TestOrchestrateSkill.test_skill_documents_escalation_rule` | ✅ |
+| AC-16 | `.claude/skills/orchestrate/SKILL.md` documents that workers are independent and the supervisor crash does not prevent individual PR notifications | `test_goal_supervisor.TestOrchestrateSkill.test_skill_documents_crash_tolerance` | ✅ |
+| AC-17 | Smoke: a goal-envelope.json with 2 entries both having `goal_state="merged"` drives `goal_supervisor.py poll` to output `{"goal_state": "all_merged"}` | `test_goal_supervisor.test_smoke_two_entry_all_merged` | ✅ |
+| AC-18 | Smoke: a goal-envelope.json with 1 entry having `goal_state="blocked"` and `blocked_needs="fix the layout"` drives `goal_supervisor.py poll` to output `{"goal_state": "escalated"}` | `test_goal_supervisor.test_smoke_one_blocked` | ✅ |
+| AC-19 | Worker prompt template contains all workflow contract elements: (a) skip-design note referencing the pre-approved plan, (b) `pipeline.py --spec --plan` invocation, (c) `--resume` fallback, (d) `pr_monitor.py` via Bash `run_in_background=true`, (e) re-engagement reads `.workflow/pr-monitor-result.json` and terminates | `test_goal_supervisor.test_worker_prompt_contains_workflow_contract` | ✅ |
 
 Status key: ✅ covered by passing test · ⚠️ test exists but failing · ❌ no test yet · 🔲 not yet implemented
 

--- a/specs/feat-1069-supervisor-pattern.md
+++ b/specs/feat-1069-supervisor-pattern.md
@@ -139,22 +139,49 @@ python scripts/goal_supervisor.py spawn <stack-json-path>
 
 1. Read and validate stack.json via `pr_stack.validate_envelope`.
 2. For each stack entry:
-   a. Compute `worktree_path` (`.worktrees/<entry.branch_suffix>` relative to repo root).
-   b. Create git worktree: `git worktree add <worktree_path> -b feat/<entry.branch_suffix>`.
-   c. Call `claude_dispatch.spawn(mode="interactive", name="worker-<id>", cwd=worktree_path, permission_mode="bypassPermissions", prompt=<worker_prompt>)`.
-   d. Record `session_short`, `session_id`, `worktree_path`, `spawned_at`, `goal_state="spawned"` on the entry.
-   e. Deliver initial inbox note via `supervisor_msg.send(worktree_path, "note", message=<goal_context>)`.
+   a. Compute worktree name from `entry.branch_suffix` (e.g., `pr-1`).
+   b. Create worktree via `python scripts/worktree-create.py --name <branch_suffix> --branch feat/<branch_suffix>` (runs from repo root). This script performs: `git fetch origin main`, stale-directory detection, `git worktree add`, and a post-create sanity check. Surface stderr and abort on non-zero.
+   c. Build worker prompt from `WORKER_PROMPT_TEMPLATE` (see below), writing to a temp file (same-directory atomic write via `tempfile` + `os.replace`).
+   d. Spawn via `python scripts/start-bg-spawn.py --worktree-abs <abs-worktree-path> --branch feat/<branch_suffix> --prompt-file <temp-path> --permission-mode bypassPermissions --model sonnet`. Parse single-line stdout JSON for `short` and `sessionId`.
+   e. Record `session_short`, `session_id`, `worktree_path`, `spawned_at`, `goal_state="spawned"` on the entry.
+   f. Deliver initial inbox note via `supervisor_msg.send(worktree_path, "note", message=<goal_context>)`.
+   g. Delete the temp prompt file.
 3. Write goal-envelope.json (v1.1) to `<supervisor_worktree>/.workflow/goal-envelope.json`.
 4. Print spawn result JSON to stdout (`{"spawned": N, "envelope": "<path>", "entries": [...]}`).
 5. Write errors to stderr; exit 0 on success, exit 1 on any spawn failure (remaining entries still attempted; failed entries get `goal_state="error"`).
 
-**Worker prompt template:**
+**Worker prompt template** (`WORKER_PROMPT_TEMPLATE`):
+
+The template embeds the standard workflow contract from `/start` Step 6b (so the worker follows the same protocol as any operator-started session), preceded by a task brief, and followed by a supervisor-specific note appended after the contract block.
+
 ```
-You are a PR stack worker for entry "{id}": {title}.
-Your worktree is at {worktree_path}. Your plan is at {plan}.
-Read your inbox first (python scripts/supervisor_msg.py read --consume).
-Then invoke /implement to start. After /pr completes, your work is done.
-Do not ask clarifying questions — make reasonable decisions and proceed.
+Task brief — PR stack worker
+Entry: {id} — {title}
+Worktree: {worktree_path}
+Spec: {spec}
+Plan: {plan}
+Branch: feat/{branch_suffix}
+Issues: {issue_numbers}
+
+You are running in headless mode via the goal supervisor. Do not ask
+clarifying questions — make reasonable decisions and proceed.
+
+Workflow contract:
+1. Read CLAUDE.md, specs/CONSTITUTION.md, .claude/interaction-patterns.md.
+2. This worker has a pre-approved plan ({plan}). Skip /design.
+   Run `python scripts/pipeline.py --spec {spec} --plan {plan}` directly.
+   On failure: python scripts/pipeline.py --resume (or --from <stage>).
+3. After `python scripts/pipeline.py` exits successfully (pipeline includes
+   /pr internally): launch pr_monitor via Bash run_in_background=true:
+     python scripts/pr_monitor.py --worktree {worktree_path} --pr <PR-number>
+   Claude Code will re-engage you when pr_monitor exits.
+4. At re-engagement: read .workflow/pr-monitor-result.json and produce a final
+   summary covering actual PR state (ready / merged / escalated / error /
+   blocked). Terminate.
+
+Supervisor note (read first, before any other action):
+  python scripts/supervisor_msg.py read --consume
+Goal context: {title}. Plan at {plan}. Implement and ship — no design phase needed.
 ```
 
 #### `poll` subcommand
@@ -307,6 +334,7 @@ This spec amends [specs/feat-1070-pr-stack-alpha.md](./feat-1070-pr-stack-alpha.
 | AC-16 | `.claude/skills/orchestrate/SKILL.md` documents that workers are independent and the supervisor crash does not prevent individual PR notifications | `TestOrchestrateSkill.test_skill_documents_crash_tolerance` | ❌ |
 | AC-17 | Smoke: a goal-envelope.json with 2 entries both having `goal_state="merged"` drives `goal_supervisor.py poll` to output `{"goal_state": "all_merged"}` | `TestGoalSupervisor.test_smoke_two_entry_all_merged` | ❌ |
 | AC-18 | Smoke: a goal-envelope.json with 1 entry having `goal_state="blocked"` and `blocked_needs="fix the layout"` drives `goal_supervisor.py poll` to output `{"goal_state": "escalated"}` | `TestGoalSupervisor.test_smoke_one_blocked` | ❌ |
+| AC-19 | Worker prompt template contains all workflow contract elements: (a) skip-design note referencing the pre-approved plan, (b) `pipeline.py --spec --plan` invocation, (c) `--resume` fallback, (d) `pr_monitor.py` via Bash `run_in_background=true`, (e) re-engagement reads `.workflow/pr-monitor-result.json` and terminates | `TestGoalSupervisor.test_worker_prompt_contains_workflow_contract` | ❌ |
 
 Status key: ✅ covered by passing test · ⚠️ test exists but failing · ❌ no test yet · 🔲 not yet implemented
 

--- a/tests/scripts/test_goal_supervisor.py
+++ b/tests/scripts/test_goal_supervisor.py
@@ -1,0 +1,513 @@
+"""Unit tests for scripts/goal_supervisor.py — ACs 01-19 from specs/feat-1069-supervisor-pattern.md."""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# tests/conftest.py prepends scripts/ to sys.path; reach the module by name.
+import goal_supervisor as gs
+import pr_stack
+
+
+# ---------- envelope helpers ----------
+
+def _valid_entry(id="pr-1", branch_suffix="pr1", depends_on=None):
+    return {
+        "id": id,
+        "title": f"feat: {id}",
+        "branch_suffix": branch_suffix,
+        "plan": f".plans/foo-{id}.md",
+        "files": ["src/a.py"],
+        "size_estimate": "~100 LOC",
+        "depends_on": depends_on or [],
+        "ac_refs": [],
+    }
+
+
+def _valid_stack(n=2, schema_version="1.0"):
+    entries = [
+        _valid_entry(
+            f"pr-{i}",
+            f"pr{i}",
+            depends_on=[f"pr-{i-1}"] if i > 1 else [],
+        )
+        for i in range(1, n + 1)
+    ]
+    return {
+        "schema_version": schema_version,
+        "spec": "specs/foo.md",
+        "created_at": "2026-05-15T00:00:00+00:00",
+        "stack": entries,
+    }
+
+
+def _write_envelope(path: Path, envelope: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(envelope, indent=2) + "\n", encoding="utf-8")
+
+
+def _make_envelope_v11(tmp_path: Path, entries_state: list, *, n=None) -> Path:
+    """Build a v1.1 envelope on disk with the given per-entry overrides.
+
+    entries_state: list of dicts (each merged onto the base entry).
+    Returns the supervisor worktree path; envelope lives at
+    <supervisor_worktree>/.workflow/goal-envelope.json.
+    """
+    if n is None:
+        n = len(entries_state)
+    stack = _valid_stack(n)
+    envelope = gs.build_envelope_v11(
+        stack, supervisor_worktree=str(tmp_path), poll_interval=270,
+    )
+    for entry, overrides in zip(envelope["stack"], entries_state):
+        entry.update(overrides)
+    sw = tmp_path / "supervisor"
+    sw.mkdir(parents=True, exist_ok=True)
+    envelope["supervisor_worktree"] = str(sw)
+    _write_envelope(sw / ".workflow" / "goal-envelope.json", envelope)
+    return sw
+
+
+# ---------- spawn-runner mocks ----------
+
+class _CompletedProcessStub:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _make_spawn_runner(*, fail_at: int | None = None):
+    """Return a fake subprocess_runner that succeeds N times then optionally fails."""
+    calls = []
+    counter = {"n": 0}
+
+    def runner(cmd, cwd=None, timeout=None):
+        calls.append({"cmd": list(cmd), "cwd": cwd, "timeout": timeout})
+        counter["n"] += 1
+        if fail_at is not None and counter["n"] == fail_at:
+            return _CompletedProcessStub(returncode=1, stderr="boom")
+        # Distinguish worktree-create vs. start-bg-spawn by script path.
+        script = cmd[1] if len(cmd) > 1 else ""
+        if script.endswith("start-bg-spawn.py"):
+            short = f"short{counter['n']:04x}"
+            payload = {"short": short, "sessionId": f"sid-{short}", "cwd": "/x"}
+            return _CompletedProcessStub(returncode=0, stdout=json.dumps(payload))
+        # worktree-create returns no useful stdout
+        return _CompletedProcessStub(returncode=0)
+
+    runner.calls = calls  # type: ignore[attr-defined]
+    return runner
+
+
+# ---------- AC-01 — spawn creates envelope ----------
+
+def test_spawn_creates_envelope(tmp_path):  # AC-01
+    stack_path = tmp_path / "stack.json"
+    stack_path.write_text(json.dumps(_valid_stack(2)), encoding="utf-8")
+
+    sw = tmp_path / "sw"; sw.mkdir()
+    inbox_calls = []
+    summary = gs.spawn(
+        str(stack_path),
+        supervisor_worktree=str(sw),
+        repo_root=str(tmp_path),
+        subprocess_runner=_make_spawn_runner(),
+        inbox_sender=lambda wt, msg: inbox_calls.append((wt, msg)),
+    )
+
+    env_path = sw / ".workflow" / "goal-envelope.json"
+    assert env_path.exists()
+    envelope = json.loads(env_path.read_text(encoding="utf-8"))
+    assert envelope["schema_version"] == "1.1"
+    assert envelope["goal_poll_interval_sec"] == 270
+    assert all(e["goal_state"] == "spawned" for e in envelope["stack"])
+    assert summary["spawned"] == 2
+    assert len(inbox_calls) == 2
+
+
+# ---------- AC-02 — invalid stack rejected ----------
+
+def test_spawn_rejects_invalid_stack(tmp_path):  # AC-02
+    bad = {"schema_version": "1.0", "spec": "", "created_at": "x", "stack": []}
+    stack_path = tmp_path / "bad.json"
+    stack_path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError):
+        gs.spawn(
+            str(stack_path),
+            supervisor_worktree=str(tmp_path),
+            subprocess_runner=_make_spawn_runner(),
+            inbox_sender=lambda *a, **kw: None,
+        )
+
+
+def test_cli_spawn_invalid_stack_exits_1(tmp_path, capsys):  # AC-02 (CLI)
+    bad = {"schema_version": "1.0", "spec": "", "created_at": "x", "stack": []}
+    stack_path = tmp_path / "bad.json"
+    stack_path.write_text(json.dumps(bad), encoding="utf-8")
+    rc = gs.main(["spawn", str(stack_path), "--supervisor-worktree", str(tmp_path)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "goal_supervisor" in captured.err
+
+
+# ---------- AC-03 — wrong major version rejected ----------
+
+def test_spawn_rejects_wrong_major(tmp_path):  # AC-03
+    bad = _valid_stack(2)
+    bad["schema_version"] = "2.0"
+    stack_path = tmp_path / "v2.json"
+    stack_path.write_text(json.dumps(bad), encoding="utf-8")
+    with pytest.raises(ValueError, match="schema_version"):
+        gs.spawn(
+            str(stack_path),
+            supervisor_worktree=str(tmp_path),
+            subprocess_runner=_make_spawn_runner(),
+            inbox_sender=lambda *a, **kw: None,
+        )
+
+
+# ---------- AC-04 — last_polled_at updated ----------
+
+def test_poll_updates_last_polled_at(tmp_path):  # AC-04
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "abc1"},
+        {"goal_state": "spawned", "session_short": "abc2"},
+    ])
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=tmp_path / "jobs",  # non-existent → empty job states
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: '{"verdict": "working", "confidence": "high", "reason": "x"}',
+        clock=lambda: "2026-05-16T10:00:00+00:00",
+    )
+    for entry in verdict["entries"]:
+        assert entry["last_polled_at"] == "2026-05-16T10:00:00+00:00"
+    # Verify it was persisted.
+    saved = json.loads((sw / ".workflow" / "goal-envelope.json").read_text(encoding="utf-8"))
+    for entry in saved["stack"]:
+        assert entry["last_polled_at"] == "2026-05-16T10:00:00+00:00"
+
+
+# ---------- AC-05 — all_merged verdict ----------
+
+def test_poll_all_merged(tmp_path):  # AC-05
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "merged"},
+        {"goal_state": "merged"},
+    ])
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=tmp_path / "jobs",
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    assert verdict["goal_state"] == "all_merged"
+
+
+# ---------- AC-06 — escalation on blocked + needs ----------
+
+def _write_job_state(jobs_dir: Path, short: str, payload: dict) -> None:
+    d = jobs_dir / short
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "state.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_poll_escalation_blocked(tmp_path):  # AC-06
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "abcd"},
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "abcd", {"state": "blocked", "needs": "fix the layout"})
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    entry = verdict["entries"][0]
+    assert entry["goal_state"] == "blocked"
+    assert entry["blocked_needs"] == "fix the layout"
+    assert verdict["goal_state"] == "escalated"
+
+
+# ---------- AC-07 — merged via gh pr view ----------
+
+def test_poll_merged_via_gh(tmp_path):  # AC-07
+    sw = _make_envelope_v11(tmp_path, [
+        {
+            "goal_state": "working",
+            "session_short": "abcd",
+            "pr_number": 1234,
+            "pr_url": "https://github.com/x/y/pull/1234",
+        },
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "abcd", {"state": "done", "needs": ""})
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: "MERGED" if n == 1234 else None,
+        haiku_runner=lambda p: "",
+        clock=lambda: "2026-05-16T11:00:00+00:00",
+    )
+    entry = verdict["entries"][0]
+    assert entry["goal_state"] == "merged"
+    assert entry["merged_at"] == "2026-05-16T11:00:00+00:00"
+    assert entry["pr_state"] == "MERGED"
+
+
+# ---------- AC-08 — worker error state ----------
+
+def test_poll_worker_error(tmp_path):  # AC-08
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "errx"},
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "errx", {"state": "error", "needs": ""})
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    assert verdict["entries"][0]["goal_state"] == "error"
+    assert verdict["goal_state"] == "escalated"
+
+
+# ---------- AC-09 — empty needs does NOT escalate ----------
+
+def test_poll_no_escalation_empty_needs(tmp_path):  # AC-09
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "okay"},
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "okay", {"state": "blocked", "needs": "   "})
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    entry = verdict["entries"][0]
+    assert entry["goal_state"] != "blocked"
+    assert verdict["goal_state"] != "escalated"
+
+
+# ---------- AC-10 — Haiku predicate template renders + parses ----------
+
+def test_haiku_predicate_parses(tmp_path):  # AC-10
+    prompt = gs.render_haiku_prompt(
+        entry_id="pr-1",
+        title="feat: foo",
+        session_state="done",
+        workflow_phase="implementing",
+        pr_url="",
+        pr_state="",
+    )
+    assert "entry_id: pr-1" in prompt
+    assert "title: feat: foo" in prompt
+    assert '"verdict"' in prompt
+
+    # Drive an actual poll that triggers Haiku (session=done, no pr_url).
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "ambi"},
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "ambi", {"state": "done", "needs": ""})
+
+    def fake_haiku(p):
+        # Return a well-formed Haiku response.
+        return '{"verdict": "error", "confidence": "high", "reason": "no pr"}'
+
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=fake_haiku,
+    )
+    assert verdict["entries"][0]["goal_state"] == "error"
+
+
+def test_haiku_parse_failure_marks_error(tmp_path):
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "working", "session_short": "ambi"},
+    ])
+    jobs = tmp_path / "jobs"
+    _write_job_state(jobs, "ambi", {"state": "done", "needs": ""})
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=jobs,
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "this is not json",
+    )
+    assert verdict["entries"][0]["goal_state"] == "error"
+
+
+# ---------- AC-11 — stdout discipline (CLI) ----------
+
+def test_stdout_discipline(tmp_path, capsys):  # AC-11
+    sw = _make_envelope_v11(tmp_path, [{"goal_state": "merged"}])
+    rc = gs.main(["poll", "--worktree", str(sw)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    # stdout must parse as JSON.
+    payload = json.loads(captured.out)
+    assert payload["goal_state"] == "all_merged"
+    # stderr must contain the progress line.
+    assert "goal_supervisor: poll" in captured.err
+
+
+# ---------- AC-12 — no extra imports ----------
+
+ALLOWED_TOPLEVEL_IMPORTS = {
+    # Standard library.
+    "argparse", "json", "os", "subprocess", "sys", "tempfile",
+    "datetime", "pathlib", "typing", "__future__",
+    # Existing project scripts.
+    "pr_stack", "supervisor_msg",
+    # claude_dispatch is imported lazily — see _default_haiku_runner.
+}
+
+
+def test_no_extra_imports():  # AC-12
+    src = Path(gs.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    bad = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                top = n.name.split(".")[0]
+                if top not in ALLOWED_TOPLEVEL_IMPORTS:
+                    bad.append(top)
+        elif isinstance(node, ast.ImportFrom):
+            mod = (node.module or "").split(".")[0]
+            if mod and mod not in ALLOWED_TOPLEVEL_IMPORTS:
+                bad.append(mod)
+    assert bad == [], f"unexpected imports: {bad}"
+
+
+# ---------- AC-13 — pr_stack accepts v1.1 envelope ----------
+
+class TestGoalSupervisorCompat:
+    def test_validate_v1_1_accepted(self):  # AC-13
+        stack = _valid_stack(2)
+        envelope = gs.build_envelope_v11(
+            stack, supervisor_worktree="/abs/path", poll_interval=270,
+        )
+        # Should not raise.
+        pr_stack.validate_envelope(envelope)
+
+
+# ---------- AC-14, AC-15, AC-16 — /orchestrate SKILL.md content ----------
+
+_SKILL_PATH = Path(gs.__file__).resolve().parent.parent / ".claude" / "skills" / "orchestrate" / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return _SKILL_PATH.read_text(encoding="utf-8")
+
+
+class TestOrchestrateSkill:
+    def test_skill_documents_spawn(self):  # AC-14
+        text = _skill_text()
+        assert "python scripts/goal_supervisor.py spawn" in text
+        assert "270" in text
+        # PushNotification + gh comment + all_merged termination
+        assert "PushNotification" in text
+        assert "gh issue comment" in text
+        assert "all_merged" in text
+
+    def test_skill_documents_escalation_rule(self):  # AC-15
+        text = _skill_text()
+        # Single-signal rule must mention both conditions.
+        assert "state=blocked" in text
+        assert 'needs != ""' in text or "needs is non-empty" in text
+
+    def test_skill_documents_crash_tolerance(self):  # AC-16
+        text = _skill_text()
+        assert "pr_monitor" in text
+        assert ("independent" in text.lower() or
+                "best-effort" in text.lower() or
+                "crash" in text.lower())
+
+
+# ---------- AC-17 — smoke two-entry all_merged ----------
+
+def test_smoke_two_entry_all_merged(tmp_path):  # AC-17
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "merged"},
+        {"goal_state": "merged"},
+    ])
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=tmp_path / "jobs",
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    assert verdict["goal_state"] == "all_merged"
+
+
+# ---------- AC-18 — smoke one blocked ----------
+
+def test_smoke_one_blocked(tmp_path):  # AC-18
+    sw = _make_envelope_v11(tmp_path, [
+        {"goal_state": "blocked", "blocked_needs": "fix the layout"},
+    ])
+    # Avoid re-evaluation overwriting goal_state (no job state file → not done).
+    verdict = gs.poll(
+        supervisor_worktree=str(sw),
+        jobs_dir=tmp_path / "jobs",
+        workflow_state_reader=lambda wt: {},
+        gh_runner=lambda n: None,
+        haiku_runner=lambda p: "",
+    )
+    assert verdict["goal_state"] == "escalated"
+
+
+# ---------- AC-19 — worker prompt template contents ----------
+
+def test_worker_prompt_contains_workflow_contract():  # AC-19
+    text = gs.WORKER_PROMPT_TEMPLATE
+    # (a) skip-design note referencing the pre-approved plan
+    assert "pre-approved plan" in text
+    assert "Skip /design" in text
+    # (b) pipeline.py --spec --plan invocation
+    assert "scripts/pipeline.py --spec" in text and "--plan" in text
+    # (c) --resume fallback
+    assert "--resume" in text
+    # (d) pr_monitor.py via Bash run_in_background=true
+    assert "pr_monitor.py" in text
+    assert "run_in_background=true" in text
+    # (e) re-engagement reads pr-monitor-result.json and terminates
+    assert "pr-monitor-result.json" in text
+    assert "Terminate" in text
+
+
+def test_render_worker_prompt_fills_placeholders():
+    entry = {
+        "id": "pr-1", "title": "feat: x",
+        "worktree_path": "/abs/path",
+        "plan": ".plans/x.md", "branch_suffix": "pr1",
+    }
+    out = gs.render_worker_prompt(entry, spec="specs/foo.md")
+    assert "/abs/path" in out
+    assert "feat: x" in out
+    assert "feat/pr1" in out
+    assert "specs/foo.md" in out


### PR DESCRIPTION
## Summary

Introduces a **supervisor pattern** workflow primitive that spawns N PR-stack workers in parallel, monitors their progress through a durable goal-envelope, and escalates only when a worker is blocked or fails.

- **`scripts/goal_supervisor.py`** — spawn/poll engine. Reads a pre-validated PR-stack JSON, dispatches each entry as a background Claude session via `start-bg-spawn.py`, and tracks per-entry state in `.workflow/goal-envelope.json` (schema v1.1). Re-entrant: supervisor crash does not block individual PRs from shipping. Subprocess-based; CLI emits result JSON on stdout and progress on stderr (I1-compliant).
- **`scripts/claude_dispatch.spawn()`** routing for the Haiku ambiguity predicate (used only when a worker session is `done` with no recorded PR url). Verdict accepted set restricted to `{blocked, working, error}` per spec — `merged` requires a verified `gh` MERGED state and timestamp.
- **`.claude/skills/orchestrate/SKILL.md`** — new `/orchestrate` skill documenting the supervisor entrypoint, escalation contract, and crash-tolerance guarantee.
- **`specs/feat-1069-supervisor-pattern.md`** — full spec, including goal-envelope v1.1 shape, AC matrix, and the spawn/poll/escalate state machine.
- **`tests/scripts/test_goal_supervisor.py`** — 22 tests covering spawn/poll, escalation, Haiku parse-failure handling, stdout discipline, and skill contract assertions.

Closes #1069.

## Test plan

- [x] `pytest tests/scripts/test_goal_supervisor.py` — 22/22 passed
- [x] `/verify` workflow mode — 9/9 behavioral scenarios passed; hooks, settings, skill/agent frontmatter clean
- [x] Pre-PR self-review identified one defect (Haiku verdict could bypass merge contract); fixed in `63ceefb72`
- [ ] CI green
- [ ] Gemini review clean
- [ ] CodeQL clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
