### PR TITLE
feat(metadata): table icon assignment + DateOnly format coercion

### DIFF
--- a/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/EntityCommand.cs
@@ -472,6 +472,21 @@ public static class EntityCommand
             Description = "Updated description"
         };
 
+        var iconSmallOption = new Option<string?>("--icon-small")
+        {
+            Description = "16×16 icon: web resource logical name (e.g. new_icons/myentity16.png). Use empty string to clear."
+        };
+
+        var iconMediumOption = new Option<string?>("--icon-medium")
+        {
+            Description = "32×32 icon: web resource logical name. Use empty string to clear."
+        };
+
+        var iconVectorOption = new Option<string?>("--icon-vector")
+        {
+            Description = "SVG vector icon: web resource logical name (primary icon in modern Dataverse). Use empty string to clear."
+        };
+
         var dryRunOption = new Option<bool>("--dry-run")
         {
             Description = "Validate only, do not persist changes",
@@ -492,6 +507,9 @@ public static class EntityCommand
             displayNameOption,
             pluralNameOption,
             descriptionOption,
+            iconSmallOption,
+            iconMediumOption,
+            iconVectorOption,
             dryRunOption,
             publishOption,
             MetadataCommandGroup.ProfileOption,
@@ -508,6 +526,9 @@ public static class EntityCommand
             var displayName = parseResult.GetValue(displayNameOption);
             var pluralName = parseResult.GetValue(pluralNameOption);
             var description = parseResult.GetValue(descriptionOption);
+            var iconSmall = parseResult.GetValue(iconSmallOption);
+            var iconMedium = parseResult.GetValue(iconMediumOption);
+            var iconVector = parseResult.GetValue(iconVectorOption);
             var dryRun = parseResult.GetValue(dryRunOption);
             var publish = parseResult.GetValue(publishOption);
             var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
@@ -515,7 +536,8 @@ public static class EntityCommand
             var globalOptions = GlobalOptions.GetValues(parseResult);
 
             return await ExecuteUpdateAsync(
-                solution, entity, displayName, pluralName, description, dryRun, publish,
+                solution, entity, displayName, pluralName, description,
+                iconSmall, iconMedium, iconVector, dryRun, publish,
                 profile, environment, globalOptions, cancellationToken);
         });
 
@@ -528,6 +550,9 @@ public static class EntityCommand
         string? displayName,
         string? pluralName,
         string? description,
+        string? iconSmall,
+        string? iconMedium,
+        string? iconVector,
         bool dryRun,
         bool publish,
         string? profile,
@@ -562,6 +587,9 @@ public static class EntityCommand
                 DisplayName = displayName,
                 PluralDisplayName = pluralName,
                 Description = description,
+                IconSmallName = iconSmall,
+                IconMediumName = iconMedium,
+                IconVectorName = iconVector,
                 DryRun = dryRun,
                 Publish = publish
             };

--- a/src/PPDS.Cli/Commands/Metadata/Table/TableCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Metadata/Table/TableCommandGroup.cs
@@ -141,6 +141,21 @@ public static class TableCommandGroup
             Description = "Updated description"
         };
 
+        var iconSmallOption = new Option<string?>("--icon-small")
+        {
+            Description = "16×16 icon: web resource logical name. Use empty string to clear."
+        };
+
+        var iconMediumOption = new Option<string?>("--icon-medium")
+        {
+            Description = "32×32 icon: web resource logical name. Use empty string to clear."
+        };
+
+        var iconVectorOption = new Option<string?>("--icon-vector")
+        {
+            Description = "SVG vector icon: web resource logical name. Use empty string to clear."
+        };
+
         var dryRunOption = new Option<bool>("--dry-run")
         {
             Description = "Validate only, do not persist changes",
@@ -160,6 +175,9 @@ public static class TableCommandGroup
             displayNameOption,
             pluralNameOption,
             descriptionOption,
+            iconSmallOption,
+            iconMediumOption,
+            iconVectorOption,
             dryRunOption,
             publishOption,
             MetadataCommandGroup.ProfileOption,
@@ -175,6 +193,9 @@ public static class TableCommandGroup
             var displayName = parseResult.GetValue(displayNameOption);
             var pluralName = parseResult.GetValue(pluralNameOption);
             var description = parseResult.GetValue(descriptionOption);
+            var iconSmall = parseResult.GetValue(iconSmallOption);
+            var iconMedium = parseResult.GetValue(iconMediumOption);
+            var iconVector = parseResult.GetValue(iconVectorOption);
             var dryRun = parseResult.GetValue(dryRunOption);
             var publish = parseResult.GetValue(publishOption);
             var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
@@ -183,7 +204,8 @@ public static class TableCommandGroup
 
             DeprecationWarning.Write("ppds metadata table update", "ppds metadata entity update");
             return await Metadata.EntityCommand.ExecuteUpdateAsync(
-                solution, entity, displayName, pluralName, description, dryRun, publish,
+                solution, entity, displayName, pluralName, description,
+                iconSmall, iconMedium, iconVector, dryRun, publish,
                 profile, environment, globalOptions, cancellationToken);
         });
 

