### PR TITLE
feat(cli): raw Web API request command — authenticated HTTP calls to Dataverse (closes #1164)

### DIFF
--- a/specs/raw-web-api.md
+++ b/specs/raw-web-api.md
@@ -1,0 +1,338 @@
+# Raw Web API Request
+
+**Status:** Draft
+**Last Updated:** 2025-07-25
+**Code:** [src/PPDS.Cli/Services/WebApi/](../src/PPDS.Cli/Services/WebApi/)
+**Surfaces:** CLI
+
+---
+
+## Overview
+
+Sends authenticated HTTP requests to the Dataverse Web API from the command line. This lets developers test endpoints, debug custom APIs, invoke actions, and inspect metadata without leaving the terminal or maintaining separate auth tokens.
+
+### Goals
+
+- **Authenticated HTTP calls**: Execute arbitrary GET/POST/PATCH/DELETE requests against Dataverse Web API with automatic token management
+- **Write protection**: Block mutating requests on production environments by default (consistent with DML safety guard pattern)
+- **Composable output**: stdout contains response body only (or headers + body with `--include`), enabling piping to `jq` and other tools
+
+### Non-Goals
+
+- Batch ($batch) request support — deferred to follow-up
+- Retry/pagination helpers — user is responsible for constructing correct URLs
+- MCP/TUI/Extension surfaces — deferred; Application Service enables future surfaces
+- Request history or saved requests — out of scope
+
+---
+
+## Architecture
+
+```
+┌──────────────────────┐      ┌────────────────────────────┐      ┌──────────────────────┐
+│  CLI: ApiRequestCmd  │─────▶│  RawWebApiService          │─────▶│  HttpClient          │
+│  (thin adapter)      │      │  (IRawWebApiService)       │      │  + Bearer token      │
+└──────────────────────┘      └────────────────────────────┘      └──────────────────────┘
+                                       │
+                                       ├── IPowerPlatformTokenProvider.GetTokenForResourceAsync(envUrl)
+                                       ├── Write protection: ProtectionLevel check
+                                       └── Default OData headers (OData-Version, Accept)
+```
+
+The CLI command is a thin presentation adapter. All logic — auth, headers, write protection, response formatting — lives in `RawWebApiService`.
+
+### Components
+
+| Component           | Responsibility                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------------- |
+| `IRawWebApiService` | Interface for sending raw Web API requests                                                  |
+| `RawWebApiService`  | Acquires token, applies write guard, sends HTTP request, returns response                   |
+| `ApiRequestCommand` | CLI adapter: parses flags, calls service, writes output to stdout/stderr                    |
+| `WebApiWriteGuard`  | Determines whether a request is allowed based on HTTP method + environment protection level |
+
+### Dependencies
+
+- Uses auth patterns from: [authentication.md](./authentication.md)
+- Reuses `ProtectionLevel` enum from `PPDS.Auth.Profiles`
+- Reuses `DmlSafetyGuard.DetectProtectionLevel(envType)` logic (not the class itself — the service has its own guard)
+
+---
+
+## Specification
+
+### Core Requirements
+
+1. The service acquires a Dataverse-scoped token via `IPowerPlatformTokenProvider.GetTokenForResourceAsync(environmentUrl)` and sets the `Authorization: Bearer {token}` header on every request.
+2. The service prepends the environment base URL to the user-supplied path (e.g., `--path /api/data/v9.2/accounts` → `https://org.crm.dynamics.com/api/data/v9.2/accounts`).
+3. Default OData headers are applied unless explicitly overridden by user-supplied headers:
+    - `OData-Version: 4.0`
+    - `Accept: application/json`
+    - `Content-Type: application/json` (when body is present)
+4. User-supplied headers (`--header`) merge with defaults; user wins on conflict.
+5. The write guard blocks POST/PATCH/DELETE/PUT on production environments (unless `--confirm` is supplied).
+6. GET requests are always allowed regardless of environment type.
+7. The response body is written to stdout. HTTP status line and headers are written to stdout only when `--include` is set.
+8. Non-2xx responses produce a non-zero exit code and write the error body to stderr.
+
+### Primary Flows
+
+**Happy-path GET:**
+
+1. **Resolve environment**: Use `--environment` URL (or active profile default)
+2. **Acquire token**: `GetTokenForResourceAsync(environmentUrl)`
+3. **Build request**: Combine base URL + path, merge headers, set auth
+4. **Send**: `HttpClient.SendAsync(request, cancellationToken)`
+5. **Output**: Write response body to stdout
+
+**Mutating request on production:**
+
+1. **Resolve environment** and detect `ProtectionLevel`
+2. **Write guard fires**: Method is POST/PATCH/DELETE/PUT + level is Production
+3. **Block**: Throw `PpdsException(ErrorCode = "Api.WriteBlocked")` unless `--confirm` is present
+4. If `--confirm`: proceed with Steps 3-5 from happy-path
+
+### Surface-Specific Behavior
+
+#### CLI Surface
+
+```
+ppds api request [options]
+
+Options:
+  --path <path>            Required. Relative URL path (e.g., /api/data/v9.2/accounts)
+  --method, -X <method>    HTTP method (default: GET)
+  --body <json>            Request body as inline JSON string
+  --body-file <file>       Request body from file (mutually exclusive with --body)
+  --header, -H <header>    Additional header (repeatable, format: "Name: Value")
+  --include, -i            Include HTTP status line and response headers in output
+  --environment, -env <url> Target environment URL (default: active profile)
+  --confirm                Bypass write protection on production environments
+```
+
+Exit codes:
+
+- 0: 2xx response received
+- 1: Non-2xx response (body written to stderr)
+- 2: Request blocked by write guard (no HTTP call made)
+- 3: Authentication or connectivity failure
+
+### Constraints
+
+- Application Service lives in `PPDS.Dataverse` (or new project `PPDS.WebApi` if warranted by dependency concerns)
+- CLI command lives in `PPDS.Cli/Commands/Api/`
+- Service accepts `IProgressReporter` for operations that may take >1s (large response streaming)
+- Service propagates `CancellationToken` through all async paths
+- No direct `Console.Write` in the service layer
+
+### Validation Rules
+
+| Field                    | Rule                       | Error                                                                  |
+| ------------------------ | -------------------------- | ---------------------------------------------------------------------- |
+| `--path`                 | Must start with `/`        | "Path must start with '/'. Example: /api/data/v9.2/accounts"           |
+| `--method`               | Must be valid HTTP method  | "Invalid HTTP method '{value}'. Use GET, POST, PATCH, PUT, DELETE, HEAD, or OPTIONS." |
+| `--body` + `--body-file` | Mutually exclusive         | "Cannot specify both --body and --body-file."                          |
+| `--body-file`            | File must exist            | "Body file not found: '{path}'"                                        |
+| `--header`               | Must contain `:` separator | "Invalid header format '{value}'. Expected 'Name: Value'."             |
+
+---
+
+## Acceptance Criteria
+
+| ID    | Criterion                                                                            | Test                                                      | Status |
+| ----- | ------------------------------------------------------------------------------------ | --------------------------------------------------------- | ------ |
+| AC-01 | GET request to valid path returns response body on stdout with exit code 0           | `RawWebApiServiceTests.Get_ValidPath_ReturnsBody`         | 🔲     |
+| AC-02 | POST request on production environment without --confirm is blocked with exit code 2 | `WebApiWriteGuardTests.Post_Production_NoConfirm_Blocks`  | 🔲     |
+| AC-03 | POST request on production with --confirm sends the request                          | `RawWebApiServiceTests.Post_Production_WithConfirm_Sends` | 🔲     |
+| AC-04 | POST/PATCH/DELETE on development environment is allowed without --confirm            | `WebApiWriteGuardTests.Mutating_Development_Allowed`      | 🔲     |
+| AC-05 | --include outputs status line and headers before body                                | `ApiRequestCommandTests.Include_OutputsHeaders`           | 🔲     |
+| AC-06 | Non-2xx response returns `IsSuccess = false` with status code and body preserved       | `RawWebApiServiceTests.Non2xx_ReturnsErrorResponse`       | 🔲     |
+| AC-07 | User-supplied headers override defaults                                              | `RawWebApiServiceTests.UserHeaders_OverrideDefaults`      | 🔲     |
+| AC-08 | --body-file reads body from file                                                     | `RawWebApiServiceTests.BodyFile_ReadsFromDisk`            | 🔲     |
+| AC-09 | --body and --body-file together produces validation error                            | `ApiRequestCommandTests.Body_And_BodyFile_Conflict`       | 🔲     |
+| AC-10 | Path without leading `/` produces validation error                                   | `ApiRequestCommandTests.Path_NoLeadingSlash_Error`        | 🔲     |
+| AC-11 | Auth token is acquired for the correct environment URL resource                      | `RawWebApiServiceTests.Token_AcquiredForEnvironmentUrl`   | 🔲     |
+| AC-12 | Default OData headers (OData-Version, Accept) are present on requests                | `RawWebApiServiceTests.DefaultHeaders_Applied`            | 🔲     |
+
+### Edge Cases
+
+| Scenario                            | Input                            | Expected Output                                     |
+| ----------------------------------- | -------------------------------- | --------------------------------------------------- |
+| Path with query string              | `/api/data/v9.2/accounts?$top=1` | Appended as-is to base URL                          |
+| Empty response body (204)           | DELETE returning 204             | Exit 0, no stdout output                            |
+| Large response body                 | Multi-MB JSON                    | Service returns string body; response streaming deferred to roadmap |
+| Environment URL with trailing slash | `https://org.crm.dynamics.com/`  | Trailing slash stripped before combining with path  |
+
+### Test Examples
+
+```csharp
+[Fact]
+public async Task Get_ValidPath_ReturnsBody()
+{
+    // Arrange
+    var mockHandler = new MockHttpMessageHandler();
+    mockHandler.When("/api/data/v9.2/accounts")
+        .Respond("application/json", "{\"value\":[]}");
+
+    var service = CreateService(mockHandler, ProtectionLevel.Development);
+
+    // Act
+    var result = await service.SendAsync(new RawWebApiRequest
+    {
+        Path = "/api/data/v9.2/accounts",
+        Method = HttpMethod.Get
+    });
+
+    // Assert
+    Assert.Equal(200, result.StatusCode);
+    Assert.Contains("\"value\":[]", result.Body);
+}
+
+[Fact]
+public async Task Post_Production_NoConfirm_Throws()
+{
+    var service = CreateService(new MockHttpMessageHandler(), ProtectionLevel.Production);
+
+    var ex = await Assert.ThrowsAsync<PpdsException>(() => service.SendAsync(new RawWebApiRequest
+    {
+        Path = "/api/data/v9.2/accounts",
+        Method = HttpMethod.Post,
+        Body = "{}",
+        IsConfirmed = false
+    }));
+
+    Assert.Equal("Api.WriteBlocked", ex.ErrorCode);
+}
+```
+
+---
+
+## Core Types
+
+### IRawWebApiService
+
+Application Service interface. UI-agnostic; no console/display dependencies.
+
+```csharp
+public interface IRawWebApiService
+{
+    Task<RawWebApiResponse> SendAsync(
+        RawWebApiRequest request,
+        IProgressReporter? progress = null,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### RawWebApiRequest
+
+```csharp
+public sealed class RawWebApiRequest
+{
+    public required string EnvironmentUrl { get; init; }
+    public required string Path { get; init; }
+    public HttpMethod Method { get; init; } = HttpMethod.Get;
+    public string? Body { get; init; }
+    public Dictionary<string, string>? Headers { get; init; }
+    public bool IsConfirmed { get; init; }
+    public ProtectionLevel ProtectionLevel { get; init; } = ProtectionLevel.Production;
+}
+```
+
+### RawWebApiResponse
+
+```csharp
+public sealed class RawWebApiResponse
+{
+    public int StatusCode { get; init; }
+    public string? ReasonPhrase { get; init; }
+    public Dictionary<string, string> Headers { get; init; } = new();
+    public string Body { get; init; } = string.Empty;
+    public bool IsSuccess => StatusCode >= 200 && StatusCode < 300;
+}
+```
+
+### WebApiWriteGuard
+
+```csharp
+public static class WebApiWriteGuard
+{
+    public static bool IsMutating(HttpMethod method)
+        => method != HttpMethod.Get && method != HttpMethod.Head && method != HttpMethod.Options;
+
+    public static bool IsBlocked(HttpMethod method, ProtectionLevel level, bool isConfirmed)
+        => IsMutating(method) && level == ProtectionLevel.Production && !isConfirmed;
+}
+```
+
+---
+
+## Error Handling
+
+### Error Types
+
+| Error               | Condition                                   | Recovery                                                     |
+| ------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `Api.WriteBlocked`  | Mutating method + Production + no --confirm | Add `--confirm` flag or switch to non-production environment |
+| `Api.AuthFailed`    | Token acquisition fails                     | Check profile credentials, re-authenticate                   |
+| `Api.InvalidPath`   | Path doesn't start with `/`                 | Fix path format                                              |
+| `Api.InvalidHeader` | Header missing `:` separator                | Fix header format                                            |
+| `Api.BodyConflict`  | Both --body and --body-file specified       | Use only one                                                 |
+
+### Recovery Strategies
+
+- **Auth failure**: Surface the inner exception's message in `UserMessage` (never GUIDs or stack traces)
+- **Write blocked**: Include the environment URL and detected protection level in the error message so users understand why
+
+---
+
+## Design Decisions
+
+### Why HttpClient + IPowerPlatformTokenProvider instead of IDataverseConnectionPool?
+
+**Context:** Need to send raw HTTP requests to Dataverse Web API. The existing pool provides `IDataverseClient` which only supports `OrganizationRequest` (SDK-level operations).
+
+**Decision:** Use `IPowerPlatformTokenProvider.GetTokenForResourceAsync(envUrl)` to get a Dataverse-scoped bearer token, then use `HttpClient` directly.
+
+**Alternatives considered:**
+
+- Use `IDataverseConnectionPool` and cast to `ServiceClient`: Tight coupling to concrete SDK type; breaks abstraction; `ServiceClient` internal HTTP methods aren't part of the public API.
+- Use `ICredentialProvider.AccessToken`: Returns null for certificate/client-secret auth providers — not universally available.
+
+**Consequences:**
+
+- Positive: Clean, works with all auth methods, testable with mock `HttpMessageHandler`
+- Negative: Doesn't share connection pool lifecycle (acceptable — raw HTTP calls are infrequent and don't benefit from pooling)
+
+### Why block at Production only (not Test)?
+
+**Context:** The DML safety guard treats Test environments differently (warn + confirm) vs. Production (block). For raw API, the granularity of "preview affected rows" doesn't apply.
+
+**Decision:** Block mutating requests only on Production environments. Development/Sandbox/Test/Trial are unrestricted. This matches user expectations: if you're in a dev environment, you're expected to be making changes.
+
+**Alternatives considered:**
+
+- Block on Test too: Overly restrictive for an API tool; users testing custom APIs need to POST freely in test environments.
+- Never block (always allow): Dangerous — accidental PATCH on production could corrupt data.
+
+---
+
+## Related Specs
+
+- [authentication.md](./authentication.md) - Token acquisition infrastructure
+- [query.md](./query.md) - DML safety guard pattern (reused concept, not code)
+
+---
+
+## Changelog
+
+| Date       | Change       |
+| ---------- | ------------ |
+| 2025-07-25 | Initial spec |
+
+---
+
+## Roadmap
+
+- MCP surface: Expose `IRawWebApiService` as an MCP tool
+- Extension surface: "Send Request" from a .http file or command palette
+- Batch support: `ppds api batch` for `$batch` requests
+- Response streaming for very large payloads

--- a/specs/raw-web-api.md
+++ b/specs/raw-web-api.md
@@ -36,7 +36,7 @@ Sends authenticated HTTP requests to the Dataverse Web API from the command line
                                        │
                                        ├── IPowerPlatformTokenProvider.GetTokenForResourceAsync(envUrl)
                                        ├── Write protection: ProtectionLevel check
-                                       └── Default OData headers (OData-Version, Accept)
+                                       └── Default OData headers (OData-Version, OData-MaxVersion, Accept)
 ```
 
 The CLI command is a thin presentation adapter. All logic — auth, headers, write protection, response formatting — lives in `RawWebApiService`.
@@ -66,13 +66,16 @@ The CLI command is a thin presentation adapter. All logic — auth, headers, wri
 2. The service prepends the environment base URL to the user-supplied path (e.g., `--path /api/data/v9.2/accounts` → `https://org.crm.dynamics.com/api/data/v9.2/accounts`).
 3. Default OData headers are applied unless explicitly overridden by user-supplied headers:
     - `OData-Version: 4.0`
+    - `OData-MaxVersion: 4.0`
     - `Accept: application/json`
     - `Content-Type: application/json` (when body is present)
 4. User-supplied headers (`--header`) merge with defaults; user wins on conflict.
-5. The write guard blocks POST/PATCH/DELETE/PUT on production environments (unless `--confirm` is supplied).
-6. GET requests are always allowed regardless of environment type.
-7. The response body is written to stdout. HTTP status line and headers are written to stdout only when `--include` is set.
-8. Non-2xx responses produce a non-zero exit code and write the error body to stderr.
+5. When `--method` is omitted and a body (`--body` or `--body-file`) is supplied, the method defaults to `POST`; otherwise it defaults to `GET`. An explicit `--method` always wins.
+6. **Write-guard fail-safe:** When the environment type cannot be determined (`Unknown`), the api-request path resolves the protection level to `Production` so mutating requests are blocked without `--confirm`. This deliberately differs from `DmlSafetyGuard.DetectProtectionLevel`, which maps `Unknown` to `Development` for SQL DML; api-request resolves `Unknown` locally to fail safe rather than fail open.
+7. The write guard blocks POST/PATCH/DELETE/PUT on production environments (unless `--confirm` is supplied).
+8. GET requests are always allowed regardless of environment type.
+9. The response body is written to stdout. HTTP status line and headers are written to stdout only when `--include` is set.
+10. Non-2xx responses produce a non-zero exit code and write the error body to stderr. The SDK (`RawWebApiService.SendAsync`) does **not** throw on non-2xx — it returns a `RawWebApiResponse` with `IsSuccess = false` (status/body preserved) for composability; the CLI adapter routes non-2xx to stderr with a nonzero exit. (Intentional deviation from issue #1164's "non-2xx throws" wording.)
 
 ### Primary Flows
 
@@ -151,7 +154,9 @@ Exit codes:
 | AC-09 | --body and --body-file together produces validation error                            | `ApiRequestCommandTests.Body_And_BodyFile_Conflict`                       | ✅     |
 | AC-10 | Path without leading `/` produces validation error                                   | `ApiRequestCommandTests.Path_NoLeadingSlash_Error`                        | ✅     |
 | AC-11 | Auth token is acquired for the correct environment URL resource                      | `RawWebApiServiceTests.Token_AcquiredForEnvironmentUrl`                   | ✅     |
-| AC-12 | Default OData headers (OData-Version, Accept) are present on requests                | `RawWebApiServiceTests.DefaultHeaders_Applied`                            | ✅     |
+| AC-12 | Default OData headers (OData-Version, OData-MaxVersion, Accept) are present on requests | `RawWebApiServiceTests.DefaultHeaders_Applied`                            | ✅     |
+| AC-13 | Omitting --method with a body (--body or --body-file) defaults the method to POST; explicit --method wins | `ApiRequestCommandTests.NoMethod_WithInlineBody_DefaultsToPost`, `ApiRequestCommandTests.NoMethod_WithBodyFile_DefaultsToPost`, `ApiRequestCommandTests.ExplicitMethod_WithBody_WinsOverPostDefault` | ✅     |
+| AC-14 | An unknown/undetectable environment resolves to Production protection and blocks mutating requests without --confirm | `ApiRequestCommandTests.ResolveProtectionLevel_UnknownEnvironment_IsProduction`, `ApiRequestCommandTests.UnknownEnvironment_BlocksMutatingRequestWithoutConfirm` | ✅     |
 
 ### Edge Cases
 
@@ -328,6 +333,7 @@ public static class WebApiWriteGuard
 | ---------- | ----------------------------------------------- |
 | 2025-07-25 | Initial spec                                    |
 | 2026-06-01 | Implemented — all 12 ACs verified and passing   |
+| 2026-06-03 | Added `OData-MaxVersion: 4.0` default header (#1164); POST-on-body method default (AC-13); Unknown-env write-guard fail-safe → Production (AC-14); documented intentional non-2xx-returns-not-throws deviation |
 
 ---
 

--- a/specs/raw-web-api.md
+++ b/specs/raw-web-api.md
@@ -1,6 +1,6 @@
 # Raw Web API Request
 
-**Status:** Draft
+**Status:** Implemented
 **Last Updated:** 2025-07-25
 **Code:** [src/PPDS.Cli/Services/WebApi/](../src/PPDS.Cli/Services/WebApi/)
 **Surfaces:** CLI
@@ -138,20 +138,20 @@ Exit codes:
 
 ## Acceptance Criteria
 
-| ID    | Criterion                                                                            | Test                                                      | Status |
-| ----- | ------------------------------------------------------------------------------------ | --------------------------------------------------------- | ------ |
-| AC-01 | GET request to valid path returns response body on stdout with exit code 0           | `RawWebApiServiceTests.Get_ValidPath_ReturnsBody`         | 🔲     |
-| AC-02 | POST request on production environment without --confirm is blocked with exit code 2 | `WebApiWriteGuardTests.Post_Production_NoConfirm_Blocks`  | 🔲     |
-| AC-03 | POST request on production with --confirm sends the request                          | `RawWebApiServiceTests.Post_Production_WithConfirm_Sends` | 🔲     |
-| AC-04 | POST/PATCH/DELETE on development environment is allowed without --confirm            | `WebApiWriteGuardTests.Mutating_Development_Allowed`      | 🔲     |
-| AC-05 | --include outputs status line and headers before body                                | `ApiRequestCommandTests.Include_OutputsHeaders`           | 🔲     |
-| AC-06 | Non-2xx response returns `IsSuccess = false` with status code and body preserved       | `RawWebApiServiceTests.Non2xx_ReturnsErrorResponse`       | 🔲     |
-| AC-07 | User-supplied headers override defaults                                              | `RawWebApiServiceTests.UserHeaders_OverrideDefaults`      | 🔲     |
-| AC-08 | --body-file reads body from file                                                     | `RawWebApiServiceTests.BodyFile_ReadsFromDisk`            | 🔲     |
-| AC-09 | --body and --body-file together produces validation error                            | `ApiRequestCommandTests.Body_And_BodyFile_Conflict`       | 🔲     |
-| AC-10 | Path without leading `/` produces validation error                                   | `ApiRequestCommandTests.Path_NoLeadingSlash_Error`        | 🔲     |
-| AC-11 | Auth token is acquired for the correct environment URL resource                      | `RawWebApiServiceTests.Token_AcquiredForEnvironmentUrl`   | 🔲     |
-| AC-12 | Default OData headers (OData-Version, Accept) are present on requests                | `RawWebApiServiceTests.DefaultHeaders_Applied`            | 🔲     |
+| ID    | Criterion                                                                            | Test                                                                      | Status |
+| ----- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------ |
+| AC-01 | GET request to valid path returns response body on stdout with exit code 0           | `RawWebApiServiceTests.Get_ValidPath_ReturnsBody`                         | ✅     |
+| AC-02 | POST request on production environment without --confirm is blocked with exit code 2 | `RawWebApiServiceTests.Post_Production_NoConfirm_ThrowsWriteBlocked`      | ✅     |
+| AC-03 | POST request on production with --confirm sends the request                          | `RawWebApiServiceTests.Post_Production_WithConfirm_Sends`                 | ✅     |
+| AC-04 | POST/PATCH/DELETE on development environment is allowed without --confirm            | `RawWebApiServiceTests.Mutating_Development_Allowed`                      | ✅     |
+| AC-05 | --include outputs status line and headers before body                                | `ApiRequestCommandTests.Include_OutputsHeaders`                           | ✅     |
+| AC-06 | Non-2xx response returns `IsSuccess = false` with status code and body preserved     | `RawWebApiServiceTests.Non2xx_ReturnsErrorResponse`                       | ✅     |
+| AC-07 | User-supplied headers override defaults                                              | `RawWebApiServiceTests.UserHeaders_OverrideDefaults`                      | ✅     |
+| AC-08 | --body-file reads body from file                                                     | `ApiRequestCommandTests.BodyFile_ReadsFromDisk`                           | ✅     |
+| AC-09 | --body and --body-file together produces validation error                            | `ApiRequestCommandTests.Body_And_BodyFile_Conflict`                       | ✅     |
+| AC-10 | Path without leading `/` produces validation error                                   | `ApiRequestCommandTests.Path_NoLeadingSlash_Error`                        | ✅     |
+| AC-11 | Auth token is acquired for the correct environment URL resource                      | `RawWebApiServiceTests.Token_AcquiredForEnvironmentUrl`                   | ✅     |
+| AC-12 | Default OData headers (OData-Version, Accept) are present on requests                | `RawWebApiServiceTests.DefaultHeaders_Applied`                            | ✅     |
 
 ### Edge Cases
 
@@ -324,9 +324,10 @@ public static class WebApiWriteGuard
 
 ## Changelog
 
-| Date       | Change       |
-| ---------- | ------------ |
-| 2025-07-25 | Initial spec |
+| Date       | Change                                          |
+| ---------- | ----------------------------------------------- |
+| 2025-07-25 | Initial spec                                    |
+| 2026-06-01 | Implemented — all 12 ACs verified and passing   |
 
 ---
 

--- a/src/PPDS.Cli/Commands/Api/ApiCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Api/ApiCommandGroup.cs
@@ -1,0 +1,13 @@
+using System.CommandLine;
+
+namespace PPDS.Cli.Commands.Api;
+
+public static class ApiCommandGroup
+{
+    public static Command Create()
+    {
+        var command = new Command("api", "Send raw HTTP requests to the Dataverse Web API");
+        command.Subcommands.Add(ApiRequestCommand.Create());
+        return command;
+    }
+}

--- a/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
+++ b/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
@@ -190,17 +190,20 @@ public static class ApiRequestCommand
 
             var response = await apiService.SendAsync(request, cancellationToken: cancellationToken);
 
-            foreach (var line in FormatResponsePreamble(response, include))
-                Console.WriteLine(line);
-
             if (response.IsSuccess)
             {
+                foreach (var line in FormatResponsePreamble(response, include))
+                    Console.WriteLine(line);
                 if (!string.IsNullOrEmpty(response.Body))
                     Console.WriteLine(response.Body);
                 return ExitCodes.Success;
             }
             else
             {
+                // Non-2xx: route entire response (preamble + body) to stderr so the
+                // stream is consistent and piping to tools like jq works on success only.
+                foreach (var line in FormatResponsePreamble(response, include))
+                    Console.Error.WriteLine(line);
                 Console.Error.WriteLine(response.Body);
                 return 1; // non-2xx per spec
             }

--- a/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
+++ b/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
@@ -112,6 +112,12 @@ public static class ApiRequestCommand
                 return ($"Invalid HTTP method '{method}'. Use GET, POST, PATCH, PUT, DELETE, HEAD, or OPTIONS.", ExitCodes.InvalidArguments);
             httpMethod = new HttpMethod(method.ToUpperInvariant());
         }
+        else if (body != null || bodyFile != null)
+        {
+            // No explicit --method but a body is present: default to POST (issue #1164).
+            // An explicit --method always wins (handled by the branch above).
+            httpMethod = HttpMethod.Post;
+        }
 
         if (headers?.Length > 0)
         {
@@ -148,16 +154,14 @@ public static class ApiRequestCommand
             return validation.Value.ExitCode;
         }
 
-        // Validation: body file exists
-        if (bodyFile != null)
+        // Resolve --body-file from disk (reads the file into the request body).
+        var bodyResolution = await ResolveBodyAsync(body, bodyFile, cancellationToken);
+        if (bodyResolution.Error != null)
         {
-            if (!File.Exists(bodyFile))
-            {
-                Console.Error.WriteLine($"Error: Body file not found: '{bodyFile}'");
-                return ExitCodes.NotFoundError;
-            }
-            body = await File.ReadAllTextAsync(bodyFile, cancellationToken);
+            Console.Error.WriteLine($"Error: {bodyResolution.Error}");
+            return bodyResolution.ExitCode;
         }
+        body = bodyResolution.Body;
 
         try
         {
@@ -174,8 +178,7 @@ public static class ApiRequestCommand
             var apiService = serviceProvider.GetRequiredService<IRawWebApiService>();
 
             var envConfig = await envConfigService.GetConfigAsync(connectionInfo.EnvironmentUrl, cancellationToken);
-            var envType = envConfig?.Type ?? EnvironmentType.Unknown;
-            var protectionLevel = envConfig?.Protection ?? DmlSafetyGuard.DetectProtectionLevel(envType);
+            var protectionLevel = ResolveProtectionLevel(envConfig?.Type ?? EnvironmentType.Unknown, envConfig?.Protection);
 
             var request = new RawWebApiRequest
             {
@@ -188,36 +191,88 @@ public static class ApiRequestCommand
                 ProtectionLevel = protectionLevel
             };
 
-            var response = await apiService.SendAsync(request, cancellationToken: cancellationToken);
-
-            if (response.IsSuccess)
-            {
-                foreach (var line in FormatResponsePreamble(response, include))
-                    Console.WriteLine(line);
-                if (!string.IsNullOrEmpty(response.Body))
-                    Console.WriteLine(response.Body);
-                return ExitCodes.Success;
-            }
-            else
-            {
-                // Non-2xx: route entire response (preamble + body) to stderr so the
-                // stream is consistent and piping to tools like jq works on success only.
-                foreach (var line in FormatResponsePreamble(response, include))
-                    Console.Error.WriteLine(line);
-                Console.Error.WriteLine(response.Body);
-                return 1; // non-2xx per spec
-            }
-        }
-        catch (PpdsException ex) when (ex.ErrorCode == "Api.WriteBlocked")
-        {
-            Console.Error.WriteLine($"Error: {ex.UserMessage}");
-            return ExitCodes.Failure; // 2 per spec
+            // Write-guard blocks (exit 2) and HTTP response routing (exit 0/1) are handled
+            // inside RunRequestAsync; only auth/connectivity failures reach the catch below.
+            return await RunRequestAsync(apiService, request, include, cancellationToken);
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 3; // auth/connectivity failure per spec
         }
+    }
+
+    /// <summary>
+    /// Resolves the effective request body: when --body-file is supplied, reads it from disk;
+    /// otherwise returns the inline --body unchanged. On a missing file, returns an error + exit code.
+    /// Exposed internal for unit testing of AC-08 (the --body-file read branch).
+    /// </summary>
+    internal static async Task<(string? Body, string? Error, int ExitCode)> ResolveBodyAsync(
+        string? body,
+        string? bodyFile,
+        CancellationToken cancellationToken)
+    {
+        if (bodyFile == null)
+            return (body, null, ExitCodes.Success);
+
+        if (!File.Exists(bodyFile))
+            return (null, $"Body file not found: '{bodyFile}'", ExitCodes.NotFoundError);
+
+        var fileBody = await File.ReadAllTextAsync(bodyFile, cancellationToken);
+        return (fileBody, null, ExitCodes.Success);
+    }
+
+    /// <summary>
+    /// Resolves the effective protection level for the write guard.
+    /// Fail-safe: an unknown/undetectable environment type resolves to Production so mutating
+    /// requests are blocked without --confirm. (DmlSafetyGuard.DetectProtectionLevel maps Unknown
+    /// to Development for SQL DML, which would fail open here — so api-request resolves Unknown locally.)
+    /// An explicit per-environment protection override always wins.
+    /// Exposed internal for unit testing of the write-guard fail-safe.
+    /// </summary>
+    internal static ProtectionLevel ResolveProtectionLevel(EnvironmentType envType, ProtectionLevel? configuredProtection)
+        => configuredProtection
+            ?? (envType == EnvironmentType.Unknown
+                ? ProtectionLevel.Production
+                : DmlSafetyGuard.DetectProtectionLevel(envType));
+
+    /// <summary>
+    /// Sends the request via the service and maps the response (or write-guard block) to an exit code.
+    /// I1: success body → stdout; non-2xx response and write-block errors → stderr.
+    /// Exposed internal for unit testing of AC-02 (exit codes) without live auth/network.
+    /// </summary>
+    internal static async Task<int> RunRequestAsync(
+        IRawWebApiService apiService,
+        RawWebApiRequest request,
+        bool include,
+        CancellationToken cancellationToken)
+    {
+        RawWebApiResponse response;
+        try
+        {
+            response = await apiService.SendAsync(request, cancellationToken: cancellationToken);
+        }
+        catch (PpdsException ex) when (ex.ErrorCode == "Api.WriteBlocked")
+        {
+            Console.Error.WriteLine($"Error: {ex.UserMessage}");
+            return ExitCodes.Failure; // 2 per spec
+        }
+
+        if (response.IsSuccess)
+        {
+            foreach (var line in FormatResponsePreamble(response, include))
+                Console.WriteLine(line);
+            if (!string.IsNullOrEmpty(response.Body))
+                Console.WriteLine(response.Body);
+            return ExitCodes.Success;
+        }
+
+        // Non-2xx: route entire response (preamble + body) to stderr so the
+        // stream is consistent and piping to tools like jq works on success only.
+        foreach (var line in FormatResponsePreamble(response, include))
+            Console.Error.WriteLine(line);
+        Console.Error.WriteLine(response.Body);
+        return 1; // non-2xx per spec
     }
 
     /// <summary>

--- a/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
+++ b/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
@@ -190,13 +190,8 @@ public static class ApiRequestCommand
 
             var response = await apiService.SendAsync(request, cancellationToken: cancellationToken);
 
-            if (include)
-            {
-                Console.WriteLine($"HTTP/1.1 {response.StatusCode} {response.ReasonPhrase}");
-                foreach (var (key, value) in response.Headers)
-                    Console.WriteLine($"{key}: {value}");
-                Console.WriteLine();
-            }
+            foreach (var line in FormatResponsePreamble(response, include))
+                Console.WriteLine(line);
 
             if (response.IsSuccess)
             {
@@ -220,5 +215,20 @@ public static class ApiRequestCommand
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 3; // auth/connectivity failure per spec
         }
+    }
+
+    /// <summary>
+    /// Returns lines for the HTTP status line and response headers when --include is set.
+    /// Exposed internal for unit testing of AC-05.
+    /// </summary>
+    internal static IEnumerable<string> FormatResponsePreamble(RawWebApiResponse response, bool include)
+    {
+        if (!include)
+            yield break;
+
+        yield return $"HTTP/1.1 {response.StatusCode} {response.ReasonPhrase}";
+        foreach (var (key, value) in response.Headers)
+            yield return $"{key}: {value}";
+        yield return string.Empty;
     }
 }

