### PR TITLE
refactor(cli): remove unused pool locals in plugin RPC handlers

### DIFF
--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
@@ -22,7 +22,6 @@ using PPDS.Dataverse.Diagnostics;
 using PPDS.Dataverse.Metadata;
 using PPDS.Dataverse.Metadata.Models;
 using Authoring = PPDS.Dataverse.Metadata.Authoring;
-using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Query;
 using PPDS.Dataverse.Query.Execution;
 using PPDS.Dataverse.Security;
@@ -77,7 +76,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var response = new PluginsGetResponse { Type = type };
@@ -140,7 +138,6 @@ public partial class RpcMethodHandler
     {
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
             var messages = await registrationService.ListMessagesAsync(filter, ct);
             return new PluginsMessagesResponse { Messages = messages };
@@ -162,7 +159,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
             var attributes = await registrationService.ListEntityAttributesAsync(entityLogicalName, ct);
             return new PluginsEntityAttributesResponse
@@ -193,7 +189,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             if (enabled)
@@ -224,7 +219,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var bytes = Convert.FromBase64String(content);
@@ -253,7 +247,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var bytes = Convert.FromBase64String(content);
@@ -303,7 +296,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var messageId = await registrationService.GetSdkMessageIdAsync(message, ct)
@@ -362,7 +354,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             // Resolve message name from step if not provided
@@ -411,7 +402,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var request = new StepUpdateRequest(
@@ -448,7 +438,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var request = new ImageUpdateRequest(
@@ -481,7 +470,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             UnregisterResult result = type.ToLowerInvariant() switch
@@ -527,7 +515,6 @@ public partial class RpcMethodHandler
 
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             (byte[] bytes, string fileName) = type.ToLowerInvariant() switch

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.Plugins.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.Plugins.cs
@@ -22,7 +22,6 @@ using PPDS.Dataverse.Diagnostics;
 using PPDS.Dataverse.Metadata;
 using PPDS.Dataverse.Metadata.Models;
 using Authoring = PPDS.Dataverse.Metadata.Authoring;
-using PPDS.Dataverse.Pooling;
 using PPDS.Dataverse.Query;
 using PPDS.Dataverse.Query.Execution;
 using PPDS.Dataverse.Security;
@@ -72,9 +71,7 @@ public partial class RpcMethodHandler
     {
         return await WithProfileAndEnvironmentAsync(profileName, environmentUrl, async (sp, ct) =>
         {
-            var pool = sp.GetRequiredService<IDataverseConnectionPool>();
-
-            // Create registration service with pool (use NullLogger for daemon context)
+            // Resolve registration service (use NullLogger for daemon context)
             var registrationService = sp.GetRequiredService<IPluginRegistrationService>();
 
             var response = new PluginsListResponse();


### PR DESCRIPTION
## Summary

Removes 13 unused `IDataverseConnectionPool` locals flagged by CodeQL (alerts **1276–1288**, `cs/useless-assignment-to-local`) in the plugin RPC handlers — **12** in `RpcMethodHandler.PluginRegistration.cs` and **1** in `RpcMethodHandler.Plugins.cs`. Each handler only uses the resolved `IPluginRegistrationService`, which checks out its own client from the pool, so the `pool` locals were dead.

These were pre-existing on `main` and surfaced when #1224 (the verbatim split of #1213) carried them into the new partial files. #1224 squash-merged before this cleanup could ride along, so this is a standalone follow-up against `main`.

Also removes the now-dead `using PPDS.Dataverse.Pooling;` from both partials (the `pool` locals were its only consumer there) and corrects a stale "create registration service with pool" comment.

## Verification

- **Build**: `PPDS.Cli` clean, 0 errors (the 8 warnings are all pre-existing in `PPDS.Auth`).
- **Tests**: 45 `RpcMethodHandler` daemon unit tests pass on net8/9/10.
- Verified no remaining `pool` / `IDataverseConnectionPool` reference in either partial.

## Risk

Pure dead-code deletion — no behavior change. The one genuinely-used pool site (`env/who`, which calls `pool.GetClientAsync`) lives in a different partial and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
