### PR TITLE
fix(cli): make view fetchxml writes succeed on managed views (#1200)

### DIFF
--- a/src/PPDS.Cli/Services/Views/ViewService.cs
+++ b/src/PPDS.Cli/Services/Views/ViewService.cs
@@ -234,7 +234,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "layoutxml", "fetchxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "layoutxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var layoutXml = entity.GetAttributeValue<string>("layoutxml") ?? "<grid><row /></grid>";
         var layoutDoc = XDocument.Parse(layoutXml);
@@ -243,15 +243,9 @@ public class ViewService : IViewService
         var update = new Entity("savedquery", savedQueryId);
         update["layoutxml"] = layoutDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after removing column '{attributeName}'.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, $"removing column '{attributeName}'", "layoutxml",
+            layoutXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -269,7 +263,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "layoutxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "layoutxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var layoutXml = entity.GetAttributeValue<string>("layoutxml") ?? "<grid><row /></grid>";
         var layoutDoc = XDocument.Parse(layoutXml);
@@ -278,15 +272,9 @@ public class ViewService : IViewService
         var update = new Entity("savedquery", savedQueryId);
         update["layoutxml"] = layoutDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after updating column width.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, "updating column width", "layoutxml",
+            layoutXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -569,10 +557,10 @@ public class ViewService : IViewService
                     Conditions = { new ConditionExpression("savedqueryid", ConditionOperator.Equal, savedQueryId) }
                 }
             };
-            var response = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(
+            var response = (RetrieveUnpublishedMultipleResponse?)await client.ExecuteAsync(
                 new RetrieveUnpublishedMultipleRequest { Query = query }, ct);
-            var result = response.EntityCollection;
-            var current = result.Entities.Count > 0
+            var result = response?.EntityCollection;
+            var current = result != null && result.Entities.Count > 0
                 ? result.Entities[0].GetAttributeValue<string>(fieldName) ?? string.Empty
                 : string.Empty;
             if (!XmlEquivalent(current, oldValue))

--- a/src/PPDS.Cli/Services/Views/ViewService.cs
+++ b/src/PPDS.Cli/Services/Views/ViewService.cs
@@ -175,7 +175,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "layoutxml", "fetchxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "layoutxml", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var layoutXml = entity.GetAttributeValue<string>("layoutxml") ?? "<grid><row /></grid>";
         var fetchXml = entity.GetAttributeValue<string>("fetchxml") ?? "<fetch><entity /></fetch>";
@@ -214,15 +214,9 @@ public class ViewService : IViewService
         if (fetchChanged)
             update["fetchxml"] = fetchDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after adding columns.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, "adding columns", "layoutxml",
+            layoutXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -321,7 +315,7 @@ public class ViewService : IViewService
 
         await ApplyViewWriteAsync(
             client, savedQueryId, viewName, "reordering columns", "layoutxml",
-            layoutXml, update, entity.GetAttributeValue<bool>("ismanaged"), cancellationToken);
+            layoutXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -341,7 +335,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "fetchxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var fetchXml = entity.GetAttributeValue<string>("fetchxml") ?? "<fetch><entity /></fetch>";
         var fetchDoc = XDocument.Parse(fetchXml);
@@ -350,15 +344,9 @@ public class ViewService : IViewService
         var update = new Entity("savedquery", savedQueryId);
         update["fetchxml"] = fetchDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after setting sort.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, "setting sort", "fetchxml",
+            fetchXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -375,7 +363,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "fetchxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var fetchXml = entity.GetAttributeValue<string>("fetchxml") ?? "<fetch><entity /></fetch>";
         var fetchDoc = XDocument.Parse(fetchXml);
@@ -384,15 +372,9 @@ public class ViewService : IViewService
         var update = new Entity("savedquery", savedQueryId);
         update["fetchxml"] = fetchDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after clearing sort.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, "clearing sort", "fetchxml",
+            fetchXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -417,7 +399,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "fetchxml", "ismanaged"), cancellationToken);
+            new ColumnSet("savedqueryid", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var fetchXml = entity.GetAttributeValue<string>("fetchxml") ?? "<fetch><entity /></fetch>";
         var fetchDoc = XDocument.Parse(fetchXml);
@@ -428,7 +410,7 @@ public class ViewService : IViewService
 
         await ApplyViewWriteAsync(
             client, savedQueryId, viewName, "setting filter", "fetchxml",
-            fetchXml, update, entity.GetAttributeValue<bool>("ismanaged"), cancellationToken);
+            fetchXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -445,7 +427,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "fetchxml"), cancellationToken);
+            new ColumnSet("savedqueryid", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var fetchXml = entity.GetAttributeValue<string>("fetchxml") ?? "<fetch><entity /></fetch>";
         var fetchDoc = XDocument.Parse(fetchXml);
@@ -454,15 +436,9 @@ public class ViewService : IViewService
         var update = new Entity("savedquery", savedQueryId);
         update["fetchxml"] = fetchDoc.ToString(SaveOptions.DisableFormatting);
 
-        try
-        {
-            await client.UpdateAsync(update, cancellationToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new PpdsException(ErrorCodes.View.UpdateFailed,
-                $"Failed to update view '{viewName}' after clearing filter.", ex);
-        }
+        await ApplyViewWriteAsync(
+            client, savedQueryId, viewName, "clearing filter", "fetchxml",
+            fetchXml, update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -485,7 +461,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "fetchxml", "ismanaged"), cancellationToken);
+            new ColumnSet("savedqueryid", "fetchxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var update = new Entity("savedquery", savedQueryId);
         update["fetchxml"] = fetchXml;
@@ -493,7 +469,7 @@ public class ViewService : IViewService
         await ApplyViewWriteAsync(
             client, savedQueryId, viewName, "setting fetchxml", "fetchxml",
             entity.GetAttributeValue<string>("fetchxml") ?? string.Empty,
-            update, entity.GetAttributeValue<bool>("ismanaged"), cancellationToken);
+            update, entity, cancellationToken);
 
         await PostMutationAsync(client, savedQueryId, entityLogicalName, publish, solution, cancellationToken);
     }
