### PR TITLE
fix(ci): gate MDA live E2E suite out of cli-smoke shard + add live-lane hang timeout

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,7 +97,12 @@ jobs:
         PPDS_TEST_CLIENT_SECRET: ${{ secrets.PPDS_TEST_CLIENT_SECRET }}
         PPDS_TEST_CERT_BASE64: ${{ secrets.PPDS_TEST_CERT_BASE64 }}
         PPDS_TEST_CERT_PASSWORD: ${{ secrets.PPDS_TEST_CERT_PASSWORD }}
-      run: dotnet test ${{ matrix.project }} --configuration Release --no-build --verbosity normal --filter "${{ matrix.filter }}"
+      # --blame-hang-timeout bounds each test: if any live test wedges (e.g. a
+      # missing pre-provisioned resource or a slow publish round-trip), the run
+      # is aborted instead of hanging the host until the job-level timeout. Scoped
+      # to this workflow's integration/live lanes only — never applied to the fast
+      # unit suites. --blame-hang-dump-type none skips the (large) process dump.
+      run: dotnet test ${{ matrix.project }} --configuration Release --no-build --verbosity normal --filter "${{ matrix.filter }}" --blame-hang-timeout 6m --blame-hang-dump-type none
 
   # Gate job for branch protection — aggregates matrix legs into a single status check.
   # Preserves the pre-matrix "Integration Tests" status check name so branch protection

--- a/tests/PPDS.LiveTests/Cli/ModelDrivenAppCommandE2ETests.cs
+++ b/tests/PPDS.LiveTests/Cli/ModelDrivenAppCommandE2ETests.cs
@@ -14,7 +14,14 @@ namespace PPDS.LiveTests.Cli;
 ///   - The environment must have an MDA named "PPDS MDA" with "account" in the sitemap.
 ///   - Credentials must be set: DATAVERSE_URL, PPDS_TEST_APP_ID, PPDS_TEST_CLIENT_SECRET, PPDS_TEST_TENANT_ID.
 ///   - CLI must be built in Release/net8.0: dotnet build src/PPDS.Cli -c Release -f net8.0
+///
+/// Categorized as SlowIntegration so every CI shard filter (which excludes
+/// Category=SlowIntegration) skips this suite. These tests mutate a shared,
+/// pre-provisioned "PPDS MDA" app (not present in the test-dataverse env) and
+/// perform slow live --publish round-trips, so they must not run in the
+/// credentialed cli-smoke shard until a dedicated lane and the app exist.
 /// </summary>
+[Trait("Category", "SlowIntegration")]
 public class ModelDrivenAppCommandE2ETests : CliE2ETestBase
 {
     // The test app and entities are fixed so we can reason about baseline state.


### PR DESCRIPTION
## Problem

The `Integration (cli-smoke)` CI job is red on `main`. #1179 added
`tests/PPDS.LiveTests/Cli/ModelDrivenAppCommandE2ETests.cs` (7
`[CliE2EWithCredentials]` tests). Their skip guards are correct (they skip with
no credentials), but in the **credentialed** `cli-smoke` shard they **hang**:

- The suite overrides `InitializeAsync`/`DisposeAsync` with live `remove-table`
  round-trips.
- `AddTable_WithPublish_AppearsInPublishedSitemap` performs a real, slow
  `--publish`.
- The whole suite hard-depends on a pre-provisioned **"PPDS MDA"** app that does
  **not** exist in the test-dataverse environment.
- There is **no session-level test timeout** in the repo, so the host wedges
  (MSB4181).

This is a **test-infra hang, not a product bug**.

## Fix (two parts, minimal + low-risk)

**1. Gate the MDA live suite out of every credentialed shard.**
Added a class-level `[Trait("Category", "SlowIntegration")]` to
`ModelDrivenAppCommandE2ETests`. Every shard filter in
`.github/workflows/integration-tests.yml` already excludes
`Category!=SlowIntegration` (see `cli-smoke` at line 59), so the suite is now
genuinely excluded from `cli-smoke` and all other credentialed shards. This
matches the existing `PluginsListCommandE2ETests` precedent (which marks its
slow live tests the same way). Verified locally: the cli-smoke filter no longer
matches any MDA test, and the suite still carries the inherited
`Category=Integration` trait so the categorization is correct.

**2. Defense-in-depth session timeout (live lanes only).**
Added `--blame-hang-timeout 6m --blame-hang-dump-type none` to the
`dotnet test` invocation in `integration-tests.yml`. This is scoped to this
workflow's integration/live lanes only — the fast unit suites are untouched. If
any live test ever wedges again, the run aborts instead of hanging the host.

## Verification

- `dotnet build tests/PPDS.LiveTests/PPDS.LiveTests.csproj` → **0 errors**.
- Local cli-smoke filter run with **no credentials** completes in ~26s with **no
  hang**; the MDA suite is fully excluded (0 matches).
- Confirmed all 7 MDA tests carry `Category=SlowIntegration`.

## Follow-up

The MDA live suite is not deleted — it is gated. Before it can be re-enabled it
needs:

1. The **"PPDS MDA"** app provisioned in the test-dataverse environment (the
   suite hard-codes `TestApp = "PPDS MDA"` and reads/mutates its sitemap).
2. A **dedicated CI lane** sized for slow, mutating, publish-heavy live tests
   (not the fast cli-smoke shard).

Recommend filing this as a separate tracking issue.

This unblocks a pending Cli/Dataverse rc release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
