### PR TITLE
fix(dependabot): parse conventional-commit titles and real grouped-PR bodies

### DIFF
--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -123,11 +123,18 @@ _BUMP_TITLE_RE = re.compile(
 # Regex for grouped bumps: "Bump the <group> group ..."
 _GROUP_TITLE_RE = re.compile(r"^[Bb]ump\s+the\s+(?P<group>[A-Za-z0-9_.-]+)\s+group", re.IGNORECASE)
 
+# Optional conventional-commit prefix dependabot prepends per .github/dependabot.yml
+# commit-message config, e.g. "deps: ", "deps(extension): ", "chore(deps-dev): ".
+# Stripped before matching the Bump/group patterns above, which anchor on "^Bump".
+_CC_PREFIX_RE = re.compile(r"^[A-Za-z]+(?:\([^)]*\))?:\s+")
+
 # Regex for individual member updates inside a grouped dependabot PR body.
-# Dependabot writes each member as "Updates `<pkg>` from <from> to <to>" (markdown
-# code-fenced package name) or "Updates <pkg> from <from> to <to>" (plain).
+# Dependabot enumerates each member with either tense ("Updates"/"Updated") and the
+# package name as a markdown link "[<pkg>](url)", code-fenced "`<pkg>`", or plain.
 _GROUP_MEMBER_RE = re.compile(
-    r"Updates\s+`?(?P<pkg>[@A-Za-z0-9._/-]+)`?\s+from\s+(?P<from>v?[0-9][^\s]*)\s+to\s+(?P<to>v?[0-9][^\s]*)",
+    r"Update[sd]\s+"
+    r"(?:\[(?P<pkg_link>[@A-Za-z0-9._/-]+)\]\([^)]*\)|`?(?P<pkg>[@A-Za-z0-9._/-]+)`?)"
+    r"\s+from\s+(?P<from>v?[0-9][^\s]*)\s+to\s+(?P<to>v?[0-9][^\s]*)",
 )
 
 
@@ -143,7 +150,8 @@ def parse_group_members(body: str) -> list[tuple[str, str, str]]:
     seen: set[tuple[str, str, str]] = set()
     out: list[tuple[str, str, str]] = []
     for m in _GROUP_MEMBER_RE.finditer(body):
-        key = (m.group("pkg"), m.group("from"), m.group("to"))
+        pkg = m.group("pkg_link") or m.group("pkg")
+        key = (pkg, m.group("from"), m.group("to"))
         if key in seen:
             continue
         seen.add(key)
@@ -215,10 +223,11 @@ def parse_title(title: str) -> tuple[Optional[str], Optional[str], Optional[str]
     For grouped bumps ("Bump the X group ..."), package is "group:<name>" and
     versions are None (the caller must inspect the body / files for individual bumps).
     """
-    m = _BUMP_TITLE_RE.match(title.strip())
+    stripped = _CC_PREFIX_RE.sub("", title.strip())
+    m = _BUMP_TITLE_RE.match(stripped)
     if m:
         return m.group("pkg"), m.group("from"), m.group("to")
-    g = _GROUP_TITLE_RE.match(title.strip())
+    g = _GROUP_TITLE_RE.match(stripped)
     if g:
         return f"group:{g.group('group')}", None, None
     return None, None, None

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -64,6 +64,29 @@ class TestParseTitle(unittest.TestCase):
         self.assertIsNone(fv)
         self.assertIsNone(tv)
 
+    def test_conventional_commit_prefix_scoped(self):
+        # dependabot prepends "deps(extension): " per .github/dependabot.yml
+        pkg, fv, tv = classify.parse_title(
+            "deps(extension): Bump eslint from 10.4.0 to 10.5.0 in /src/PPDS.Extension"
+        )
+        self.assertEqual(pkg, "eslint")
+        self.assertEqual(fv, "10.4.0")
+        self.assertEqual(tv, "10.5.0")
+
+    def test_conventional_commit_prefix_bare(self):
+        pkg, fv, tv = classify.parse_title("deps: Bump the microsoft-extensions group with 12 updates")
+        self.assertEqual(pkg, "group:microsoft-extensions")
+        self.assertIsNone(fv)
+        self.assertIsNone(tv)
+
+    def test_conventional_commit_prefix_dev(self):
+        pkg, fv, tv = classify.parse_title(
+            "chore(deps-dev): Bump vite from 8.0.8 to 8.0.16 in /tests/PPDS.DocsGen.Extension.Tests"
+        )
+        self.assertEqual(pkg, "vite")
+        self.assertEqual(fv, "8.0.8")
+        self.assertEqual(tv, "8.0.16")
+
     def test_unparseable(self):
         pkg, fv, tv = classify.parse_title("docs: tweak readme")
         self.assertIsNone(pkg)
@@ -301,6 +324,28 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "A")
         self.assertEqual(c.update_type, "patch")
         self.assertIn("most-conservative=patch", c.reason)
+
+    def test_grouped_real_body_markdown_link_past_tense(self):
+        # Real dependabot grouped-PR body: past-tense "Updated", markdown-link
+        # package names, trailing period (regression for #1255/#1256 format).
+        pr = make_pr(
+            number=1255,
+            title="deps: Bump the microsoft-extensions group with 2 updates",
+            body=(
+                "Bumps the microsoft-extensions group with 2 updates:\n\n"
+                "Updated [Microsoft.Extensions.Configuration](https://github.com/dotnet/dotnet) from 10.0.8 to 10.0.9.\n"
+                "Updated [Microsoft.Extensions.Logging](https://github.com/dotnet/dotnet) from 10.0.8 to 10.0.9.\n"
+            ),
+            labels=["dependencies"],
+            head_ref="dependabot/nuget/microsoft-extensions-151a844973",
+            files=["Directory.Packages.props"],
+        )
+        members = classify.parse_group_members(pr["body"])
+        self.assertEqual(len(members), 2)
+        self.assertEqual(members[0][0], "Microsoft.Extensions.Configuration")
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "patch")
 
     def test_grouped_with_minor_is_group_b(self):
         # Mix of patch + minor (no major) -> Group B (verify-then-merge).


### PR DESCRIPTION
## Problem

During a `/dependabot-triage` run, the classifier (`scripts/dependabot/classify.py`) mis-routed **all 9 open dependabot PRs to Group C (manual review)**. Two regexes had drifted out of sync with dependabot's current output format:

1. **Title parsing** — `_BUMP_TITLE_RE` / `_GROUP_TITLE_RE` anchor on `^Bump`, but titles now carry a conventional-commit prefix (`deps:`, `deps(extension):`, `chore(deps-dev):`) from the `.github/dependabot.yml` commit-message config. Every parseable title fell through to the Group C "could not classify" default.
2. **Grouped-PR member parsing** — `_GROUP_MEMBER_RE` expected `` Updates `pkg` from X to Y `` (present tense, code-fenced), but dependabot's actual body is `Updated [pkg](url) from X to Y.` (past tense, markdown link). Grouped NuGet PRs couldn't enumerate members and defaulted to Group C.

## Fix

- `parse_title()` strips an optional leading `<type>(scope)?: ` conventional-commit prefix before matching.
- `_GROUP_MEMBER_RE` accepts both `Updated`/`Updates` and the markdown-link package form; `parse_group_members` reads whichever package capture matched.

## Verification

- 4 new regression tests using the **real** #1255 / #1253 PR formats.
- Full suite: **57/57 passing** (`python -m pytest tests/scripts/dependabot/test_classify.py`).
- Re-ran the classifier against the 9 live PRs: output now matches the hand-classification exactly (8 Group A, 1 Group C for the @vscode/test-electron major).

`docs/MERGE-POLICY.md` is unchanged — this only repairs the parser that operationalizes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)