@@ -515,9 +491,9 @@ public class ViewService : IViewService
     }
 
     /// <summary>
-    /// Writes a savedquery field update, then confirms it persisted. Surfaces the real Dataverse
-    /// fault on failure — with managed-view guidance for the unpatchable case (#1190) — and fails
-    /// loudly when the platform accepts the write but silently drops it (#1194) rather than
+    /// Writes a savedquery field update, then confirms it persisted. Carries returnedtypecode so the
+    /// write succeeds on managed views (#1200), surfaces the real Dataverse fault on failure (#1190),
+    /// and fails loudly when the platform accepts the write but silently drops it (#1194) rather than
     /// reporting a false success.
     /// </summary>
     private async Task ApplyViewWriteAsync(
@@ -528,9 +504,17 @@ public class ViewService : IViewService
         string fieldName,
         string oldValue,
         Entity update,
-        bool isManaged,
+        Entity source,
         CancellationToken ct)
     {
+        // Carry returnedtypecode so the platform has the entity context for the write. Without it,
+        // updates that change fetchxml are rejected with 0x80040216 ("An unexpected error occurred")
+        // on managed views — most visibly when editing find columns on a managed Quick Find view.
+        // The Power Apps maker sends it the same way (confirmed by capturing its network call). (#1200)
+        if (source.Contains("returnedtypecode"))
+            update["returnedtypecode"] = source["returnedtypecode"];
+
+        var isManaged = source.GetAttributeValue<bool>("ismanaged");
         var newValue = update.GetAttributeValue<string>(fieldName) ?? string.Empty;
 
         try
@@ -543,9 +527,7 @@ public class ViewService : IViewService
             if (isManaged)
                 throw new PpdsException(ErrorCodes.View.ManagedComponentNotEditable,
                     $"Cannot update {fieldName} on managed view '{viewName}' ({fault}). " +
-                    $"PPDS cannot patch a managed view's {fieldName} through the Web API. " +
-                    "Edit it in the maker UI and Publish (for Quick Find search columns: open the table's " +
-                    "Quick Find view and use \"Edit find table columns\").", ex);
+                    "The managed component may be locked for this change (iscustomizable = false).", ex);
             throw new PpdsException(ErrorCodes.View.UpdateFailed,
                 $"Failed to update view '{viewName}' after {operation}: {fault}", ex);
         }
