### PR TITLE
fix(ci): release-cli binary upload fails on immutable releases (draft-then-publish fallback)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -150,19 +150,35 @@ jobs:
           gh release edit "${{ steps.version.outputs.tag }}" --draft=false
           echo "Release published with binaries attached"
 
-      # Fallback flow: create new release if no draft exists (manual tag push)
-      - name: Create new release with assets
+      # Fallback flow: no pre-created draft (e.g. direct tag push).
+      # Create the release as a DRAFT with assets, then publish — required because
+      # this repo has immutable releases (assets must be attached before publish).
+      - name: Create draft release with assets
         if: steps.check_release.outputs.is_draft == 'false'
-        uses: softprops/action-gh-release@v3
-        with:
-          name: PPDS CLI v${{ steps.version.outputs.version }}
-          tag_name: ${{ steps.version.outputs.tag }}
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          generate_release_notes: true
-          files: |
-            ./release/ppds-win-x64.exe
-            ./release/ppds-win-arm64.exe
-            ./release/ppds-osx-x64
-            ./release/ppds-osx-arm64
-            ./release/ppds-linux-x64
-            ./release/checksums.sha256
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PRERELEASE_FLAG=""
+          case "${{ steps.version.outputs.version }}" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          gh release create "${{ steps.version.outputs.tag }}" \
+            ./release/ppds-win-x64.exe \
+            ./release/ppds-win-arm64.exe \
+            ./release/ppds-osx-x64 \
+            ./release/ppds-osx-arm64 \
+            ./release/ppds-linux-x64 \
+            ./release/checksums.sha256 \
+            --draft \
+            --generate-notes \
+            --title "PPDS CLI v${{ steps.version.outputs.version }}" \
+            $PRERELEASE_FLAG
+
+      - name: Publish fallback release
+        if: steps.check_release.outputs.is_draft == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release edit "${{ steps.version.outputs.tag }}" --draft=false


### PR DESCRIPTION
## Problem

Tag `Cli-v1.2.0-rc.1` triggered `.github/workflows/release-cli.yml`. All 5 platform binaries (win-x64, win-arm64, osx-x64, osx-arm64, linux-x64) built successfully, but the `release` job's **fallback** step — used on a direct tag push when no pre-created draft release exists — failed to publish the binaries.

That fallback used `softprops/action-gh-release@v3`, which **creates and publishes** the release first and then uploads assets. This repository has **immutable releases** enabled, so the release is locked the moment it is published, and the asset upload was rejected:

> Cannot upload asset ... to an immutable release ... keep the release as a draft with `draft: true`, then publish it later.

Result: rc.1's GitHub release was published with **no binaries attached**.

## Fix

Replace the single fallback step with a **draft-then-publish** flow using the `gh` CLI, mirroring the existing pre-created-draft path that already works:

1. `gh release create ... --draft` — creates the release as a draft with all binaries + `checksums.sha256` attached (prerelease flag derived from the version containing a `-`).
2. `gh release edit ... --draft=false` — publishes the now-complete draft.

Because all assets are attached **before** publish, immutable releases accept them.

The existing draft-flow steps (`check_release` / "Upload assets to draft release" / "Publish draft release") are unchanged — only the broken fallback was replaced.

## Impact

- Unblocks the stable **1.2.0** binary release (and all future direct-tag-push releases).
- rc.1's already-published empty release **cannot be retro-fixed** because it is immutable; this PR is not retagging or re-releasing rc.1. The fix applies to future tags.

YAML validated with `yaml.safe_load` (parses cleanly). `git diff` confirms only the fallback step changed (one step → two steps), nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