--- a/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
+++ b/src/PPDS.Cli/Commands/Api/ApiRequestCommand.cs
@@ -1,0 +1,224 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using PPDS.Auth.Profiles;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.Environment;
+using PPDS.Cli.Services.Query;
+using PPDS.Cli.Services.WebApi;
+
+namespace PPDS.Cli.Commands.Api;
+
+public static class ApiRequestCommand
+{
+    public static Command Create()
+    {
+        var pathOption = new Option<string>("--path")
+        {
+            Description = "Relative URL path (e.g., /api/data/v9.2/accounts)",
+            Required = true
+        };
+        var methodOption = new Option<string?>("--method", "-X")
+        {
+            Description = "HTTP method (default: GET)"
+        };
+        var bodyOption = new Option<string?>("--body")
+        {
+            Description = "Request body as inline JSON string"
+        };
+        var bodyFileOption = new Option<string?>("--body-file")
+        {
+            Description = "Request body from file (mutually exclusive with --body)"
+        };
+        var headerOption = new Option<string[]?>("--header", "-H")
+        {
+            Description = "Additional header, repeatable (format: \"Name: Value\")",
+            AllowMultipleArgumentsPerToken = false
+        };
+        headerOption.Arity = ArgumentArity.ZeroOrMore;
+        var includeOption = new Option<bool>("--include", "-i")
+        {
+            Description = "Include HTTP status line and response headers in output"
+        };
+        var environmentOption = new Option<string?>("--environment", "-env")
+        {
+            Description = "Target environment URL (default: active profile)"
+        };
+        var confirmOption = new Option<bool>("--confirm")
+        {
+            Description = "Bypass write protection on production environments"
+        };
+
+        var command = new Command("request", "Send a raw HTTP request to the Dataverse Web API")
+        {
+            pathOption,
+            methodOption,
+            bodyOption,
+            bodyFileOption,
+            headerOption,
+            includeOption,
+            environmentOption,
+            confirmOption
+        };
+
+        GlobalOptions.AddToCommand(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var path = parseResult.GetValue(pathOption)!;
+            var method = parseResult.GetValue(methodOption);
+            var body = parseResult.GetValue(bodyOption);
+            var bodyFile = parseResult.GetValue(bodyFileOption);
+            var headers = parseResult.GetValue(headerOption);
+            var include = parseResult.GetValue(includeOption);
+            var environment = parseResult.GetValue(environmentOption);
+            var confirm = parseResult.GetValue(confirmOption);
+            var globalOptions = GlobalOptions.GetValues(parseResult);
+
+            return await ExecuteAsync(
+                path, method, body, bodyFile, headers, include,
+                environment, confirm, globalOptions, cancellationToken);
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Validates raw inputs before any I/O. Returns an error message + exit code, or null if valid.
+    /// Also returns parsed method and headers on success.
+    /// </summary>
+    internal static (string Error, int ExitCode)? ValidateInputs(
+        string path,
+        string? method,
+        string? body,
+        string? bodyFile,
+        string[]? headers,
+        out HttpMethod httpMethod,
+        out Dictionary<string, string>? parsedHeaders)
+    {
+        httpMethod = HttpMethod.Get;
+        parsedHeaders = null;
+
+        if (!path.StartsWith('/'))
+            return ("Path must start with '/'. Example: /api/data/v9.2/accounts", ExitCodes.InvalidArguments);
+
+        if (body != null && bodyFile != null)
+            return ("Cannot specify both --body and --body-file.", ExitCodes.InvalidArguments);
+
+        if (!string.IsNullOrEmpty(method))
+        {
+            var valid = new[] { "GET", "POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS" };
+            if (!valid.Contains(method.ToUpperInvariant()))
+                return ($"Invalid HTTP method '{method}'. Use GET, POST, PATCH, PUT, DELETE, HEAD, or OPTIONS.", ExitCodes.InvalidArguments);
+            httpMethod = new HttpMethod(method.ToUpperInvariant());
+        }
+
+        if (headers?.Length > 0)
+        {
+            parsedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in headers)
+            {
+                var idx = header.IndexOf(':');
+                if (idx <= 0)
+                    return ($"Invalid header format '{header}'. Expected 'Name: Value'.", ExitCodes.InvalidArguments);
+                parsedHeaders[header[..idx].Trim()] = header[(idx + 1)..].Trim();
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string path,
+        string? method,
+        string? body,
+        string? bodyFile,
+        string[]? headers,
+        bool include,
+        string? environment,
+        bool confirm,
+        GlobalOptionValues globalOptions,
+        CancellationToken cancellationToken)
+    {
+        var validation = ValidateInputs(path, method, body, bodyFile, headers,
+            out var httpMethod, out var parsedHeaders);
+        if (validation.HasValue)
+        {
+            Console.Error.WriteLine($"Error: {validation.Value.Error}");
+            return validation.Value.ExitCode;
+        }
+
+        // Validation: body file exists
+        if (bodyFile != null)
+        {
+            if (!File.Exists(bodyFile))
+            {
+                Console.Error.WriteLine($"Error: Body file not found: '{bodyFile}'");
+                return ExitCodes.NotFoundError;
+            }
+            body = await File.ReadAllTextAsync(bodyFile, cancellationToken);
+        }
+
+        try
+        {
+            await using var serviceProvider = await ProfileServiceFactory.CreateFromProfilesAsync(
+                null,
+                environment,
+                globalOptions.Verbose,
+                globalOptions.Debug,
+                ProfileServiceFactory.DefaultDeviceCodeCallback,
+                cancellationToken);
+
+            var connectionInfo = serviceProvider.GetRequiredService<ResolvedConnectionInfo>();
+            var envConfigService = serviceProvider.GetRequiredService<IEnvironmentConfigService>();
+            var apiService = serviceProvider.GetRequiredService<IRawWebApiService>();
+
+            var envConfig = await envConfigService.GetConfigAsync(connectionInfo.EnvironmentUrl, cancellationToken);
+            var envType = envConfig?.Type ?? EnvironmentType.Unknown;
+            var protectionLevel = envConfig?.Protection ?? DmlSafetyGuard.DetectProtectionLevel(envType);
+
+            var request = new RawWebApiRequest
+            {
+                EnvironmentUrl = connectionInfo.EnvironmentUrl,
+                Path = path,
+                Method = httpMethod,
+                Body = body,
+                Headers = parsedHeaders,
+                IsConfirmed = confirm,
+                ProtectionLevel = protectionLevel
+            };
+
+            var response = await apiService.SendAsync(request, cancellationToken: cancellationToken);
+
+            if (include)
+            {
+                Console.WriteLine($"HTTP/1.1 {response.StatusCode} {response.ReasonPhrase}");
+                foreach (var (key, value) in response.Headers)
+                    Console.WriteLine($"{key}: {value}");
+                Console.WriteLine();
+            }
+
+            if (response.IsSuccess)
+            {
+                if (!string.IsNullOrEmpty(response.Body))
+                    Console.WriteLine(response.Body);
+                return ExitCodes.Success;
+            }
+            else
+            {
+                Console.Error.WriteLine(response.Body);
+                return 1; // non-2xx per spec
+            }
+        }
+        catch (PpdsException ex) when (ex.ErrorCode == "Api.WriteBlocked")
+        {
+            Console.Error.WriteLine($"Error: {ex.UserMessage}");
+            return ExitCodes.Failure; // 2 per spec
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 3; // auth/connectivity failure per spec
+        }
+    }
+}

--- a/src/PPDS.Cli/Program.cs
+++ b/src/PPDS.Cli/Program.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using PPDS.Cli.Commands.Api;
 using PPDS.Cli.Commands.Auth;
 using PPDS.Cli.Commands.Connections;
 using PPDS.Cli.Commands.ConnectionReferences;
@@ -88,6 +89,7 @@ public static class Program
             $"Documentation: {DocsCommand.DocsUrl}");
 
         // Add command groups
+        rootCommand.Subcommands.Add(ApiCommandGroup.Create());
         rootCommand.Subcommands.Add(AuthCommandGroup.Create());
         rootCommand.Subcommands.Add(EnvCommandGroup.Create());
         rootCommand.Subcommands.Add(EnvCommandGroup.CreateOrgAlias()); // 'org' alias for 'env'

--- a/src/PPDS.Cli/Services/ServiceRegistration.cs
+++ b/src/PPDS.Cli/Services/ServiceRegistration.cs
@@ -25,6 +25,7 @@ using PPDS.Cli.Services.SolutionComponents;
 using PPDS.Cli.Services.Solutions;
 using PPDS.Cli.Services.UpdateCheck;
 using PPDS.Cli.Services.Users;
+using PPDS.Cli.Services.WebApi;
 using PPDS.Cli.Services.WebResources;
 using PPDS.Cli.Tui.Infrastructure;
 using PPDS.Dataverse.BulkOperations;
@@ -196,6 +197,36 @@ public static class ServiceRegistration
                 profile.Cloud,
                 connectionInfo.EnvironmentId,
                 logger);
+        });
+
+        // Raw Web API service — uses same auth pattern as IConnectionService.
+        // DI factory creates the token provider from the resolved profile.
+        services.AddTransient<IRawWebApiService>(sp =>
+        {
+            var connectionInfo = sp.GetRequiredService<ResolvedConnectionInfo>();
+            var credentialStore = sp.GetRequiredService<ISecureCredentialStore>();
+            var logger = sp.GetRequiredService<ILogger<RawWebApiService>>();
+            var profile = connectionInfo.Profile;
+
+            IPowerPlatformTokenProvider tokenProvider;
+            if (profile.AuthMethod == AuthMethod.ClientSecret)
+            {
+                if (string.IsNullOrEmpty(profile.ApplicationId))
+                    throw new AuthenticationException(
+                        $"Profile '{profile.DisplayIdentifier}' is configured for ClientSecret auth but has no ApplicationId.",
+                        "Auth.InvalidCredentials");
+
+#pragma warning disable PPDS012 // Sync-over-async: DI factory cannot be async
+                var storedCredential = credentialStore.GetAsync(profile.ApplicationId).GetAwaiter().GetResult();
+#pragma warning restore PPDS012
+                tokenProvider = PowerPlatformTokenProvider.FromProfileWithSecret(profile, storedCredential?.ClientSecret ?? "");
+            }
+            else
+            {
+                tokenProvider = PowerPlatformTokenProvider.FromProfile(profile);
+            }
+
+            return new RawWebApiService(tokenProvider, new HttpClient(), logger);
         });
 
         // Update check service — singleton, manages its own cache file

