### PR TITLE
fix(cli): MDA add-components passes AppId as Guid not EntityReference (#1183)

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `ppds metadata table|column|choice` are now deprecated shims; use `entity|attribute|optionset` instead.
 
+### Fixed
+- `ppds model-driven-app set-views|set-forms|set-charts` with explicit named components no longer fail with `Input field type 'EntityReference' does not match expected type 'Guid' for field 'AppId'`. The shared `AddAppComponents` helper now passes the appmodule id as a `Guid` (matching the working `RemoveAppComponents` sibling); a regression test asserts the request parameter type (#1183).
+
 ## [1.1.0] - 2026-04-26
 
 ### Added

--- a/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
+++ b/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
@@ -893,7 +893,7 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
 
         var refs = componentIds.Select(id => new EntityReference(componentEntityName, id)).ToList();
         var request = new OrganizationRequest("AddAppComponents");
-        request["AppId"] = new EntityReference("appmodule", appModuleId);
+        request["AppId"] = appModuleId;
         request["Components"] = new EntityReferenceCollection(refs);
 
         try

--- a/tests/PPDS.Cli.Tests/Services/ModelDrivenApps/ModelDrivenAppServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ModelDrivenApps/ModelDrivenAppServiceTests.cs
@@ -58,7 +58,7 @@ public class ModelDrivenAppServiceTests
         /// <summary>The XML written by the last UpdateAsync on the sitemap record, if any.</summary>
         public string? WrittenSitemapXml { get; private set; }
 
-        /// <summary>All organization requests passed to ExecuteAsync (for RemoveAppComponents assertions).</summary>
+        /// <summary>All organization requests passed to ExecuteAsync (for Add/RemoveAppComponents assertions).</summary>
         public List<OrganizationRequest> ExecutedRequests { get; } = new();
 
         public ModelDrivenAppService Build()
@@ -493,6 +493,52 @@ public class ModelDrivenAppServiceTests
 
         var ex = await act.Should().ThrowAsync<PpdsException>();
         ex.Which.ErrorCode.Should().Be(ModelDrivenAppErrorCodes.InvalidArguments);
+    }
+
+    // ── set-views: AddAppComponents passes AppId as Guid, not EntityReference (#1183) ──
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SetViews_NamedView_AddAppComponentsPassesAppIdAsGuid()
+    {
+        var h = new Harness();
+        h.Setup(SitemapWithAccount, DefaultEntities);
+
+        var viewId = new Guid("eeeeeeee-5555-5555-5555-555555555555");
+        const string viewName = "Active Accounts";
+
+        // ResolveViewIdsAsync → savedquery lookup returns the named view to add.
+        h.Client.Setup(c => c.RetrieveMultipleAsync(
+                It.Is<QueryExpression>(qe => qe.EntityName == "savedquery"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EntityCollection(new List<Entity>
+            {
+                new("savedquery") { ["savedqueryid"] = viewId, ["name"] = viewName }
+            }));
+
+        var service = h.Build();
+
+        // Explicit named view (NOT --all) — this is the only path that hits the add helper.
+        var options = new ComponentSelectionOptions(
+            All: false,
+            ComponentNames: new[] { viewName },
+            Solution: null,
+            Publish: false);
+
+        await service.SetViewsAsync(
+            AppName, "account", options, progress: null, CancellationToken.None);
+
+        // The AddAppComponents message must type AppId as the appmodule Guid. Passing an
+        // EntityReference triggers Dataverse's "Input field type 'EntityReference' does not
+        // match expected type 'Guid' for field 'AppId'" — the #1183 regression.
+        var addReq = h.ExecutedRequests.Single(r => r.RequestName == "AddAppComponents");
+
+        addReq["AppId"].Should().BeOfType<Guid>()
+            .Which.Should().Be(AppModuleId);
+
+        // The components themselves are still EntityReferences to the savedquery rows.
+        addReq["Components"].Should().BeOfType<EntityReferenceCollection>()
+            .Which.Should().ContainSingle(er => er.LogicalName == "savedquery" && er.Id == viewId);
     }
 
     // ── ResolveAppAsync: app not found throws AppNotFound (D4) ──────────────────


### PR DESCRIPTION
## Summary

`ppds model-driven-app set-views` (and `set-forms` / `set-charts`) failed when adding explicit named components with:

> Input field type 'EntityReference' does not match expected type 'Guid' for field 'AppId'

`AddAppComponentsAsync` built the `AddAppComponents` SDK message with `AppId` typed as an `EntityReference`, but that message expects a `Guid`. The sibling `RemoveAppComponentsAsync` already passes the `Guid` correctly — which is why **remove worked and add failed**.

## Fix

`src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs` — `AddAppComponentsAsync`:

```diff
- request["AppId"] = new EntityReference("appmodule", appModuleId);
+ request["AppId"] = appModuleId;
```

`appModuleId` is already a `Guid` parameter; the assignment is now identical to the working `RemoveAppComponentsAsync`.

## Blast radius — one fix covers all three commands

All three `set-*` commands route their add path through the shared `AddAppComponentsAsync` helper, so this single change fixes every affected command. Verified by reading each call site:

| Command | Service method | Add call |
|---|---|---|
| `set-forms` | `SetFormsAsync` | `AddAppComponentsAsync(…, "systemform", …)` |
| `set-views` | `SetViewsAsync` | `AddAppComponentsAsync(…, "savedquery", …)` |
| `set-charts` | `SetChartsAsync` | `AddAppComponentsAsync(…, "savedqueryvisualization", …)` |

The remove path was always correct; `--all` skips the add and so dodged the bug.

## Regression test

Adds `SetViews_NamedView_AddAppComponentsPassesAppIdAsGuid` in `ModelDrivenAppServiceTests`. It drives the add path via `SetViewsAsync` with an explicit named `--view` (not `--all`), captures the `OrganizationRequest` passed to the mocked `ExecuteAsync`, and asserts `request["AppId"]` is a `Guid` (and that `Components` remains an `EntityReferenceCollection`).

**Why this shipped:** the existing tests mocked `ExecuteAsync` and never inspected the parameter type. The new test **fails on the old code and passes after the fix** — confirmed by reverting the one-line change and observing it go red across net8/9/10.

## Verification

- `dotnet build PPDS.sln` — 0 errors
- `PPDS.Cli.Tests` — 4047/4047 pass (incl. the new regression test) across net8/9/10
- New test confirmed red→green by reverting the source fix
- CLI command surfaces (`set-views`/`set-forms`/`set-charts` with `--view`/`--form`/`--chart`) build, render help, and parse correctly
- AC-2 (success against a live dev org) is not exercisable in this environment — no Dataverse connection. The unit test asserting the exact `AppId` request type that triggered the live error is the proxy.

## Out of scope

The separate Copilot / `appelement` polymorphic-binding finding is Dataverse-side (`ppds api request` is a verified verbatim passthrough), not a PPDS defect — untouched here, per the issue.

Closes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