--- a/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
+++ b/src/PPDS.Cli/Services/Metadata/Authoring/DataverseMetadataAuthoringService.cs
@@ -208,6 +208,15 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
         if (!string.IsNullOrEmpty(request.EntityColor))
             entityMetadata.EntityColor = request.EntityColor;
 
+        // Icon fields must be set via UpdateEntityRequest (SDK) — Web API EntityDefinitions PATCH
+        // rejects these properties. Pass null to leave an icon unchanged; pass "" to clear it.
+        if (request.IconSmallName != null)
+            entityMetadata.IconSmallName = request.IconSmallName;
+        if (request.IconMediumName != null)
+            entityMetadata.IconMediumName = request.IconMediumName;
+        if (request.IconVectorName != null)
+            entityMetadata.IconVectorName = request.IconVectorName;
+
         var sdkRequest = new UpdateEntityRequest
         {
             Entity = entityMetadata,
@@ -1914,11 +1923,7 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
                 ImeMode = ParseImeMode(request.ImeMode)
             },
             SchemaColumnType.Boolean => BuildBooleanAttribute(request),
-            SchemaColumnType.DateTime => new DateTimeAttributeMetadata
-            {
-                DateTimeBehavior = ParseDateTimeBehavior(request.DateTimeBehavior),
-                Format = ParseDateTimeFormat(request.Format)
-            },
+            SchemaColumnType.DateTime => BuildDateTimeAttribute(request),
             SchemaColumnType.Choice => BuildChoiceAttribute(request),
             SchemaColumnType.Choices => BuildMultiSelectChoiceAttribute(request),
             SchemaColumnType.Image => new ImageAttributeMetadata
@@ -2396,6 +2401,16 @@ public class DataverseMetadataAuthoringService : IMetadataAuthoringService
             "disabled" => ImeMode.Disabled,
             _ => null
         };
+    }
+
+    private static DateTimeAttributeMetadata BuildDateTimeAttribute(CreateColumnRequest request)
+    {
+        var behavior = ParseDateTimeBehavior(request.DateTimeBehavior);
+        // DateOnly behavior requires DateOnly format; Dataverse rejects any other combination.
+        var format = behavior == Microsoft.Xrm.Sdk.Metadata.DateTimeBehavior.DateOnly
+            ? DateTimeFormat.DateOnly
+            : ParseDateTimeFormat(request.Format);
+        return new DateTimeAttributeMetadata { DateTimeBehavior = behavior, Format = format };
     }
 
     private static DateTimeBehavior? ParseDateTimeBehavior(string? behavior)

--- a/src/PPDS.Dataverse/Metadata/Authoring/UpdateTableRequest.cs
+++ b/src/PPDS.Dataverse/Metadata/Authoring/UpdateTableRequest.cs
@@ -44,6 +44,15 @@ public sealed class UpdateTableRequest
     /// <summary>Gets or sets the entity color (hex string).</summary>
     public string? EntityColor { get; set; }
 
+    /// <summary>Gets or sets the 16×16 icon web resource logical name.</summary>
+    public string? IconSmallName { get; set; }
+
+    /// <summary>Gets or sets the 32×32 icon web resource logical name.</summary>
+    public string? IconMediumName { get; set; }
+
+    /// <summary>Gets or sets the SVG vector icon web resource logical name (used as primary icon in modern Dataverse).</summary>
+    public string? IconVectorName { get; set; }
+
     /// <summary>Gets or sets whether this is a dry-run (validation only, no changes persisted).</summary>
     public bool DryRun { get; set; }
 

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/CreateColumnTypeTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/CreateColumnTypeTests.cs
@@ -231,6 +231,22 @@ public class CreateColumnTypeTests
     }
 
     [Fact]
