### PR TITLE
fix(cli): route text-mode data output to stdout — fixes #1077

### DIFF
--- a/src/PPDS.Cli/Commands/ConnectionReferences/AnalyzeCommand.cs
+++ b/src/PPDS.Cli/Commands/ConnectionReferences/AnalyzeCommand.cs
@@ -106,23 +106,23 @@ public static class AnalyzeCommand
             }
             else
             {
-                Console.Error.WriteLine("Flow-Connection Reference Analysis");
-                Console.Error.WriteLine("===================================");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"  Valid relationships: {analysis.ValidCount}");
-                Console.Error.WriteLine($"  Orphaned flows (missing CRs): {analysis.OrphanedFlowCount}");
-                Console.Error.WriteLine($"  Orphaned connection references (unused): {analysis.OrphanedConnectionReferenceCount}");
-                Console.Error.WriteLine();
+                Console.WriteLine("Flow-Connection Reference Analysis");
+                Console.WriteLine("===================================");
+                Console.WriteLine();
+                Console.WriteLine($"  Valid relationships: {analysis.ValidCount}");
+                Console.WriteLine($"  Orphaned flows (missing CRs): {analysis.OrphanedFlowCount}");
+                Console.WriteLine($"  Orphaned connection references (unused): {analysis.OrphanedConnectionReferenceCount}");
+                Console.WriteLine();
 
                 if (!analysis.HasOrphans && orphansOnly)
                 {
-                    Console.Error.WriteLine("No orphans detected.");
+                    Console.WriteLine("No orphans detected.");
                     return ExitCodes.Success;
                 }
 
                 if (relationships.Count == 0)
                 {
-                    Console.Error.WriteLine("No relationships found.");
+                    Console.WriteLine("No relationships found.");
                     return ExitCodes.Success;
                 }
 
@@ -133,46 +133,46 @@ public static class AnalyzeCommand
 
                 if (orphanedFlows.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("ORPHANED FLOWS (referencing missing connection references):");
-                    Console.Error.WriteLine("------------------------------------------------------------");
+                    Console.WriteLine();
+                    Console.WriteLine("ORPHANED FLOWS (referencing missing connection references):");
+                    Console.WriteLine("------------------------------------------------------------");
                     foreach (var r in orphanedFlows)
                     {
-                        Console.Error.WriteLine($"  Flow: {r.FlowDisplayName ?? r.FlowUniqueName}");
-                        Console.Error.WriteLine($"    References missing CR: {r.ConnectionReferenceLogicalName}");
-                        Console.Error.WriteLine();
+                        Console.WriteLine($"  Flow: {r.FlowDisplayName ?? r.FlowUniqueName}");
+                        Console.WriteLine($"    References missing CR: {r.ConnectionReferenceLogicalName}");
+                        Console.WriteLine();
                     }
                 }
 
                 if (orphanedCRs.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("ORPHANED CONNECTION REFERENCES (not used by any flow):");
-                    Console.Error.WriteLine("------------------------------------------------------");
+                    Console.WriteLine();
+                    Console.WriteLine("ORPHANED CONNECTION REFERENCES (not used by any flow):");
+                    Console.WriteLine("------------------------------------------------------");
                     foreach (var r in orphanedCRs)
                     {
                         var boundStatus = r.IsBound == true ? "Bound" : "Unbound";
-                        Console.Error.WriteLine($"  {r.ConnectionReferenceDisplayName ?? r.ConnectionReferenceLogicalName}");
-                        Console.Error.WriteLine($"    Name: {r.ConnectionReferenceLogicalName}  Status: {boundStatus}");
+                        Console.WriteLine($"  {r.ConnectionReferenceDisplayName ?? r.ConnectionReferenceLogicalName}");
+                        Console.WriteLine($"    Name: {r.ConnectionReferenceLogicalName}  Status: {boundStatus}");
                         if (r.ConnectorId != null)
                         {
-                            Console.Error.WriteLine($"    Connector: {r.ConnectorId}");
+                            Console.WriteLine($"    Connector: {r.ConnectorId}");
                         }
-                        Console.Error.WriteLine();
+                        Console.WriteLine();
                     }
                 }
 
                 if (!orphansOnly && validRelationships.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("VALID RELATIONSHIPS:");
-                    Console.Error.WriteLine("--------------------");
+                    Console.WriteLine();
+                    Console.WriteLine("VALID RELATIONSHIPS:");
+                    Console.WriteLine("--------------------");
                     foreach (var r in validRelationships)
                     {
                         var boundStatus = r.IsBound == true ? "Bound" : "Unbound";
-                        Console.Error.WriteLine($"  Flow: {r.FlowDisplayName ?? r.FlowUniqueName}");
-                        Console.Error.WriteLine($"    -> CR: {r.ConnectionReferenceLogicalName} ({boundStatus})");
-                        Console.Error.WriteLine();
+                        Console.WriteLine($"  Flow: {r.FlowDisplayName ?? r.FlowUniqueName}");
+                        Console.WriteLine($"    -> CR: {r.ConnectionReferenceLogicalName} ({boundStatus})");
+                        Console.WriteLine();
                     }
                 }
             }

--- a/src/PPDS.Cli/Commands/ConnectionReferences/ConnectionsCommand.cs
+++ b/src/PPDS.Cli/Commands/ConnectionReferences/ConnectionsCommand.cs
@@ -100,10 +100,10 @@ public static class ConnectionsCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Connection Reference: {cr.DisplayName ?? cr.LogicalName}");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("This connection reference is not bound to a connection.");
-                    Console.Error.WriteLine("Use the Power Apps portal or pac solution commands to bind a connection.");
+                    Console.WriteLine($"Connection Reference: {cr.DisplayName ?? cr.LogicalName}");
+                    Console.WriteLine();
+                    Console.WriteLine("This connection reference is not bound to a connection.");
+                    Console.WriteLine("Use the Power Apps portal or pac solution commands to bind a connection.");
                 }
                 return ExitCodes.Success;
             }

--- a/src/PPDS.Cli/Commands/ConnectionReferences/ConnectionsCommand.cs
+++ b/src/PPDS.Cli/Commands/ConnectionReferences/ConnectionsCommand.cs
@@ -103,7 +103,7 @@ public static class ConnectionsCommand
                     Console.WriteLine($"Connection Reference: {cr.DisplayName ?? cr.LogicalName}");
                     Console.WriteLine();
                     Console.WriteLine("This connection reference is not bound to a connection.");
-                    Console.WriteLine("Use the Power Apps portal or pac solution commands to bind a connection.");
+                    Console.Error.WriteLine("Use the Power Apps portal or pac solution commands to bind a connection.");
                 }
                 return ExitCodes.Success;
             }

