### PR TITLE
fix(cli): validate customApis/register nested parameters (#1228)

### DIFF
--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.CustomApis.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.CustomApis.cs
@@ -138,17 +138,36 @@ public partial class RpcMethodHandler
         if (string.IsNullOrWhiteSpace(pluginTypeId) || !Guid.TryParse(pluginTypeId, out var pluginTypeGuid))
             throw new RpcException(ErrorCodes.Validation.RequiredField, "The 'pluginTypeId' parameter must be a valid GUID");
 
+        // Validate each nested parameter with the same rules as customApis/addParameter
+        // so a null/whitespace field is rejected up front rather than silently coerced
+        // to an empty string downstream (issue #1228).
+        if (parameters is not null)
+        {
+            for (var i = 0; i < parameters.Count; i++)
+            {
+                var p = parameters[i];
+                if (p is null)
+                    throw new RpcException(ErrorCodes.Validation.RequiredField, $"parameter[{i}] cannot be null");
+                if (string.IsNullOrWhiteSpace(p.UniqueName))
+                    throw new RpcException(ErrorCodes.Validation.RequiredField, $"The 'uniqueName' field of parameter[{i}] is required");
+                if (string.IsNullOrWhiteSpace(p.DisplayName))
+                    throw new RpcException(ErrorCodes.Validation.RequiredField, $"The 'displayName' field of parameter[{i}] is required");
+                if (string.IsNullOrWhiteSpace(p.Type))
+                    throw new RpcException(ErrorCodes.Validation.RequiredField, $"The 'type' field of parameter[{i}] is required");
+            }
+        }
+
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
             var service = sp.GetRequiredService<ICustomApiService>();
 
             var paramRegistrations = parameters?
                 .Select(p => new CustomApiParameterRegistration(
-                    p.UniqueName ?? "",
-                    p.DisplayName ?? "",
+                    p.UniqueName!,
+                    p.DisplayName!,
                     p.Name,
                     p.Description,
-                    p.Type ?? "",
+                    p.Type!,
                     p.LogicalEntityName,
                     p.IsOptional,
                     p.Direction ?? "Request"))

--- a/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/CustomApisRpcValidationTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/CustomApisRpcValidationTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using PPDS.Auth.DependencyInjection;
+using PPDS.Cli.Commands.Serve.Handlers;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Errors;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Serve.Handlers;
+
+/// <summary>
+/// Validation-parity tests for the customApis RPC handlers.
+///
+/// Issue #1228: customApis/register mapped nested parameters with `?? ""`, silently
+/// coercing a null/whitespace uniqueName/displayName/type to an empty string, while
+/// customApis/addParameter validated the same fields and threw RequiredField. These
+/// tests pin the two entry points to the same validation rules.
+/// </summary>
+[Trait("Category", "Unit")]
+public class CustomApisRpcValidationTests
+{
+    private const string ValidPluginTypeId = "11111111-1111-1111-1111-111111111111";
+    private const string ValidApiId = "22222222-2222-2222-2222-222222222222";
+
+    private static IServiceProvider CreateAuthServices() =>
+        new ServiceCollection().AddAuthServices().BuildServiceProvider();
+
+    private static RpcMethodHandler CreateHandler() =>
+        new(new Mock<IDaemonConnectionPoolManager>().Object, CreateAuthServices());
+
+    private static List<CustomApiParameterDto> SingleParameter(
+        string? uniqueName = "in_param",
+        string? displayName = "In Param",
+        string? type = "String") =>
+        new()
+        {
+            new CustomApiParameterDto
+            {
+                UniqueName = uniqueName,
+                DisplayName = displayName,
+                Type = type,
+                Direction = "Request",
+            }
+        };
+
+    #region register: nested parameter validation
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Register_ParameterEmptyUniqueName_ThrowsRequiredField(string? uniqueName)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisRegisterAsync(
+            "ppds_MyApi",
+            "My API",
+            ValidPluginTypeId,
+            parameters: SingleParameter(uniqueName: uniqueName));
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Register_ParameterEmptyDisplayName_ThrowsRequiredField(string? displayName)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisRegisterAsync(
+            "ppds_MyApi",
+            "My API",
+            ValidPluginTypeId,
+            parameters: SingleParameter(displayName: displayName));
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Register_ParameterEmptyType_ThrowsRequiredField(string? type)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisRegisterAsync(
+            "ppds_MyApi",
+            "My API",
+            ValidPluginTypeId,
+            parameters: SingleParameter(type: type));
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Fact]
+    public async Task Register_NullParameterElement_ThrowsRequiredField()
+    {
+        var handler = CreateHandler();
+
+        // A malformed payload can deserialize to a list containing a null element;
+        // it must produce a structured RequiredField error, not a NullReferenceException.
+        var act = () => handler.CustomApisRegisterAsync(
+            "ppds_MyApi",
+            "My API",
+            ValidPluginTypeId,
+            parameters: new List<CustomApiParameterDto> { null! });
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Fact]
+    public async Task Register_NullParameters_DoesNotThrowValidation()
+    {
+        var handler = CreateHandler();
+
+        // No parameters supplied: must pass the nested-parameter gate. It still fails
+        // later (no real connection), but never with a parameter RequiredField.
+        var act = () => handler.CustomApisRegisterAsync(
+            "ppds_MyApi",
+            "My API",
+            ValidPluginTypeId,
+            parameters: null);
+
+        var ex = await Record.ExceptionAsync(act);
+        (ex as RpcException)?.StructuredErrorCode.Should().NotBe(ErrorCodes.Validation.RequiredField);
+    }
+
+    #endregion
+
+    #region addParameter: parity reference
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AddParameter_EmptyUniqueName_ThrowsRequiredField(string? uniqueName)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisAddParameterAsync(
+            ValidApiId,
+            uniqueName!,
+            "In Param",
+            "String",
+            "Request");
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AddParameter_EmptyDisplayName_ThrowsRequiredField(string? displayName)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisAddParameterAsync(
+            ValidApiId,
+            "in_param",
+            displayName!,
+            "String",
+            "Request");
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AddParameter_EmptyType_ThrowsRequiredField(string? type)
+    {
+        var handler = CreateHandler();
+
+        var act = () => handler.CustomApisAddParameterAsync(
+            ValidApiId,
+            "in_param",
+            "In Param",
+            type!,
+            "Request");
+
+        (await act.Should().ThrowAsync<RpcException>())
+            .Which.StructuredErrorCode.Should().Be(ErrorCodes.Validation.RequiredField);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

The `customApis/register` RPC handler mapped each nested parameter DTO with `?? ""`, silently coercing a null/whitespace `uniqueName`/`displayName`/`type` into an empty string and passing it downstream. In contrast, `customApis/addParameter` validated those same fields and threw `RpcException(ErrorCodes.Validation.RequiredField)`.

This restores validation parity between the two RPC entry points that create the same kind of object. Each nested parameter in `register` is now validated up front and rejected with `RequiredField`, naming the offending parameter index in the message.

## Changes

- `RpcMethodHandler.CustomApisRegisterAsync`: validate each nested parameter's `uniqueName`, `displayName`, and `type` (non-null/non-whitespace) before any connection is established — mirroring `CustomApisAddParameterAsync`. The downstream mapping now uses the validated values instead of `?? ""`.
- New `CustomApisRpcValidationTests`: parity tests pinning `register` and `addParameter` to the same rules (null/empty/whitespace → `RequiredField`), plus a guard that null `parameters` does not trip the new validation.

`customApis/update` is unaffected — it takes no `parameters` argument and does not share the mapping.

## Provenance

Found by Gemini review on #1224. Pre-existing behavior — that PR was a pure file move (#1213), so the finding was correctly out of scope there and is fixed here.

## Verification

- `/gates`: .NET build (0 errors), full non-integration test suite (12,860+ passed, 0 failed), enforcement audit — all PASS.
- `/verify` (cli): 19 parity tests pass across net8.0/net9.0/net10.0.

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)