--- a/src/PPDS.Cli/Services/WebApi/IRawWebApiService.cs
+++ b/src/PPDS.Cli/Services/WebApi/IRawWebApiService.cs
@@ -1,0 +1,11 @@
+using PPDS.Cli.Infrastructure.Progress;
+
+namespace PPDS.Cli.Services.WebApi;
+
+public interface IRawWebApiService
+{
+    Task<RawWebApiResponse> SendAsync(
+        RawWebApiRequest request,
+        IProgressReporter? progress = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiRequest.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiRequest.cs
@@ -1,0 +1,14 @@
+using PPDS.Auth.Profiles;
+
+namespace PPDS.Cli.Services.WebApi;
+
+public sealed class RawWebApiRequest
+{
+    public required string EnvironmentUrl { get; init; }
+    public required string Path { get; init; }
+    public HttpMethod Method { get; init; } = HttpMethod.Get;
+    public string? Body { get; init; }
+    public Dictionary<string, string>? Headers { get; init; }
+    public bool IsConfirmed { get; init; }
+    public ProtectionLevel ProtectionLevel { get; init; } = ProtectionLevel.Production;
+}

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiResponse.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiResponse.cs
@@ -1,0 +1,10 @@
+namespace PPDS.Cli.Services.WebApi;
+
+public sealed class RawWebApiResponse
+{
+    public int StatusCode { get; init; }
+    public string? ReasonPhrase { get; init; }
+    public Dictionary<string, string> Headers { get; init; } = new();
+    public string Body { get; init; } = string.Empty;
+    public bool IsSuccess => StatusCode >= 200 && StatusCode < 300;
+}

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
@@ -1,0 +1,107 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using PPDS.Auth.Credentials;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Infrastructure.Progress;
+
+namespace PPDS.Cli.Services.WebApi;
+
+public sealed class RawWebApiService : IRawWebApiService
+{
+    private readonly IPowerPlatformTokenProvider _tokenProvider;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<RawWebApiService> _logger;
+
+    public RawWebApiService(
+        IPowerPlatformTokenProvider tokenProvider,
+        HttpClient httpClient,
+        ILogger<RawWebApiService> logger)
+    {
+        _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<RawWebApiResponse> SendAsync(
+        RawWebApiRequest request,
+        IProgressReporter? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (WebApiWriteGuard.IsBlocked(request.Method, request.ProtectionLevel, request.IsConfirmed))
+        {
+            throw new PpdsException(
+                "Api.WriteBlocked",
+                $"Mutating request blocked on Production environment '{request.EnvironmentUrl}'. Add --confirm to proceed.");
+        }
+
+        var baseUrl = request.EnvironmentUrl.TrimEnd('/');
+        var url = baseUrl + request.Path;
+
+        PowerPlatformToken token;
+        try
+        {
+            token = await _tokenProvider.GetTokenForResourceAsync(request.EnvironmentUrl, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new PpdsException(
+                "Api.AuthFailed",
+                $"Failed to acquire token for '{request.EnvironmentUrl}': {ex.Message}",
+                ex);
+        }
+
+        using var httpRequest = new HttpRequestMessage(request.Method, url);
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
+
+        // Merge defaults with user-supplied headers; user wins on conflict.
+        var effectiveHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["OData-Version"] = "4.0",
+            ["Accept"] = "application/json"
+        };
+        if (request.Headers != null)
+        {
+            foreach (var (key, value) in request.Headers)
+                effectiveHeaders[key] = value;
+        }
+
+        // Set body before applying content headers so Content-Type lands on HttpContent.
+        if (!string.IsNullOrEmpty(request.Body))
+        {
+            var contentType = effectiveHeaders.TryGetValue("Content-Type", out var ct)
+                ? ct
+                : "application/json";
+            httpRequest.Content = new StringContent(request.Body, Encoding.UTF8);
+            httpRequest.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        }
+
+        foreach (var (key, value) in effectiveHeaders)
+        {
+            if (key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
+                continue;
+            httpRequest.Headers.TryAddWithoutValidation(key, value);
+        }
+
+        progress?.ReportPhase("Sending request");
+        _logger.LogDebug("Sending {Method} {Url}", request.Method, url);
+
+        var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in response.Headers)
+            headers[header.Key] = string.Join(", ", header.Value);
+        foreach (var header in response.Content.Headers)
+            headers[header.Key] = string.Join(", ", header.Value);
+
+        return new RawWebApiResponse
+        {
+            StatusCode = (int)response.StatusCode,
+            ReasonPhrase = response.ReasonPhrase,
+            Headers = headers,
+            Body = body
+        };
+    }
+}

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
@@ -7,7 +7,7 @@ using PPDS.Cli.Infrastructure.Progress;
 
 namespace PPDS.Cli.Services.WebApi;
 
-public sealed class RawWebApiService : IRawWebApiService
+public sealed class RawWebApiService : IRawWebApiService, IDisposable
 {
     private readonly IPowerPlatformTokenProvider _tokenProvider;
     private readonly HttpClient _httpClient;
@@ -103,5 +103,11 @@ public sealed class RawWebApiService : IRawWebApiService
             Headers = headers,
             Body = body
         };
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+        _tokenProvider.Dispose();
     }
 }

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
@@ -60,6 +60,7 @@ public sealed class RawWebApiService : IRawWebApiService, IDisposable
         var effectiveHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["OData-Version"] = "4.0",
+            ["OData-MaxVersion"] = "4.0",
             ["Accept"] = "application/json"
         };
         if (request.Headers != null)

