### PR TITLE
feat(mda): draft-app sitemap resolution, table-component fix, sitemap --raw/--unpublished

### DIFF
--- a/specs/model-driven-apps.md
+++ b/specs/model-driven-apps.md
@@ -82,7 +82,7 @@ CLI commands for managing model-driven app (MDA) navigation — listing apps, in
 ppds model-driven-app
 ├── list                    # List all MDAs in environment
 ├── get --app <name>        # Show app metadata + component counts
-├── sitemap --app <name>    # Display sitemap navigation structure
+├── sitemap --app <name> [--unpublished] [--raw]   # Display sitemap navigation structure (or raw XML)
 ├── set-sitemap-xml --app <name> --xml <path>   # Set sitemap from file
 ├── add-table <entities...> --app <name> [--group] [--area] [--title] [--solution] [--publish]
 ├── remove-table --app <name> --entity <name> [--solution] [--publish]
@@ -109,7 +109,7 @@ All write subcommands (`set-sitemap-xml`, `add-table`, `remove-table`, `set-form
 
 ### Core Requirements
 
-1. All read operations (`list`, `get`, `sitemap`) work against the current published state
+1. All read operations (`list`, `get`, `sitemap`) work against the current published state by default; `sitemap --unpublished` reads the latest draft (via `RetrieveUnpublishedMultiple`), and `sitemap --raw` emits the sitemap XML verbatim instead of the parsed structure (JSON mode returns `{ "xml": "…" }`)
 2. All write operations validate sitemap XML against bundled XSD before PATCH
 3. Entity additions modify sitemap XML (not `AddAppComponents` — see Design Decisions)
 4. Form/view/chart additions use `AddAppComponents` with correct `@odata.type`

--- a/src/PPDS.Cli/Commands/ModelDrivenApps/SitemapCommand.cs
+++ b/src/PPDS.Cli/Commands/ModelDrivenApps/SitemapCommand.cs
@@ -15,9 +15,21 @@ public static class SitemapCommand
 {
     public static Command Create()
     {
+        var unpublishedOption = new Option<bool>("--unpublished")
+        {
+            Description = "Read the unpublished (latest draft) sitemap instead of the published version"
+        };
+
+        var rawOption = new Option<bool>("--raw")
+        {
+            Description = "Output the raw sitemap XML instead of the parsed navigation structure"
+        };
+
         var command = new Command("sitemap", "Display the sitemap navigation structure of an app")
         {
             ModelDrivenAppCommandGroup.AppOption,
+            unpublishedOption,
+            rawOption,
             ModelDrivenAppCommandGroup.ProfileOption,
             ModelDrivenAppCommandGroup.EnvironmentOption
         };
@@ -27,10 +39,12 @@ public static class SitemapCommand
         command.SetAction(async (parseResult, ct) =>
         {
             var app = parseResult.GetValue(ModelDrivenAppCommandGroup.AppOption);
+            var unpublished = parseResult.GetValue(unpublishedOption);
+            var raw = parseResult.GetValue(rawOption);
             var profile = parseResult.GetValue(ModelDrivenAppCommandGroup.ProfileOption);
             var environment = parseResult.GetValue(ModelDrivenAppCommandGroup.EnvironmentOption);
             var globalOptions = GlobalOptions.GetValues(parseResult);
-            return await ExecuteAsync(app, profile, environment, globalOptions, ct);
+            return await ExecuteAsync(app, unpublished, raw, profile, environment, globalOptions, ct);
         });
 
         return command;
@@ -38,6 +52,8 @@ public static class SitemapCommand
 
     private static async Task<int> ExecuteAsync(
         string? appName,
+        bool unpublished,
+        bool raw,
         string? profile,
         string? environment,
         GlobalOptionValues globalOptions,
@@ -66,7 +82,24 @@ public static class SitemapCommand
                 Console.Error.WriteLine();
             }
 
-            var sitemap = await service.GetSitemapAsync(appName, ct);
+            if (raw)
+            {
+                var xml = await service.GetSitemapXmlAsync(appName, unpublished, ct);
+
+                if (globalOptions.IsJsonMode)
+                {
+                    writer.WriteSuccess(new { xml });
+                }
+                else
+                {
+                    // Raw XML is the requested data — write it to stdout (Constitution I1).
+                    Console.WriteLine(xml);
+                }
+
+                return ExitCodes.Success;
+            }
+
+            var sitemap = await service.GetSitemapAsync(appName, unpublished, ct);
 
             if (globalOptions.IsJsonMode)
             {

--- a/src/PPDS.Cli/Services/ModelDrivenApps/IModelDrivenAppService.cs
+++ b/src/PPDS.Cli/Services/ModelDrivenApps/IModelDrivenAppService.cs
@@ -13,8 +13,11 @@ public interface IModelDrivenAppService
     /// <summary>Returns detailed information about a single app by display or unique name.</summary>
     Task<ModelDrivenAppDetails> GetAppAsync(string appName, CancellationToken ct);
 
-    /// <summary>Returns the hierarchical sitemap structure for an app.</summary>
-    Task<SitemapStructure> GetSitemapAsync(string appName, CancellationToken ct);
+    /// <summary>Returns the hierarchical sitemap structure for an app. Set <paramref name="unpublished"/> to read the latest draft.</summary>
+    Task<SitemapStructure> GetSitemapAsync(string appName, bool unpublished, CancellationToken ct);
+
+    /// <summary>Returns the raw sitemap XML for an app. Set <paramref name="unpublished"/> to read the latest draft.</summary>
+    Task<string> GetSitemapXmlAsync(string appName, bool unpublished, CancellationToken ct);
 
     /// <summary>Replaces the sitemap XML for an app after validating against the XSD.</summary>
     Task SetSitemapXmlAsync(string appName, string xml, SetSitemapOptions options, IProgressReporter? progress, CancellationToken ct);

--- a/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
+++ b/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
@@ -86,7 +86,9 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         EntityCollection result;
         try
         {
-            result = await client.RetrieveMultipleAsync(query, ct);
+            var request = new RetrieveUnpublishedMultipleRequest { Query = query };
+            var response = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(request, ct);
+            result = response.EntityCollection;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -158,14 +160,23 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
     }
 
     /// <inheritdoc />
-    public async Task<SitemapStructure> GetSitemapAsync(string appName, CancellationToken ct)
+    public async Task<SitemapStructure> GetSitemapAsync(string appName, bool unpublished, CancellationToken ct)
     {
         await using var client = await _pool.GetClientAsync(cancellationToken: ct);
 
         var (appModuleId, _) = await ResolveAppAsync(appName, client, ct);
-        var xml = await FetchSitemapXmlForAppAsync(client, appModuleId, ct);
+        var xml = await FetchSitemapXmlForAppAsync(client, appModuleId, ct, unpublished);
 
         return ParseSitemapStructure(xml);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetSitemapXmlAsync(string appName, bool unpublished, CancellationToken ct)
+    {
+        await using var client = await _pool.GetClientAsync(cancellationToken: ct);
+
+        var (appModuleId, _) = await ResolveAppAsync(appName, client, ct);
+        return await FetchSitemapXmlForAppAsync(client, appModuleId, ct, unpublished);
     }
 
     /// <inheritdoc />
@@ -225,8 +236,10 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         await using var client = await _pool.GetClientAsync(cancellationToken: ct);
         var (appModuleId, uniqueName) = await ResolveAppAsync(appName, client, ct);
         await EnsureWriteAllowedAsync(options.Confirm, ct);
-        var sitemapId = await GetSitemapIdAsync(client, appModuleId, ct);
-        var sitemapXml = await FetchSitemapXmlByIdAsync(client, sitemapId, ct, unpublished: true);
+        var existingSitemapId = await TryGetSitemapIdAsync(client, appModuleId, ct);
+        var sitemapXml = existingSitemapId.HasValue
+            ? await FetchSitemapXmlByIdAsync(client, existingSitemapId.Value, ct, unpublished: true)
+            : "<SiteMap />";
 
         var doc = XDocument.Parse(sitemapXml);
         var siteMapEl = doc.Root!;
@@ -287,6 +300,7 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var isFirst = true;
+        var entityComponents = new EntityReferenceCollection();
         foreach (var entityName in entities)
         {
             progress?.ReportInfo($"Adding {entityName}");
@@ -315,13 +329,36 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
 
             groupEl.Add(subAreaEl);
             existingEntities.Add(entitySummary.LogicalName);
+
+            // Register the table component by its OWN logical name, not the literal "entity":
+            // "entity" is itself a real table (the metadata-definition table), so AddAppComponents
+            // would resolve the reference to that table (adding a spurious "Entity" component) and
+            // ignore the table we mean. The objectid Dataverse stores is the table's MetadataId.
+            if (entitySummary.MetadataId != Guid.Empty)
+                entityComponents.Add(new EntityReference(entitySummary.LogicalName, entitySummary.MetadataId));
         }
 
         var updatedXml = doc.ToString(SaveOptions.DisableFormatting);
         _validator.Validate(XDocument.Parse(updatedXml));
 
-        progress?.ReportPhase("Updating sitemap");
-        await PatchSitemapAsync(client, sitemapId, updatedXml, ct);
+        Guid sitemapId;
+        if (existingSitemapId.HasValue)
+        {
+            progress?.ReportPhase("Updating sitemap");
+            await PatchSitemapAsync(client, existingSitemapId.Value, updatedXml, ct);
+            sitemapId = existingSitemapId.Value;
+        }
+        else
+        {
+            progress?.ReportPhase("Creating sitemap");
+            sitemapId = await CreateSitemapForAppAsync(client, appModuleId, uniqueName, updatedXml, ct);
+        }
+
+        if (entityComponents.Count > 0)
+        {
+            progress?.ReportPhase("Registering table components");
+            await AddAppComponentsAsync(client, appModuleId, entityComponents, ct);
+        }
 
         if (options.Solution != null)
         {
@@ -716,7 +753,9 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         IPooledClient client,
         CancellationToken ct)
     {
-        // Filter server-side to avoid over-fetching all apps (no TopCount cap).
+        // appmodule is a publishable entity. RetrieveMultiple only returns published records, so draft
+        // apps (never published) would not be found — the query below uses RetrieveUnpublishedMultiple
+        // so both draft and published apps are visible. Filter server-side to avoid over-fetching.
         var query = new QueryExpression("appmodule")
         {
             ColumnSet = new ColumnSet("appmoduleid", "uniquename", "name"),
@@ -731,7 +770,9 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         EntityCollection result;
         try
         {
-            result = await client.RetrieveMultipleAsync(query, ct);
+            var request = new RetrieveUnpublishedMultipleRequest { Query = query };
+            var response = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(request, ct);
+            result = response.EntityCollection;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -968,10 +1009,23 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         || (ex.Message.Contains("uniquename", StringComparison.OrdinalIgnoreCase)
             && ex.Message.Contains("Cannot complete", StringComparison.OrdinalIgnoreCase));
 
-    // Queries appmodulecomponent joined to appmodule via appmoduleidunique relationship,
-    // filtering by appmodule.appmoduleid to avoid EntityReference cast issues.
     private async Task<Guid> GetSitemapIdAsync(IPooledClient client, Guid appModuleId, CancellationToken ct)
     {
+        var id = await TryGetSitemapIdAsync(client, appModuleId, ct);
+        return id ?? throw new PpdsException(ModelDrivenAppErrorCodes.GetFailed, "App has no associated sitemap record.");
+    }
+
+    // Returns null only when the app truly has no sitemap (never-published app with no navigation yet).
+    // Three-tier lookup:
+    //   Tier 1: appmodulecomponent (fast path; works for apps that have been published at least once)
+    //   Tier 2: match sitemap.sitemapnameunique == appmodule.uniquename (handles draft apps whose
+    //           sitemap isn't in appmodulecomponent yet). The Power Apps maker creates an app-aware
+    //           sitemap whose unique name equals the app's uniquename; this shared name is the only
+    //           reliable link for a draft sitemap, since sitemap has no FK to appmodule.
+    //   Tier 3: OData navigation property (works for published apps with a published sitemap).
+    private async Task<Guid?> TryGetSitemapIdAsync(IPooledClient client, Guid appModuleId, CancellationToken ct)
+    {
+        // Tier 1: appmodulecomponent SDK query (works for published apps).
         var query = new QueryExpression("appmodulecomponent")
         {
             ColumnSet = new ColumnSet("objectid"),
@@ -993,13 +1047,158 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         }
 
         var sitemapId = result.Entities.FirstOrDefault()?.GetAttributeValue<Guid>("objectid");
+        if (sitemapId.HasValue && sitemapId.Value != Guid.Empty)
+            return sitemapId;
 
-        if (sitemapId == null || sitemapId == Guid.Empty)
+        // Tier 2: match the app's sitemap by shared unique name. The Power Apps maker creates an
+        // app-aware sitemap whose sitemapnameunique equals the app's uniquename; this is how a draft
+        // (never-published) app links to its sitemap, since sitemap has no FK to appmodule and the
+        // sitemap is not registered in appmodulecomponent until the app is published. Query
+        // unpublished so draft sitemaps are visible.
+        var appUniqueName = await TryResolveAppUniqueNameAsync(client, appModuleId, ct);
+        if (!string.IsNullOrEmpty(appUniqueName))
         {
-            throw new PpdsException(ModelDrivenAppErrorCodes.GetFailed, "App has no associated sitemap record.");
+            var nameQuery = new QueryExpression("sitemap")
+            {
+                ColumnSet = new ColumnSet("sitemapid"),
+                TopCount = 1
+            };
+            nameQuery.Criteria.AddCondition("sitemapnameunique", ConditionOperator.Equal, appUniqueName);
+
+            try
+            {
+                var nameRequest = new RetrieveUnpublishedMultipleRequest { Query = nameQuery };
+                var nameResponse = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(nameRequest, ct);
+                var nameMatch = nameResponse.EntityCollection.Entities.FirstOrDefault();
+                if (nameMatch != null)
+                {
+                    var id = nameMatch.GetAttributeValue<Guid>("sitemapid");
+                    if (id != Guid.Empty)
+                        return id;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(ex, "Sitemap lookup by app uniquename '{UniqueName}' failed for app {AppModuleId}.", appUniqueName, appModuleId);
+            }
         }
 
-        return sitemapId.Value;
+        // Tier 3: OData navigation property (works for published apps with a published sitemap).
+        var sitemapViaNav = await TryGetSitemapIdViaNavigationAsync(client, appModuleId, ct);
+        if (sitemapViaNav.HasValue)
+            return sitemapViaNav;
+
+        return null;
+    }
+
+    private async Task<Guid?> TryGetSitemapIdViaNavigationAsync(IPooledClient client, Guid appModuleId, CancellationToken ct)
+    {
+        // Tier A: direct navigation property. Works when a published sitemap is linked.
+        try
+        {
+            var json = await client.GetRawWebApiAsync(
+                $"appmodules({appModuleId:D})/appmodulesitemap?$select=sitemapid", ct);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("sitemapid", out var el)
+                    && el.ValueKind == System.Text.Json.JsonValueKind.String
+                    && Guid.TryParse(el.GetString(), out var g) && g != Guid.Empty)
+                    return g;
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "appmodulesitemap direct GET failed for app {AppModuleId}.", appModuleId);
+        }
+
+        // Tier B: $ref endpoint. Returns just the entity reference URL, which may succeed even
+        // when the full navigation returns 404 for an unpublished sitemap.
+        try
+        {
+            var json = await client.GetRawWebApiAsync(
+                $"appmodules({appModuleId:D})/appmodulesitemap/$ref", ct);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(json);
+                // Response: {"@odata.id":"https://org.crm.dynamics.com/api/data/v9.2/sitemaps(guid)"}
+                if (doc.RootElement.TryGetProperty("@odata.id", out var idProp))
+                {
+                    var odataId = idProp.GetString();
+                    if (!string.IsNullOrEmpty(odataId))
+                    {
+                        var start = odataId.LastIndexOf('(') + 1;
+                        var end = odataId.LastIndexOf(')');
+                        if (start > 0 && end > start
+                            && Guid.TryParse(odataId.AsSpan(start, end - start), out var refGuid)
+                            && refGuid != Guid.Empty)
+                            return refGuid;
+                    }
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "appmodulesitemap $ref GET failed for app {AppModuleId}.", appModuleId);
+        }
+
+        return null;
+    }
+
+    // Resolves the app's uniquename from a draft-or-published appmodule record. Used to find the
+    // maker-created sitemap by shared unique name (Tier 2) and to name a sitemap we create so it is
+    // discoverable on subsequent runs. Returns null if the app can't be resolved.
+    private async Task<string?> TryResolveAppUniqueNameAsync(IPooledClient client, Guid appModuleId, CancellationToken ct)
+    {
+        var query = new QueryExpression("appmodule")
+        {
+            ColumnSet = new ColumnSet("uniquename"),
+            TopCount = 1
+        };
+        query.Criteria.AddCondition("appmoduleid", ConditionOperator.Equal, appModuleId);
+
+        try
+        {
+            var request = new RetrieveUnpublishedMultipleRequest { Query = query };
+            var response = (RetrieveUnpublishedMultipleResponse)await client.ExecuteAsync(request, ct);
+            return response.EntityCollection.Entities.FirstOrDefault()?.GetAttributeValue<string>("uniquename");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to resolve uniquename for app {AppModuleId}.", appModuleId);
+            return null;
+        }
+    }
+
+    private async Task<Guid> CreateSitemapForAppAsync(IPooledClient client, Guid appModuleId, string appUniqueName, string sitemapXml, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(appUniqueName))
+        {
+            throw new PpdsException(ModelDrivenAppErrorCodes.UpdateFailed,
+                "Cannot create a sitemap for an app with no uniquename.");
+        }
+
+        var sitemap = new Entity("sitemap")
+        {
+            // Match the maker convention: an app-aware sitemap shares the app's uniquename. Naming
+            // it this way means a subsequent run finds it via Tier 2 instead of creating a second
+            // sitemap, which Dataverse rejects with "App can't have multiple site maps" (0x80050111).
+            ["sitemapnameunique"] = appUniqueName,
+            ["sitemapxml"] = sitemapXml
+        };
+
+        Guid sitemapId;
+        try
+        {
+            sitemapId = await client.CreateAsync(sitemap, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new PpdsException(ModelDrivenAppErrorCodes.UpdateFailed, "Failed to create sitemap for app.", ex);
+        }
+
+        await AddAppComponentsAsync(client, appModuleId, "sitemap", [sitemapId], ct);
+        return sitemapId;
     }
 
     private async Task<string> FetchSitemapXmlForAppAsync(IPooledClient client, Guid appModuleId, CancellationToken ct, bool unpublished = false)
@@ -1315,7 +1514,9 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
 
         if (entityMeta != null && entityMeta.MetadataId != Guid.Empty)
         {
-            var entityRef = new EntityReference("entity", entityMeta.MetadataId);
+            // Reference the table by its OWN logical name (not the literal "entity", which is itself
+            // a real table) so the remove targets the table component that add-table registered.
+            var entityRef = new EntityReference(entityMeta.LogicalName, entityMeta.MetadataId);
             await RemoveAppComponentsAsync(client, appModuleId, [entityRef], ct);
         }
     }
@@ -1347,22 +1548,35 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         }
     }
 
-    private async Task AddAppComponentsAsync(
+    // Registers component records (forms, views, charts, sitemap) that all live in the same entity:
+    // the EntityReference logical name is that entity, the id is the record id.
+    private Task AddAppComponentsAsync(
         IPooledClient client,
         Guid appModuleId,
         string componentEntityName,
         List<Guid> componentIds,
         CancellationToken ct)
+        => AddAppComponentsAsync(
+            client,
+            appModuleId,
+            new EntityReferenceCollection(
+                componentIds.Select(id => new EntityReference(componentEntityName, id)).ToList()),
+            ct);
+
+    private async Task AddAppComponentsAsync(
+        IPooledClient client,
+        Guid appModuleId,
+        EntityReferenceCollection components,
+        CancellationToken ct)
     {
-        if (componentIds.Count == 0)
+        if (components.Count == 0)
         {
             return;
         }
 
-        var refs = componentIds.Select(id => new EntityReference(componentEntityName, id)).ToList();
         var request = new OrganizationRequest("AddAppComponents");
         request["AppId"] = appModuleId;
-        request["Components"] = new EntityReferenceCollection(refs);
+        request["Components"] = components;
 
         try
         {
@@ -1370,6 +1584,7 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            _logger.LogWarning(ex, "Failed to add {Count} app components", components.Count);
             throw new PpdsException(ModelDrivenAppErrorCodes.UpdateFailed,
                 $"Failed to add app components: {ex.Message}", ex);
         }

--- a/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
+++ b/src/PPDS.Cli/Services/ModelDrivenApps/ModelDrivenAppService.cs
@@ -1122,7 +1122,8 @@ public sealed class ModelDrivenAppService : IModelDrivenAppService
             {
                 using var doc = System.Text.Json.JsonDocument.Parse(json);
                 // Response: {"@odata.id":"https://org.crm.dynamics.com/api/data/v9.2/sitemaps(guid)"}
-                if (doc.RootElement.TryGetProperty("@odata.id", out var idProp))
+                if (doc.RootElement.TryGetProperty("@odata.id", out var idProp)
+                    && idProp.ValueKind == System.Text.Json.JsonValueKind.String)
                 {
                     var odataId = idProp.GetString();
                     if (!string.IsNullOrEmpty(odataId))

--- a/src/PPDS.Dataverse/Client/DataverseClient.cs
+++ b/src/PPDS.Dataverse/Client/DataverseClient.cs
@@ -265,7 +265,7 @@ namespace PPDS.Dataverse.Client
         /// <inheritdoc />
         public async Task<string?> GetRawWebApiAsync(string queryString, CancellationToken ct)
         {
-            var response = await _serviceClient.ExecuteWebRequestAsync(HttpMethod.Get, queryString, string.Empty, null, "application/json", ct);
+            using var response = await _serviceClient.ExecuteWebRequestAsync(HttpMethod.Get, queryString, string.Empty, null, "application/json", ct);
             if (!response.IsSuccessStatusCode)
                 return null;
             return await response.Content.ReadAsStringAsync(ct);

--- a/src/PPDS.Dataverse/Client/DataverseClient.cs
+++ b/src/PPDS.Dataverse/Client/DataverseClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerPlatform.Dataverse.Client;
@@ -260,6 +261,15 @@ namespace PPDS.Dataverse.Client
         }
 
         #endregion
+
+        /// <inheritdoc />
+        public async Task<string?> GetRawWebApiAsync(string queryString, CancellationToken ct)
+        {
+            var response = await _serviceClient.ExecuteWebRequestAsync(HttpMethod.Get, queryString, string.Empty, null, "application/json", ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+            return await response.Content.ReadAsStringAsync(ct);
+        }
 
         /// <summary>
         /// Disposes of the client and releases resources.

--- a/src/PPDS.Dataverse/Client/IDataverseClient.cs
+++ b/src/PPDS.Dataverse/Client/IDataverseClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace PPDS.Dataverse.Client
@@ -77,5 +79,12 @@ namespace PPDS.Dataverse.Client
         /// </summary>
         /// <returns>A cloned client instance.</returns>
         IDataverseClient Clone();
+
+        /// <summary>
+        /// GETs a raw WebAPI query string and returns the response body as JSON.
+        /// Used to traverse OData navigation properties not exposed as SDK attributes.
+        /// Returns null on 404 or if the response is empty.
+        /// </summary>
+        Task<string?> GetRawWebApiAsync(string queryString, CancellationToken ct);
     }
 }

--- a/src/PPDS.Dataverse/Pooling/PooledClient.cs
+++ b/src/PPDS.Dataverse/Pooling/PooledClient.cs
@@ -160,6 +160,10 @@ namespace PPDS.Dataverse.Pooling
         /// <inheritdoc />
         public IDataverseClient Clone() => _client.Clone();
 
+        /// <inheritdoc />
+        public Task<string?> GetRawWebApiAsync(string queryString, CancellationToken ct)
+            => _client.GetRawWebApiAsync(queryString, ct);
+
         /// <summary>
         /// Updates the last used timestamp.
         /// </summary>

--- a/tests/PPDS.Cli.Tests/Commands/ModelDrivenApps/SitemapCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/ModelDrivenApps/SitemapCommandTests.cs
@@ -36,4 +36,16 @@ public class SitemapCommandTests
     {
         Assert.Contains(_command.Options, o => o.Name == "--profile");
     }
+
+    [Fact]
+    public void Create_HasUnpublishedOption()
+    {
+        Assert.Contains(_command.Options, o => o.Name == "--unpublished");
+    }
+
+    [Fact]
+    public void Create_HasRawOption()
+    {
+        Assert.Contains(_command.Options, o => o.Name == "--raw");
+    }
 }

--- a/tests/PPDS.Cli.Tests/Services/ModelDrivenApps/ModelDrivenAppServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/ModelDrivenApps/ModelDrivenAppServiceTests.cs
@@ -71,6 +71,12 @@ public class ModelDrivenAppServiceTests
         /// <summary>The XML written by the last UpdateAsync on the sitemap record, if any.</summary>
         public string? WrittenSitemapXml { get; private set; }
 
+        /// <summary>The sitemapxml passed to CreateAsync when a new sitemap was created, if any.</summary>
+        public string? CreatedSitemapXml { get; private set; }
+
+        /// <summary>The sitemapnameunique passed to CreateAsync when a new sitemap was created, if any.</summary>
+        public string? CreatedSitemapName { get; private set; }
+
         /// <summary>All organization requests passed to ExecuteAsync (for Add/RemoveAppComponents assertions).</summary>
         public List<OrganizationRequest> ExecutedRequests { get; } = new();
 
@@ -149,7 +155,9 @@ public class ModelDrivenAppServiceTests
                     return new EntityCollection(new List<Entity>());
                 });
 
-            // FetchSitemapXmlByIdAsync(unpublished: true) → RetrieveUnpublishedMultiple.
+            // ResolveAppAsync → RetrieveUnpublishedMultiple on appmodule.
+            // FetchSitemapXmlByIdAsync → RetrieveUnpublishedMultiple on sitemap.
+            // Route by EntityName so each call gets the right response.
             Client.Setup(c => c.ExecuteAsync(
                     It.IsAny<OrganizationRequest>(),
                     It.IsAny<CancellationToken>()))
@@ -157,8 +165,28 @@ public class ModelDrivenAppServiceTests
                 {
                     ExecutedRequests.Add(req);
 
-                    if (req is RetrieveUnpublishedMultipleRequest)
+                    if (req is RetrieveUnpublishedMultipleRequest unpubReq)
                     {
+                        var qe = (QueryExpression)unpubReq.Query;
+                        if (qe.EntityName == "appmodule")
+                        {
+                            return new RetrieveUnpublishedMultipleResponse
+                            {
+                                Results =
+                                {
+                                    ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                    {
+                                        new("appmodule")
+                                        {
+                                            ["appmoduleid"] = AppModuleId,
+                                            ["uniquename"] = AppUniqueName,
+                                            ["name"] = AppName
+                                        }
+                                    })
+                                }
+                            };
+                        }
+
                         return new RetrieveUnpublishedMultipleResponse
                         {
                             Results =
@@ -186,6 +214,160 @@ public class ModelDrivenAppServiceTests
                     {
                         WrittenSitemapXml = (string)e["sitemapxml"];
                     }
+                })
+                .Returns(Task.CompletedTask);
+        }
+
+        /// <summary>
+        /// Like Setup but simulates a draft app: appmodulecomponent has no sitemap entry
+        /// (componenttype=62). AddTableAsync will build the full XML first then create the
+        /// sitemap record via CreateAsync (captured in CreatedSitemapXml).
+        /// </summary>
+        public void SetupDraftApp(IReadOnlyList<EntitySummary> entities)
+        {
+            Client.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
+            Client.Setup(c => c.Dispose());
+            Pool.Setup(p => p.GetClientAsync(null, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Client.Object);
+            Metadata.Setup(m => m.GetEntitiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entities);
+
+            // appmodulecomponent returns empty — TryGetSitemapIdAsync returns null.
+            Client.Setup(c => c.RetrieveMultipleAsync(
+                    It.Is<QueryExpression>(qe => qe.EntityName == "appmodulecomponent"),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EntityCollection(new List<Entity>()));
+
+            // RetrieveUnpublishedMultiple: appmodule (ResolveAppAsync + Tier 2 uniquename resolve)
+            // returns the app; sitemap (Tier 2 lookup-by-uniquename) returns nothing, so PPDS falls
+            // through to creating the sitemap via CreateAsync.
+            Client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
+                {
+                    ExecutedRequests.Add(req);
+
+                    if (req is RetrieveUnpublishedMultipleRequest unpubReq)
+                    {
+                        var qe = (QueryExpression)unpubReq.Query;
+                        if (qe.EntityName == "appmodule")
+                        {
+                            return new RetrieveUnpublishedMultipleResponse
+                            {
+                                Results =
+                                {
+                                    ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                    {
+                                        new("appmodule")
+                                        {
+                                            ["appmoduleid"] = AppModuleId,
+                                            ["uniquename"] = AppUniqueName,
+                                            ["name"] = AppName
+                                        }
+                                    })
+                                }
+                            };
+                        }
+
+                        // sitemap lookup-by-uniquename: no existing sitemap for this draft app.
+                        return new RetrieveUnpublishedMultipleResponse
+                        {
+                            Results = { ["EntityCollection"] = new EntityCollection(new List<Entity>()) }
+                        };
+                    }
+
+                    return new OrganizationResponse();
+                });
+
+            // CreateAsync captures the sitemapxml and unique name so tests can verify them.
+            Client.Setup(c => c.CreateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()))
+                .Callback<Entity, CancellationToken>((e, _) =>
+                {
+                    if (e.LogicalName == "sitemap" && e.Contains("sitemapxml"))
+                        CreatedSitemapXml = (string)e["sitemapxml"];
+                    if (e.LogicalName == "sitemap" && e.Contains("sitemapnameunique"))
+                        CreatedSitemapName = (string)e["sitemapnameunique"];
+                })
+                .ReturnsAsync(SitemapId);
+        }
+
+        /// <summary>
+        /// Simulates a maker-created draft app: appmodulecomponent has no sitemap entry (Tier 1
+        /// misses), but a sitemap exists whose sitemapnameunique equals the app's uniquename. Tier 2
+        /// must find it by shared unique name and patch it via UpdateAsync rather than creating a
+        /// duplicate.
+        /// </summary>
+        public void SetupMakerDraftApp(string sitemapXml, IReadOnlyList<EntitySummary> entities)
+        {
+            Client.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
+            Client.Setup(c => c.Dispose());
+            Pool.Setup(p => p.GetClientAsync(null, null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Client.Object);
+            Metadata.Setup(m => m.GetEntitiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(entities);
+
+            // Tier 1: appmodulecomponent returns empty — the draft sitemap is not a component yet.
+            Client.Setup(c => c.RetrieveMultipleAsync(
+                    It.Is<QueryExpression>(qe => qe.EntityName == "appmodulecomponent"),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EntityCollection(new List<Entity>()));
+
+            // RetrieveUnpublishedMultiple: appmodule → app (with uniquename); sitemap → the existing
+            // maker sitemap (serves both the Tier 2 lookup-by-uniquename and FetchSitemapXmlByIdAsync).
+            Client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
+                {
+                    ExecutedRequests.Add(req);
+
+                    if (req is RetrieveUnpublishedMultipleRequest unpubReq)
+                    {
+                        var qe = (QueryExpression)unpubReq.Query;
+                        if (qe.EntityName == "appmodule")
+                        {
+                            return new RetrieveUnpublishedMultipleResponse
+                            {
+                                Results =
+                                {
+                                    ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                    {
+                                        new("appmodule")
+                                        {
+                                            ["appmoduleid"] = AppModuleId,
+                                            ["uniquename"] = AppUniqueName,
+                                            ["name"] = AppName
+                                        }
+                                    })
+                                }
+                            };
+                        }
+
+                        if (qe.EntityName == "sitemap")
+                        {
+                            return new RetrieveUnpublishedMultipleResponse
+                            {
+                                Results =
+                                {
+                                    ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                    {
+                                        new("sitemap")
+                                        {
+                                            ["sitemapid"] = SitemapId,
+                                            ["sitemapxml"] = sitemapXml
+                                        }
+                                    })
+                                }
+                            };
+                        }
+                    }
+
+                    return new OrganizationResponse();
+                });
+
+            // PatchSitemapAsync → capture the written XML.
+            Client.Setup(c => c.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()))
+                .Callback<Entity, CancellationToken>((e, _) =>
+                {
+                    if (e.LogicalName == "sitemap" && e.Contains("sitemapxml"))
+                        WrittenSitemapXml = (string)e["sitemapxml"];
                 })
                 .Returns(Task.CompletedTask);
         }
@@ -337,6 +519,35 @@ public class ModelDrivenAppServiceTests
             .Should().Be("A & B <\"injected\"/>");
     }
 
+    // ── add-table: entity component (type 1) registered via AddAppComponents ─────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddTable_RegistersEntityComponentViaAddAppComponents()
+    {
+        var h = new Harness();
+        h.Setup(EmptySitemap, DefaultEntities);
+        var service = h.Build();
+
+        await service.AddTableAsync(
+            AppName,
+            new[] { "contact" },
+            new AddTableOptions(Group: null, Area: null, Title: null, Solution: null, Publish: false),
+            progress: null,
+            CancellationToken.None);
+
+        // An AddAppComponents request must target the table component by the table's OWN logical
+        // name (not the literal "entity", which is itself a real table) and its metadata ID, with
+        // AppId typed as Guid (not EntityReference — see #1183).
+        var addReq = h.ExecutedRequests.Single(r => r.RequestName == "AddAppComponents");
+
+        addReq["AppId"].Should().BeOfType<Guid>()
+            .Which.Should().Be(AppModuleId);
+
+        addReq["Components"].Should().BeOfType<EntityReferenceCollection>()
+            .Which.Should().ContainSingle(er => er.LogicalName == "contact" && er.Id == ContactMetadataId);
+    }
+
     // ── add-table: duplicate entity throws EntityAlreadyInApp ──────────────────
 
     [Fact]
@@ -419,7 +630,8 @@ public class ModelDrivenAppServiceTests
             progress: null,
             CancellationToken.None);
 
-        // A RemoveAppComponents request must target the "entity" component by metadata ID.
+        // A RemoveAppComponents request must target the table component by the table's OWN logical
+        // name (not the literal "entity") and its metadata ID.
         var removeReqs = h.ExecutedRequests
             .Where(r => r.RequestName == "RemoveAppComponents")
             .ToList();
@@ -429,7 +641,7 @@ public class ModelDrivenAppServiceTests
             .Select(r => r["Components"] as EntityReferenceCollection)
             .Where(c => c != null)
             .SelectMany(c => c!)
-            .Any(er => er.LogicalName == "entity" && er.Id == AccountMetadataId);
+            .Any(er => er.LogicalName == "account" && er.Id == AccountMetadataId);
 
         entityRefRemoved.Should().BeTrue();
     }
@@ -566,6 +778,169 @@ public class ModelDrivenAppServiceTests
             .Which.Should().ContainSingle(er => er.LogicalName == "savedquery" && er.Id == viewId);
     }
 
+    // ── ResolveAppAsync: draft app resolved via RetrieveUnpublishedMultiple ────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddTable_DraftApp_ResolvedViaUnpublishedMultiple()
+    {
+        // Draft apps are not returned by RetrieveMultiple. ResolveAppAsync must use
+        // RetrieveUnpublishedMultiple so both draft and published apps are found.
+        // The harness's Setup() routes ExecuteAsync/appmodule to the app entity, so
+        // this test verifies the full flow succeeds without any RetrieveMultiple on appmodule.
+        var h = new Harness();
+        h.Setup(EmptySitemap, DefaultEntities);
+        var service = h.Build();
+
+        // Should not throw AppNotFound even though no RetrieveMultiple mock for appmodule is set.
+        await service.AddTableAsync(
+            AppName,
+            new[] { "contact" },
+            new AddTableOptions(Group: null, Area: null, Title: null, Solution: null, Publish: false),
+            progress: null,
+            CancellationToken.None);
+
+        h.WrittenSitemapXml.Should().NotBeNull();
+    }
+
+    // ── add-table: draft app — sitemap created when appmodulecomponent is empty ────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddTable_DraftApp_FallsBackToSitemapDirectQuery()
+    {
+        // Draft/brand-new app: appmodulecomponent has no sitemap entry (componenttype=62).
+        // AddTableAsync must build the full XML first, then create the sitemap record via
+        // CreateAsync with that content (no dummy structure left behind).
+        var h = new Harness();
+        h.SetupDraftApp(DefaultEntities);
+        var service = h.Build();
+
+        await service.AddTableAsync(
+            AppName,
+            new[] { "contact" },
+            new AddTableOptions(Group: null, Area: null, Title: null, Solution: null, Publish: false),
+            progress: null,
+            CancellationToken.None);
+
+        // Sitemap must have been CREATED (not patched) with the entity already in it.
+        h.CreatedSitemapXml.Should().NotBeNull();
+        var doc = XDocument.Parse(h.CreatedSitemapXml!);
+        doc.Descendants("SubArea")
+            .Should().ContainSingle(s => (string?)s.Attribute("Entity") == "contact");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddTable_BrandNewDraftApp_CreatesSitemap()
+    {
+        // Brand-new draft app: AddTableAsync must create the sitemap via CreateAsync and
+        // register it via AddAppComponents so subsequent calls find it in appmodulecomponent.
+        var h = new Harness();
+        h.SetupDraftApp(DefaultEntities);
+        var service = h.Build();
+
+        await service.AddTableAsync(
+            AppName,
+            new[] { "contact" },
+            new AddTableOptions(Group: null, Area: null, Title: null, Solution: null, Publish: false),
+            progress: null,
+            CancellationToken.None);
+
+        // CreateAsync must have been called with a sitemap entity.
+        h.Client.Verify(c => c.CreateAsync(
+            It.Is<Entity>(e => e.LogicalName == "sitemap"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // AddAppComponents must have been called to register the new sitemap.
+        var sitemapAddReq = h.ExecutedRequests
+            .Where(r => r.RequestName == "AddAppComponents")
+            .FirstOrDefault(r =>
+            {
+                var comps = r["Components"] as EntityReferenceCollection;
+                return comps != null && comps.Any(er => er.LogicalName == "sitemap" && er.Id == SitemapId);
+            });
+        sitemapAddReq.Should().NotBeNull("an AddAppComponents call for the sitemap component was expected");
+
+        // The contact table must be in the created sitemap XML.
+        h.CreatedSitemapXml.Should().NotBeNull();
+        var doc = XDocument.Parse(h.CreatedSitemapXml!);
+        doc.Descendants("SubArea").Should().ContainSingle(s => (string?)s.Attribute("Entity") == "contact");
+
+        // The created sitemap must share the app's uniquename so a later run discovers it via Tier 2
+        // instead of minting a duplicate (which Dataverse rejects: "App can't have multiple site maps").
+        h.CreatedSitemapName.Should().Be(AppUniqueName);
+    }
+
+    // ── add-table: maker-created draft sitemap found via uniquename (Tier 2) ────
+
+    /// <summary>
+    /// Regression for the duplicate-sitemap bug: a maker-created draft app has a sitemap whose
+    /// sitemapnameunique equals the app's uniquename, but it is NOT yet in appmodulecomponent
+    /// (Tier 1 misses). Tier 2 must find it by shared unique name and PATCH it — never create a
+    /// second sitemap, which Dataverse rejects with 0x80050111 "App can't have multiple site maps".
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddTable_MakerDraftApp_FindsSitemapByUniqueNameAndPatches()
+    {
+        var h = new Harness();
+        h.SetupMakerDraftApp(SitemapWithAccount, DefaultEntities);
+        var service = h.Build();
+
+        await service.AddTableAsync(
+            AppName,
+            new[] { "contact" },
+            new AddTableOptions(Group: null, Area: null, Title: null, Solution: null, Publish: false),
+            progress: null,
+            CancellationToken.None);
+
+        // Existing sitemap must be UPDATED, not duplicated.
+        h.WrittenSitemapXml.Should().NotBeNull("sitemap found via uniquename must be patched via UpdateAsync");
+        h.Client.Verify(
+            c => c.CreateAsync(It.Is<Entity>(e => e.LogicalName == "sitemap"), It.IsAny<CancellationToken>()),
+            Times.Never(),
+            "no new sitemap must be created when an existing one is found by shared uniquename");
+
+        var doc = XDocument.Parse(h.WrittenSitemapXml!);
+        doc.Descendants("SubArea")
+            .Select(s => s.Attribute("Entity")?.Value)
+            .Should().Contain("contact", "the new entity must appear in the patched sitemap XML");
+    }
+
+    // ── sitemap read: raw XML + unpublished ────────────────────────────────────
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetSitemapXml_Unpublished_ReturnsRawXmlUnparsed()
+    {
+        // The raw read must return the sitemap XML verbatim (not a parsed structure), reading the
+        // unpublished/draft record via RetrieveUnpublishedMultiple.
+        var h = new Harness();
+        h.Setup(SitemapWithAccount, DefaultEntities);
+        var service = h.Build();
+
+        var xml = await service.GetSitemapXmlAsync(AppName, unpublished: true, CancellationToken.None);
+
+        xml.Should().Be(SitemapWithAccount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetSitemap_Unpublished_ParsesDraftStructure()
+    {
+        var h = new Harness();
+        h.Setup(SitemapWithAccount, DefaultEntities);
+        var service = h.Build();
+
+        var structure = await service.GetSitemapAsync(AppName, unpublished: true, CancellationToken.None);
+
+        structure.Areas
+            .SelectMany(a => a.Groups)
+            .SelectMany(g => g.SubAreas)
+            .Should().Contain(s => s.Entity == "account");
+    }
+
     // ── ResolveAppAsync: app not found throws AppNotFound (D4) ──────────────────
 
     [Fact]
@@ -574,11 +949,23 @@ public class ModelDrivenAppServiceTests
     {
         var h = new Harness();
         h.Setup(SitemapWithAccount, DefaultEntities);
-        // Override appmodule lookup to return nothing.
-        h.Client.Setup(c => c.RetrieveMultipleAsync(
-                It.Is<QueryExpression>(qe => qe.EntityName == "appmodule"),
+        // Override ExecuteAsync so the RetrieveUnpublishedMultiple on appmodule returns nothing.
+        h.Client.Setup(c => c.ExecuteAsync(
+                It.IsAny<OrganizationRequest>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EntityCollection(new List<Entity>()));
+            .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
+            {
+                h.ExecutedRequests.Add(req);
+                if (req is RetrieveUnpublishedMultipleRequest unpubReq
+                    && ((QueryExpression)unpubReq.Query).EntityName == "appmodule")
+                {
+                    return new RetrieveUnpublishedMultipleResponse
+                    {
+                        Results = { ["EntityCollection"] = new EntityCollection(new List<Entity>()) }
+                    };
+                }
+                return new OrganizationResponse();
+            });
         var service = h.Build();
 
         var act = async () => await service.RemoveTableAsync(
@@ -668,19 +1055,6 @@ public class ModelDrivenAppServiceTests
             .ReturnsAsync(h.Client.Object);
 
         h.Client.Setup(c => c.RetrieveMultipleAsync(
-                It.Is<QueryExpression>(qe => qe.EntityName == "appmodule"),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EntityCollection(new List<Entity>
-            {
-                new("appmodule")
-                {
-                    ["appmoduleid"] = AppModuleId,
-                    ["uniquename"] = AppUniqueName,
-                    ["name"] = AppName
-                }
-            }));
-
-        h.Client.Setup(c => c.RetrieveMultipleAsync(
                 It.Is<QueryExpression>(qe => qe.EntityName == "bot"),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EntityCollection(new List<Entity>
@@ -703,14 +1077,31 @@ public class ModelDrivenAppServiceTests
                 new("appmodulecomponent") { ["objectid"] = SitemapId }
             }));
 
+        // ResolveAppAsync resolves the appmodule via RetrieveUnpublishedMultiple (draft apps visible);
+        // the sitemap fetch also uses RetrieveUnpublishedMultiple. Branch on the queried entity.
         h.Client.Setup(c => c.ExecuteAsync(
                 It.IsAny<OrganizationRequest>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
             {
                 h.ExecutedRequests.Add(req);
-                if (req is RetrieveUnpublishedMultipleRequest)
+                if (req is RetrieveUnpublishedMultipleRequest unpubReq)
                 {
+                    var qe = (QueryExpression)unpubReq.Query;
+                    if (qe.EntityName == "appmodule")
+                    {
+                        return new RetrieveUnpublishedMultipleResponse
+                        {
+                            Results =
+                            {
+                                ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                {
+                                    new("appmodule") { ["appmoduleid"] = AppModuleId, ["uniquename"] = AppUniqueName, ["name"] = AppName }
+                                })
+                            }
+                        };
+                    }
+
                     return new RetrieveUnpublishedMultipleResponse
                     {
                         Results =
@@ -847,12 +1238,44 @@ public class ModelDrivenAppServiceTests
 
         // A long app unique name would push the maker-convention name past the 100-char limit.
         var longAppUnique = new string('a', 120);
-        h.Client.Setup(c => c.RetrieveMultipleAsync(
-                It.Is<QueryExpression>(qe => qe.EntityName == "appmodule"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EntityCollection(new List<Entity>
+        h.Client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
             {
-                new("appmodule") { ["appmoduleid"] = AppModuleId, ["uniquename"] = longAppUnique, ["name"] = AppName }
-            }));
+                if (req is RetrieveUnpublishedMultipleRequest unpubReq)
+                {
+                    var qe = (QueryExpression)unpubReq.Query;
+                    if (qe.EntityName == "appmodule")
+                    {
+                        return new RetrieveUnpublishedMultipleResponse
+                        {
+                            Results =
+                            {
+                                ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                {
+                                    new("appmodule")
+                                    {
+                                        ["appmoduleid"] = AppModuleId,
+                                        ["uniquename"] = longAppUnique,
+                                        ["name"] = AppName
+                                    }
+                                })
+                            }
+                        };
+                    }
+
+                    return new RetrieveUnpublishedMultipleResponse
+                    {
+                        Results =
+                        {
+                            ["EntityCollection"] = new EntityCollection(new List<Entity>
+                            {
+                                new("sitemap") { ["sitemapid"] = SitemapId, ["sitemapxml"] = SitemapWithAccount }
+                            })
+                        }
+                    };
+                }
+                return new OrganizationResponse();
+            });
         h.Client.Setup(c => c.RetrieveMultipleAsync(
                 It.Is<QueryExpression>(qe => qe.EntityName == "appelement"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EntityCollection(new List<Entity>()));
@@ -1122,13 +1545,43 @@ public class ModelDrivenAppServiceTests
         var h = new Harness();
         SetupCopilotCommon(h);
         // Override the app to a known-unsupported first-party app (matched by display name).
-        h.Client.Setup(c => c.RetrieveMultipleAsync(
-                It.Is<QueryExpression>(qe => qe.EntityName == "appmodule"),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EntityCollection(new List<Entity>
+        // Resolution uses RetrieveUnpublishedMultiple, so override that path (appmodule → Sales Hub;
+        // sitemap → default) ahead of SetupCopilotCommon's setup.
+        h.Client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
             {
-                new("appmodule") { ["appmoduleid"] = AppModuleId, ["uniquename"] = "msdyn_saleshub", ["name"] = "Sales Hub" }
-            }));
+                h.ExecutedRequests.Add(req);
+                if (req is RetrieveUnpublishedMultipleRequest unpubReq)
+                {
+                    var qe = (QueryExpression)unpubReq.Query;
+                    if (qe.EntityName == "appmodule")
+                    {
+                        return new RetrieveUnpublishedMultipleResponse
+                        {
+                            Results =
+                            {
+                                ["EntityCollection"] = new EntityCollection(new List<Entity>
+                                {
+                                    new("appmodule") { ["appmoduleid"] = AppModuleId, ["uniquename"] = "msdyn_saleshub", ["name"] = "Sales Hub" }
+                                })
+                            }
+                        };
+                    }
+
+                    return new RetrieveUnpublishedMultipleResponse
+                    {
+                        Results =
+                        {
+                            ["EntityCollection"] = new EntityCollection(new List<Entity>
+                            {
+                                new("sitemap") { ["sitemapid"] = SitemapId, ["sitemapxml"] = SitemapWithAccount }
+                            })
+                        }
+                    };
+                }
+
+                return new OrganizationResponse();
+            });
         h.Client.Setup(c => c.RetrieveMultipleAsync(
                 It.Is<QueryExpression>(qe => qe.EntityName == "appelement"),
                 It.IsAny<CancellationToken>()))
@@ -1223,18 +1676,30 @@ public class ModelDrivenAppServiceTests
         h.Pool.Setup(p => p.GetClientAsync(null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(h.Client.Object);
 
-        h.Client.Setup(c => c.RetrieveMultipleAsync(
-                It.Is<QueryExpression>(qe => qe.EntityName == "appmodule"),
+        // ResolveAppAsync resolves the appmodule via RetrieveUnpublishedMultiple (draft apps visible).
+        h.Client.Setup(c => c.ExecuteAsync(
+                It.IsAny<OrganizationRequest>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new EntityCollection(new List<Entity>
+            .ReturnsAsync((OrganizationRequest req, CancellationToken _) =>
             {
-                new("appmodule")
+                h.ExecutedRequests.Add(req);
+                if (req is RetrieveUnpublishedMultipleRequest unpubReq
+                    && ((QueryExpression)unpubReq.Query).EntityName == "appmodule")
                 {
-                    ["appmoduleid"] = AppModuleId,
-                    ["uniquename"] = AppUniqueName,
-                    ["name"] = AppName
+                    return new RetrieveUnpublishedMultipleResponse
+                    {
+                        Results =
+                        {
+                            ["EntityCollection"] = new EntityCollection(new List<Entity>
+                            {
+                                new("appmodule") { ["appmoduleid"] = AppModuleId, ["uniquename"] = AppUniqueName, ["name"] = AppName }
+                            })
+                        }
+                    };
                 }
-            }));
+
+                return new OrganizationResponse();
+            });
     }
 
     private static void SetupAppElements(Harness h, params Entity[] rows)
@@ -1387,10 +1852,12 @@ public class ModelDrivenAppServiceTests
         var service = h.Build();
         await service.InspectAppAssistantAsync(AppName, CancellationToken.None);
 
-        // The diagnostic is read-only: no create/update/delete/execute against Dataverse.
+        // The diagnostic is read-only: no create/update/delete, and the only Execute is the
+        // read-only RetrieveUnpublishedMultiple used to resolve the app — never a mutating message.
         h.Client.Verify(c => c.CreateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()), Times.Never);
         h.Client.Verify(c => c.UpdateAsync(It.IsAny<Entity>(), It.IsAny<CancellationToken>()), Times.Never);
         h.Client.Verify(c => c.DeleteAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
-        h.Client.Verify(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        h.Client.Verify(c => c.ExecuteAsync(
+            It.Is<OrganizationRequest>(r => r.GetType() != typeof(RetrieveUnpublishedMultipleRequest)), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/PPDS.Dataverse.IntegrationTests/Mocks/FakePooledClient.cs
+++ b/tests/PPDS.Dataverse.IntegrationTests/Mocks/FakePooledClient.cs
@@ -64,6 +64,10 @@ public class FakePooledClient : IPooledClient
 
     public IDataverseClient Clone() => new FakePooledClient(_service, _connectionName, _serviceLock);
 
+    // FakeXrmEasy has no Web API surface; raw OData traversal isn't supported in these tests.
+    public Task<string?> GetRawWebApiAsync(string queryString, CancellationToken ct) =>
+        throw new NotSupportedException("FakePooledClient does not support raw Web API requests.");
+
     // IOrganizationService implementation - delegate to FakeXrmEasy
     // All operations are serialized via _serviceLock because FakeXrmEasy's
     // in-memory store is not thread-safe for concurrent mutations.


### PR DESCRIPTION
## Summary
Makes `model-driven-app add-table` / `remove-table` work on **draft (never-published) maker apps**, fixes a wrong table-component registration, and adds read affordances to `model-driven-app sitemap`.

## Problem & root cause
- **Draft maker apps:** the app-aware sitemap isn't in `appmodulecomponent` yet, and there is no `sitemap → appmodule` FK. The CLI couldn't find the maker's sitemap, so it minted a second one — which Dataverse rejects with `0x80050111 "App can't have multiple site maps"`. The maker's app-aware sitemap actually shares the app's `uniquename`.
- **Wrong component:** `add-table` registered the entity app-component using the literal logical name `"entity"` — but `"entity"` is itself a real table, so a spurious **"Entity"** component was added instead of the target table.

## Fix
- Resolve the sitemap by `sitemapnameunique == appmodule.uniquename` (and name newly-created sitemaps the same way), so the maker's sitemap is patched instead of duplicated.
- App resolution and sitemap reads use `RetrieveUnpublishedMultiple` so draft apps are visible at all.
- Register the entity component by the table's **own** logical name.
- `sitemap` command: `--raw` emits the sitemap XML verbatim (JSON mode → `{ "xml": ... }`); `--unpublished` reads the draft.
- Adds `GetRawWebApiAsync` to `IDataverseClient` for the OData navigation fallback used during resolution.

## Testing
- Builds + **55** model-driven-app / sitemap unit tests pass standalone on this branch.
- Verified live against draft apps: `add-table` patches the maker sitemap (no duplicate), the entity component registers the correct table, and `sitemap --raw/--unpublished` return the draft XML.