+    public async Task DateTime_DateOnlyBehavior_ForcesDateOnlyFormat_WhenFormatOmitted()
+    {
+        // Dataverse rejects DateOnly behavior + DateAndTime format. PPDS should coerce the
+        // format to DateOnly automatically so the user doesn't have to specify it explicitly.
+        var request = MakeRequest(SchemaColumnType.DateTime);
+        request.DateTimeBehavior = "DateOnly";
+        // Format deliberately omitted — was previously defaulting to DateAndTime.
+
+        var sdkRequest = await CaptureCreateAttributeRequest(request);
+
+        var attr = sdkRequest.Attribute.Should().BeOfType<DateTimeAttributeMetadata>().Subject;
+        attr.DateTimeBehavior.Should().Be(Microsoft.Xrm.Sdk.Metadata.DateTimeBehavior.DateOnly);
+        attr.Format.Should().Be(DateTimeFormat.DateOnly);
+    }
+
+    [Fact]
     public async Task Choice_WithLocalOptions_CreatesPicklistAttributeMetadata()
     {
         var request = MakeRequest(SchemaColumnType.Choice);

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -231,6 +231,38 @@ public class MetadataAuthoringServiceTests
     }
 
     [Fact]
+    public async Task UpdateTableAsync_SetsIconFields_ViaUpdateEntityRequest()
+    {
+        // Dataverse rejects icon assignment through Web API EntityDefinitions PATCH.
+        // The correct path is UpdateEntityRequest (SDK) which accepts IconSmallName,
+        // IconMediumName, and IconVectorName on EntityMetadata.
+        UpdateEntityRequest? capturedRequest = null;
+
+        _client.Setup(c => c.ExecuteAsync(It.IsAny<OrganizationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<OrganizationRequest, CancellationToken>((req, _) =>
+            {
+                if (req is UpdateEntityRequest update) capturedRequest = update;
+            })
+            .ReturnsAsync(new OrganizationResponse());
+
+        var request = new UpdateTableRequest
+        {
+            SolutionUniqueName = "TestSolution",
+            EntityLogicalName = "new_pet",
+            IconSmallName = "new_icons/pet16.png",
+            IconMediumName = "new_icons/pet32.png",
+            IconVectorName = "new_icons/pet.svg"
+        };
+
+        await _service.UpdateTableAsync(request);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.Entity.IconSmallName.Should().Be("new_icons/pet16.png");
+        capturedRequest.Entity.IconMediumName.Should().Be("new_icons/pet32.png");
+        capturedRequest.Entity.IconVectorName.Should().Be("new_icons/pet.svg");
+    }
+
+    [Fact]
     public async Task UpdateTableAsync_WithPublish_PublishesEntity() // #1171
     {
         Microsoft.Crm.Sdk.Messages.PublishXmlRequest? publishRequest = null;


### PR DESCRIPTION
## Summary
Adds table **icon assignment** and **DateOnly format coercion** to `metadata entity update` / table authoring.

## Problem & fix
- **Icon assignment:** Dataverse rejects icon updates through the Web API `EntityDefinitions` PATCH but accepts them via the SDK `UpdateEntityRequest` on `EntityMetadata`. Adds `IconSmallName`/`IconMediumName`/`IconVectorName` to `UpdateTableRequest`, maps them in `UpdateTableAsync`, and exposes `--icon-small`/`--icon-medium`/`--icon-vector` on `metadata entity update`.
- **DateOnly coercion:** Dataverse rejects a DateTime attribute where `DateTimeBehavior=DateOnly` but `Format=DateAndTime` (the default when `Format` is omitted). `BuildDateTimeAttribute` now sets `Format=DateOnly` automatically when the behavior is `DateOnly`.

## Testing
- Builds + **55** metadata-authoring unit tests pass standalone; coexists cleanly with the recent #1169-1172 / #1208 metadata work this branch was rebased onto.
- Icon assignment verified live (SVG vector icon assigned to a table via `UpdateEntityRequest` and rendered in the app).
