### PR TITLE
fix(cli): forward Color when adding a global option-set value

### DIFF
--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -854,6 +854,8 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
 
         if (!string.IsNullOrEmpty(request.Description))
             sdkRequest.Description = new Label(request.Description, 1033);
+        if (!string.IsNullOrEmpty(request.Color))
+            sdkRequest["Color"] = request.Color;
         if (!string.IsNullOrEmpty(request.EntityLogicalName))
             sdkRequest["EntityLogicalName"] = request.EntityLogicalName;
         if (!string.IsNullOrEmpty(request.AttributeLogicalName))

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataGlobalOptionServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataGlobalOptionServiceTests.cs
@@ -1,0 +1,80 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Moq;
+using PPDS.Cli.Services.Metadata.Authoring;
+using PPDS.Cli.Tests.Services.Shared;
+using PPDS.Dataverse.Metadata.Authoring;
+using PPDS.Dataverse.Pooling;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Services.Metadata.Authoring;
+
+/// <summary>
+/// Covers global (option-set-scoped) option management on the authoring service.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MetadataGlobalOptionServiceTests
+{
+    private readonly Mock<IDataverseConnectionPool> _pool = new();
+    private readonly Mock<IPooledClient> _client = new();
+    private readonly DataverseMetadataAuthoringService _service;
+    private OrganizationRequest? _captured;
+
+    public MetadataGlobalOptionServiceTests()
+    {
+        _pool.Setup(p => p.GetClientAsync(null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _service = new DataverseMetadataAuthoringService(_pool.Object, new SchemaValidator(), new InactiveFakeShakedownGuard());
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Returns<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                switch (req)
+                {
+                    case InsertOptionValueRequest insert:
+                        _captured = req;
+                        var ins = new InsertOptionValueResponse();
+                        ins.Results["NewOptionValue"] = insert.Value ?? 0;
+                        return Task.FromResult<OrganizationResponse>(ins);
+                    default:
+                        return Task.FromResult(new OrganizationResponse());
+                }
+            });
+    }
+
+    [Fact]
+    public async Task AddOptionValue_WithColor_ForwardsColorToInsertRequest()
+    {
+        var assigned = await _service.AddOptionValueAsync(new AddOptionValueRequest
+        {
+            OptionSetName = "hsl_severity",
+            SolutionUniqueName = "MySolution",
+            Label = "Severe",
+            Value = 864630001,
+            Color = "#FF0000"
+        });
+
+        assigned.Should().Be(864630001);
+        var insert = _captured.Should().BeOfType<InsertOptionValueRequest>().Subject;
+        insert.Value.Should().Be(864630001);
+        insert["Color"].Should().Be("#FF0000");
+    }
+
+    [Fact]
+    public async Task AddOptionValue_WithoutColor_DoesNotSetColorParameter()
+    {
+        await _service.AddOptionValueAsync(new AddOptionValueRequest
+        {
+            OptionSetName = "hsl_severity",
+            SolutionUniqueName = "MySolution",
+            Label = "Mild",
+            Value = 864630000
+        });
+
+        var insert = _captured.Should().BeOfType<InsertOptionValueRequest>().Subject;
+        insert.Parameters.ContainsKey("Color").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`AddOptionValueAsync` in `DataverseMetadataAuthoringService` built an
`InsertOptionValueRequest` from `AddOptionValueRequest` but never forwarded
`request.Color`, so `ppds metadata optionset add-option --color #RRGGBB`
silently dropped the color. Both the CLI command and the DTO already carried
`Color` — only the service-to-SDK mapping was missing it.

This forwards it the same way the sibling methods do (`AddColumnOptionAsync`,
`UpdateOptionValueAsync`): set `sdkRequest["Color"]` when non-empty.

## Changes

- `src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs`
  — forward `Color` into the `InsertOptionValueRequest`.
- `tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataGlobalOptionServiceTests.cs`
  — new test class capturing the `InsertOptionValueRequest` and asserting
  `["Color"]` is forwarded when supplied and omitted otherwise.

## Testing

- `dotnet build PPDS.sln` — 0 errors.
- `dotnet test PPDS.sln --filter "Category!=Integration"` — all suites green,
  including the 2 new tests (net8.0/net9.0/net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
