### PR TITLE
docs(readme): fix CLI flag drift in plugins and mcp quick starts

### DIFF
--- a/src/PPDS.Mcp/README.md
+++ b/src/PPDS.Mcp/README.md
@@ -83,10 +83,12 @@ ppds auth create --deviceCode
 # Service principal (for CI/CD and automation)
 ppds auth create --name ci \
   --applicationId <id> \
-  --clientSecret <secret> \
+  --clientSecret "$DATAVERSE_CLIENT_SECRET" \
   --tenant <tid> \
   --environment https://org.crm.dynamics.com
 ```
+
+> **Note:** Avoid hardcoding the client secret in scripts or passing a literal value on the command line, where it can leak into shell history, CI logs, or process listings. Supply it from your CI/CD system's secret store via an environment variable, as shown above.
 
 After creating a profile and selecting an environment, the MCP server automatically uses those credentials for all Dataverse operations.
 

--- a/src/PPDS.Mcp/README.md
+++ b/src/PPDS.Mcp/README.md
@@ -78,10 +78,14 @@ PPDS.Mcp reads authentication from your PPDS profile store. Create a profile bef
 ppds auth create
 
 # Device code flow (for remote/headless scenarios)
-ppds auth create --method DeviceCode
+ppds auth create --deviceCode
 
 # Service principal (for CI/CD and automation)
-ppds auth create --method ClientSecret --client-id <id> --tenant-id <tid>
+ppds auth create --name ci \
+  --applicationId <id> \
+  --clientSecret <secret> \
+  --tenant <tid> \
+  --environment https://org.crm.dynamics.com
 ```
 
 After creating a profile and selecting an environment, the MCP server automatically uses those credentials for all Dataverse operations.

--- a/src/PPDS.Plugins/README.md
+++ b/src/PPDS.Plugins/README.md
@@ -37,13 +37,19 @@ public class AccountUpdatePlugin : IPlugin
 }
 ```
 
-Build your plugin project, then deploy with the PPDS CLI:
+Build your plugin project, then deploy with the PPDS CLI in two steps. First extract the attribute metadata from the compiled assembly into a `registrations.json` config:
 
 ```bash
-ppds plugins deploy --assembly bin/Release/net462/MyPlugins.dll
+ppds plugins extract --input bin/Release/net462/MyPlugins.dll
 ```
 
-The CLI reflects over the assembly, extracts every `[PluginStep]`, `[PluginImage]`, and `[CustomApi]` attribute, and creates or updates the corresponding Dataverse plugin type, step, image, and Custom API records.
+This reflects over the assembly and writes every `[PluginStep]`, `[PluginImage]`, and `[CustomApi]` attribute to `registrations.json` (next to the assembly by default; use `--output` to choose another path). Then deploy that config to the connected environment:
+
+```bash
+ppds plugins deploy --config registrations.json
+```
+
+Deploy reads the config and creates or updates the corresponding Dataverse plugin type, step, image, and Custom API records. Check the config into source control so registrations diff cleanly in pull requests.
 
 ## Attributes
 

--- a/src/PPDS.Plugins/README.md
+++ b/src/PPDS.Plugins/README.md
@@ -51,6 +51,8 @@ ppds plugins deploy --config registrations.json
 
 Deploy reads the config and creates or updates the corresponding Dataverse plugin type, step, image, and Custom API records. Check the config into source control so registrations diff cleanly in pull requests.
 
+> **Important:** If any step sets a `secureConfiguration` value, do not commit that secret to source control. Keep secrets out of the tracked `registrations.json` and supply them at deploy time from a git-ignored file, an environment variable, or a secret manager.
+
 ## Attributes
 
 | Attribute | Applies To | Purpose |


### PR DESCRIPTION
## Summary

Fixes CLI flag drift between `src/*/README.md` examples and the actual command definitions in `src/PPDS.Cli/Commands/`.

### `src/PPDS.Plugins/README.md` (the reported bug)

The Quick Start showed a single-step deploy invocation with an `--assembly` flag. The `deploy` command has **no** `--assembly` flag — it requires `--config <registrations.json>` (alias `-c`, required), and that config is produced by the `extract` command via `--input <dll>`. Rewrote it as the real two-step extract-then-deploy flow, and corrected the surrounding prose (the "CLI reflects over the assembly" sentence was describing `extract`, not `deploy`).

### `src/PPDS.Mcp/README.md` (same class of drift, found during the scan)

The auth examples used three flags that do not exist on the auth-create command:

- `--method DeviceCode` &rarr; real flag is the boolean `--deviceCode`
- `--client-id` &rarr; real flag is `--applicationId`
- `--tenant-id` &rarr; real flag is `--tenant`

Corrected to the real flags and added the `--environment <url>` that service-principal auth requires.

## Verified clean (no drift)

- **PPDS.Cli** Quick Start — auth-create `--name`, env-select `--environment`, data-export `--schema`/`--output` all match the command defs.
- **PPDS.Query** Quick Start — the `explain` subcommand is real (positional `sql` arg); `-f csv` is valid (`--output-format` short alias is `-f`).
- **PPDS.Auth / PPDS.Dataverse / PPDS.Migration** Quick Starts — pure C# library usage, no CLI flags.
- **PPDS.Extension** Quick Start — numbered UI steps, no CLI flags.

## Notes

Out of scope but worth flagging: the PPDS.Cli README **Global Options** reference table lists `--output-format` with short flag `-o`, but the actual alias is `-f` (`-o` is `--output`). Left untouched since it is a reference table, not a Quick Start example.

Docs-only change; no build/test run required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