--- a/src/PPDS.Cli/Commands/ConnectionReferences/FlowsCommand.cs
+++ b/src/PPDS.Cli/Commands/ConnectionReferences/FlowsCommand.cs
@@ -105,17 +105,17 @@ public static class FlowsCommand
             }
             else
             {
-                Console.Error.WriteLine($"Connection Reference: {cr.DisplayName ?? cr.LogicalName}");
-                Console.Error.WriteLine();
+                Console.WriteLine($"Connection Reference: {cr.DisplayName ?? cr.LogicalName}");
+                Console.WriteLine();
 
                 if (flows.Count == 0)
                 {
-                    Console.Error.WriteLine("No flows use this connection reference.");
+                    Console.WriteLine("No flows use this connection reference.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Flows using this connection reference ({flows.Count}):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Flows using this connection reference ({flows.Count}):");
+                    Console.WriteLine();
 
                     foreach (var f in flows)
                     {

--- a/src/PPDS.Cli/Commands/ConnectionReferences/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/ConnectionReferences/ListCommand.cs
@@ -96,12 +96,12 @@ public static class ListCommand
             {
                 if (connectionRefs.Count == 0)
                 {
-                    Console.Error.WriteLine("No connection references found.");
+                    Console.WriteLine("No connection references found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {connectionRefs.Count} connection reference(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {connectionRefs.Count} connection reference(s):");
+                    Console.WriteLine();
 
                     foreach (var cr in connectionRefs)
                     {

--- a/src/PPDS.Cli/Commands/Connections/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Connections/ListCommand.cs
@@ -92,12 +92,12 @@ public static class ListCommand
             {
                 if (connections.Count == 0)
                 {
-                    Console.Error.WriteLine("No connections found.");
+                    Console.WriteLine("No connections found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {connections.Count} connection(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {connections.Count} connection(s):");
+                    Console.WriteLine();
 
                     foreach (var c in connections)
                     {

--- a/src/PPDS.Cli/Commands/CustomApis/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/CustomApis/GetCommand.cs
@@ -156,22 +156,22 @@ public static class GetCommand
 
                 if (api.RequestParameters.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("  Request Parameters:");
+                    Console.WriteLine();
+                    Console.WriteLine("  Request Parameters:");
                     foreach (var p in api.RequestParameters)
                     {
                         var optional = p.IsOptional ? " [optional]" : "";
-                        Console.Error.WriteLine($"    {p.UniqueName} ({p.Type}){optional}");
+                        Console.WriteLine($"    {p.UniqueName} ({p.Type}){optional}");
                     }
                 }
 
                 if (api.ResponseProperties.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine("  Response Properties:");
+                    Console.WriteLine();
+                    Console.WriteLine("  Response Properties:");
                     foreach (var p in api.ResponseProperties)
                     {
-                        Console.Error.WriteLine($"    {p.UniqueName} ({p.Type})");
+                        Console.WriteLine($"    {p.UniqueName} ({p.Type})");
                     }
                 }
             }
@@ -195,7 +195,7 @@ public static class GetCommand
         foreach (var kvp in properties)
         {
             var key = kvp.Key.PadRight(maxKeyLength);
-            Console.Error.WriteLine($"  {key}  {kvp.Value}");
+            Console.WriteLine($"  {key}  {kvp.Value}");
         }
     }
 

--- a/src/PPDS.Cli/Commands/CustomApis/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/CustomApis/ListCommand.cs
@@ -84,7 +84,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No Custom APIs found.");
+                    Console.WriteLine("No Custom APIs found.");
                 }
                 return ExitCodes.Success;
             }
@@ -120,17 +120,17 @@ public static class ListCommand
                     if (api.IsFunction) flags.Add("function");
                     if (api.IsPrivate) flags.Add("private");
                     var flagStr = flags.Count > 0 ? $" ({string.Join(", ", flags)})" : "";
-                    Console.Error.WriteLine($"{api.UniqueName}{managed}{flagStr}");
-                    Console.Error.WriteLine($"  Display: {api.DisplayName}");
-                    Console.Error.WriteLine($"  Binding: {api.BindingType}");
+                    Console.WriteLine($"{api.UniqueName}{managed}{flagStr}");
+                    Console.WriteLine($"  Display: {api.DisplayName}");
+                    Console.WriteLine($"  Binding: {api.BindingType}");
                     if (!string.IsNullOrEmpty(api.BoundEntity))
-                        Console.Error.WriteLine($"  Entity: {api.BoundEntity}");
+                        Console.WriteLine($"  Entity: {api.BoundEntity}");
                     if (!string.IsNullOrEmpty(api.PluginTypeName))
-                        Console.Error.WriteLine($"  Plugin: {api.PluginTypeName}");
+                        Console.WriteLine($"  Plugin: {api.PluginTypeName}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {apis.Count} Custom API(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {apis.Count} Custom API(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Data/AnalyzeCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/AnalyzeCommand.cs
@@ -172,50 +172,50 @@ public static class AnalyzeCommand
 
     private static void WriteTextOutput(SchemaAnalysis analysis, string schemaPath)
     {
-        Console.Error.WriteLine("[Schema Analysis]");
-        Console.Error.WriteLine();
-        Console.Error.WriteLine($"Schema: {schemaPath}");
-        Console.Error.WriteLine();
+        Console.WriteLine("[Schema Analysis]");
+        Console.WriteLine();
+        Console.WriteLine($"Schema: {schemaPath}");
+        Console.WriteLine();
 
         if (analysis.EntityCount == 0)
         {
-            Console.Error.WriteLine("No entities found in schema.");
+            Console.WriteLine("No entities found in schema.");
             return;
         }
 
-        Console.Error.WriteLine($"Entities: {analysis.EntityCount}");
-        Console.Error.WriteLine($"Dependencies: {analysis.DependencyCount}");
-        Console.Error.WriteLine($"Circular References: {analysis.CircularReferenceCount}");
-        Console.Error.WriteLine();
+        Console.WriteLine($"Entities: {analysis.EntityCount}");
+        Console.WriteLine($"Dependencies: {analysis.DependencyCount}");
+        Console.WriteLine($"Circular References: {analysis.CircularReferenceCount}");
+        Console.WriteLine();
 
-        Console.Error.WriteLine("Import Tiers:");
+        Console.WriteLine("Import Tiers:");
         foreach (var tier in analysis.Tiers)
         {
             var entities = string.Join(", ", tier.Entities);
             var suffix = tier.HasCircular ? " (circular)" : "";
-            Console.Error.WriteLine($"  Tier {tier.Tier}: {entities}{suffix}");
+            Console.WriteLine($"  Tier {tier.Tier}: {entities}{suffix}");
         }
-        Console.Error.WriteLine();
+        Console.WriteLine();
 
         if (analysis.DeferredFields.Count > 0)
         {
-            Console.Error.WriteLine("Deferred Fields:");
+            Console.WriteLine("Deferred Fields:");
             foreach (var (entity, fields) in analysis.DeferredFields)
             {
                 foreach (var field in fields)
                 {
-                    Console.Error.WriteLine($"  {entity}.{field}");
+                    Console.WriteLine($"  {entity}.{field}");
                 }
             }
-            Console.Error.WriteLine();
+            Console.WriteLine();
         }
 
         if (analysis.ManyToManyRelationships.Length > 0)
         {
-            Console.Error.WriteLine("Many-to-Many Relationships:");
+            Console.WriteLine("Many-to-Many Relationships:");
             foreach (var relationship in analysis.ManyToManyRelationships)
             {
-                Console.Error.WriteLine($"  {relationship}");
+                Console.WriteLine($"  {relationship}");
             }
         }
     }

--- a/src/PPDS.Cli/Commands/DataProviders/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/DataProviders/ListCommand.cs
@@ -103,7 +103,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No data providers found.");
+                    Console.WriteLine("No data providers found.");
                 }
                 return ExitCodes.Success;
             }
@@ -132,23 +132,23 @@ public static class ListCommand
                 foreach (var provider in providers)
                 {
                     var managed = provider.IsManaged ? " [managed]" : "";
-                    Console.Error.WriteLine($"Data Provider: {provider.Name}{managed}");
+                    Console.WriteLine($"Data Provider: {provider.Name}{managed}");
                     if (!string.IsNullOrEmpty(provider.DataSourceName))
-                        Console.Error.WriteLine($"  Data Source: {provider.DataSourceName}");
+                        Console.WriteLine($"  Data Source: {provider.DataSourceName}");
                     if (provider.RetrievePlugin.HasValue)
-                        Console.Error.WriteLine($"  Retrieve: {provider.RetrievePlugin}");
+                        Console.WriteLine($"  Retrieve: {provider.RetrievePlugin}");
                     if (provider.RetrieveMultiplePlugin.HasValue)
-                        Console.Error.WriteLine($"  RetrieveMultiple: {provider.RetrieveMultiplePlugin}");
+                        Console.WriteLine($"  RetrieveMultiple: {provider.RetrieveMultiplePlugin}");
                     if (provider.CreatePlugin.HasValue)
-                        Console.Error.WriteLine($"  Create: {provider.CreatePlugin}");
+                        Console.WriteLine($"  Create: {provider.CreatePlugin}");
                     if (provider.UpdatePlugin.HasValue)
-                        Console.Error.WriteLine($"  Update: {provider.UpdatePlugin}");
+                        Console.WriteLine($"  Update: {provider.UpdatePlugin}");
                     if (provider.DeletePlugin.HasValue)
-                        Console.Error.WriteLine($"  Delete: {provider.DeletePlugin}");
+                        Console.WriteLine($"  Delete: {provider.DeletePlugin}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {providers.Count} data provider(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {providers.Count} data provider(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/DataSources/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/DataSources/ListCommand.cs
@@ -72,7 +72,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No data sources found.");
+                    Console.WriteLine("No data sources found.");
                 }
                 return ExitCodes.Success;
             }
@@ -93,11 +93,11 @@ public static class ListCommand
             {
                 foreach (var ds in dataSources)
                 {
-                    Console.Error.WriteLine($"Data Source: {ds.Name}");
+                    Console.WriteLine($"Data Source: {ds.Name}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {dataSources.Count} data source(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {dataSources.Count} data source(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Env/EnvCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Env/EnvCommandGroup.cs
@@ -145,11 +145,11 @@ public static class EnvCommandGroup
         {
             if (!string.IsNullOrWhiteSpace(filter))
             {
-                Console.Error.WriteLine($"No environments matching '{filter}'.");
+                Console.WriteLine($"No environments matching '{filter}'.");
             }
             else
             {
-                Console.Error.WriteLine("No environments found.");
+                Console.WriteLine("No environments found.");
                 Console.Error.WriteLine();
                 Console.Error.WriteLine("This may indicate the user has no access to any environments.");
             }
@@ -643,7 +643,7 @@ public static class EnvCommandGroup
         var config = await service.GetConfigAsync(url, ct);
         if (config == null)
         {
-            Console.Error.WriteLine($"No configuration found for: {url}");
+            Console.WriteLine($"No configuration found for: {url}");
             Console.Error.WriteLine("Use 'ppds env config <url> --label <label> --type <type> --color <color>' to configure.");
             return ExitCodes.Success;
         }

--- a/src/PPDS.Cli/Commands/EnvironmentVariables/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/EnvironmentVariables/ListCommand.cs
@@ -94,12 +94,12 @@ public static class ListCommand
             {
                 if (variables.Count == 0)
                 {
-                    Console.Error.WriteLine("No environment variables found.");
+                    Console.WriteLine("No environment variables found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {variables.Count} environment variable(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {variables.Count} environment variable(s):");
+                    Console.WriteLine();
 
                     foreach (var v in variables)
                     {

--- a/src/PPDS.Cli/Commands/Flows/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Flows/ListCommand.cs
@@ -110,12 +110,12 @@ public static class ListCommand
             {
                 if (flows.Count == 0)
                 {
-                    Console.Error.WriteLine("No cloud flows found.");
+                    Console.WriteLine("No cloud flows found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {flows.Count} cloud flow(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {flows.Count} cloud flow(s):");
+                    Console.WriteLine();
 
                     foreach (var f in flows)
                     {

--- a/src/PPDS.Cli/Commands/ImportJobs/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/ImportJobs/ListCommand.cs
@@ -90,7 +90,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No import jobs found.");
+                    Console.WriteLine("No import jobs found.");
                 }
                 return ExitCodes.Success;
             }

--- a/src/PPDS.Cli/Commands/ImportJobs/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/ImportJobs/ListCommand.cs
@@ -114,8 +114,8 @@ public static class ListCommand
             }
             else
             {
-                Console.Error.WriteLine($"{"Solution",-30} {"Progress",-10} {"Status",-12} {"Started",-20} {"Completed",-20}");
-                Console.Error.WriteLine(new string('-', 95));
+                Console.WriteLine($"{"Solution",-30} {"Progress",-10} {"Status",-12} {"Started",-20} {"Completed",-20}");
+                Console.WriteLine(new string('-', 95));
 
                 foreach (var job in jobs)
                 {
@@ -125,11 +125,11 @@ public static class ListCommand
                     var started = job.StartedOn?.ToString("g") ?? "-";
                     var completed = job.CompletedOn?.ToString("g") ?? "-";
 
-                    Console.Error.WriteLine($"{solution,-30} {progress,-10} {status,-12} {started,-20} {completed,-20}");
+                    Console.WriteLine($"{solution,-30} {progress,-10} {status,-12} {started,-20} {completed,-20}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {jobs.Count} import job(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {jobs.Count} import job(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
@@ -89,9 +89,9 @@ public static class AttributesCommand
             }
             else
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"{"Logical Name",-35} {"Type",-20} {"Display Name",-30} {"Flags"}");
-                Console.Error.WriteLine(new string('-', 100));
+                Console.WriteLine();
+                Console.WriteLine($"{"Logical Name",-35} {"Type",-20} {"Display Name",-30} {"Flags"}");
+                Console.WriteLine(new string('-', 100));
 
                 foreach (var attr in attributes)
                 {
@@ -104,11 +104,11 @@ public static class AttributesCommand
                         flags.Add("required");
 
                     var flagText = flags.Count > 0 ? string.Join(", ", flags) : "";
-                    Console.Error.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-20} {attr.DisplayName,-30} {flagText}");
+                    Console.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-20} {attr.DisplayName,-30} {flagText}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {attributes.Count} attributes");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {attributes.Count} attributes");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntitiesCommand.cs
@@ -90,7 +90,7 @@ public static class EntitiesCommand
             }
             else
             {
-                Console.Error.WriteLine();
+                Console.WriteLine();
                 foreach (var entity in entities)
                 {
                     var markers = new List<string>();
@@ -98,11 +98,11 @@ public static class EntitiesCommand
                     if (entity.IsManaged) markers.Add("managed");
 
                     var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
-                    Console.Error.WriteLine($"  {entity.LogicalName,-40} {entity.DisplayName}{markerText}");
+                    Console.WriteLine($"  {entity.LogicalName,-40} {entity.DisplayName}{markerText}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {entities.Count} entities");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {entities.Count} entities");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
@@ -98,22 +98,22 @@ public static class EntityCommand
             }
             else
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Entity: {metadata.LogicalName}");
-                Console.Error.WriteLine($"  Display Name:     {metadata.DisplayName}");
-                Console.Error.WriteLine($"  Schema Name:      {metadata.SchemaName}");
-                Console.Error.WriteLine($"  Entity Set Name:  {metadata.EntitySetName}");
-                Console.Error.WriteLine($"  Primary ID:       {metadata.PrimaryIdAttribute}");
-                Console.Error.WriteLine($"  Primary Name:     {metadata.PrimaryNameAttribute}");
-                Console.Error.WriteLine($"  Object Type Code: {metadata.ObjectTypeCode}");
-                Console.Error.WriteLine($"  Ownership Type:   {metadata.OwnershipType}");
-                Console.Error.WriteLine($"  Custom Entity:    {metadata.IsCustomEntity}");
-                Console.Error.WriteLine($"  Managed:          {metadata.IsManaged}");
+                Console.WriteLine();
+                Console.WriteLine($"Entity: {metadata.LogicalName}");
+                Console.WriteLine($"  Display Name:     {metadata.DisplayName}");
+                Console.WriteLine($"  Schema Name:      {metadata.SchemaName}");
+                Console.WriteLine($"  Entity Set Name:  {metadata.EntitySetName}");
+                Console.WriteLine($"  Primary ID:       {metadata.PrimaryIdAttribute}");
+                Console.WriteLine($"  Primary Name:     {metadata.PrimaryNameAttribute}");
+                Console.WriteLine($"  Object Type Code: {metadata.ObjectTypeCode}");
+                Console.WriteLine($"  Ownership Type:   {metadata.OwnershipType}");
+                Console.WriteLine($"  Custom Entity:    {metadata.IsCustomEntity}");
+                Console.WriteLine($"  Managed:          {metadata.IsManaged}");
 
                 if (metadata.Attributes.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"Attributes ({metadata.Attributes.Count}):");
+                    Console.WriteLine();
+                    Console.WriteLine($"Attributes ({metadata.Attributes.Count}):");
                     foreach (var attr in metadata.Attributes.Take(20))
                     {
                         var markers = new List<string>();
@@ -122,12 +122,12 @@ public static class EntityCommand
                         if (attr.IsCustomAttribute) markers.Add("custom");
 
                         var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
-                        Console.Error.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-15} {attr.DisplayName}{markerText}");
+                        Console.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-15} {attr.DisplayName}{markerText}");
                     }
 
                     if (metadata.Attributes.Count > 20)
                     {
-                        Console.Error.WriteLine($"  ... and {metadata.Attributes.Count - 20} more attributes");
+                        Console.WriteLine($"  ... and {metadata.Attributes.Count - 20} more attributes");
                     }
                 }
 
@@ -137,30 +137,30 @@ public static class EntityCommand
 
                 if (totalRels > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"Relationships ({totalRels}):");
-                    Console.Error.WriteLine($"  1:N: {metadata.OneToManyRelationships.Count}");
-                    Console.Error.WriteLine($"  N:1: {metadata.ManyToOneRelationships.Count}");
-                    Console.Error.WriteLine($"  N:N: {metadata.ManyToManyRelationships.Count}");
+                    Console.WriteLine();
+                    Console.WriteLine($"Relationships ({totalRels}):");
+                    Console.WriteLine($"  1:N: {metadata.OneToManyRelationships.Count}");
+                    Console.WriteLine($"  N:1: {metadata.ManyToOneRelationships.Count}");
+                    Console.WriteLine($"  N:N: {metadata.ManyToManyRelationships.Count}");
                 }
 
                 if (metadata.Keys.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"Alternate Keys ({metadata.Keys.Count}):");
+                    Console.WriteLine();
+                    Console.WriteLine($"Alternate Keys ({metadata.Keys.Count}):");
                     foreach (var key in metadata.Keys)
                     {
-                        Console.Error.WriteLine($"  {key.LogicalName}: {string.Join(", ", key.KeyAttributes)}");
+                        Console.WriteLine($"  {key.LogicalName}: {string.Join(", ", key.KeyAttributes)}");
                     }
                 }
 
                 if (metadata.Privileges.Count > 0)
                 {
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"Privileges ({metadata.Privileges.Count}):");
+                    Console.WriteLine();
+                    Console.WriteLine($"Privileges ({metadata.Privileges.Count}):");
                     foreach (var priv in metadata.Privileges)
                     {
-                        Console.Error.WriteLine($"  {priv.PrivilegeType}: {priv.Name}");
+                        Console.WriteLine($"  {priv.PrivilegeType}: {priv.Name}");
                     }
                 }
             }

--- a/src/PPDS.Cli/Commands/Metadata/KeysCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/KeysCommand.cs
@@ -81,9 +81,9 @@ public static class KeysCommand
             }
             else
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"{"Logical Name",-30} {"Display Name",-30} {"Attributes",-30} {"Status"}");
-                Console.Error.WriteLine(new string('-', 100));
+                Console.WriteLine();
+                Console.WriteLine($"{"Logical Name",-30} {"Display Name",-30} {"Attributes",-30} {"Status"}");
+                Console.WriteLine(new string('-', 100));
 
                 foreach (var key in keys)
                 {
@@ -93,11 +93,11 @@ public static class KeysCommand
                     if (key.EntityKeyIndexStatus != "Active") flags.Add(key.EntityKeyIndexStatus ?? "unknown");
 
                     var flagText = flags.Count > 0 ? string.Join(", ", flags) : "Active";
-                    Console.Error.WriteLine($"  {key.LogicalName,-30} {key.DisplayName,-30} {attributes,-30} {flagText}");
+                    Console.WriteLine($"  {key.LogicalName,-30} {key.DisplayName,-30} {attributes,-30} {flagText}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {keys.Count} alternate keys");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {keys.Count} alternate keys");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/OptionSetCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/OptionSetCommand.cs
@@ -81,23 +81,23 @@ public static class OptionSetCommand
             }
             else
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Option Set: {optionSet.Name}");
-                Console.Error.WriteLine($"  Display Name: {optionSet.DisplayName}");
-                Console.Error.WriteLine($"  Type:         {optionSet.OptionSetType}");
-                Console.Error.WriteLine($"  Is Global:    {optionSet.IsGlobal}");
-                Console.Error.WriteLine($"  Is Custom:    {optionSet.IsCustomOptionSet}");
-                Console.Error.WriteLine($"  Is Managed:   {optionSet.IsManaged}");
+                Console.WriteLine();
+                Console.WriteLine($"Option Set: {optionSet.Name}");
+                Console.WriteLine($"  Display Name: {optionSet.DisplayName}");
+                Console.WriteLine($"  Type:         {optionSet.OptionSetType}");
+                Console.WriteLine($"  Is Global:    {optionSet.IsGlobal}");
+                Console.WriteLine($"  Is Custom:    {optionSet.IsCustomOptionSet}");
+                Console.WriteLine($"  Is Managed:   {optionSet.IsManaged}");
 
                 if (!string.IsNullOrEmpty(optionSet.Description))
                 {
-                    Console.Error.WriteLine($"  Description:  {optionSet.Description}");
+                    Console.WriteLine($"  Description:  {optionSet.Description}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Options ({optionSet.Options.Count}):");
-                Console.Error.WriteLine($"  {"Value",-10} {"Label",-40} {"Flags"}");
-                Console.Error.WriteLine($"  {new string('-', 70)}");
+                Console.WriteLine();
+                Console.WriteLine($"Options ({optionSet.Options.Count}):");
+                Console.WriteLine($"  {"Value",-10} {"Label",-40} {"Flags"}");
+                Console.WriteLine($"  {new string('-', 70)}");
 
                 foreach (var option in optionSet.Options)
                 {
@@ -107,7 +107,7 @@ public static class OptionSetCommand
                     if (!string.IsNullOrEmpty(option.Color)) flags.Add($"color={option.Color}");
 
                     var flagText = flags.Count > 0 ? string.Join(", ", flags) : "";
-                    Console.Error.WriteLine($"  {option.Value,-10} {option.Label,-40} {flagText}");
+                    Console.WriteLine($"  {option.Value,-10} {option.Label,-40} {flagText}");
                 }
             }
 

--- a/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/OptionSetsCommand.cs
@@ -81,9 +81,9 @@ public static class OptionSetsCommand
             }
             else
             {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"{"Name",-45} {"Type",-15} {"Display Name",-30} {"Options"}");
