### PR TITLE
feat(skill): /await-operator + /resume-with-answer — real bg-session pause primitive (closes #1137)

### DIFF
--- a/.claude/hooks/preuse-askuserquestion.py
+++ b/.claude/hooks/preuse-askuserquestion.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""PreToolUse hook on AskUserQuestion: block in bg/headless sessions.
+
+`AskUserQuestion` does NOT pause a bg/headless Claude session — the daemon
+auto-injects an answer within ~15-60s (the "Recommended" option, or the
+implicit "Something else" when none is marked). Issue #1137 documents the
+smoking gun; PR #1105 was filed unilaterally by a bg worker that thought
+it was asking.
+
+Detection signal: CLAUDE_JOB_DIR is exported into every bg/headless
+session by the daemon. Interactive sessions do not set it.
+
+Exit codes: 0 = allow, 2 = block (Claude Code re-feeds stderr to the
+caller, so the worker sees the message and can switch to /await-operator).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+_MESSAGE = (
+    "BLOCKED — AskUserQuestion does not pause a bg/headless session.\n"
+    "The daemon auto-answers within ~15-60s (see #1137 / #1105 smoking gun).\n"
+    "Use /await-operator instead:\n"
+    "  Skill(skill=\"await-operator\",\n"
+    "        artifact_path=\"<draft you want ratified>\",\n"
+    "        question=\"<one-sentence decision>\",\n"
+    "        options=[\"option1\", \"option2\", ...])\n"
+    "Then EXIT THE TURN — do not call further tools.\n"
+)
+
+
+def main() -> int:
+    if not os.environ.get("CLAUDE_JOB_DIR", "").strip():
+        return 0
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    if payload.get("tool_name") != "AskUserQuestion":
+        return 0
+    sys.stderr.write(_MESSAGE)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/interaction-patterns.md
+++ b/.claude/interaction-patterns.md
@@ -101,6 +101,24 @@ When the AI needs a decision:
 
 If a recommendation is rejected, return with a different recommendation — not "here are the other options." The user should not weigh unweighted options.
 
+## 5a. Pause primitives by session type <!-- since: #1137 -->
+
+When a session needs to wait on a human decision, the right primitive
+depends on whether the session is interactive or background. Picking the
+wrong one is silent — the worker thinks it asked, but no human ever sees
+the question.
+
+| Session type | Pause primitive | Why |
+|--------------|-----------------|-----|
+| **Interactive** (operator at terminal) | `AskUserQuestion` | Synchronous, in-channel. Works as documented. |
+| **Background** (`claude --bg` / daemon-spawned worker) | `/await-operator` skill | `AskUserQuestion` does NOT block in `--bg` — the daemon auto-injects an answer within ~15-60s (Recommended option or implicit "Something else"). Smoking gun: PR #1105 filed unilaterally. |
+| **Pipeline (headless `claude -p` stage)** | Don't pause — fail or default | Pipeline stages must be deterministic. If a decision is genuinely needed, exit non-zero so the orchestrator escalates. `/await-operator` works here too but stalls the pipeline. |
+
+Resume mechanism for `/await-operator`: operator runs
+`/resume-with-answer <short> <choice>` (writes `.workflow/operator-answer.json`
++ clears daemon `state=blocked`). See `.claude/skills/await-operator/SKILL.md`
+and `.claude/skills/resume-with-answer/SKILL.md` for the full round-trip.
+
 ## 6. HTML artifacts vs. chat interaction
 
 **Chat interaction** (decisions, dialogue): ASCII + markdown only. No HTML, no forms, no browser detours. Chat is synchronous text.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -235,6 +235,16 @@
         ]
       },
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/.claude/hooks/preuse-askuserquestion.py\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Edit",
         "hooks": [
           {

--- a/.claude/skills/await-operator/SKILL.md
+++ b/.claude/skills/await-operator/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: await-operator
+description: Pause a bg/headless worker to wait for operator input. Use when a worker needs a real human decision before continuing — ratifying a draft, choosing between options, escalating ambiguity. THE primitive for bg/headless sessions; AskUserQuestion does NOT pause in --bg sessions (the daemon auto-answers within ~15-60s — see #1137 / smoking gun #1105).
+---
+
+# /await-operator
+
+`/await-operator` is the only correct way for a bg or headless worker to wait
+on a human. `AskUserQuestion` does not block in those contexts.
+
+## Arguments
+
+- `artifact_path` (required) — path (in the worktree, repo-relative) to the
+  draft artifact the operator should review before deciding.
+- `question` (required) — one sentence, the decision the operator must make.
+- `options` (optional) — list of suggested choice labels. Informational
+  only; the operator answers freeform via `/resume-with-answer`.
+
+## Process
+
+### Step 1 — Make sure the artifact exists
+
+The operator opens `artifact_path` to make the decision. If you have not
+already written the draft, write it now. The artifact must be on disk
+before you invoke the helper.
+
+### Step 2 — Invoke the helper
+
+```bash
+python scripts/await_operator.py \
+  --artifact-path "<repo-relative artifact path>" \
+  --question "<one-sentence decision>" \
+  --option "<label 1>" --option "<label 2>"
+```
+
+The helper writes `.workflow/pending-ratification.json` and flips the daemon
+session state to `state=blocked` with `needs:` populated. The supervisor's
+existing poll (`scripts/claude_dispatch.py` `BgHandle.wait`,
+`scripts/goal_supervisor.py:_evaluate_entry`) escalates on that shape with
+no further wiring.
+
+### Step 3 — EXIT THE TURN
+
+**After the helper returns, the worker MUST exit the current turn.** Do not
+call further tools. Do not write a summary. Do not advance to the next
+phase. The session must be quiescent so the daemon-poll snapshots
+`state=blocked` and the supervisor escalates.
+
+If you do anything after the helper, the daemon may overwrite `state` back
+to `working` and the operator never sees the question.
+
+### Step 4 — Operator answers (out-of-band)
+
+The operator (or supervisor on autonomous loop) reads
+`.workflow/pending-ratification.json` and the draft at `artifact_path`,
+then runs:
+
+```bash
+/resume-with-answer <short> <choice>
+```
+
+This writes `.workflow/operator-answer.json` and clears the daemon
+`state=blocked`. See `.claude/skills/resume-with-answer/SKILL.md`.
+
+### Step 5 — Resumed worker re-reads on next turn
+
+When this session is re-engaged (the operator runs `claude attach <short>`
+or the supervisor re-polls and sees state cleared), the **first action the
+worker takes** is to read `.workflow/operator-answer.json` from the
+worktree root and act on `choice`. Then delete (or archive) both
+`.workflow/pending-ratification.json` and `.workflow/operator-answer.json`
+before continuing, so a later `/await-operator` call starts from a clean
+slate.
+
+## Contract summary
+
+| Stage | Who writes | Where | Daemon `state` after |
+|-------|-----------|-------|----------------------|
+| 1. pause | worker (this skill) | `.workflow/pending-ratification.json` + daemon `state.json` | `blocked` |
+| 2. escalate | supervisor poll | (none — reads only) | `blocked` |
+| 3. answer | operator (`/resume-with-answer`) | `.workflow/operator-answer.json` + clears daemon `state` | `working` |
+| 4. consume | worker (next turn) | reads `operator-answer.json`, deletes both files | `working` → `done` |
+
+## When NOT to use
+
+- **Interactive sessions** (you are at the terminal): use `AskUserQuestion`.
+  The bg-pause primitive adds latency for no benefit.
+- **Trivial choices you can default**: pick a sensible default and document
+  the assumption in the PR body. Pausing is expensive — the worker tears
+  down, the operator context-switches.
+- **Hard failures**: just fail. `state=blocked` + `needs:` is for *I need
+  input*, not *I crashed*. For crashes, exit non-zero and let the
+  supervisor surface the transcript.
+
+## Schema — `.workflow/pending-ratification.json`
+
+```json
+{
+  "question": "string — the operator-facing question",
+  "artifact_path": "string — repo-relative path to draft",
+  "options": ["string", "..."],
+  "created_at": "ISO 8601 UTC",
+  "session_short": "8-char daemon session short"
+}
+```
+
+Idempotent — re-invoking the skill overwrites the file.
+
+## Schema — `.workflow/operator-answer.json`
+
+```json
+{
+  "choice": "string — operator's freeform answer",
+  "answered_at": "ISO 8601 UTC",
+  "operator": "string — handle / email"
+}
+```
+
+Written by `/resume-with-answer`. Read by the resumed worker.
+
+## Related
+
+- Issue #1137 — design rationale and acceptance criteria.
+- `.workflow/investigation-bg-pause-primitive.md` (branch
+  `feat/investigate-bg-pause-primitive`) — why `AskUserQuestion` doesn't
+  work in bg sessions.
+- `.claude/skills/resume-with-answer/SKILL.md` — the operator-side half.
+- `.claude/interaction-patterns.md` §"Pause primitives by session type".
+- `scripts/await_operator.py` — the helper this skill wraps.

--- a/.claude/skills/resume-with-answer/SKILL.md
+++ b/.claude/skills/resume-with-answer/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: resume-with-answer
+description: Deliver an operator decision to a bg/headless worker that paused via /await-operator. Use after reading the worker's .workflow/pending-ratification.json and deciding the answer. Operator-side companion to /await-operator (#1137).
+---
+
+# /resume-with-answer
+
+`/resume-with-answer <short> <choice>` — write the operator's answer to a
+paused bg/headless worker and clear its `state=blocked` flag so the
+supervisor (and `claude attach`) re-engage it.
+
+## When to use
+
+- A bg/headless worker invoked `/await-operator` and is now sitting at
+  `state=blocked` with `needs:` populated. You see it in `claude` Agent
+  View as blocked, or `goal_supervisor.py` escalated it.
+- You have read `.workflow/pending-ratification.json` (in that worker's
+  worktree) and the draft artifact it references, and you have decided
+  the answer.
+
+## Arguments
+
+- `<short>` (required) — the 8-character daemon session short (visible in
+  Agent View or in the supervisor escalation entry).
+- `<choice>` (required) — the freeform answer. Quote it if it contains
+  spaces. The label may be one of the suggested `options` from the pending
+  artifact, or a fresh sentence — the resumed worker treats it as text.
+
+## Process
+
+### Step 1 — Read the pending artifact
+
+```bash
+cat <worktree>/.workflow/pending-ratification.json
+```
+
+The file gives you `question`, `artifact_path`, and any suggested
+`options`. Read `artifact_path` (the actual draft under review) before
+deciding.
+
+### Step 2 — Decide
+
+Compose the choice. Default to one of the listed `options` when one fits;
+otherwise write a freeform sentence the worker can act on.
+
+### Step 3 — Deliver the answer
+
+```bash
+python scripts/resume_with_answer.py <short> "<choice>"
+```
+
+This:
+
+1. Writes `.workflow/operator-answer.json` in the worker's worktree (the
+   worktree is read from the daemon state's `cwd` field; override with
+   `--worktree <path>` if stale).
+2. Clears the daemon state — `state=working`, `needs=""`.
+
+### Step 4 — Re-engage the worker
+
+```bash
+claude attach <short>
+```
+
+…or do nothing: the supervisor's next poll sees the cleared state and
+re-engages the worker automatically. The worker's first action on its
+next turn is to read `.workflow/operator-answer.json` and act on `choice`.
+
+## Schema — `.workflow/operator-answer.json`
+
+```json
+{
+  "choice": "string — your answer",
+  "answered_at": "ISO 8601 UTC",
+  "operator": "string — your handle / $USER"
+}
+```
+
+The resumed worker is expected to delete this file (and the matching
+`pending-ratification.json`) after consuming the answer, so a later
+`/await-operator` call starts from a clean slate. If you see stale
+`operator-answer.json` files lingering, the worker did not consume them —
+that is a worker-side bug, not a resume bug.
+
+## When NOT to use
+
+- The worker is `state=working` (not blocked). It hasn't asked you
+  anything. Leave it alone.
+- The worker is `state=error`. That is a crash, not a question. Read the
+  transcript via `claude transcript <short>` and decide whether to
+  re-spawn.
+- You want to inject arbitrary instructions into a running worker. This
+  skill is narrow — it answers a specific outstanding question. To direct
+  a running worker, use `claude attach <short>` and send a message.
+
+## Related
+
+- `.claude/skills/await-operator/SKILL.md` — the worker-side half.
+- Issue #1137 — design rationale.
+- `scripts/resume_with_answer.py` — the helper this skill wraps.
+- `.claude/interaction-patterns.md` §"Pause primitives by session type".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Agent topology, decision UX, lane assignment: **`.claude/interaction-patterns.md
 - Trust a `release/X` branch as the source of truth for what shipped as version X — verify with `git merge-base --is-ancestor <release-tag> <branch>`. Tags are authoritative; the branch tip may sit on a separate lineage. <!-- since: 2026-05-15 cleanup retro --> <!-- enforcement: T3 escape-hatch: only fires when reasoning about release history -->
 - Invoke `claude -p` or any Anthropic SDK without going through `scripts/claude_dispatch.py:spawn()`. <!-- enforcement: T2 hook:sdk-spend-warn -->
 - Use PowerShell cmdlets (`Test-Path`, `Get-ChildItem`, etc.) via the Bash tool, or embed Windows backslash paths in inline `python -c` literals — see `.claude/WORKFLOW.md` "Bash Tool Portability". <!-- since: #1130 #1131 --> <!-- enforcement: T3 escape-hatch: runtime emission; tests/test_skill_bash_portability.py covers checked-in skill files -->
+- Call `AskUserQuestion` from a bg/headless session — the daemon auto-answers within ~15-60s. Use `/await-operator` instead. <!-- since: #1137 --> <!-- enforcement: T2 hook:preuse-askuserquestion -->
 
 ## ALWAYS <!-- enforcement: T3 not-a-directive -->
 

--- a/scripts/await_operator.py
+++ b/scripts/await_operator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""await-operator helper: pause a bg/headless worker for operator input.
+
+Invoked by the `/await-operator` skill. Performs two writes atomically from
+the worker's perspective:
+
+  1. `.workflow/pending-ratification.json` in the worktree (the operator-
+     facing artifact describing the question and the draft under review).
+  2. `$CLAUDE_JOB_DIR/state.json` — flip `state` to `blocked` and populate
+     `needs` so the supervisor's `BgHandle.poll` / `goal_supervisor._evaluate_entry`
+     escalate on the next poll (see scripts/claude_dispatch.py L295-321 and
+     scripts/goal_supervisor.py L502-522).
+
+Idempotent: re-invoking overwrites pending-ratification.json and re-applies
+the same state flip.
+
+Usage:
+  python scripts/await_operator.py \
+      --artifact-path .plans/draft.md \
+      --question "Approve the draft?" \
+      --option "Approve" --option "Reject" --option "Revise"
+
+Exits 0 on success, 1 on failure (e.g., CLAUDE_JOB_DIR not set / not a bg
+session — the skill should not have been invoked from an interactive
+session).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PENDING_REL = ".workflow/pending-ratification.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _worktree_root() -> Path:
+    """Resolve the worktree root via git, falling back to CWD."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return Path(out.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+
+def _session_short_from_job_dir(job_dir: Path) -> str:
+    """The daemon-side `short` is the basename of CLAUDE_JOB_DIR."""
+    return job_dir.name
+
+
+def _write_pending(
+    worktree: Path,
+    *,
+    question: str,
+    artifact_path: str,
+    options: list[str],
+    session_short: str,
+) -> Path:
+    payload = {
+        "question": question,
+        "artifact_path": artifact_path,
+        "options": options,
+        "created_at": _now_iso(),
+        "session_short": session_short,
+    }
+    target = worktree / PENDING_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def _flip_daemon_state(state_path: Path, needs: str) -> None:
+    """Set state=blocked and needs=<needs> in the daemon state.json.
+
+    Preserves all other fields. The daemon may rewrite the file between
+    our read and write — this is best-effort; if the write races and gets
+    clobbered, the operator can re-invoke the skill.
+    """
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    data["state"] = "blocked"
+    data["needs"] = needs
+    data["tempo"] = "idle"
+    data["updatedAt"] = _now_iso()
+    state_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="Pause worker for operator input.")
+    p.add_argument("--artifact-path", required=True,
+                   help="Path to the draft artifact the operator should review.")
+    p.add_argument("--question", required=True,
+                   help="The question for the operator (one sentence).")
+    p.add_argument("--option", action="append", default=[],
+                   help="Repeatable. Suggested choice label.")
+    p.add_argument("--rationale", default="",
+                   help="Optional short rationale prefix for the needs string.")
+    args = p.parse_args(argv)
+
+    job_dir_str = os.environ.get("CLAUDE_JOB_DIR", "").strip()
+    if not job_dir_str:
+        sys.stderr.write(
+            "await_operator: CLAUDE_JOB_DIR is not set. /await-operator is "
+            "only meaningful inside a bg or headless Claude session. In an "
+            "interactive session, call AskUserQuestion instead.\n"
+        )
+        return 1
+    job_dir = Path(job_dir_str)
+    state_path = job_dir / "state.json"
+    if not state_path.exists():
+        sys.stderr.write(
+            f"await_operator: daemon state.json not found at {state_path}.\n"
+        )
+        return 1
+
+    worktree = _worktree_root()
+    short = _session_short_from_job_dir(job_dir)
+
+    pending = _write_pending(
+        worktree,
+        question=args.question,
+        artifact_path=args.artifact_path,
+        options=list(args.option),
+        session_short=short,
+    )
+
+    rationale = args.rationale.strip() or args.question.strip()
+    rationale = rationale.rstrip(";.")
+    needs = f"{rationale}; review .workflow/pending-ratification.json"
+    _flip_daemon_state(state_path, needs)
+
+    sys.stdout.write(
+        f"await_operator: paused session {short}\n"
+        f"  pending: {pending}\n"
+        f"  needs:   {needs}\n"
+        f"  resume:  /resume-with-answer {short} <choice>\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/resume_with_answer.py
+++ b/scripts/resume_with_answer.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""resume-with-answer helper: deliver operator's choice to a paused worker.
+
+Operator-side companion to scripts/await_operator.py. Two writes:
+
+  1. `.workflow/operator-answer.json` in the target worktree — the answer
+     the resumed worker reads on its next turn.
+  2. `~/.claude/jobs/<short>/state.json` — clear `state` back to `working`
+     and blank `needs`, so the supervisor's poll stops treating the
+     session as escalated.
+
+Usage:
+  python scripts/resume_with_answer.py <short> <choice> \
+      [--operator <handle>] [--worktree <path>]
+
+`<choice>` is the freeform answer (label string). `--worktree` defaults to
+the worktree recorded in the daemon state.json `cwd` field; pass it
+explicitly when the daemon state is stale.
+
+Exits 0 on success, 1 on bad arguments / missing state files.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+PENDING_REL = ".workflow/pending-ratification.json"
+ANSWER_REL = ".workflow/operator-answer.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _jobs_dir() -> Path:
+    """Resolve the Claude jobs directory (~/.claude/jobs)."""
+    home = Path(os.environ.get("USERPROFILE") or os.path.expanduser("~"))
+    return home / ".claude" / "jobs"
+
+
+def _resolve_worktree(state_path: Path, override: str | None) -> Path | None:
+    if override:
+        return Path(override)
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    cwd = data.get("cwd")
+    if not cwd:
+        return None
+    return Path(cwd)
+
+
+def _write_answer(worktree: Path, *, choice: str, operator: str) -> Path:
+    target = worktree / ANSWER_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "choice": choice,
+        "answered_at": _now_iso(),
+        "operator": operator,
+    }
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def _clear_blocked(state_path: Path) -> None:
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    data["state"] = "working"
+    data["needs"] = ""
+    data["tempo"] = "active"
+    data["updatedAt"] = _now_iso()
+    state_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description="Deliver operator answer.")
+    p.add_argument("short", help="8-char daemon session short.")
+    p.add_argument("choice", help="Freeform answer (label or sentence).")
+    p.add_argument("--operator", default=os.environ.get("USER")
+                   or os.environ.get("USERNAME") or "operator",
+                   help="Operator handle to stamp on the answer.")
+    p.add_argument("--worktree", default=None,
+                   help="Override worktree path (default: read from daemon state).")
+    args = p.parse_args(argv)
+
+    state_path = _jobs_dir() / args.short / "state.json"
+    if not state_path.exists():
+        sys.stderr.write(
+            f"resume_with_answer: no daemon state at {state_path}.\n"
+            f"  Check the short ({args.short!r}) and that the session "
+            f"exists in `claude` Agent View.\n"
+        )
+        return 1
+
+    worktree = _resolve_worktree(state_path, args.worktree)
+    if worktree is None or not worktree.exists():
+        sys.stderr.write(
+            f"resume_with_answer: cannot resolve worktree (state cwd missing "
+            f"or stale). Pass --worktree explicitly.\n"
+        )
+        return 1
+
+    pending = worktree / PENDING_REL
+    if not pending.exists():
+        sys.stderr.write(
+            f"resume_with_answer: warning — no pending-ratification.json at "
+            f"{pending}. The worker may not actually be paused via "
+            f"/await-operator. Continuing anyway.\n"
+        )
+
+    answer = _write_answer(worktree, choice=args.choice, operator=args.operator)
+    _clear_blocked(state_path)
+
+    sys.stdout.write(
+        f"resume_with_answer: answer delivered to {args.short}\n"
+        f"  answer:   {answer}\n"
+        f"  worktree: {worktree}\n"
+        f"  state:    cleared (state=working, needs='')\n"
+        f"  next:     claude attach {args.short}  # or let supervisor re-poll\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_await_operator_skill.py
+++ b/tests/test_await_operator_skill.py
@@ -1,0 +1,246 @@
+"""Smoke test for #1137 — /await-operator + /resume-with-answer round-trip.
+
+Drives the helper scripts directly (no real bg session spawn — that would
+require a Claude daemon in CI). Verifies the four state transitions the
+issue calls out in AC-6:
+
+  1. pause artifact written
+  2. daemon state.json flipped to state=blocked with needs populated
+  3. resume answer written
+  4. daemon state cleared (state=working, needs="")
+
+The skill SKILL.md files are also sanity-checked for the required
+contract phrasing (frontmatter args, "EXIT THE TURN" directive, schema
+sections).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+AWAIT_SCRIPT = REPO_ROOT / "scripts" / "await_operator.py"
+RESUME_SCRIPT = REPO_ROOT / "scripts" / "resume_with_answer.py"
+AWAIT_SKILL = REPO_ROOT / ".claude" / "skills" / "await-operator" / "SKILL.md"
+RESUME_SKILL = REPO_ROOT / ".claude" / "skills" / "resume-with-answer" / "SKILL.md"
+HOOK = REPO_ROOT / ".claude" / "hooks" / "preuse-askuserquestion.py"
+
+
+# ---------------------------------------------------------------------------
+# Helper-script round-trip
+# ---------------------------------------------------------------------------
+
+def _make_fake_session(tmp_path: Path, short: str = "abcd1234") -> tuple[Path, Path]:
+    """Build a fake job-dir + worktree pair mimicking a live bg session."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    # Need a git repo for await_operator's worktree root detection. Fall back
+    # to CLAUDE_PROJECT_DIR when git is unavailable; we point CPD at worktree.
+    (worktree / ".workflow").mkdir()
+
+    job_dir = tmp_path / "jobs" / short
+    job_dir.mkdir(parents=True)
+    state = {
+        "state": "working",
+        "detail": "running…",
+        "tempo": "active",
+        "cwd": str(worktree),
+        "daemonShort": short,
+        "createdAt": "2026-05-16T00:00:00.000Z",
+    }
+    (job_dir / "state.json").write_text(json.dumps(state, indent=2), encoding="utf-8")
+    return worktree, job_dir
+
+
+def _run_await(worktree: Path, job_dir: Path, *, artifact: str,
+               question: str, options: list[str]) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CLAUDE_JOB_DIR"] = str(job_dir)
+    env["CLAUDE_PROJECT_DIR"] = str(worktree)
+    cmd = [sys.executable, str(AWAIT_SCRIPT),
+           "--artifact-path", artifact,
+           "--question", question]
+    for opt in options:
+        cmd.extend(["--option", opt])
+    return subprocess.run(cmd, cwd=str(worktree), env=env,
+                          stdin=subprocess.DEVNULL,
+                          capture_output=True, text=True, timeout=15)
+
+
+def _run_resume(short: str, choice: str, *, worktree: Path,
+                fake_home: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    # resume_with_answer resolves ~/.claude/jobs/<short>/state.json.
+    # Point USERPROFILE / HOME at our fake home so the lookup hits our fixture.
+    env["USERPROFILE"] = str(fake_home)
+    env["HOME"] = str(fake_home)
+    cmd = [sys.executable, str(RESUME_SCRIPT),
+           short, choice,
+           "--worktree", str(worktree),
+           "--operator", "smoke-test"]
+    return subprocess.run(cmd, env=env, stdin=subprocess.DEVNULL,
+                          capture_output=True, text=True, timeout=15)
+
+
+def test_pause_then_resume_round_trip(tmp_path: Path) -> None:
+    short = "abcd1234"
+    worktree, job_dir = _make_fake_session(tmp_path, short=short)
+
+    # ----- Phase 1: pause -----
+    proc = _run_await(worktree, job_dir,
+                      artifact=".plans/draft.md",
+                      question="Approve the draft?",
+                      options=["Approve", "Reject", "Revise"])
+    assert proc.returncode == 0, f"await_operator failed: {proc.stderr}"
+
+    pending = worktree / ".workflow" / "pending-ratification.json"
+    assert pending.exists(), "pending-ratification.json was not written"
+    payload = json.loads(pending.read_text(encoding="utf-8"))
+    assert payload["question"] == "Approve the draft?"
+    assert payload["artifact_path"] == ".plans/draft.md"
+    assert payload["options"] == ["Approve", "Reject", "Revise"]
+    assert payload["session_short"] == short
+    assert "created_at" in payload
+
+    # ----- Phase 2: state flip -----
+    state = json.loads((job_dir / "state.json").read_text(encoding="utf-8"))
+    assert state["state"] == "blocked"
+    assert "review .workflow/pending-ratification.json" in state["needs"]
+    assert state["cwd"] == str(worktree), "cwd field must be preserved"
+
+    # ----- Phase 3: idempotency — second pause overwrites cleanly -----
+    proc2 = _run_await(worktree, job_dir,
+                       artifact=".plans/draft.md",
+                       question="Approve the draft v2?",
+                       options=["Yes", "No"])
+    assert proc2.returncode == 0
+    payload2 = json.loads(pending.read_text(encoding="utf-8"))
+    assert payload2["question"] == "Approve the draft v2?"
+    assert payload2["options"] == ["Yes", "No"]
+
+    # ----- Phase 4: resume -----
+    # resume_with_answer expects ~/.claude/jobs/<short>/state.json.
+    # Build a fake home that satisfies that layout, mirroring our job_dir.
+    fake_home = tmp_path / "fakehome"
+    claude_jobs = fake_home / ".claude" / "jobs" / short
+    claude_jobs.mkdir(parents=True)
+    (claude_jobs / "state.json").write_text(
+        (job_dir / "state.json").read_text(encoding="utf-8"), encoding="utf-8")
+
+    proc3 = _run_resume(short, "Approve",
+                        worktree=worktree,
+                        fake_home=fake_home)
+    assert proc3.returncode == 0, f"resume_with_answer failed: {proc3.stderr}"
+
+    answer_path = worktree / ".workflow" / "operator-answer.json"
+    assert answer_path.exists(), "operator-answer.json was not written"
+    answer = json.loads(answer_path.read_text(encoding="utf-8"))
+    assert answer["choice"] == "Approve"
+    assert answer["operator"] == "smoke-test"
+    assert "answered_at" in answer
+
+    cleared = json.loads(
+        (claude_jobs / "state.json").read_text(encoding="utf-8"))
+    assert cleared["state"] == "working"
+    assert cleared["needs"] == ""
+
+
+def test_await_operator_refuses_without_job_dir(tmp_path: Path) -> None:
+    """The skill must not pretend to pause if CLAUDE_JOB_DIR is unset
+    (interactive session → wrong primitive)."""
+    env = os.environ.copy()
+    env.pop("CLAUDE_JOB_DIR", None)
+    proc = subprocess.run(
+        [sys.executable, str(AWAIT_SCRIPT),
+         "--artifact-path", "x.md", "--question", "y?"],
+        cwd=str(tmp_path), env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 1
+    assert "CLAUDE_JOB_DIR" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Static contract checks on the SKILL.md files
+# ---------------------------------------------------------------------------
+
+def test_await_skill_frontmatter_and_contract() -> None:
+    content = AWAIT_SKILL.read_text(encoding="utf-8")
+    # AC-1: frontmatter present with name
+    assert content.startswith("---"), "SKILL.md must start with frontmatter"
+    assert "name: await-operator" in content
+    # AC-1: documents the three args
+    for arg in ("artifact_path", "question", "options"):
+        assert arg in content, f"SKILL.md must document {arg!r} arg"
+    # AC-4: EXIT THE TURN directive
+    assert "EXIT THE TURN" in content or "exit the turn" in content.lower()
+    # AC-5: documents the resume mechanism
+    assert "/resume-with-answer" in content
+    # AC-2: documents the schema
+    assert "pending-ratification.json" in content
+    # Schema fields
+    for key in ("question", "artifact_path", "options", "created_at", "session_short"):
+        assert key in content
+
+
+def test_resume_skill_frontmatter_and_contract() -> None:
+    content = RESUME_SKILL.read_text(encoding="utf-8")
+    assert content.startswith("---")
+    assert "name: resume-with-answer" in content
+    assert "operator-answer.json" in content
+    # Documents both halves of the round-trip
+    assert "/await-operator" in content
+    for key in ("choice", "answered_at", "operator"):
+        assert key in content
+
+
+def test_hook_blocks_only_in_bg_sessions() -> None:
+    """Static smoke: hook references CLAUDE_JOB_DIR and tool_name guard."""
+    content = HOOK.read_text(encoding="utf-8")
+    assert "CLAUDE_JOB_DIR" in content
+    assert "AskUserQuestion" in content
+    assert "/await-operator" in content
+
+
+def test_hook_pretooluse_behavior(tmp_path: Path) -> None:
+    """Run the hook directly with a fake PreToolUse payload."""
+    payload = {"tool_name": "AskUserQuestion",
+               "tool_input": {"questions": []}}
+
+    # In a bg session (CLAUDE_JOB_DIR set), should block (exit 2).
+    env = os.environ.copy()
+    env["CLAUDE_JOB_DIR"] = str(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload), env=env,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 2
+    assert "/await-operator" in proc.stderr
+
+    # In an interactive session (CLAUDE_JOB_DIR unset), should allow (exit 0).
+    env_int = os.environ.copy()
+    env_int.pop("CLAUDE_JOB_DIR", None)
+    proc2 = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload), env=env_int,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc2.returncode == 0
+
+    # Wrong tool_name in bg session → still allow.
+    env_other = os.environ.copy()
+    env_other["CLAUDE_JOB_DIR"] = str(tmp_path)
+    proc3 = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps({"tool_name": "Bash"}), env=env_other,
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc3.returncode == 0


### PR DESCRIPTION
## Summary

- New `/await-operator` worker-side skill — the real pause primitive for bg/headless Claude sessions. `AskUserQuestion` is silently broken in `--bg` (daemon auto-answers ~15-60s); this writes `.workflow/pending-ratification.json` + flips daemon `state.json` to `state=blocked` with `needs:` populated, then the worker exits its turn. Composes with the PR #1129 supervisor — no supervisor-side wiring needed.
- New `/resume-with-answer <short> <choice>` operator-side skill — writes `.workflow/operator-answer.json` in the worker's worktree and clears `state=blocked` so the supervisor/operator re-engages the worker, which reads the answer on its next turn.
- T2 defense-in-depth hook (`.claude/hooks/preuse-askuserquestion.py`) blocks `AskUserQuestion` calls in any session where `CLAUDE_JOB_DIR` is set, pointing at `/await-operator`. CLAUDE.md NEVER bullet promoted T3 → T2.

## Acceptance criteria

- AC-1: `.claude/skills/await-operator/SKILL.md` exists with proper frontmatter (`name`, `description`) and documents `artifact_path` / `question` / `options` args.
- AC-2: Writes `.workflow/pending-ratification.json` with schema `{question, artifact_path, options, created_at, session_short}`. Idempotent — second invocation overwrites cleanly (covered by test).
- AC-3: Flips daemon `state.json` (`$CLAUDE_JOB_DIR/state.json`) to `state=blocked` with `needs:` populated; matches what `BgHandle.wait` (claude_dispatch.py L295-321) and `goal_supervisor._evaluate_entry` (L502-522) key on.
- AC-4: SKILL.md spells out the EXIT THE TURN contract.
- AC-5: Resume = operator-side `/resume-with-answer` (option b from the issue). Both SKILL.md files document the round-trip.
- AC-6: End-to-end smoke test `tests/test_await_operator_skill.py::test_pause_then_resume_round_trip` verifies the four state transitions (pause artifact written → state=blocked → resume answer written → state cleared).
- AC-7: `.claude/interaction-patterns.md` §5a "Pause primitives by session type" added with rows for interactive / bg / pipeline (headless).
- AC-8: **Bundled** per pre-decided design. Hook is 47 LOC, well under the ~50 LOC threshold; clean single CLAUDE_JOB_DIR guard.

## Rule change

- Context: `AskUserQuestion` in bg/headless sessions is silently broken — the daemon auto-injects an answer within ~15-60s with no flag to disable it (PR #1105 was filed unilaterally as a result).
- Old rule (T3, not-a-directive): trust skills to pick the right primitive.
- New rule (T2, hook-enforced): bg/headless sessions MUST use `/await-operator`; `AskUserQuestion` is blocked by `.claude/hooks/preuse-askuserquestion.py` when `CLAUDE_JOB_DIR` is set.
- Why: T3 wasn't enough — bg workers can't observe their own session type reliably enough to self-enforce, and the failure mode is silent (the worker thinks it asked).
- Falsification: if the Claude Code daemon's bg behavior changes (`AskUserQuestion` actually blocks), drop the hook and demote the NEVER bullet; keep `/await-operator` as an explicit escape hatch.

## Test plan

- [x] `pytest tests/test_await_operator_skill.py -v` — 6 tests pass (round-trip, idempotency, guards, hook behavior in bg + interactive + non-AskUserQuestion).
- [x] `pytest tests/test_skill_bash_portability.py` — passes against new skills.
- [x] `python scripts/audit-enforcement.py --strict` — passes (7 T1 markers, all wired).
- [x] Hook smoke (`echo '{}' | python .claude/hooks/preuse-askuserquestion.py`) — exits 0 when CLAUDE_JOB_DIR unset, exits 2 with stderr pointing at /await-operator when set + tool_name=AskUserQuestion.
- [ ] **Operator should validate** the end-to-end flow with a real `claude --bg` session — the smoke test exercises the helper scripts directly (no real daemon spawn).

## Out of scope

Pre-existing test failures reproduce on `main` with this branch stashed — not from this change:
- `tests/test_workflow_state_bump.py::test_workflow_state_bump_rejects_non_integer` (4 parametrized failures)
- `scripts/verify-workflow.py` scenarios `commit-ref-validation` and `workflow-only-no-qa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)