@@ -565,9 +547,13 @@ public class ViewService : IViewService
     }
 
     /// <summary>
-    /// Re-reads a savedquery field and returns true once it differs from its pre-write value.
-    /// Tolerates read-after-write lag with a small bounded retry so a delayed read does not
-    /// produce a false "did not persist".
+    /// Re-reads a savedquery field from the UNPUBLISHED (draft) record and returns true once it
+    /// differs from its pre-write value. A savedquery write lands in the draft version and is not
+    /// visible via a normal retrieve until <c>PublishXml</c> runs, so a published read-back would
+    /// falsely report "did not persist" for any not-yet-published change — especially on managed
+    /// views. RetrieveUnpublished reflects the write immediately while still catching a genuine
+    /// silent drop (#1194); it is also what the Power Apps maker reads back. (#1200)
+    /// Tolerates read-after-write lag with a small bounded retry.
     /// </summary>
     private static async Task<bool> VerifyViewWritePersistedAsync(
         IDataverseClient client, Guid savedQueryId, string fieldName, string oldValue, CancellationToken ct)
@@ -583,7 +569,9 @@ public class ViewService : IViewService
                     Conditions = { new ConditionExpression("savedqueryid", ConditionOperator.Equal, savedQueryId) }
                 }
             };
-            var result = await client.RetrieveMultipleAsync(query, ct);
+            var response = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(
+                new RetrieveUnpublishedMultipleRequest { Query = query }, ct);
+            var result = response.EntityCollection;
             var current = result.Entities.Count > 0
                 ? result.Entities[0].GetAttributeValue<string>(fieldName) ?? string.Empty
                 : string.Empty;

--- a/src/PPDS.Cli/Services/Views/ViewService.cs
+++ b/src/PPDS.Cli/Services/Views/ViewService.cs
@@ -304,7 +304,7 @@ public class ViewService : IViewService
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
         var (savedQueryId, entity) = await FetchViewRecordAsync(
             client, entityLogicalName, viewName,
-            new ColumnSet("savedqueryid", "layoutxml", "ismanaged"), cancellationToken);
+            new ColumnSet("savedqueryid", "layoutxml", "ismanaged", "returnedtypecode"), cancellationToken);
 
         var layoutXml = entity.GetAttributeValue<string>("layoutxml") ?? "<grid><row /></grid>";
         var layoutDoc = XDocument.Parse(layoutXml);

--- a/src/PPDS.Cli/Services/Views/ViewService.cs
+++ b/src/PPDS.Cli/Services/Views/ViewService.cs
@@ -495,6 +495,9 @@ public class ViewService : IViewService
         Entity source,
         CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(update);
+
         // Carry returnedtypecode so the platform has the entity context for the write. Without it,
         // updates that change fetchxml are rejected with 0x80040216 ("An unexpected error occurred")
         // on managed views — most visibly when editing find columns on a managed Quick Find view.
@@ -541,9 +544,12 @@ public class ViewService : IViewService
     /// falsely report "did not persist" for any not-yet-published change — especially on managed
     /// views. RetrieveUnpublished reflects the write immediately while still catching a genuine
     /// silent drop (#1194); it is also what the Power Apps maker reads back. (#1200)
-    /// Tolerates read-after-write lag with a small bounded retry.
+    /// Tolerates read-after-write lag with a small bounded retry. Verification is best-effort: if
+    /// the unpublished read itself fails (e.g. the caller lacks the privilege RetrieveUnpublished
+    /// requires, or a transient error), we assume the write persisted rather than block an
+    /// otherwise-successful update with a false "did not persist".
     /// </summary>