-                Console.Error.WriteLine(new string('-', 100));
+                Console.WriteLine();
+                Console.WriteLine($"{"Name",-45} {"Type",-15} {"Display Name",-30} {"Options"}");
+                Console.WriteLine(new string('-', 100));
 
                 foreach (var os in optionSets)
                 {
@@ -92,11 +92,11 @@ public static class OptionSetsCommand
                     if (os.IsManaged) markers.Add("managed");
 
                     var markerText = markers.Count > 0 ? $" [{string.Join(", ", markers)}]" : "";
-                    Console.Error.WriteLine($"  {os.Name,-45} {os.OptionSetType,-15} {os.DisplayName,-30} {os.OptionCount}{markerText}");
+                    Console.WriteLine($"  {os.Name,-45} {os.OptionSetType,-15} {os.DisplayName,-30} {os.OptionCount}{markerText}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {optionSets.Count} option sets");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {optionSets.Count} option sets");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Metadata/RelationshipsCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/RelationshipsCommand.cs
@@ -89,56 +89,56 @@ public static class RelationshipsCommand
             }
             else
             {
-                Console.Error.WriteLine();
+                Console.WriteLine();
 
                 if (relationships.OneToMany.Count > 0)
                 {
-                    Console.Error.WriteLine("One-to-Many (1:N) Relationships:");
-                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Related Entity",-30} {"Lookup Field"}");
-                    Console.Error.WriteLine($"  {new string('-', 90)}");
+                    Console.WriteLine("One-to-Many (1:N) Relationships:");
+                    Console.WriteLine($"  {"Schema Name",-45} {"Related Entity",-30} {"Lookup Field"}");
+                    Console.WriteLine($"  {new string('-', 90)}");
 
                     foreach (var rel in relationships.OneToMany)
                     {
                         var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
-                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencingEntity,-30} {rel.ReferencingAttribute}{customMarker}");
+                        Console.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencingEntity,-30} {rel.ReferencingAttribute}{customMarker}");
                     }
 