--- a/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
+++ b/src/PPDS.Cli/Services/WebApi/RawWebApiService.cs
@@ -36,7 +36,8 @@ public sealed class RawWebApiService : IRawWebApiService, IDisposable
         }
 
         var baseUrl = request.EnvironmentUrl.TrimEnd('/');
-        var url = baseUrl + request.Path;
+        var path = request.Path.StartsWith('/') ? request.Path : "/" + request.Path;
+        var url = baseUrl + path;
 
         PowerPlatformToken token;
         try
@@ -81,20 +82,28 @@ public sealed class RawWebApiService : IRawWebApiService, IDisposable
         {
             if (key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))
                 continue;
-            httpRequest.Headers.TryAddWithoutValidation(key, value);
+            // Try request headers first; fall back to content headers for content-specific ones
+            // (e.g., Content-Encoding, Content-Language) that TryAddWithoutValidation rejects.
+            if (!httpRequest.Headers.TryAddWithoutValidation(key, value))
+                httpRequest.Content?.Headers.TryAddWithoutValidation(key, value);
         }
 
         progress?.ReportPhase("Sending request");
         _logger.LogDebug("Sending {Method} {Url}", request.Method, url);
 
         var response = await _httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var body = response.Content != null
+            ? await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)
+            : string.Empty;
 
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var header in response.Headers)
             headers[header.Key] = string.Join(", ", header.Value);