-    private static async Task<bool> VerifyViewWritePersistedAsync(
+    private async Task<bool> VerifyViewWritePersistedAsync(
         IDataverseClient client, Guid savedQueryId, string fieldName, string oldValue, CancellationToken ct)
     {
         const int maxAttempts = 3;
@@ -557,8 +563,21 @@ public class ViewService : IViewService
                     Conditions = { new ConditionExpression("savedqueryid", ConditionOperator.Equal, savedQueryId) }
                 }
             };
-            var response = (RetrieveUnpublishedMultipleResponse?)await client.ExecuteAsync(
-                new RetrieveUnpublishedMultipleRequest { Query = query }, ct);
+
+            RetrieveUnpublishedMultipleResponse? response;
+            try
+            {
+                response = (RetrieveUnpublishedMultipleResponse?)await client.ExecuteAsync(
+                    new RetrieveUnpublishedMultipleRequest { Query = query }, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Could not verify the write to savedquery {SavedQueryId} via RetrieveUnpublished; " +
+                    "assuming it persisted.", savedQueryId);
+                return true;
+            }
+
             var result = response?.EntityCollection;
             var current = result != null && result.Entities.Count > 0
                 ? result.Entities[0].GetAttributeValue<string>(fieldName) ?? string.Empty

--- a/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
@@ -350,7 +350,7 @@ public class ViewServiceTests
     /// either throws a supplied Dataverse fault or succeeds, and whose read-back returns
     /// <paramref name="fetchAfterWrite"/> — letting tests drive every ApplyViewWriteAsync branch.
     /// </summary>
-    private static ViewService BuildViewWriteService(bool isManaged, Exception? updateThrows, string fetchAfterWrite, Action<Entity>? onUpdate = null)
+    private static ViewService BuildViewWriteService(bool isManaged, Exception? updateThrows, string fetchAfterWrite, Action<Entity>? onUpdate = null, Exception? readBackThrows = null)
     {
         var pool = new Mock<IDataverseConnectionPool>();
         var client = new Mock<IPooledClient>();
@@ -388,9 +388,12 @@ public class ViewServiceTests
             }));
 
         // Read-back verification reads the UNPUBLISHED (draft) record via RetrieveUnpublishedMultiple.
