### PR TITLE
docs(changelog): complete 1.2.0-rc entries (CLI + Dataverse)

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ppds views`** — savedquery (view) management: list/get, add/remove/update/reorder columns, set/clear sort, set/clear filter, and set-fetchxml (#1162).
 - **`ppds model-driven-app`** — app navigation management: list, get, sitemap, set-sitemap-xml, add-table/remove-table, and set-forms/views/charts, with bundled sitemap XSD validation (#1165).
 - **`ppds api request`** — authenticated raw Web API calls to Dataverse (GET/POST/PATCH/DELETE) with default OData headers and production write protection (#1164).
-- **Local Choice columns** — `attribute create --type Choice` with inline --option/--options-file, plus attribute add-/update-/remove-option for column-scoped option sets (#1161).
+- **Local Choice columns** — `ppds metadata attribute create --type Choice` with inline --option/--options-file, plus `ppds metadata attribute add-option|update-option|remove-option` for column-scoped option sets (#1161).
 
 ### Changed
 - `ppds metadata table|column|choice` are now deprecated shims; use `entity|attribute|optionset` instead.

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Canonical metadata nouns** `entity`, `attribute`, `optionset` replace `table`, `column`, `choice` as the primary command surface. Old nouns remain as deprecation shims that delegate to the same execute path and print a migration hint to stderr (#1159).
 - **Status reason management** — `ppds metadata entity add-statusreason|list-statusreasons|update-statusreason|remove-statusreason` for first-class statuscode option-value management (#1160).
 - **`OptionValueDeriver`** shared pure helper for publisher-prefix-based option value derivation — explicit-value wins, prefix×10000 base, gap-fill over existing values (#1160).
+- **`ppds forms`** — form (systemform) management: list/get, set-xml with schema validation, and structured tab/section/field/sub-grid editing on Main forms, with --publish/--solution side effects (#1163).
+- **`ppds views`** — savedquery (view) management: list/get, add/remove/update/reorder columns, set/clear sort, set/clear filter, and set-fetchxml (#1162).
+- **`ppds model-driven-app`** — app navigation management: list, get, sitemap, set-sitemap-xml, add-table/remove-table, and set-forms/views/charts, with bundled sitemap XSD validation (#1165).
+- **`ppds api request`** — authenticated raw Web API calls to Dataverse (GET/POST/PATCH/DELETE) with default OData headers and production write protection (#1164).
+- **Local Choice columns** — `attribute create --type Choice` with inline --option/--options-file, plus attribute add-/update-/remove-option for column-scoped option sets (#1161).
 
 ### Changed
 - `ppds metadata table|column|choice` are now deprecated shims; use `entity|attribute|optionset` instead.

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Metadata-authoring support for status reasons and local option sets** — `InsertStatusValue`/`UpdateOptionValue`/`DeleteOptionValue` request DTOs, `StatusReasonInfo`, and the shared `OptionValueDeriver` for publisher-prefix-based option value derivation, backing entity status-reason management and column-scoped (local) Choice option sets ([#1167](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1167), [#1159](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1159), [#1160](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1160), [#1161](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1161)).
+
+### Fixed
+
+- **M:N relationship create** — populate `IntersectEntitySchemaName` on the create request (defaulting to the relationship schema name) so many-to-many relationship creation no longer fails with `Required field 'IntersectEntitySchemaName' is missing` ([#1018](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1018)).
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. Consolidates features developed across the `1.0.0-beta.1` through `1.0.0-beta.7` series. Targets `net8.0`, `net9.0`, `net10.0`.

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Metadata-authoring support for status reasons and local option sets** — `InsertStatusValue`/`UpdateOptionValue`/`DeleteOptionValue` request DTOs, `StatusReasonInfo`, and the shared `OptionValueDeriver` for publisher-prefix-based option value derivation, backing entity status-reason management and column-scoped (local) Choice option sets ([#1167](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1167), [#1159](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1159), [#1160](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1160), [#1161](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1161)).
+- **Metadata-authoring support for status reasons and local option sets** — `AddStatusReasonRequest`/`UpdateStatusReasonRequest`/`RemoveStatusReasonRequest`/`StatusReasonInfo` for entity status-reason management, and `AddOptionValueRequest`/`UpdateOptionValueRequest`/`DeleteOptionValueRequest` plus the shared `OptionValueDeriver` (publisher-prefix-based option value derivation) for column-scoped (local) Choice option sets ([#1167](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1167), [#1159](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1159), [#1160](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1160), [#1161](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1161)).
 
 ### Fixed
 


### PR DESCRIPTION
Completes the per-package `[Unreleased]` CHANGELOG sections ahead of tagging **Cli-v1.2.0-rc.1** and **Dataverse-v1.2.0-rc.1**. Versioning stays MinVer/tag-driven — no version headers or release dates are stamped here.

## PPDS.Cli — `### Added`
- **`ppds forms`** — systemform management: list/get, set-xml with schema validation, structured tab/section/field/sub-grid editing on Main forms (#1163).
- **`ppds views`** — savedquery management: list/get, column add/remove/update/reorder, sort, filter, set-fetchxml (#1162).
- **`ppds model-driven-app`** — app navigation management: list/get/sitemap, set-sitemap-xml, add-/remove-table, set-forms/views/charts, bundled sitemap XSD validation (#1165).
- **`ppds api request`** — authenticated raw Web API calls (GET/POST/PATCH/DELETE) with default OData headers and production write protection (#1164).
- **Local Choice columns** — `attribute create --type Choice` with inline options plus column-scoped option management (#1161).

## PPDS.Dataverse
- **Added** — metadata-authoring support for status reasons and local option sets (InsertStatusValue/UpdateOptionValue/DeleteOptionValue DTOs, StatusReasonInfo, shared OptionValueDeriver) (#1167 / #1159 #1160 #1161).
- **Fixed** — populate `IntersectEntitySchemaName` for M:N relationship create (#1018).

Docs-only — no code change. The root `CHANGELOG.md` index is intentionally untouched.