-        foreach (var header in response.Content.Headers)
-            headers[header.Key] = string.Join(", ", header.Value);
+        if (response.Content != null)
+        {
+            foreach (var header in response.Content.Headers)
+                headers[header.Key] = string.Join(", ", header.Value);
+        }
 
         return new RawWebApiResponse
         {

--- a/src/PPDS.Cli/Services/WebApi/WebApiWriteGuard.cs
+++ b/src/PPDS.Cli/Services/WebApi/WebApiWriteGuard.cs
@@ -1,0 +1,12 @@
+using PPDS.Auth.Profiles;
+
+namespace PPDS.Cli.Services.WebApi;
+
+public static class WebApiWriteGuard
+{
+    public static bool IsMutating(HttpMethod method)
+        => method != HttpMethod.Get && method != HttpMethod.Head && method != HttpMethod.Options;
+
+    public static bool IsBlocked(HttpMethod method, ProtectionLevel level, bool isConfirmed)
+        => IsMutating(method) && level == ProtectionLevel.Production && !isConfirmed;
+}

--- a/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
@@ -254,6 +254,18 @@ public class ApiRequestCommandTests
 
     #endregion
 
+    #region AC-02: write-blocked exit code is exactly 2
+
+    [Fact]
+    public void WriteBlocked_ExitCode_IsExactly2()
+    {
+        // ExitCodes.Failure must equal 2 so callers can distinguish write-blocked (2)
+        // from non-2xx HTTP response (1). This guards against accidental renumbering.
+        Assert.Equal(2, ExitCodes.Failure);
+    }
+
+    #endregion
+
     #region AC-08: --body-file reads body from file
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
@@ -1,4 +1,6 @@
 using System.CommandLine;
+using Moq;
+using PPDS.Auth.Profiles;
 using PPDS.Cli.Commands.Api;
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Services.WebApi;
@@ -254,14 +256,108 @@ public class ApiRequestCommandTests
 
     #endregion
 
-    #region AC-02: write-blocked exit code is exactly 2
+    #region AC-02: write-blocked returns exit code 2
 
     [Fact]
-    public void WriteBlocked_ExitCode_IsExactly2()
+    public async Task WriteBlocked_ReturnsExitCode2()
     {
-        // ExitCodes.Failure must equal 2 so callers can distinguish write-blocked (2)
-        // from non-2xx HTTP response (1). This guards against accidental renumbering.
-        Assert.Equal(2, ExitCodes.Failure);
+        // Drive the real command path: a production mutating request whose service raises
+        // the write-guard PpdsException must map to exit code 2 (distinct from non-2xx = 1).
+        var service = new Mock<IRawWebApiService>();
+        service
+            .Setup(s => s.SendAsync(It.IsAny<RawWebApiRequest>(), null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PpdsException(
+                "Api.WriteBlocked",
+                "Mutating request blocked on Production environment. Add --confirm to proceed."));
+
+        var request = new RawWebApiRequest
+        {
+            EnvironmentUrl = "https://org.crm.dynamics.com",
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Post,
+            Body = "{}",
+            IsConfirmed = false,
+            ProtectionLevel = ProtectionLevel.Production
+        };
+
+        var exitCode = await ApiRequestCommand.RunRequestAsync(
+            service.Object, request, include: false, CancellationToken.None);
+
+        Assert.Equal(2, exitCode);
+        Assert.Equal(2, ExitCodes.Failure); // contract: write-blocked exit code is exactly 2
+    }
+
+    [Fact]
+    public async Task Non2xxResponse_ReturnsExitCode1()
+    {
+        // A non-2xx response (not a write block) routes to stderr and maps to exit 1,
+        // keeping it distinguishable from the write-blocked exit code (2).
+        var service = new Mock<IRawWebApiService>();
+        service
+            .Setup(s => s.SendAsync(It.IsAny<RawWebApiRequest>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RawWebApiResponse
+            {
+                StatusCode = 404,
+                ReasonPhrase = "Not Found",
+                Body = "{\"error\":{}}"
+            });
+
+        var request = new RawWebApiRequest
+        {
+            EnvironmentUrl = "https://org.crm.dynamics.com",
+            Path = "/api/data/v9.2/nope",
+            Method = HttpMethod.Get
+        };
+
+        var exitCode = await ApiRequestCommand.RunRequestAsync(
+            service.Object, request, include: false, CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    #endregion
+
+    #region AC-02/write-guard fail-safe: unknown environment blocks mutating requests
+
+    [Fact]
+    public void ResolveProtectionLevel_UnknownEnvironment_IsProduction()
+    {
+        // Fail-safe: an undetectable environment must resolve to Production so the write
+        // guard is conservative (unlike DmlSafetyGuard.DetectProtectionLevel which maps
+        // Unknown -> Development for SQL DML).
+        var level = ApiRequestCommand.ResolveProtectionLevel(EnvironmentType.Unknown, configuredProtection: null);
+        Assert.Equal(ProtectionLevel.Production, level);
+    }
+
+    [Fact]
+    public void UnknownEnvironment_BlocksMutatingRequestWithoutConfirm()
+    {
+        // End-to-end through the real guard: Unknown env -> Production -> POST without
+        // --confirm is blocked.
+        var level = ApiRequestCommand.ResolveProtectionLevel(EnvironmentType.Unknown, configuredProtection: null);
+
+        var blocked = WebApiWriteGuard.IsBlocked(HttpMethod.Post, level, isConfirmed: false);
+
+        Assert.True(blocked, "Unknown environment must block a mutating request without --confirm");
+    }
+
+    [Fact]
+    public void UnknownEnvironment_AllowsMutatingRequestWithConfirm()
+    {
+        var level = ApiRequestCommand.ResolveProtectionLevel(EnvironmentType.Unknown, configuredProtection: null);
+
+        var blocked = WebApiWriteGuard.IsBlocked(HttpMethod.Post, level, isConfirmed: true);
+
+        Assert.False(blocked, "--confirm must bypass the write guard even on an unknown environment");
+    }
+
+    [Fact]
+    public void ConfiguredProtection_OverridesUnknownFailSafe()
+    {
+        // An explicit per-environment protection override always wins over the Unknown fail-safe.
+        var level = ApiRequestCommand.ResolveProtectionLevel(
+            EnvironmentType.Unknown, configuredProtection: ProtectionLevel.Development);
+        Assert.Equal(ProtectionLevel.Development, level);
     }
 
     #endregion
@@ -277,20 +373,92 @@ public class ApiRequestCommandTests
             const string expectedBody = "{\"name\":\"test\"}";
             await File.WriteAllTextAsync(tempFile, expectedBody);
 
-            // Validate passes (file reading is post-validation in the handler)
-            var validationResult = ApiRequestCommand.ValidateInputs(
-                "/api/data/v9.2/accounts", "POST", null, tempFile, null,
-                out _, out _);
-            Assert.Null(validationResult);
+            // Drive the command's actual file-read branch (ResolveBodyAsync), not a
+            // re-implementation: this exercises the --body-file reading path the handler uses.
+            var (resolvedBody, error, exitCode) = await ApiRequestCommand.ResolveBodyAsync(
+                body: null, bodyFile: tempFile, CancellationToken.None);
 
-            // The actual file read that the handler performs
-            var actualBody = await File.ReadAllTextAsync(tempFile);
-            Assert.Equal(expectedBody, actualBody);
+            Assert.Null(error);
+            Assert.Equal(ExitCodes.Success, exitCode);
+            Assert.Equal(expectedBody, resolvedBody);
         }
         finally
         {
             File.Delete(tempFile);
         }
+    }
+
+    [Fact]
+    public async Task BodyFile_Missing_ReturnsNotFound()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"ppds-missing-{Guid.NewGuid():N}.json");
+
+        var (resolvedBody, error, exitCode) = await ApiRequestCommand.ResolveBodyAsync(
+            body: null, bodyFile: missing, CancellationToken.None);
+
+        Assert.Null(resolvedBody);
+        Assert.NotNull(error);
+        Assert.Contains(missing, error);
+        Assert.Equal(ExitCodes.NotFoundError, exitCode);
+    }
+
+    [Fact]
+    public async Task ResolveBody_NoFile_ReturnsInlineBody()
+    {
+        var (resolvedBody, error, _) = await ApiRequestCommand.ResolveBodyAsync(
+            body: "{\"inline\":true}", bodyFile: null, CancellationToken.None);
+
+        Assert.Null(error);
+        Assert.Equal("{\"inline\":true}", resolvedBody);
+    }
+
+    #endregion
+
+    #region POST-on-body default (issue #1164)
+
+    [Fact]
+    public void NoMethod_WithInlineBody_DefaultsToPost()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", method: null, body: "{}", bodyFile: null, headers: null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(HttpMethod.Post, method);
+    }
+
+    [Fact]
+    public void NoMethod_WithBodyFile_DefaultsToPost()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", method: null, body: null, bodyFile: "file.json", headers: null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(HttpMethod.Post, method);
+    }
+
+    [Fact]
+    public void NoMethod_NoBody_DefaultsToGet()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", method: null, body: null, bodyFile: null, headers: null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(HttpMethod.Get, method);
+    }
+
+    [Fact]
+    public void ExplicitMethod_WithBody_WinsOverPostDefault()
+    {
+        // An explicit --method always wins, even when a body is present.
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", method: "PATCH", body: "{}", bodyFile: null, headers: null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(HttpMethod.Patch, method);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using PPDS.Cli.Commands.Api;
 using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.WebApi;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Commands.Api;
@@ -218,6 +219,66 @@ public class ApiRequestCommandTests
         Assert.Null(result);
         Assert.NotNull(headers);
         Assert.Equal("text/plain", headers!["Accept"]);
+    }
+
+    #endregion
+
+    #region AC-05: --include outputs status line and headers
+
+    [Fact]
+    public void Include_OutputsHeaders()
+    {
+        var response = new RawWebApiResponse
+        {
+            StatusCode = 200,
+            ReasonPhrase = "OK",
+            Headers = new Dictionary<string, string> { ["OData-Version"] = "4.0", ["Content-Type"] = "application/json" },
+            Body = "{\"value\":[]}"
+        };
+
+        var lines = ApiRequestCommand.FormatResponsePreamble(response, include: true).ToList();
+
+        Assert.Contains("HTTP/1.1 200 OK", lines);
+        Assert.Contains("OData-Version: 4.0", lines);
+        Assert.Contains("Content-Type: application/json", lines);
+        Assert.Contains(string.Empty, lines); // blank separator before body
+    }
+
+    [Fact]
+    public void Include_False_OutputsNoPreamble()
+    {
+        var response = new RawWebApiResponse { StatusCode = 200, ReasonPhrase = "OK" };
+        var lines = ApiRequestCommand.FormatResponsePreamble(response, include: false).ToList();
+        Assert.Empty(lines);
+    }
+
+    #endregion
+
+    #region AC-08: --body-file reads body from file
+
+    [Fact]
+    public async Task BodyFile_ReadsFromDisk()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            const string expectedBody = "{\"name\":\"test\"}";
+            await File.WriteAllTextAsync(tempFile, expectedBody);
+
+            // Validate passes (file reading is post-validation in the handler)
+            var validationResult = ApiRequestCommand.ValidateInputs(
+                "/api/data/v9.2/accounts", "POST", null, tempFile, null,
+                out _, out _);
+            Assert.Null(validationResult);
+
+            // The actual file read that the handler performs
+            var actualBody = await File.ReadAllTextAsync(tempFile);
+            Assert.Equal(expectedBody, actualBody);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Api/ApiRequestCommandTests.cs
@@ -1,0 +1,224 @@
+using System.CommandLine;
+using PPDS.Cli.Commands.Api;
+using PPDS.Cli.Infrastructure.Errors;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Api;
+
+[Trait("Category", "Unit")]
+public class ApiRequestCommandTests
+{
+    private readonly Command _command;
+
+    public ApiRequestCommandTests()
+    {
+        _command = ApiRequestCommand.Create();
+    }
+
+    #region Command Structure
+
+    [Fact]
+    public void Create_ReturnsCommandWithCorrectName()
+    {
+        Assert.Equal("request", _command.Name);
+    }
+
+    [Fact]
+    public void Create_HasPathOption_Required()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--path");
+        Assert.NotNull(option);
+        Assert.True(option!.Required);
+    }
+
+    [Fact]
+    public void Create_HasMethodOption_WithAlias()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--method");
+        Assert.NotNull(option);
+        Assert.False(option!.Required);
+        Assert.Contains("-X", option.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasBodyOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--body");
+        Assert.NotNull(option);
+        Assert.False(option!.Required);
+    }
+
+    [Fact]
+    public void Create_HasBodyFileOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--body-file");
+        Assert.NotNull(option);
+        Assert.False(option!.Required);
+    }
+
+    [Fact]
+    public void Create_HasHeaderOption_WithAlias()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--header");
+        Assert.NotNull(option);
+        Assert.Contains("-H", option!.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasIncludeOption_WithAlias()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--include");
+        Assert.NotNull(option);
+        Assert.Contains("-i", option!.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasEnvironmentOption_WithAlias()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--environment");
+        Assert.NotNull(option);
+        Assert.Contains("-env", option!.Aliases);
+    }
+
+    [Fact]
+    public void Create_HasConfirmOption()
+    {
+        var option = _command.Options.FirstOrDefault(o => o.Name == "--confirm");
+        Assert.NotNull(option);
+        Assert.False(option!.Required);
+    }
+
+    [Fact]
+    public void Create_HasAction()
+    {
+        Assert.NotNull(_command.Action);
+    }
+
+    #endregion
+
+    #region Validation — AC-10: Path without leading slash
+
+    [Fact]
+    public void Path_NoLeadingSlash_Error()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "api/data/v9.2/accounts", null, null, null, null,
+            out _, out _);
+
+        Assert.NotNull(result);
+        Assert.Equal(ExitCodes.InvalidArguments, result!.Value.ExitCode);
+        Assert.Contains("/", result.Value.Error);
+    }
+
+    [Fact]
+    public void Path_WithLeadingSlash_Valid()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", null, null, null, null,
+            out _, out _);
+
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region Validation — AC-09: --body and --body-file conflict
+
+    [Fact]
+    public void Body_And_BodyFile_Conflict()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", null, "{}", "file.json", null,
+            out _, out _);
+
+        Assert.NotNull(result);
+        Assert.Equal(ExitCodes.InvalidArguments, result!.Value.ExitCode);
+        Assert.Contains("--body", result.Value.Error);
+        Assert.Contains("--body-file", result.Value.Error);
+    }
+
+    [Fact]
+    public void Body_Only_Valid()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", "POST", "{}", null, null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(HttpMethod.Post, method);
+    }
+
+    [Fact]
+    public void BodyFile_Only_Valid()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", "POST", null, "file.json", null,
+            out _, out _);
+
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region Validation — invalid HTTP method
+
+    [Fact]
+    public void InvalidMethod_Error()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/api/data/v9.2/accounts", "BREW", null, null, null,
+            out _, out _);
+
+        Assert.NotNull(result);
+        Assert.Equal(ExitCodes.InvalidArguments, result!.Value.ExitCode);
+        Assert.Contains("BREW", result.Value.Error);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void ValidMethods_NoError(string methodName)
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/path", methodName, null, null, null,
+            out var method, out _);
+
+        Assert.Null(result);
+        Assert.Equal(new HttpMethod(methodName), method);
+    }
+
+    #endregion
+
+    #region Validation — invalid header format
+
+    [Fact]
+    public void InvalidHeader_Format_Error()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/path", null, null, null, new[] { "BadHeader" },
+            out _, out _);
+
+        Assert.NotNull(result);
+        Assert.Equal(ExitCodes.InvalidArguments, result!.Value.ExitCode);
+        Assert.Contains("BadHeader", result.Value.Error);
+    }
+
+    [Fact]
+    public void ValidHeader_Parsed()
+    {
+        var result = ApiRequestCommand.ValidateInputs(
+            "/path", null, null, null, new[] { "Accept: text/plain" },
+            out _, out var headers);
+
+        Assert.Null(result);
+        Assert.NotNull(headers);
+        Assert.Equal("text/plain", headers!["Accept"]);
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Cli.Tests/Services/WebApi/RawWebApiServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebApi/RawWebApiServiceTests.cs
@@ -236,6 +236,7 @@ public class RawWebApiServiceTests
         var request = getRequest();
         Assert.NotNull(request);
         Assert.Contains("4.0", request!.Headers.GetValues("OData-Version"));
+        Assert.Contains("4.0", request.Headers.GetValues("OData-MaxVersion"));
         Assert.Contains("application/json", request.Headers.GetValues("Accept"));
     }
 

