### PR TITLE
fix(cli): drop redundant cast flagged by CodeQL (ViewService)

### DIFF
--- a/src/PPDS.Cli/Services/Views/ViewService.cs
+++ b/src/PPDS.Cli/Services/Views/ViewService.cs
@@ -506,7 +506,7 @@ public class ViewService : IViewService
     /// </summary>
     private static string DescribeDataverseFault(Exception ex)
     {
-        for (var current = (Exception?)ex; current != null; current = current.InnerException)
+        for (Exception? current = ex; current != null; current = current.InnerException)
         {
             if (current is FaultException<OrganizationServiceFault> typed && typed.Detail != null)
                 return $"Dataverse error 0x{typed.Detail.ErrorCode:x8}: {typed.Detail.Message}";


### PR DESCRIPTION
Removes the redundant `(Exception?)ex` cast at `ViewService.cs:509` (CodeQL `cs/redundant-cast`, alert #1275) — `ex` is already `Exception`. One-line follow-up to #1190/#1194 (PR #1191), which auto-merged before CodeQL's comment landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)