-                    Console.Error.WriteLine();
+                    Console.WriteLine();
                 }
 
                 if (relationships.ManyToOne.Count > 0)
                 {
-                    Console.Error.WriteLine("Many-to-One (N:1) Relationships:");
-                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Referenced Entity",-30} {"Lookup Field"}");
-                    Console.Error.WriteLine($"  {new string('-', 90)}");
+                    Console.WriteLine("Many-to-One (N:1) Relationships:");
+                    Console.WriteLine($"  {"Schema Name",-45} {"Referenced Entity",-30} {"Lookup Field"}");
+                    Console.WriteLine($"  {new string('-', 90)}");
 
                     foreach (var rel in relationships.ManyToOne)
                     {
                         var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
-                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencedEntity,-30} {rel.ReferencingAttribute}{customMarker}");
+                        Console.WriteLine($"  {rel.SchemaName,-45} {rel.ReferencedEntity,-30} {rel.ReferencingAttribute}{customMarker}");
                     }
 
-                    Console.Error.WriteLine();
+                    Console.WriteLine();
                 }
 
                 if (relationships.ManyToMany.Count > 0)
                 {
-                    Console.Error.WriteLine("Many-to-Many (N:N) Relationships:");
-                    Console.Error.WriteLine($"  {"Schema Name",-45} {"Entity 1",-20} {"Entity 2",-20} {"Intersect Entity"}");
-                    Console.Error.WriteLine($"  {new string('-', 100)}");
+                    Console.WriteLine("Many-to-Many (N:N) Relationships:");
+                    Console.WriteLine($"  {"Schema Name",-45} {"Entity 1",-20} {"Entity 2",-20} {"Intersect Entity"}");
+                    Console.WriteLine($"  {new string('-', 100)}");
 
                     foreach (var rel in relationships.ManyToMany)
                     {
                         var customMarker = rel.IsCustomRelationship ? " [custom]" : "";
                         var reflexiveMarker = rel.IsReflexive ? " [reflexive]" : "";
-                        Console.Error.WriteLine($"  {rel.SchemaName,-45} {rel.Entity1LogicalName,-20} {rel.Entity2LogicalName,-20} {rel.IntersectEntityName}{customMarker}{reflexiveMarker}");
+                        Console.WriteLine($"  {rel.SchemaName,-45} {rel.Entity1LogicalName,-20} {rel.Entity2LogicalName,-20} {rel.IntersectEntityName}{customMarker}{reflexiveMarker}");
                     }
 
-                    Console.Error.WriteLine();
+                    Console.WriteLine();
                 }
 
                 var total = relationships.OneToMany.Count + relationships.ManyToOne.Count + relationships.ManyToMany.Count;