-        client.Setup(c => c.ExecuteAsync(
-                It.Is<OrganizationRequest>(r => r is RetrieveUnpublishedMultipleRequest), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new RetrieveUnpublishedMultipleResponse
+        var readBack = client.Setup(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r => r is RetrieveUnpublishedMultipleRequest), It.IsAny<CancellationToken>()));
+        if (readBackThrows != null)
+            readBack.ThrowsAsync(readBackThrows);
+        else
+            readBack.ReturnsAsync(new RetrieveUnpublishedMultipleResponse
             {
                 Results = new ParameterCollection
                 {
@@ -464,6 +467,19 @@ public class ViewServiceTests
     {
         // Update succeeds and the read-back reflects the new value → no throw.
         var svc = BuildViewWriteService(isManaged: false, updateThrows: null, fetchAfterWrite: NewFetch);
+
+        await FluentActions.Awaiting(() => svc.SetFetchXmlAsync("contact", ViewName, NewFetch))
+            .Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SetFetchXml_ReadBackFails_AssumesPersisted_DoesNotThrow()
+    {
+        // The unpublished read-back itself fails (e.g. missing RetrieveUnpublished privilege).
+        // Verification is best-effort, so a successful write must not be reported as not-persisted.
+        // fetchAfterWrite=OriginalFetch would otherwise trip UpdateNotPersisted if read-back ran.
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: OriginalFetch,
+            readBackThrows: new InvalidOperationException("PrincipalPrivilegeDenied: prvReadSavedQuery"));
 
         await FluentActions.Awaiting(() => svc.SetFetchXmlAsync("contact", ViewName, NewFetch))
             .Should().NotThrowAsync();

--- a/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
@@ -342,6 +342,8 @@ public class ViewServiceTests
     private const string ViewName = "Quick Find Active Contacts";
     private const string OriginalFetch = "<fetch><entity name=\"contact\"><attribute name=\"fullname\" /></entity></fetch>";
     private const string NewFetch = "<fetch><entity name=\"contact\"><attribute name=\"fullname\" /><attribute name=\"emailaddress1\" /></entity></fetch>";
+    private const string OriginalLayout = "<grid><row><cell name=\"fullname\" width=\"200\" /><cell name=\"telephone1\" width=\"150\" /></row></grid>";
+    private const string NewLayout = "<grid><row><cell name=\"fullname\" width=\"300\" /></row></grid>";
 
     /// <summary>
     /// Builds a ViewService whose fetch returns a single contact view (managed or not), whose write
@@ -379,6 +381,7 @@ public class ViewServiceTests
                 {
                     ["savedqueryid"] = ViewId,
                     ["fetchxml"] = OriginalFetch,
+                    ["layoutxml"] = OriginalLayout,
                     ["ismanaged"] = isManaged,
                     ["returnedtypecode"] = "contact"
                 }
@@ -391,7 +394,10 @@ public class ViewServiceTests
             {
                 Results = new ParameterCollection
                 {
-                    { "EntityCollection", new EntityCollection(new List<Entity> { new("savedquery") { ["fetchxml"] = fetchAfterWrite } }) }
+                    { "EntityCollection", new EntityCollection(new List<Entity>
+                        {
+                            new("savedquery") { ["fetchxml"] = fetchAfterWrite, ["layoutxml"] = NewLayout }
+                        }) }
                 }
             });
 
@@ -503,6 +509,33 @@ public class ViewServiceTests
             onUpdate: e => captured = e);
 
         await svc.ClearSortAsync("contact", ViewName);
+
+        captured.Should().NotBeNull();
+        captured!["returnedtypecode"].Should().Be("contact");
+    }
+
+    [Fact]
+    public async Task RemoveColumn_UpdatePayload_IncludesReturnedTypeCode()
+    {
+        // layoutxml-only writers now also route through the verified write path (#1200 parity).
+        Entity? captured = null;
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: NewFetch,
+            onUpdate: e => captured = e);
+
+        await svc.RemoveColumnAsync("contact", ViewName, "telephone1");
+
+        captured.Should().NotBeNull();
+        captured!["returnedtypecode"].Should().Be("contact");
+    }
+
+    [Fact]
+    public async Task UpdateColumn_UpdatePayload_IncludesReturnedTypeCode()
+    {
+        Entity? captured = null;
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: NewFetch,
+            onUpdate: e => captured = e);
+
+        await svc.UpdateColumnAsync("contact", ViewName, "fullname", 300);
 
         captured.Should().NotBeNull();
         captured!["returnedtypecode"].Should().Be("contact");

--- a/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Views/ViewServiceTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
@@ -347,7 +348,7 @@ public class ViewServiceTests
     /// either throws a supplied Dataverse fault or succeeds, and whose read-back returns
     /// <paramref name="fetchAfterWrite"/> — letting tests drive every ApplyViewWriteAsync branch.
     /// </summary>
-    private static ViewService BuildViewWriteService(bool isManaged, Exception? updateThrows, string fetchAfterWrite)
+    private static ViewService BuildViewWriteService(bool isManaged, Exception? updateThrows, string fetchAfterWrite, Action<Entity>? onUpdate = null)
     {
         var pool = new Mock<IDataverseConnectionPool>();
         var client = new Mock<IPooledClient>();
@@ -370,26 +371,36 @@ public class ViewServiceTests
                 }
             });
 
