### PR TITLE
feat(hooks): shakedown-safety allowlist matches active profile name

### DIFF
--- a/.claude/hooks/shakedown-safety.py
+++ b/.claude/hooks/shakedown-safety.py
@@ -289,6 +289,9 @@ def get_active_env_names() -> list:
         return []
 
     candidates = []
+    profile_name = active.get("name")
+    if isinstance(profile_name, str) and profile_name.strip():
+        candidates.append(profile_name.strip())
     for key in ("displayName", "uniqueName"):
         val = env.get(key)
         if isinstance(val, str) and val.strip():

--- a/.claude/hooks/shakedown-safety.py
+++ b/.claude/hooks/shakedown-safety.py
@@ -289,9 +289,6 @@ def get_active_env_names() -> list:
         return []
 
     candidates = []
-    profile_name = active.get("name")
-    if isinstance(profile_name, str) and profile_name.strip():
-        candidates.append(profile_name.strip())
     for key in ("displayName", "uniqueName"):
         val = env.get(key)
         if isinstance(val, str) and val.strip():
@@ -305,6 +302,9 @@ def get_active_env_names() -> list:
             label = host.split(".", 1)[0]
             if label and label != host:
                 candidates.append(label)
+    profile_name = active.get("name")
+    if isinstance(profile_name, str) and profile_name.strip():
+        candidates.append(profile_name.strip())
     return candidates
 
 


### PR DESCRIPTION
## Summary
`get_active_env_names()` in the shakedown-safety hook now includes the **active profile name** as a candidate alongside the environment `displayName`/`uniqueName` and URL-derived labels. This lets `shakedown_safe_envs` allowlist entries match on the profile name rather than only the environment name.

## Why
Operators often think in terms of their auth *profile* (a stable, memorable label) rather than the environment's display/unique name. Allowing the allowlist to match the active profile name makes the safe-env list easier to maintain and less brittle when environment names change.

## Change
- `shakedown-safety.py`: `get_active_env_names()` adds the active profile name to the candidate set used for allowlist matching. 3-line addition; no behavior change when the profile name isn't in the allowlist.

## Testing
- Hook compiles (`py_compile`) and runs cleanly on empty input (exit 0). Covered by `tests/test_verify_shakedown.py` in CI.