-                Console.Error.WriteLine($"Total: {total} relationships (1:N: {relationships.OneToMany.Count}, N:1: {relationships.ManyToOne.Count}, N:N: {relationships.ManyToMany.Count})");
+                Console.WriteLine($"Total: {total} relationships (1:N: {relationships.OneToMany.Count}, N:1: {relationships.ManyToOne.Count}, N:N: {relationships.ManyToMany.Count})");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/PluginTraces/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/GetCommand.cs
@@ -141,69 +141,69 @@ public static class GetCommand
 
     private static void WriteTextOutput(PluginTraceDetail trace)
     {
-        Console.Error.WriteLine($"Plugin Trace: {trace.Id}");
-        Console.Error.WriteLine(new string('=', 60));
-        Console.Error.WriteLine();
+        Console.WriteLine($"Plugin Trace: {trace.Id}");
+        Console.WriteLine(new string('=', 60));
+        Console.WriteLine();
 
         // Basic info
-        Console.Error.WriteLine($"  Type:          {trace.TypeName}");
-        Console.Error.WriteLine($"  Message:       {trace.MessageName ?? "-"}");
-        Console.Error.WriteLine($"  Entity:        {trace.PrimaryEntity ?? "-"}");
-        Console.Error.WriteLine($"  Mode:          {trace.Mode}");
-        Console.Error.WriteLine($"  Operation:     {trace.OperationType}");
-        Console.Error.WriteLine($"  Depth:         {trace.Depth}");
-        Console.Error.WriteLine();
+        Console.WriteLine($"  Type:          {trace.TypeName}");
+        Console.WriteLine($"  Message:       {trace.MessageName ?? "-"}");
+        Console.WriteLine($"  Entity:        {trace.PrimaryEntity ?? "-"}");
+        Console.WriteLine($"  Mode:          {trace.Mode}");
+        Console.WriteLine($"  Operation:     {trace.OperationType}");
+        Console.WriteLine($"  Depth:         {trace.Depth}");
+        Console.WriteLine();
 
         // Timing
-        Console.Error.WriteLine("Timing:");
-        Console.Error.WriteLine($"  Created:              {trace.CreatedOn:G}");
+        Console.WriteLine("Timing:");
+        Console.WriteLine($"  Created:              {trace.CreatedOn:G}");
         if (trace.ExecutionStartTime.HasValue)
         {
-            Console.Error.WriteLine($"  Execution Start:      {trace.ExecutionStartTime:G}");
+            Console.WriteLine($"  Execution Start:      {trace.ExecutionStartTime:G}");
         }
         if (trace.ConstructorStartTime.HasValue)
         {
-            Console.Error.WriteLine($"  Constructor Start:    {trace.ConstructorStartTime:G}");
+            Console.WriteLine($"  Constructor Start:    {trace.ConstructorStartTime:G}");
         }
-        Console.Error.WriteLine($"  Execution Duration:   {trace.DurationMs?.ToString() ?? "-"} ms");
-        Console.Error.WriteLine($"  Constructor Duration: {trace.ConstructorDurationMs?.ToString() ?? "-"} ms");
-        Console.Error.WriteLine();
+        Console.WriteLine($"  Execution Duration:   {trace.DurationMs?.ToString() ?? "-"} ms");
+        Console.WriteLine($"  Constructor Duration: {trace.ConstructorDurationMs?.ToString() ?? "-"} ms");
+        Console.WriteLine();
 
         // Correlation
-        Console.Error.WriteLine("Correlation:");
-        Console.Error.WriteLine($"  Correlation ID: {trace.CorrelationId?.ToString() ?? "-"}");
-        Console.Error.WriteLine($"  Request ID:     {trace.RequestId?.ToString() ?? "-"}");
-        Console.Error.WriteLine($"  Plugin Step ID: {trace.PluginStepId?.ToString() ?? "-"}");
-        Console.Error.WriteLine();
+        Console.WriteLine("Correlation:");
+        Console.WriteLine($"  Correlation ID: {trace.CorrelationId?.ToString() ?? "-"}");
+        Console.WriteLine($"  Request ID:     {trace.RequestId?.ToString() ?? "-"}");
+        Console.WriteLine($"  Plugin Step ID: {trace.PluginStepId?.ToString() ?? "-"}");
+        Console.WriteLine();
 
         // Exception details
         if (trace.HasException && !string.IsNullOrEmpty(trace.ExceptionDetails))
         {
-            Console.Error.WriteLine("Exception:");
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine(trace.ExceptionDetails);
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine();
+            Console.WriteLine("Exception:");
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine(trace.ExceptionDetails);
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine();
         }
 
         // Message block (trace output)
         if (!string.IsNullOrEmpty(trace.MessageBlock))
         {
-            Console.Error.WriteLine("Trace Output:");
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine(trace.MessageBlock);
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine();
+            Console.WriteLine("Trace Output:");
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine(trace.MessageBlock);
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine();
         }
 
         // Configuration
         if (!string.IsNullOrEmpty(trace.Configuration))
         {
-            Console.Error.WriteLine("Configuration:");
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine(trace.Configuration);
-            Console.Error.WriteLine(new string('-', 60));
-            Console.Error.WriteLine();
+            Console.WriteLine("Configuration:");
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine(trace.Configuration);
+            Console.WriteLine(new string('-', 60));
+            Console.WriteLine();
         }
     }
 

--- a/src/PPDS.Cli/Commands/PluginTraces/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/ListCommand.cs
@@ -363,7 +363,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No plugin traces found.");
+                    Console.WriteLine("No plugin traces found.");
                 }
                 return ExitCodes.Success;
             }
@@ -412,8 +412,8 @@ public static class ListCommand
 
     private static void WriteTextOutput(List<PluginTraceInfo> traces)
     {
-        Console.Error.WriteLine($"{"Type",-35} {"Message",-12} {"Entity",-20} {"Mode",-6} {"Duration",-10} {"Status",-6} {"Created",-20}");
-        Console.Error.WriteLine(new string('-', 115));
+        Console.WriteLine($"{"Type",-35} {"Message",-12} {"Entity",-20} {"Mode",-6} {"Duration",-10} {"Status",-6} {"Created",-20}");
+        Console.WriteLine(new string('-', 115));
 
         foreach (var trace in traces)
         {
@@ -425,11 +425,11 @@ public static class ListCommand
             var status = trace.HasException ? "Error" : "OK";
             var created = trace.CreatedOn.ToString("g");
 
-            Console.Error.WriteLine($"{type,-35} {message,-12} {entity,-20} {mode,-6} {duration,-10} {status,-6} {created,-20}");
+            Console.WriteLine($"{type,-35} {message,-12} {entity,-20} {mode,-6} {duration,-10} {status,-6} {created,-20}");
         }
 
-        Console.Error.WriteLine();
-        Console.Error.WriteLine($"Total: {traces.Count} trace(s)");
+        Console.WriteLine();
+        Console.WriteLine($"Total: {traces.Count} trace(s)");
     }
 
     private static string GetCsvHeader()

--- a/src/PPDS.Cli/Commands/PluginTraces/RelatedCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/RelatedCommand.cs
@@ -159,7 +159,7 @@ public static class RelatedCommand
                     }
                     else
                     {
-                        Console.Error.WriteLine($"No traces found for entity: {recordEntity}");
+                        Console.WriteLine($"No traces found for entity: {recordEntity}");
                     }
                     return ExitCodes.Success;
                 }
