### PR TITLE
fix(workflow): retro/pipeline portability — replace Test-Path + handle Windows paths in inline Python (closes #1130 #1131)

### DIFF
--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -93,6 +93,51 @@ Every headless invocation appends a JSONL row to `.claude/state/sdk-spend.jsonl`
 (gitignored). Tail it for live visibility:
 `tail -f .claude/state/sdk-spend.jsonl`.
 
+## Bash Tool Portability
+
+The Bash tool runs commands through Git Bash / MSYS, not PowerShell. Two
+runtime anti-patterns recur from prior retros (R-01 #1130, R-02 #1131):
+
+### Anti-pattern 1: PowerShell cmdlets via Bash tool
+
+PowerShell cmdlets (`Test-Path`, `Get-Item`, `Remove-Item`, etc.) fail with
+exit 127 — the Bash tool's shell does not resolve them. Use POSIX
+equivalents or shell out to Python:
+
+| Instead of | Use |
+|------------|-----|
+| `Test-Path .workflow/state.json` | `[ -e .workflow/state.json ] && echo exists \|\| echo missing` |
+| `Test-Path .workflow/state.json` | `python -c "import os; print(os.path.exists('.workflow/state.json'))"` |
+| `Get-ChildItem .retros` | `ls .retros` |
+| `Remove-Item -Recurse .workflow/tmp` | `rm -rf .workflow/tmp` |
+
+PowerShell-native scripts (`scripts/*.ps1`) are exempt — they run under
+`pwsh.exe`, not the Bash tool's shell.
+
+### Anti-pattern 2: Windows backslash paths in inline Python literals
+
+Inline `python -c "..."` and heredoc snippets passed via the Bash tool
+treat the payload as Python source code. Backslashes in regular string
+literals become escape sequences — `'.workflow\state.json'` becomes
+`.workflow<TAB>tate.json` (a literal tab + truncated path), and
+`'C:\Users\foo'` is a `SyntaxError: (unicode error) ...`.
+
+Fix the path literal at write time, not the file system at read time:
+
+| Instead of | Use |
+|------------|-----|
+| `python -c "open('.workflow\state.json')"` | `python -c "open('.workflow/state.json')"` (forward slashes) |
+| `python -c "open('C:\Users\foo')"` | `python -c "open(r'C:\Users\foo')"` (raw string) |
+| Inline heredoc + Windows path | Save to a `.py` file and run it — escapes go away |
+
+POSIX paths work on Windows Python — `open('.workflow/state.json')` opens
+the same file as `open('.workflow\\state.json')`. Forward slashes are the
+correct default for cross-platform inline Python.
+
+Regression test: `tests/test_skill_bash_portability.py` scans every
+`.claude/skills/**/*.md` for these patterns. Edits that reintroduce them
+fail in `/gates`.
+
 ## Related Docs
 
 - `CLAUDE.md` — repo-level rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Agent topology, decision UX, lane assignment: **`.claude/interaction-patterns.md
 - Edit `PublicAPI.Unshipped.txt` during a rebase — accept `--theirs` and let it regenerate; manual edits produce phantom API-drift conflicts. <!-- since: PR#956 rationale --> <!-- enforcement: T3 escape-hatch: rebase-context detection too brittle for hook -->
 - Trust a `release/X` branch as the source of truth for what shipped as version X — verify with `git merge-base --is-ancestor <release-tag> <branch>`. Tags are authoritative; the branch tip may sit on a separate lineage. <!-- since: 2026-05-15 cleanup retro --> <!-- enforcement: T3 escape-hatch: only fires when reasoning about release history -->
 - Invoke `claude -p` or any Anthropic SDK without going through `scripts/claude_dispatch.py:spawn()`. <!-- enforcement: T2 hook:sdk-spend-warn -->
+- Use PowerShell cmdlets (`Test-Path`, `Get-ChildItem`, etc.) via the Bash tool, or embed Windows backslash paths in inline `python -c` literals — see `.claude/WORKFLOW.md` "Bash Tool Portability". <!-- since: #1130 #1131 --> <!-- enforcement: T3 escape-hatch: runtime emission; tests/test_skill_bash_portability.py covers checked-in skill files -->
 
 ## ALWAYS <!-- enforcement: T3 not-a-directive -->
 

--- a/tests/test_skill_bash_portability.py
+++ b/tests/test_skill_bash_portability.py
@@ -1,0 +1,158 @@
+r"""Regression test for #1130 and #1131 - Bash-tool portability.
+
+Scans every .claude/skills/**/*.md for two patterns that fail at runtime
+when Claude generates them via the Bash tool on Windows:
+
+R-01 (#1130): PowerShell cmdlets (Test-Path, etc.) inside bash code
+fences. The Bash tool's shell is Git Bash / MSYS; PowerShell cmdlets exit
+127. Use POSIX ([ -e ... ], ls) or python -c "import os; ...".
+
+R-02 (#1131): Windows backslash paths inside inline Python literals
+(python -c "..."). The Bash tool passes the payload as Python source, so
+'\u' and '\w' become escape sequences that produce SyntaxError or wrong
+paths. Use forward slashes or raw strings (r'...').
+
+Canonical guidance: .claude/WORKFLOW.md "Bash Tool Portability".
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+
+# PowerShell cmdlets that the Bash tool's shell will not resolve.
+_POWERSHELL_CMDLETS = (
+    "Test-Path",
+    "Get-ChildItem",
+    "Remove-Item",
+    "New-Item",
+    "Copy-Item",
+    "Move-Item",
+    "Get-Content",
+    "Set-Content",
+)
+
+# Stage 1: line invokes inline python (-c). Stage 2: line contains a
+# non-raw string literal (opening quote NOT preceded by `r`) holding a
+# backslash followed by a letter -- the pattern that becomes an unintended
+# Python escape sequence (`\u`, `\w`, `\s`, etc.).
+_INLINE_PY_INVOKE_RE = re.compile(r"python\s+-c\s+[\"']")
+_NONRAW_BACKSLASH_LITERAL_RE = re.compile(
+    r"(?<![rRbB])(['\"])"   # opening quote not prefixed with r/R/b/B
+    r"[^'\"]*?"               # any chars except matching quotes
+    r"\\[A-Za-z]"            # backslash + letter -- Python escape
+    r"[^'\"]*?\1"             # to matching closing quote
+)
+
+
+def _has_inline_py_backslash_path(line: str) -> bool:
+    if not _INLINE_PY_INVOKE_RE.search(line):
+        return False
+    return bool(_NONRAW_BACKSLASH_LITERAL_RE.search(line))
+
+
+def _iter_skill_md_files():
+    return sorted(SKILLS_DIR.rglob("*.md"))
+
+
+def _code_fence_lines(text: str) -> list[tuple[int, str]]:
+    """Return (line_number, line) pairs INSIDE fenced code blocks only.
+
+    Markdown prose discussing forbidden patterns is fine; the runtime
+    hazard is code blocks Claude copies and executes.
+    """
+    inside = False
+    out: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            inside = not inside
+            continue
+        if inside:
+            out.append((lineno, line))
+    return out
+
+
+def test_no_powershell_cmdlets_in_skill_code_fences():
+    """R-01 (#1130) regression - no PowerShell cmdlets inside skill code fences."""
+    offenses: list[str] = []
+    for path in _iter_skill_md_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in _code_fence_lines(text):
+            for cmdlet in _POWERSHELL_CMDLETS:
+                if re.search(rf"\b{re.escape(cmdlet)}\b", line):
+                    offenses.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: {cmdlet} in code "
+                        f"fence - use POSIX ([ -e ... ], ls) or python -c"
+                    )
+    assert not offenses, (
+        "PowerShell cmdlets found in skill code fences (see "
+        ".claude/WORKFLOW.md 'Bash Tool Portability'):\n  "
+        + "\n  ".join(offenses)
+    )
+
+
+def test_no_windows_backslash_paths_in_inline_python():
+    """R-02 (#1131) regression - no backslash paths in inline python -c strings."""
+    offenses: list[str] = []
+    for path in _iter_skill_md_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in _code_fence_lines(text):
+            if _has_inline_py_backslash_path(line):
+                offenses.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}: backslash path in "
+                    f"inline python -c - use forward slashes or r'...' raw string"
+                )
+    assert not offenses, (
+        "Windows backslash paths in inline python -c literals (see "
+        ".claude/WORKFLOW.md 'Bash Tool Portability'):\n  "
+        + "\n  ".join(offenses)
+    )
+
+
+def test_detectors_catch_known_bad_samples():
+    """Self-test: confirm the regex catches the patterns it claims to catch."""
+    bad_powershell = [
+        "Test-Path .workflow/state.json",
+        "if (Test-Path .workflow) { ... }",
+        "Get-ChildItem -Recurse .retros",
+    ]
+    for sample in bad_powershell:
+        assert any(
+            re.search(rf"\b{re.escape(c)}\b", sample) for c in _POWERSHELL_CMDLETS
+        ), f"PowerShell detector missed: {sample!r}"
+
+    bad_inline_py = [
+        r'''python -c "open('.workflow\state.json')"''',
+        r'''python -c "import os; print(os.path.exists('C:\Users\foo'))"''',
+        r"""python -c 'open(".workflow\state.json")'""",
+    ]
+    for sample in bad_inline_py:
+        assert _has_inline_py_backslash_path(sample), (
+            f"Backslash-path detector missed: {sample!r}"
+        )
+
+    good_inline_py = [
+        r'''python -c "open('.workflow/state.json')"''',
+        r'''python -c "open(r'C:\Users\foo')"''',
+        r'''python -c "import json; json.load(open('.claude/settings.json'))"''',
+    ]
+    for sample in good_inline_py:
+        assert not _has_inline_py_backslash_path(sample), (
+            f"Backslash-path detector false-positived: {sample!r}"
+        )
+
+
+def test_workflow_md_documents_portability_rules():
+    """WORKFLOW.md must document the portability rules the tests enforce."""
+    workflow = (REPO_ROOT / ".claude" / "WORKFLOW.md").read_text(encoding="utf-8")
+    assert "Bash Tool Portability" in workflow, (
+        ".claude/WORKFLOW.md must contain 'Bash Tool Portability' section"
+    )
+    assert "Test-Path" in workflow, (
+        "Portability section must call out Test-Path as a forbidden cmdlet"
+    )
+    assert "raw string" in workflow.lower() or "r'" in workflow, (
+        "Portability section must document raw-string fix for Windows paths"
+    )

--- a/tests/test_skill_bash_portability.py
+++ b/tests/test_skill_bash_portability.py
@@ -25,6 +25,7 @@ SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
 # PowerShell cmdlets that the Bash tool's shell will not resolve.
 _POWERSHELL_CMDLETS = (
     "Test-Path",
+    "Get-Item",
     "Get-ChildItem",
     "Remove-Item",
     "New-Item",
@@ -40,7 +41,7 @@ _POWERSHELL_CMDLETS = (
 # Python escape sequence (`\u`, `\w`, `\s`, etc.).
 _INLINE_PY_INVOKE_RE = re.compile(r"python\s+-c\s+[\"']")
 _NONRAW_BACKSLASH_LITERAL_RE = re.compile(
-    r"(?<![rRbB])(['\"])"   # opening quote not prefixed with r/R/b/B
+    r"(?<![rR])(?<![rR][fFbB])(?<![fFbB][rR])(['\"])"   # opening quote not part of a raw string prefix
     r"[^'\"]*?"               # any chars except matching quotes
     r"\\[A-Za-z]"            # backslash + letter -- Python escape
     r"[^'\"]*?\1"             # to matching closing quote


### PR DESCRIPTION
## Summary

Two retro auto-findings (R-01 #1130, R-02 #1131) flagged Bash-tool runtime patterns that fail on Windows. No checked-in skill files contained the patterns — they were Claude's runtime emissions. Fix is preventive guidance + a regression scan so future skill edits can't introduce them.

- `.claude/WORKFLOW.md`: new **Bash Tool Portability** section documenting POSIX / forward-slash / raw-string substitutions for the two anti-patterns.
- `CLAUDE.md`: one-line NEVER rule pointing to WORKFLOW.md (always-loaded reminder).
- `tests/test_skill_bash_portability.py`: regression scan of every `.claude/skills/**/*.md` for both patterns inside code fences. Includes a self-test that asserts the detectors actually catch known-bad samples (so future edits to the detector logic don't silently turn it into a no-op).

The bugs:
- **R-01 (#1130):** PowerShell cmdlets (`Test-Path`, `Get-ChildItem`, etc.) invoked via the Bash tool exit 127 — the shell is Git Bash / MSYS, not pwsh.
- **R-02 (#1131):** Inline `python -c "..."` payloads containing Windows backslash paths produce `SyntaxError` when `\u` / `\w` / `\s` are misread as Python escape sequences.

Closes #1130, closes #1131

## Test Plan

- [x] `pytest tests/test_skill_bash_portability.py -v` — 4 tests pass (PowerShell scan, backslash scan, detector self-test, WORKFLOW.md doc check)
- [x] `pytest tests/test_claudemd_*.py tests/test_retro_skill.py` — 59 tests pass, no CLAUDE.md governance regression
- [x] `python scripts/audit-enforcement.py --strict` — passes (7 T1 markers wired)
- [x] Self-test catches: `Test-Path .workflow/state.json`, `python -c "open('.workflow\state.json')"`, `python -c "import os; print(os.path.exists('C:\Users\foo'))"`
- [x] Self-test rejects (good patterns): `python -c "open('.workflow/state.json')"`, `python -c "open(r'C:\Users\foo')"`

## Verification

- [x] /gates passed (Python tests + enforcement audit; no C# / TS changes in scope)
- [x] /verify skipped — pure docs + test, no runtime surface change
- [x] /qa skipped — no product behavior change
- [x] /review skipped (--no-self-review justification: small docs+test diff, no source-code or skill content changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