-        // The view-fetch (filters by name) returns the original record; the read-back verification
-        // (filters by savedqueryid) returns fetchAfterWrite.
+        // The view-fetch (RetrieveMultiple, filters by name) returns the original record.
         client.Setup(c => c.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((QueryBase q, CancellationToken _) =>
+            .ReturnsAsync(new EntityCollection(new List<Entity>
             {
-                var qe = (QueryExpression)q;
-                var isReadBack = qe.Criteria.Conditions.Any(c => c.AttributeName == "savedqueryid");
-                var e = new Entity("savedquery")
+                new("savedquery")
                 {
                     ["savedqueryid"] = ViewId,
-                    ["fetchxml"] = isReadBack ? fetchAfterWrite : OriginalFetch,
-                    ["ismanaged"] = isManaged
-                };
-                return new EntityCollection(new List<Entity> { e });
+                    ["fetchxml"] = OriginalFetch,
+                    ["ismanaged"] = isManaged,
+                    ["returnedtypecode"] = "contact"
+                }
+            }));
+
+        // Read-back verification reads the UNPUBLISHED (draft) record via RetrieveUnpublishedMultiple.
+        client.Setup(c => c.ExecuteAsync(
+                It.Is<OrganizationRequest>(r => r is RetrieveUnpublishedMultipleRequest), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RetrieveUnpublishedMultipleResponse
+            {
+                Results = new ParameterCollection
+                {
+                    { "EntityCollection", new EntityCollection(new List<Entity> { new("savedquery") { ["fetchxml"] = fetchAfterWrite } }) }
+                }
             });
 
         if (updateThrows != null)
             client.Setup(c => c.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>())).ThrowsAsync(updateThrows);
         else
-            client.Setup(c => c.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()))
+                .Callback<Entity, CancellationToken>((e, _) => onUpdate?.Invoke(e))
+                .Returns(Task.CompletedTask);
 
         return new ViewService(pool.Object, metadata.Object, new InactiveFakeShakedownGuard(), new NullLogger<ViewService>());
     }
@@ -400,6 +411,9 @@ public class ViewServiceTests
     [Fact]
     public async Task SetFetchXml_ManagedView_WriteRejected_ThrowsManagedComponentNotEditableWithGuidance()
     {
+        // With returnedtypecode now sent (#1200), a managed-view fetchxml write succeeds; this
+        // simulates a genuinely locked component (still rejected) and asserts the honest fault +
+        // accurate guidance — no longer the incorrect "PPDS can't do this, use the maker UI".
         var svc = BuildViewWriteService(
             isManaged: true,
             updateThrows: DataverseFault(unchecked((int)0x80040216), "An unexpected error occurred."),
@@ -409,7 +423,7 @@ public class ViewServiceTests
             .Should().ThrowAsync<PpdsException>();
 
         ex.Which.ErrorCode.Should().Be(ErrorCodes.View.ManagedComponentNotEditable);
-        ex.Which.Message.Should().Contain("0x80040216").And.Contain("maker UI");
+        ex.Which.Message.Should().Contain("0x80040216").And.Contain("locked");
     }
 
     [Fact]
@@ -447,5 +461,50 @@ public class ViewServiceTests
 
         await FluentActions.Awaiting(() => svc.SetFetchXmlAsync("contact", ViewName, NewFetch))
             .Should().NotThrowAsync();
+    }
+
+    // ─── returnedtypecode carried in fetchxml writes (#1200) ────────────────────
+    // Without returnedtypecode, Dataverse rejects fetchxml updates on managed views with
+    // 0x80040216. The shared write path must include it for every fetchxml-mutating command.
+
+    [Fact]
+    public async Task SetFetchXml_UpdatePayload_IncludesReturnedTypeCode()
+    {
+        Entity? captured = null;
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: NewFetch,
+            onUpdate: e => captured = e);
+
+        await svc.SetFetchXmlAsync("contact", ViewName, NewFetch);
+
+        captured.Should().NotBeNull();
+        captured!.Contains("returnedtypecode").Should().BeTrue();
+        captured["returnedtypecode"].Should().Be("contact");
+    }
+
+    [Fact]
+    public async Task SetFilter_UpdatePayload_IncludesReturnedTypeCode()
+    {
+        Entity? captured = null;
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: NewFetch,
+            onUpdate: e => captured = e);
+
+        await svc.SetFilterAsync("contact", ViewName,
+            "<filter type=\"and\"><condition attribute=\"statecode\" operator=\"eq\" value=\"0\" /></filter>");
+
+        captured.Should().NotBeNull();
+        captured!["returnedtypecode"].Should().Be("contact");
+    }
+
+    [Fact]
+    public async Task ClearSort_UpdatePayload_IncludesReturnedTypeCode()
+    {
+        Entity? captured = null;
+        var svc = BuildViewWriteService(isManaged: true, updateThrows: null, fetchAfterWrite: NewFetch,
+            onUpdate: e => captured = e);
+
+        await svc.ClearSortAsync("contact", ViewName);
+
+        captured.Should().NotBeNull();
+        captured!["returnedtypecode"].Should().Be("contact");
     }
 }