@@ -186,10 +186,10 @@ public static class RelatedCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Traces for entity: {recordEntity}");
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"{"#",-3} {"Depth",-5} {"Type",-35} {"Message",-12} {"Duration",-10} {"Status",-6}");
-                    Console.Error.WriteLine(new string('-', 75));
+                    Console.WriteLine($"Traces for entity: {recordEntity}");
+                    Console.WriteLine();
+                    Console.WriteLine($"{"#",-3} {"Depth",-5} {"Type",-35} {"Message",-12} {"Duration",-10} {"Status",-6}");
+                    Console.WriteLine(new string('-', 75));
 
                     int idx = 1;
                     foreach (var trace in traces)
@@ -199,12 +199,12 @@ public static class RelatedCommand
                         var duration = trace.DurationMs.HasValue ? $"{trace.DurationMs}ms" : "-";
                         var status = trace.HasException ? "Error" : "OK";
 
-                        Console.Error.WriteLine($"{idx,-3} {trace.Depth,-5} {type,-35} {message,-12} {duration,-10} {status,-6}");
+                        Console.WriteLine($"{idx,-3} {trace.Depth,-5} {type,-35} {message,-12} {duration,-10} {status,-6}");
                         idx++;
                     }
 
-                    Console.Error.WriteLine();
-                    Console.Error.WriteLine($"Total: {traces.Count} trace(s)");
+                    Console.WriteLine();
+                    Console.WriteLine($"Total: {traces.Count} trace(s)");
                 }
 
                 return ExitCodes.Success;
@@ -295,10 +295,10 @@ public static class RelatedCommand
             }
             else
             {
-                Console.Error.WriteLine($"Related traces for correlation ID: {lookupCorrelationId}");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"{"#",-3} {"Depth",-5} {"Type",-35} {"Message",-12} {"Duration",-10} {"Status",-6}");
-                Console.Error.WriteLine(new string('-', 75));
+                Console.WriteLine($"Related traces for correlation ID: {lookupCorrelationId}");
+                Console.WriteLine();
+                Console.WriteLine($"{"#",-3} {"Depth",-5} {"Type",-35} {"Message",-12} {"Duration",-10} {"Status",-6}");
+                Console.WriteLine(new string('-', 75));
 
                 int idx = 1;
                 foreach (var trace in traces)
@@ -308,12 +308,12 @@ public static class RelatedCommand
                     var duration = trace.DurationMs.HasValue ? $"{trace.DurationMs}ms" : "-";
                     var status = trace.HasException ? "Error" : "OK";
 
-                    Console.Error.WriteLine($"{idx,-3} {trace.Depth,-5} {type,-35} {message,-12} {duration,-10} {status,-6}");
+                    Console.WriteLine($"{idx,-3} {trace.Depth,-5} {type,-35} {message,-12} {duration,-10} {status,-6}");
                     idx++;
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {traces.Count} related trace(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {traces.Count} related trace(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/PluginTraces/RelatedCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/RelatedCommand.cs
@@ -268,7 +268,7 @@ public static class RelatedCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"No related traces found for correlation ID: {lookupCorrelationId}");
+                    Console.WriteLine($"No related traces found for correlation ID: {lookupCorrelationId}");
                 }
                 return ExitCodes.Success;
             }

--- a/src/PPDS.Cli/Commands/PluginTraces/TimelineCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/TimelineCommand.cs
@@ -234,7 +234,7 @@ public static class TimelineCommand
         }
         sb.Append($" ({durationStr}) {statusIcon}");
 
-        Console.WriteLine(sb.ToString());
+        Console.WriteLine(sb);
 
         // If there's an exception, show a truncated message
         if (trace.HasException)

--- a/src/PPDS.Cli/Commands/PluginTraces/TimelineCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/TimelineCommand.cs
@@ -160,7 +160,7 @@ public static class TimelineCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"No traces found for correlation ID: {lookupCorrelationId}");
+                    Console.WriteLine($"No traces found for correlation ID: {lookupCorrelationId}");
                 }
                 return ExitCodes.Success;
             }
@@ -185,9 +185,9 @@ public static class TimelineCommand
             {
                 // Display header
                 var firstTrace = timeline.First().Trace;
-                Console.Error.WriteLine($"Request: {lookupCorrelationId}  ({firstTrace.CreatedOn:G})");
-                Console.Error.WriteLine($"Total Duration: {totalDuration}ms  |  {totalNodes} plugin executions");
-                Console.Error.WriteLine();
+                Console.WriteLine($"Request: {lookupCorrelationId}  ({firstTrace.CreatedOn:G})");
+                Console.WriteLine($"Total Duration: {totalDuration}ms  |  {totalNodes} plugin executions");
+                Console.WriteLine();
 
                 // Draw tree
                 foreach (var node in timeline)
@@ -234,13 +234,13 @@ public static class TimelineCommand
         }
         sb.Append($" ({durationStr}) {statusIcon}");
 
-        Console.Error.WriteLine(sb.ToString());
+        Console.WriteLine(sb.ToString());
 
         // If there's an exception, show a truncated message
         if (trace.HasException)
         {
             var exceptionPrefix = prefix + (isLast ? "    " : "\u2502   "); // "│   " or "    "
-            Console.Error.WriteLine($"{exceptionPrefix}Exception: (use 'get {trace.Id}' for details)");
+            Console.WriteLine($"{exceptionPrefix}Exception: (use 'get {trace.Id}' for details)");
         }
 
         // Draw children

--- a/src/PPDS.Cli/Commands/Plugins/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/GetCommand.cs
@@ -489,7 +489,7 @@ public static class GetCommand
         foreach (var kvp in properties)
         {
             var key = kvp.Key.PadRight(maxKeyLength);
-            Console.Error.WriteLine($"  {key}  {kvp.Value}");
+            Console.WriteLine($"  {key}  {kvp.Value}");
         }
     }
 

--- a/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ListCommand.cs
@@ -185,7 +185,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No plugin assemblies or packages found.");
+                    Console.WriteLine("No plugin assemblies or packages found.");
                 }
                 return ExitCodes.Success;
             }
@@ -199,18 +199,18 @@ public static class ListCommand
                 // Print assemblies
                 foreach (var assembly in output.Assemblies)
                 {
-                    Console.Error.WriteLine($"Assembly: {assembly.Name} (v{assembly.Version})");
+                    Console.WriteLine($"Assembly: {assembly.Name} (v{assembly.Version})");
                     PrintTypes(assembly.Types);
-                    Console.Error.WriteLine();
+                    Console.WriteLine();
                 }
 
                 // Print packages
                 foreach (var package in output.Packages)
                 {
                     var uniqueName = package.UniqueName != package.Name ? $" [{package.UniqueName}]" : "";
-                    Console.Error.WriteLine($"Package: {package.Name}{uniqueName} (v{package.Version})");
+                    Console.WriteLine($"Package: {package.Name}{uniqueName} (v{package.Version})");
                     PrintPackageAssemblies(package.Assemblies);
-                    Console.Error.WriteLine();
+                    Console.WriteLine();
                 }
 
                 var totalPackageAssemblies = output.Packages.Sum(p => p.Assemblies.Count);
@@ -238,7 +238,7 @@ public static class ListCommand
                     summaryParts.Add(Pluralize(totalImages, "image", "images"));
                 }
 
-                Console.Error.WriteLine($"Total: {string.Join(", ", summaryParts)}");
+                Console.WriteLine($"Total: {string.Join(", ", summaryParts)}");
             }
 
             return ExitCodes.Success;