--- a/tests/PPDS.Cli.Tests/Services/WebApi/RawWebApiServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebApi/RawWebApiServiceTests.cs
@@ -1,0 +1,347 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using PPDS.Auth.Credentials;
+using PPDS.Auth.Profiles;
+using PPDS.Cli.Infrastructure.Errors;
+using PPDS.Cli.Services.WebApi;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.WebApi;
+
+public class RawWebApiServiceTests
+{
+    private const string EnvironmentUrl = "https://org.crm.dynamics.com";
+
+    private readonly Mock<IPowerPlatformTokenProvider> _tokenProvider;
+    private readonly Mock<ILogger<RawWebApiService>> _logger;
+
+    public RawWebApiServiceTests()
+    {
+        _tokenProvider = new Mock<IPowerPlatformTokenProvider>();
+        _tokenProvider
+            .Setup(p => p.GetTokenForResourceAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PowerPlatformToken
+            {
+                AccessToken = "test-token",
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1),
+                Resource = EnvironmentUrl
+            });
+
+        _logger = new Mock<ILogger<RawWebApiService>>();
+    }
+
+    private RawWebApiService CreateService(HttpClient httpClient, ProtectionLevel protectionLevel = ProtectionLevel.Development)
+        => new(_tokenProvider.Object, httpClient, _logger.Object);
+
+    private static HttpClient CreateHttpClient(HttpStatusCode statusCode, string body, string contentType = "application/json")
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(body, Encoding.UTF8, contentType)
+            });
+        return new HttpClient(handler.Object);
+    }
+
+    private static HttpClient CreateCapturingHttpClient(
+        HttpStatusCode statusCode,
+        string body,
+        out Func<HttpRequestMessage?> getLastRequest)
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        getLastRequest = () => captured;
+        return new HttpClient(handler.Object);
+    }
+
+    // AC-01: GET valid path returns response body
+    [Fact]
+    public async Task Get_ValidPath_ReturnsBody()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.OK, "{\"value\":[]}");
+        var service = CreateService(httpClient);
+
+        var result = await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Get
+        });
+
+        Assert.Equal(200, result.StatusCode);
+        Assert.Contains("\"value\":[]", result.Body);
+        Assert.True(result.IsSuccess);
+    }
+
+    // AC-03: POST production with --confirm sends the request
+    [Fact]
+    public async Task Post_Production_WithConfirm_Sends()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.Created, "{}");
+        var service = CreateService(httpClient);
+
+        var result = await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Post,
+            Body = "{}",
+            IsConfirmed = true,
+            ProtectionLevel = ProtectionLevel.Production
+        });
+
+        Assert.Equal(201, result.StatusCode);
+        Assert.True(result.IsSuccess);
+    }
+
+    // Service-side portion of AC-02: write guard throws PpdsException
+    [Fact]
+    public async Task Post_Production_NoConfirm_ThrowsWriteBlocked()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.OK, "{}");
+        var service = CreateService(httpClient);
+
+        var ex = await Assert.ThrowsAsync<PpdsException>(() => service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Post,
+            Body = "{}",
+            IsConfirmed = false,
+            ProtectionLevel = ProtectionLevel.Production
+        }));
+
+        Assert.Equal("Api.WriteBlocked", ex.ErrorCode);
+    }
+
+    // AC-04: Mutating request on development is allowed without --confirm
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    public async Task Mutating_Development_Allowed(string methodName)
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.NoContent, string.Empty);
+        var service = CreateService(httpClient);
+
+        var result = await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts(00000000-0000-0000-0000-000000000001)",
+            Method = new HttpMethod(methodName),
+            IsConfirmed = false,
+            ProtectionLevel = ProtectionLevel.Development
+        });
+
+        Assert.True(result.IsSuccess || result.StatusCode == 204);
+    }
+
+    // AC-06: Non-2xx returns IsSuccess=false
+    [Fact]
+    public async Task Non2xx_ReturnsErrorResponse()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.NotFound, "{\"error\":{\"message\":\"Not Found\"}}");
+        var service = CreateService(httpClient);
+
+        var result = await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts(00000000-0000-0000-0000-000000000099)",
+            Method = HttpMethod.Get
+        });
+
+        Assert.Equal(404, result.StatusCode);
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Not Found", result.Body);
+    }
+
+    // AC-07: User-supplied headers override defaults
+    [Fact]
+    public async Task UserHeaders_OverrideDefaults()
+    {
+        var httpClient = CreateCapturingHttpClient(HttpStatusCode.OK, "{}", out var getRequest);
+        var service = CreateService(httpClient);
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Get,
+            Headers = new Dictionary<string, string>
+            {
+                ["Accept"] = "text/plain",
+                ["X-Custom-Header"] = "custom-value"
+            }
+        });
+
+        var request = getRequest();
+        Assert.NotNull(request);
+        Assert.Contains("text/plain", request!.Headers.GetValues("Accept"));
+        Assert.Contains("custom-value", request.Headers.GetValues("X-Custom-Header"));
+    }
+
+    // AC-11: Token acquired for the correct environment URL
+    [Fact]
+    public async Task Token_AcquiredForEnvironmentUrl()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.OK, "{}");
+        var service = CreateService(httpClient);
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/WhoAmI",
+            Method = HttpMethod.Get
+        });
+
+        _tokenProvider.Verify(
+            p => p.GetTokenForResourceAsync(EnvironmentUrl, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // AC-12: Default OData headers applied
+    [Fact]
+    public async Task DefaultHeaders_Applied()
+    {
+        var httpClient = CreateCapturingHttpClient(HttpStatusCode.OK, "{}", out var getRequest);
+        var service = CreateService(httpClient);
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Get
+        });
+
+        var request = getRequest();
+        Assert.NotNull(request);
+        Assert.Contains("4.0", request!.Headers.GetValues("OData-Version"));
+        Assert.Contains("application/json", request.Headers.GetValues("Accept"));
+    }
+
+    // Edge: environment URL trailing slash stripped
+    [Fact]
+    public async Task TrailingSlash_StrippedFromEnvironmentUrl()
+    {
+        var httpClient = CreateCapturingHttpClient(HttpStatusCode.OK, "{}", out var getRequest);
+        var service = CreateService(httpClient);
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = "https://org.crm.dynamics.com/",
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Get
+        });
+
+        var request = getRequest();
+        Assert.NotNull(request);
+        Assert.Equal("https://org.crm.dynamics.com/api/data/v9.2/accounts", request!.RequestUri?.ToString());
+    }
+
+    // Edge: path with query string preserved
+    [Fact]
+    public async Task PathWithQueryString_PreservedAsIs()
+    {
+        var httpClient = CreateCapturingHttpClient(HttpStatusCode.OK, "{}", out var getRequest);
+        var service = CreateService(httpClient);
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts?$top=1",
+            Method = HttpMethod.Get
+        });
+
+        var request = getRequest();
+        Assert.NotNull(request);
+        Assert.Equal("https://org.crm.dynamics.com/api/data/v9.2/accounts?$top=1", request!.RequestUri?.ToString());
+    }
+
+    // Edge: 204 empty body returns success with empty body
+    [Fact]
+    public async Task EmptyBody_204_ReturnsSuccessWithEmptyBody()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NoContent,
+                Content = new StringContent(string.Empty)
+            });
+        var service = CreateService(new HttpClient(handler.Object));
+
+        var result = await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts(00000000-0000-0000-0000-000000000001)",
+            Method = HttpMethod.Delete,
+            ProtectionLevel = ProtectionLevel.Development
+        });
+
+        Assert.Equal(204, result.StatusCode);
+        Assert.True(result.IsSuccess);
+        Assert.Equal(string.Empty, result.Body);
+    }
+
+    // AC-08 foundation: body from string is sent in request
+    [Fact]
+    public async Task Body_SentInRequest()
+    {
+        const string body = "{\"name\":\"test\"}";
+        string? capturedBody = null;
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                // Read body before the request is disposed.
+                capturedBody = await req.Content!.ReadAsStringAsync(ct);
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.Created,
+                    Content = new StringContent("{}")
+                };
+            });
+
+        var service = CreateService(new HttpClient(handler.Object));
+
+        await service.SendAsync(new RawWebApiRequest
+        {
+            EnvironmentUrl = EnvironmentUrl,
+            Path = "/api/data/v9.2/accounts",
+            Method = HttpMethod.Post,
+            Body = body,
+            ProtectionLevel = ProtectionLevel.Development
+        });
+
+        Assert.Equal(body, capturedBody);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Services/WebApi/WebApiWriteGuardTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/WebApi/WebApiWriteGuardTests.cs
@@ -1,0 +1,68 @@
+using PPDS.Auth.Profiles;
+using PPDS.Cli.Services.WebApi;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.WebApi;
+
+public class WebApiWriteGuardTests
+{
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsMutating_MutatingMethods_ReturnsTrue(string methodName)
+    {
+        var method = new HttpMethod(methodName);
+        Assert.True(WebApiWriteGuard.IsMutating(method));
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public void IsMutating_SafeMethods_ReturnsFalse(string methodName)
+    {
+        var method = new HttpMethod(methodName);
+        Assert.False(WebApiWriteGuard.IsMutating(method));
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsBlocked_MutatingOnProduction_NoConfirm_ReturnsTrue(string methodName)
+    {
+        var method = new HttpMethod(methodName);
+        Assert.True(WebApiWriteGuard.IsBlocked(method, ProtectionLevel.Production, isConfirmed: false));
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsBlocked_MutatingOnProduction_WithConfirm_ReturnsFalse(string methodName)
+    {
+        var method = new HttpMethod(methodName);
+        Assert.False(WebApiWriteGuard.IsBlocked(method, ProtectionLevel.Production, isConfirmed: true));
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PATCH")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsBlocked_MutatingOnDevelopment_ReturnsFalse(string methodName)
+    {
+        var method = new HttpMethod(methodName);
+        Assert.False(WebApiWriteGuard.IsBlocked(method, ProtectionLevel.Development, isConfirmed: false));
+    }
+
+    [Fact]
+    public void IsBlocked_GetOnProduction_ReturnsFalse()
+    {
+        Assert.False(WebApiWriteGuard.IsBlocked(HttpMethod.Get, ProtectionLevel.Production, isConfirmed: false));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ppds api request` command for sending authenticated HTTP requests to Dataverse Web API from the terminal — GET/POST/PATCH/DELETE with automatic token management, default OData headers, and write protection on production environments
- Implements `RawWebApiService` + `WebApiWriteGuard` in `src/PPDS.Cli/Services/WebApi/` with 12 AC tests covering auth, write blocking, header merging, and non-2xx handling
- Registers the new `api` command group in Program.cs and `IRawWebApiService` in ServiceRegistration via the same token-provider factory pattern as `IConnectionService`

Closes #1164

## Acceptance criteria

All 12 ACs from `specs/raw-web-api.md` pass:

| AC | Description | Test |
|----|-------------|------|
| AC-01 | GET returns body on stdout, exit 0 | `Get_ValidPath_ReturnsBody` |
| AC-02 | POST on production without --confirm blocked, exit 2 | `Post_Production_NoConfirm_ThrowsWriteBlocked` |
| AC-03 | POST on production with --confirm sends | `Post_Production_WithConfirm_Sends` |
| AC-04 | Mutating on development allowed | `Mutating_Development_Allowed` |
| AC-05 | --include outputs status line + headers | `Include_OutputsHeaders` |
| AC-06 | Non-2xx returns IsSuccess=false | `Non2xx_ReturnsErrorResponse` |
| AC-07 | User headers override defaults | `UserHeaders_OverrideDefaults` |
| AC-08 | --body-file reads from disk | `BodyFile_ReadsFromDisk` |
| AC-09 | --body + --body-file = validation error | `Body_And_BodyFile_Conflict` |
| AC-10 | Path without leading / = validation error | `Path_NoLeadingSlash_Error` |
| AC-11 | Token acquired for correct environment URL | `Token_AcquiredForEnvironmentUrl` |
| AC-12 | Default OData headers applied | `DefaultHeaders_Applied` |

## Test plan

- [x] `dotnet test PPDS.sln --filter "Category!=Integration"` — 3675/3675 pass across net8/9/10
- [x] Live verification: `ppds api request --path /api/data/v9.2/WhoAmI` returns JSON on stdout, exit 0
- [x] Live verification: `--include` prints `HTTP/1.1 200 OK` + response headers before body
- [x] Live verification: path validation, body/body-file conflict, invalid method all produce correct errors

## Notes

- `HttpClient` is created inline in the DI factory (same pattern as `IConnectionService` for `IPowerPlatformTokenProvider`). `RawWebApiService` implements `IDisposable` so the DI container disposes both `HttpClient` and `IPowerPlatformTokenProvider` when the command scope exits.
- Non-2xx responses: body AND `--include` preamble both route to stderr so stdout remains pipeable.
- MCP/TUI/Extension surfaces deferred per spec non-goals; `IRawWebApiService` is the extension point.

## Review fixes (2026-06-03)

- **OData-MaxVersion default header** — added `OData-MaxVersion: 4.0` alongside `OData-Version`/`Accept` defaults (#1164). User `--header` overrides still win (merged before user headers). AC-12 test now asserts it.
- **POST-on-body default** — when `--method` is omitted and a body (`--body`/`--body-file`) is supplied, the method now defaults to `POST` instead of `GET`. Explicit `--method` always wins. (AC-13)
- **Write-guard fail-safe** — an `Unknown`/undetectable environment now resolves to `ProtectionLevel.Production` in the api-request path, so mutating requests are blocked without `--confirm` (previously fell open to `Development`). Resolved locally rather than changing shared `DmlSafetyGuard.DetectProtectionLevel` to avoid altering SQL DML behavior for the other 4 callers. (AC-14)
- **Strengthened tests** — `BodyFile_ReadsFromDisk` now drives the command's real file-read branch (`ResolveBodyAsync`) instead of re-reading the file itself; AC-02 now executes the command path (`RunRequestAsync`) for a blocked write and asserts the returned exit code is 2.

### Intentional deviation from issue #1164

The SDK (`RawWebApiService.SendAsync`) returns a `RawWebApiResponse` with `IsSuccess = false` on non-2xx responses rather than throwing — this keeps the service composable for future surfaces (status/body preserved). The CLI adapter routes non-2xx to stderr with a nonzero exit code. Documented in `specs/raw-web-api.md`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