### PR DESCRIPTION
## What & why

CLI view commands that write `savedquery.fetchxml` failed on **managed** views — most visibly when editing the searchable **find columns** of a managed Quick Find view. First the platform returned the opaque `0x80040216` ("An unexpected error occurred"); after the #1190/#1194 honest-errors work landed, it instead reported a false `did not persist`.

I confirmed the real mechanism by **capturing and replaying the Power Apps maker's own network calls** against `PPDS Demo - Dev`. The maker does nothing exotic — a plain, supported `PATCH /savedqueries(id)` + `PublishXml` (no solution header). There were **two** root causes:

1. **The update omitted `returnedtypecode`.** Dataverse rejects a savedquery `fetchxml` update that lacks the entity context with `0x80040216`. Including `returnedtypecode` — exactly as the maker does — makes the write apply. Bisected on the live org:

   | Update body | Result |
   |---|---|
   | `fetchxml` only (± `MSCRM.MergeLabels`, ± `name`, ± `layoutxml`) | **400 `0x80040216`** |
   | **`fetchxml` + `returnedtypecode`** | **204 ✅** |

   `returnedtypecode` is necessary and sufficient; the `MSCRM.MergeLabels` header is **not** required.

2. **The #1194 read-back checked the *published* record.** A savedquery write lands in the **unpublished draft** and isn't visible to a normal `RetrieveMultiple` until `PublishXml` runs — so the read-back falsely reported "did not persist" on managed views. It now verifies against the **unpublished** record (`RetrieveUnpublishedMultiple`), which reflects the write immediately and still catches a genuine silent drop. This mirrors the maker's `RetrieveUnpublished` read-back.

## Changes

- `ApplyViewWriteAsync` (the #1190/#1194 write path) now echoes `returnedtypecode` from the fetched record, derives `ismanaged` from it, and **every fetchxml-mutating command** — `set-fetchxml`, `set-filter`, `clear-filter`, `set-sort`, `clear-sort`, and related-column `add-column` — routes through it, keeping fault-surfacing + read-back while now **succeeding on managed views**.
- Read-back verification reads the unpublished draft via `RetrieveUnpublishedMultipleRequest`.
- The managed-view error no longer claims PPDS *cannot* patch managed views ("edit it in the maker UI") — that premise is now false. It surfaces the real fault and notes a genuinely locked component (`iscustomizable = false`).
- `reorder-columns` ColumnSet includes `returnedtypecode` for parity (layoutxml-only; harmless).

## Testing

- **Unit:** full suite green (CLI 4088 passed). New tests assert the write payload carries `returnedtypecode` (`set-fetchxml`/`set-filter`/`clear-sort`) and that read-back reads the unpublished record; the managed-rejected test updated to assert the corrected guidance.
- **Live (SDK path) against PPDS Demo - Dev:** `views set-fetchxml` adds and removes `jobtitle` as a find column on the managed `Quick Find Active Contacts` view and the change persists — the exact path that previously failed with `0x80040216` / false "did not persist". Org left in its original state.
- Gates: build 0 errors, enforcement audit OK.

## Follow-up (out of scope)

`remove-column` / `update-column` are layoutxml-only and remain on the old inline-update path (no read-back / fault-surfacing). No bug today, but worth routing through `ApplyViewWriteAsync` for parity in a separate change.

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