@@ -311,13 +311,13 @@ public static class ListCommand
     {
         foreach (var type in types)
         {
-            Console.Error.WriteLine($"{indent}Type: {type.TypeName}");
+            Console.WriteLine($"{indent}Type: {type.TypeName}");
 
             foreach (var step in type.Steps)
             {
                 var status = step.IsEnabled ? "" : " [DISABLED]";
-                Console.Error.WriteLine($"{indent}  Step: {step.Name}{status}");
-                Console.Error.WriteLine($"{indent}    {step.Message} on {step.Entity} ({step.Stage}, {step.Mode})");
+                Console.WriteLine($"{indent}  Step: {step.Name}{status}");
+                Console.WriteLine($"{indent}    {step.Message} on {step.Entity} ({step.Stage}, {step.Mode})");
 
                 // Show non-default deployment/user/async settings on one line if any are set
                 var stepOptions = new List<string>();
@@ -335,23 +335,23 @@ public static class ListCommand
                 }
                 if (stepOptions.Count > 0)
                 {
-                    Console.Error.WriteLine($"{indent}    {string.Join(" | ", stepOptions)}");
+                    Console.WriteLine($"{indent}    {string.Join(" | ", stepOptions)}");
                 }
 
                 if (!string.IsNullOrEmpty(step.FilteringAttributes))
                 {
-                    Console.Error.WriteLine($"{indent}    Filtering: {step.FilteringAttributes}");
+                    Console.WriteLine($"{indent}    Filtering: {step.FilteringAttributes}");
                 }
 
                 if (!string.IsNullOrEmpty(step.Description))
                 {
-                    Console.Error.WriteLine($"{indent}    Description: {step.Description}");
+                    Console.WriteLine($"{indent}    Description: {step.Description}");
                 }
 
                 foreach (var image in step.Images)
                 {
                     var attrs = string.IsNullOrEmpty(image.Attributes) ? "all" : image.Attributes;
-                    Console.Error.WriteLine($"{indent}    Image: {image.Name} ({image.ImageType}) - {attrs}");
+                    Console.WriteLine($"{indent}    Image: {image.Name} ({image.ImageType}) - {attrs}");
                 }
             }
         }
@@ -361,7 +361,7 @@ public static class ListCommand
     {
         foreach (var assembly in assemblies)
         {
-            Console.Error.WriteLine($"  Assembly: {assembly.Name} (v{assembly.Version})");
+            Console.WriteLine($"  Assembly: {assembly.Name} (v{assembly.Version})");
             PrintTypes(assembly.Types, "    ");
         }
     }

--- a/src/PPDS.Cli/Commands/Query/FetchCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/FetchCommand.cs
@@ -256,7 +256,7 @@ public static class FetchCommand
 
         if (result.MoreRecords)
         {
-            Console.WriteLine("More records available (use --page or --paging-cookie for continuation)");
+            Console.Error.WriteLine("More records available (use --page or --paging-cookie for continuation)");
         }
 
         Console.WriteLine($"Execution Time: {result.ExecutionTimeMs}ms");

--- a/src/PPDS.Cli/Commands/Query/FetchCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/FetchCommand.cs
@@ -238,29 +238,29 @@ public static class FetchCommand
 
     private static void WriteTableOutput(QueryResult result)
     {
-        Console.Error.WriteLine();
+        Console.WriteLine();
 
         if (result.Count == 0)
         {
-            Console.Error.WriteLine("No records found.");
+            Console.WriteLine("No records found.");
             return;
         }
 
-        Console.Error.WriteLine($"Entity: {result.EntityLogicalName}");
-        Console.Error.WriteLine($"Records: {result.Count}");
+        Console.WriteLine($"Entity: {result.EntityLogicalName}");
+        Console.WriteLine($"Records: {result.Count}");
 
         if (result.TotalCount.HasValue)
         {
-            Console.Error.WriteLine($"Total Count: {result.TotalCount}");
+            Console.WriteLine($"Total Count: {result.TotalCount}");
         }
 
         if (result.MoreRecords)
         {
-            Console.Error.WriteLine("More records available (use --page or --paging-cookie for continuation)");
+            Console.WriteLine("More records available (use --page or --paging-cookie for continuation)");
         }
 
-        Console.Error.WriteLine($"Execution Time: {result.ExecutionTimeMs}ms");
-        Console.Error.WriteLine();
+        Console.WriteLine($"Execution Time: {result.ExecutionTimeMs}ms");
+        Console.WriteLine();
 
         // Print table header
         var columns = result.Columns;
@@ -302,9 +302,9 @@ public static class FetchCommand
 
         if (result.MoreRecords && !string.IsNullOrEmpty(result.PagingCookie))
         {
-            Console.Error.WriteLine();
-            Console.Error.WriteLine($"Paging cookie (for continuation):");
-            Console.Error.WriteLine(result.PagingCookie);
+            Console.WriteLine();
+            Console.WriteLine($"Paging cookie (for continuation):");
+            Console.WriteLine(result.PagingCookie);
         }
     }
 

--- a/src/PPDS.Cli/Commands/Query/History/GetCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/GetCommand.cs
@@ -112,20 +112,20 @@ public static class GetCommand
 
     private static void WriteTextOutput(QueryHistoryEntry entry)
     {
-        Console.Error.WriteLine($"ID:           {entry.Id}");
-        Console.Error.WriteLine($"Executed At:  {entry.ExecutedAt.LocalDateTime:yyyy-MM-dd HH:mm:ss}");
-        Console.Error.WriteLine($"Row Count:    {entry.RowCount?.ToString() ?? "-"}");
-        Console.Error.WriteLine($"Duration:     {(entry.ExecutionTimeMs.HasValue ? $"{entry.ExecutionTimeMs}ms" : "-")}");
-        Console.Error.WriteLine($"Success:      {entry.Success}");
+        Console.WriteLine($"ID:           {entry.Id}");
+        Console.WriteLine($"Executed At:  {entry.ExecutedAt.LocalDateTime:yyyy-MM-dd HH:mm:ss}");
+        Console.WriteLine($"Row Count:    {entry.RowCount?.ToString() ?? "-"}");
+        Console.WriteLine($"Duration:     {(entry.ExecutionTimeMs.HasValue ? $"{entry.ExecutionTimeMs}ms" : "-")}");
+        Console.WriteLine($"Success:      {entry.Success}");
 
         if (!string.IsNullOrEmpty(entry.ErrorMessage))
         {
-            Console.Error.WriteLine($"Error:        {entry.ErrorMessage}");
+            Console.WriteLine($"Error:        {entry.ErrorMessage}");
         }
 
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("SQL:");
-        Console.Error.WriteLine(new string('-', 40));
+        Console.WriteLine();
+        Console.WriteLine("SQL:");
+        Console.WriteLine(new string('-', 40));
         Console.WriteLine(entry.Sql);
     }
 

--- a/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
@@ -133,8 +133,8 @@ public static class ListCommand
 
     private static void WriteTextOutput(IReadOnlyList<QueryHistoryEntry> entries)
     {
-        Console.Error.WriteLine($"{"ID",-14} {"Executed",-18} {"Rows",-8} {"Time",-10} {"Query Preview",-40}");
-        Console.Error.WriteLine(new string('-', 95));
+        Console.WriteLine($"{"ID",-14} {"Executed",-18} {"Rows",-8} {"Time",-10} {"Query Preview",-40}");
+        Console.WriteLine(new string('-', 95));
 
         foreach (var entry in entries)
         {
@@ -144,11 +144,11 @@ public static class ListCommand
             var time = entry.ExecutionTimeMs.HasValue ? $"{entry.ExecutionTimeMs}ms" : "-";
             var preview = GetQueryPreview(entry.Sql, 40);
 
-            Console.Error.WriteLine($"{id,-14} {executed,-18} {rows,-8} {time,-10} {preview,-40}");
+            Console.WriteLine($"{id,-14} {executed,-18} {rows,-8} {time,-10} {preview,-40}");
         }
 
-        Console.Error.WriteLine();
-        Console.Error.WriteLine($"Total: {entries.Count} entries");
+        Console.WriteLine();
+        Console.WriteLine($"Total: {entries.Count} entries");
     }
 
     private static string GetQueryPreview(string sql, int maxLength)

--- a/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ListCommand.cs
@@ -94,7 +94,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No query history found.");
+                    Console.WriteLine("No query history found.");
                 }
                 return ExitCodes.Success;
             }

--- a/src/PPDS.Cli/Commands/Roles/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Roles/ListCommand.cs
@@ -91,12 +91,12 @@ public static class ListCommand
             {
                 if (roles.Count == 0)
                 {
-                    Console.Error.WriteLine("No roles found.");
+                    Console.WriteLine("No roles found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {roles.Count} role(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {roles.Count} role(s):");
+                    Console.WriteLine();
 
                     foreach (var role in roles)
                     {

--- a/src/PPDS.Cli/Commands/ServiceEndpoints/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/ServiceEndpoints/ListCommand.cs
@@ -72,7 +72,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No service endpoints found.");
+                    Console.WriteLine("No service endpoints found.");
                 }
                 return ExitCodes.Success;
             }
@@ -108,19 +108,19 @@ public static class ListCommand
                     var managed = endpoint.IsManaged ? " [managed]" : "";
                     if (endpoint.IsWebhook)
                     {
-                        Console.Error.WriteLine($"Webhook: {endpoint.Name}{managed}");
+                        Console.WriteLine($"Webhook: {endpoint.Name}{managed}");
                         if (!string.IsNullOrEmpty(endpoint.Url))
-                            Console.Error.WriteLine($"  URL: {endpoint.Url}");
+                            Console.WriteLine($"  URL: {endpoint.Url}");
                     }
                     else
                     {
-                        Console.Error.WriteLine($"Service Bus ({endpoint.ContractType}): {endpoint.Name}{managed}");
+                        Console.WriteLine($"Service Bus ({endpoint.ContractType}): {endpoint.Name}{managed}");
                         if (!string.IsNullOrEmpty(endpoint.NamespaceAddress))
-                            Console.Error.WriteLine($"  Namespace: {endpoint.NamespaceAddress}");
+                            Console.WriteLine($"  Namespace: {endpoint.NamespaceAddress}");
                         if (!string.IsNullOrEmpty(endpoint.Path))
-                            Console.Error.WriteLine($"  Path: {endpoint.Path}");
+                            Console.WriteLine($"  Path: {endpoint.Path}");
                     }
-                    Console.Error.WriteLine($"  Auth: {endpoint.AuthType}");
+                    Console.WriteLine($"  Auth: {endpoint.AuthType}");
                 }
 
                 var webhookCount = endpoints.Count(e => e.IsWebhook);
@@ -128,8 +128,8 @@ public static class ListCommand
                 var parts = new List<string>();
                 if (webhookCount > 0) parts.Add($"{webhookCount} webhook(s)");
                 if (serviceBusCount > 0) parts.Add($"{serviceBusCount} service bus endpoint(s)");
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {string.Join(", ", parts)}");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {string.Join(", ", parts)}");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Solutions/ComponentsCommand.cs
+++ b/src/PPDS.Cli/Commands/Solutions/ComponentsCommand.cs
@@ -101,7 +101,7 @@ public static class ComponentsCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine($"No components found in solution '{uniqueName}'.");
+                    Console.WriteLine($"No components found in solution '{uniqueName}'.");
                 }
                 return ExitCodes.Success;
             }
@@ -129,11 +129,11 @@ public static class ComponentsCommand
 
                 foreach (var group in grouped)
                 {
-                    Console.Error.WriteLine($"{group.Key}: {group.Count()}");
+                    Console.WriteLine($"{group.Key}: {group.Count()}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {components.Count} component(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {components.Count} component(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Solutions/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Solutions/ListCommand.cs
@@ -90,7 +90,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No solutions found.");
+                    Console.WriteLine("No solutions found.");
                 }
                 return ExitCodes.Success;
             }
@@ -115,8 +115,8 @@ public static class ListCommand
             else
             {
                 // Table output
-                Console.Error.WriteLine($"{"Name",-40} {"Unique Name",-30} {"Version",-12} {"Publisher",-20} {"Managed"}");
-                Console.Error.WriteLine(new string('-', 120));
+                Console.WriteLine($"{"Name",-40} {"Unique Name",-30} {"Version",-12} {"Publisher",-20} {"Managed"}");
+                Console.WriteLine(new string('-', 120));
 
                 foreach (var solution in solutions)
                 {
@@ -126,11 +126,11 @@ public static class ListCommand
                     var publisher = Truncate(solution.PublisherName ?? "-", 20);
                     var managed = solution.IsManaged ? "Yes" : "No";
 
-                    Console.Error.WriteLine($"{name,-40} {uniqueName,-30} {version,-12} {publisher,-20} {managed}");
+                    Console.WriteLine($"{name,-40} {uniqueName,-30} {version,-12} {publisher,-20} {managed}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {solutions.Count} solution(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {solutions.Count} solution(s)");
             }
 
             return ExitCodes.Success;

--- a/src/PPDS.Cli/Commands/Users/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/Users/ListCommand.cs
@@ -110,12 +110,12 @@ public static class ListCommand
             {
                 if (users.Count == 0)
                 {
-                    Console.Error.WriteLine("No users found.");
+                    Console.WriteLine("No users found.");
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Found {users.Count} user(s):");
-                    Console.Error.WriteLine();
+                    Console.WriteLine($"Found {users.Count} user(s):");
+                    Console.WriteLine();
 
                     foreach (var u in users)
                     {

--- a/src/PPDS.Cli/Commands/WebResources/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/WebResources/ListCommand.cs
@@ -166,7 +166,7 @@ public static class ListCommand
                 }
                 else
                 {
-                    Console.Error.WriteLine("No web resources found.");
+                    Console.WriteLine("No web resources found.");
                 }
                 return ExitCodes.Success;
             }
@@ -194,8 +194,8 @@ public static class ListCommand
             }
             else
             {
-                Console.Error.WriteLine($"{"Name",-50} {"Type",-12} {"Managed",-10} {"Modified On",-20} {"Modified By"}");
-                Console.Error.WriteLine(new string('-', 112));
+                Console.WriteLine($"{"Name",-50} {"Type",-12} {"Managed",-10} {"Modified On",-20} {"Modified By"}");
+                Console.WriteLine(new string('-', 112));
 
                 foreach (var r in resources)
                 {
@@ -205,11 +205,11 @@ public static class ListCommand
                     var modified = r.ModifiedOn?.ToString("yyyy-MM-dd HH:mm") ?? "-";
                     var modifiedBy = Truncate(r.ModifiedByName ?? "-", 20);
 
-                    Console.Error.WriteLine($"{name,-50} {type_,-12} {managed,-10} {modified,-20} {modifiedBy}");
+                    Console.WriteLine($"{name,-50} {type_,-12} {managed,-10} {modified,-20} {modifiedBy}");
                 }
 
-                Console.Error.WriteLine();
-                Console.Error.WriteLine($"Total: {resources.Count} web resource(s)");
+                Console.WriteLine();
+                Console.WriteLine($"Total: {resources.Count} web resource(s)");
             }
 
             return ExitCodes.Success;


### PR DESCRIPTION
## Summary

- Routes text-mode data output to stdout across 38 CLI command files; previously it was going to stderr, breaking `ppds X | grep ...` and `ppds X > file.txt` pipes
- Keeps status/progress/errors, connection headers, and mutation confirmations on stderr where they belong
- Fixes `Data/AnalyzeCommand` whose entire `WriteTextOutput()` block was on stderr while its JSON counterpart correctly used stdout

Closes #1077

## What changed

**Rule applied:** table rows, "No X found." empty-list messages, and structured query results → `Console.WriteLine` (stdout). Status, progress, errors, mutation confirmations → `Console.Error.WriteLine` (stderr) unchanged.

**Files fixed (38 total):**
- `ConnectionReferences/` — AnalyzeCommand, ConnectionsCommand, FlowsCommand, ListCommand
- `Connections/ListCommand`
- `CustomApis/` — GetCommand, ListCommand
- `Data/AnalyzeCommand` — entire `WriteTextOutput()` was on stderr
- `DataProviders/ListCommand`, `DataSources/ListCommand`
- `Env/EnvCommandGroup` — "No environments found/matching", "No configuration found" (show)
- `EnvironmentVariables/ListCommand`, `Flows/ListCommand`, `ImportJobs/ListCommand`
- `Metadata/` — AttributesCommand, EntitiesCommand, EntityCommand, KeysCommand, OptionSetCommand, OptionSetsCommand, RelationshipsCommand
- `PluginTraces/` — GetCommand, ListCommand, RelatedCommand, TimelineCommand
- `Plugins/` — GetCommand, ListCommand
- `Query/` — FetchCommand, History/GetCommand, History/ListCommand
- `Roles/ListCommand`, `ServiceEndpoints/ListCommand`
- `Solutions/` — ComponentsCommand, ListCommand
- `Users/ListCommand`, `WebResources/ListCommand`

**Left on stderr (legitimate):**
- Connection headers (`ConsoleHeader.WriteConnectedAs`)
- Progress/status: "Retrieving...", "Discovering...", "Loading..."
- Mutation confirmations: "Parameter added:", "Custom API registered:", "Deleted: N step(s)"
- Delete/clean commands' "No X found" (exit 0 but mutation context)
- Auth/login command output

## Test plan

- [ ] `dotnet test PPDS.sln --filter "Category!=Integration"` — 3609 passed, 0 failures
- [ ] `dotnet build PPDS.sln` — 0 errors
- [ ] Verify stdout discipline audit: `grep -rn "Console.Error.WriteLine.*No .*found" src/PPDS.Cli/Commands/` returns only mutation/error contexts
- [ ] Shell pipe test: `ppds solutions list 2>/dev/null | grep -c "."` returns non-zero when solutions exist (data on stdout, not stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
