### PR TITLE
chore: pre-1.2 cleanup — 29 security/quality alerts + changelog gaps + /release skill fix

### DIFF
--- a/.claude/skills/release/REFERENCE.md
+++ b/.claude/skills/release/REFERENCE.md
@@ -19,10 +19,11 @@ Which keys sign which surfaces:
 | Surface | Signing input | Workflow source |
 |---------|---------------|-----------------|
 | .NET assemblies (.dll) | strong-name SNK in `pks/PPDS.snk` (committed; protected by `snk-protect.py`) | Built into csproj |
-| NuGet packages | NuGet API key from secret `NUGET_API_KEY` | `.github/workflows/publish.yml` |
-| VS Code extension | `vsce` token from secret `VSCE_TOKEN` | `.github/workflows/publish.yml` |
-| GitHub releases | GITHUB_TOKEN (auto) | `.github/workflows/publish.yml` |
-| Code-signing (Windows .exe) | Cert + password from secrets `WINSIGN_CERT`, `WINSIGN_PWD` | `.github/workflows/publish.yml` |
+| Plugins assembly strong-name | `PLUGINS_SNK_BASE64` secret (decoded at pack time, `Plugins-v*` tags only) | `.github/workflows/publish-nuget.yml` |
+| NuGet packages | `NUGET_API_KEY` secret | `.github/workflows/publish-nuget.yml` |
+| VS Code extension | `ADO_MARKETPLACE_PAT` secret (vsce PAT) | `.github/workflows/extension-publish.yml` |
+| GitHub releases / CLI binaries | `GITHUB_TOKEN` (auto) | `.github/workflows/release-cli.yml` |
+| Windows code-signing (CLI `.exe`) | **NOT IMPLEMENTED** — `release-cli.yml` ships **unsigned** `.exe`; no `WINSIGN_*` secrets or `signtool` step exist (tracked follow-up) | n/a |
 
 If a signing job fails, do NOT retag. Investigate the secret, fix it via repo settings, then re-run the workflow:
 
@@ -69,11 +70,9 @@ Example:
 
 ## §5 - Platform-specific notes
 
-### Windows code-signing
+### Windows code-signing (not yet implemented)
 
-The cert lives in repo secret `WINSIGN_CERT` (base64-encoded PFX). The password is `WINSIGN_PWD`. If signing fails with "cert not found", verify the secret is base64 and decodable. The publish workflow does the decode.
-
-If the cert expires, request a new one from the cert authority and update both secrets. Test with a manual workflow_dispatch before tagging.
+CLI `.exe` binaries (`release-cli.yml`, `win-x64`/`win-arm64`) currently ship **unsigned** — there is no `signtool` step and no `WINSIGN_CERT`/`WINSIGN_PWD` secrets. Users may see SmartScreen warnings. Wiring Authenticode signing (cert + secrets + signtool step) is a tracked follow-up; until then, do not assume a signing job exists.
 
 ### NuGet v3-flatcontainer URL casing
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -42,40 +42,37 @@ For each commit, decide which section it belongs in. Drop empty sections from th
 
 ### 3. Version Bump
 
-Files to update:
+PPDS versions are **MinVer-derived from per-surface git tags** — there is NO `<Version>` property to edit. To set a .NET package's version you push its tag (Step 5); MinVer reads the nearest `<Prefix>-vX.Y.Z` tag and stamps the build. Each packable project declares its own `<MinVerTagPrefix>` (`Cli-v`, `Dataverse-v`, `Auth-v`, `Migration-v`, `Mcp-v`, `Query-v`, `Plugins-v`).
 
-- `Directory.Build.props` (Version property for all .NET projects)
-- `src/PPDS.Extension/package.json` (version field)
-- Any other manifest files containing the version
+The only manifest "bump" is documentation:
+
+- Per-surface `<surface>/CHANGELOG.md`: rename `## [Unreleased]` → `## [X.Y.Z] - <date>` and retarget the compare-link footer to the new tag range.
+- `src/PPDS.Extension/package.json` `version`: the Extension is npm/`vsce`-published (NOT MinVer); keep its `version` in sync with the `Extension-vX.Y.Z` tag you will push.
+
+Do NOT edit `Directory.Build.props` — it has no `<Version>` element; injecting one would override MinVer for every surface at once.
+
+### 4. Commit the changelog rename
 
 ```bash
-# .NET projects
-sed -i 's|<Version>.*</Version>|<Version>X.Y.Z</Version>|' Directory.Build.props
-
-# Extension
-cd src/PPDS.Extension && npm version X.Y.Z --no-git-tag-version && cd -
+git add <surface>/CHANGELOG.md   # + src/PPDS.Extension/package.json when releasing the Extension
+git commit -m "release: <surface> X.Y.Z"
 ```
 
-### 4. Commit Version Bump
+Commit from a clean `main`. The published version comes from the tag, not this commit.
+
+### 5. Tag (per surface, in dependency order)
+
+Read REFERENCE.md §2 "Signing matrix" for which surfaces sign.
+
+Each surface is tagged independently with its prefix. Packable libraries reference each other via `<ProjectReference>` (no `PrivateAssets`), so their nupkgs declare versioned inter-package dependencies — tag + publish **leaf libraries before their dependents**, else `dotnet tool install` can't restore: `Dataverse`/`Auth`/`Query` → `Migration` → `Cli` → `Mcp`. The `Extension` is independent.
 
 ```bash
-git add CHANGELOG.md Directory.Build.props src/PPDS.Extension/package.json
-git commit -m "release: X.Y.Z"
-```
-
-The commit message must start with `release:` - the publish workflow keys off this.
-
-### 5. Tag
-
-Read REFERENCE.md §2 "Signing matrix" if any signing inputs need preparation.
-
-```bash
-git tag v<X.Y.Z> -m "release: X.Y.Z"
+git tag <Prefix>-vX.Y.Z -m "release: <Prefix> X.Y.Z"   # annotated, on the exact main commit
 git push origin main
-git push origin v<X.Y.Z>
+git push origin <Prefix>-vX.Y.Z
 ```
 
-The tag push triggers `.github/workflows/publish.yml`. CI signs, packs, and uploads to NuGet, the VS Code marketplace, and the GitHub releases page.
+Tag pushes trigger publishing: NuGet surfaces via `.github/workflows/publish-nuget.yml` (keyed on each `<Prefix>-v*` tag), the Extension via `.github/workflows/extension-publish.yml` (`Extension-v*`; **even minor = stable channel, odd = pre-release**), and CLI binaries via `.github/workflows/release-cli.yml`.
 
 ### 6. Monitor CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This repository contains multiple packages with independent release cycles.
 - [PPDS.Cli](src/PPDS.Cli/CHANGELOG.md) - Unified CLI tool (`ppds` command)
 - [PPDS.Query](src/PPDS.Query/CHANGELOG.md) - SQL query engine for Dataverse
 - [PPDS.Mcp](src/PPDS.Mcp/CHANGELOG.md) - MCP server for AI assistant integration
+- [PPDS.Extension](src/PPDS.Extension/CHANGELOG.md) - VS Code extension (published to the Marketplace via vsce)
 
 ## GitHub Releases
 
@@ -24,13 +25,14 @@ Each package has its own tag prefix:
 
 | Package | Tag Format | Example |
 |---------|------------|---------|
-| PPDS.Plugins | `Plugins-v{version}` | `Plugins-v1.2.0` |
+| PPDS.Plugins | `Plugins-v{version}` | `Plugins-v3.0.0` |
 | PPDS.Dataverse | `Dataverse-v{version}` | `Dataverse-v1.0.0` |
 | PPDS.Migration | `Migration-v{version}` | `Migration-v1.0.0` |
 | PPDS.Auth | `Auth-v{version}` | `Auth-v1.0.0` |
 | PPDS.Cli | `Cli-v{version}` | `Cli-v1.0.0` |
 | PPDS.Query | `Query-v{version}` | `Query-v1.0.0` |
 | PPDS.Mcp | `Mcp-v{version}` | `Mcp-v1.0.0` |
+| PPDS.Extension | `Extension-v{version}` | `Extension-v1.2.0` |
 
 Pre-release versions follow SemVer:
 - Alpha: `Dataverse-v1.0.0-alpha.1`

--- a/src/PPDS.Analyzers/PPDS.Analyzers.csproj
+++ b/src/PPDS.Analyzers/PPDS.Analyzers.csproj
@@ -10,6 +10,8 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <DevelopmentDependency>true</DevelopmentDependency>
+    <!-- Consumed only as an analyzer ProjectReference; never published as a standalone NuGet package. -->
+    <IsPackable>false</IsPackable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- Disable release tracking warning until we have shipped releases -->
     <NoWarn>$(NoWarn);RS2008</NoWarn>

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -111,5 +111,6 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **`ppds flows get|url` accept GUID or unique name** — The `name` argument resolves by workflow ID (GUID) when provided, falling back to unique-name lookup ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Extension panel UX** — Unified panel navigation and filtering, 300 ms filter debouncing, and race-condition prevention across 8 VS Code panels ([#633](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/633)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...HEAD
+[1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0...Cli-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Cli-v1.0.0

--- a/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/ConnectionReferencesScreen.cs
@@ -421,22 +421,15 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
                     Text = text
                 };
 
-                var dialog = new Dialog(
+                using var dialog = new Dialog(
                     "Connection Reference Analysis",
                     new Button("Close", is_default: true))
                 {
                     Width = Dim.Percent(80),
                     Height = Dim.Percent(80)
                 };
-                try
-                {
-                    dialog.Add(textView);
-                    Application.Run(dialog);
-                }
-                finally
-                {
-                    dialog.Dispose();
-                }
+                dialog.Add(textView);
+                Application.Run(dialog);
             });
         }
         catch (OperationCanceledException) { /* screen closing */ }
@@ -485,7 +478,7 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
                 var selectButton = new Button("Select", is_default: true);
                 var cancelButton = new Button("Cancel");
 
-                var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
+                using var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
                 {
                     Width = Dim.Percent(60),
                     Height = Dim.Percent(70)
@@ -531,7 +524,6 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
                     selectButton.Clicked -= selectHandler;
                     cancelButton.Clicked -= cancelHandler;
                     listView.OpenSelectedItem -= openHandler;
-                    dialog.Dispose();
                 }
             });
         }
@@ -552,21 +544,14 @@ internal sealed class ConnectionReferencesScreen : TuiScreenBase
             ErrorService.ReportError("No environment URL available");
             return;
         }
-        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        using var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
         {
             Width = 60,
             Height = 7
         };
-        try
-        {
-            dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
-            dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/connectors" });
-            Application.Run(dialog);
-        }
-        finally
-        {
-            dialog.Dispose();
-        }
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/connectors" });
+        Application.Run(dialog);
     }
 
     protected override void OnDispose()

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -564,40 +564,42 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 var selectButton = new Button("Select", is_default: true);
                 var cancelButton = new Button("Cancel");
 
-                using var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
+                using (var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
                 {
                     Width = Dim.Percent(60),
                     Height = Dim.Percent(70)
-                };
-                dialog.Add(listView);
-
-                var confirmed = false;
-                selectButton.Clicked += () =>
+                })
                 {
-                    confirmed = true;
-                    Application.RequestStop();
-                };
-                cancelButton.Clicked += () => Application.RequestStop();
-                listView.OpenSelectedItem += _ =>
-                {
-                    confirmed = true;
-                    Application.RequestStop();
-                };
+                    dialog.Add(listView);
 
-                Application.Run(dialog);
+                    var confirmed = false;
+                    selectButton.Clicked += () =>
+                    {
+                        confirmed = true;
+                        Application.RequestStop();
+                    };
+                    cancelButton.Clicked += () => Application.RequestStop();
+                    listView.OpenSelectedItem += _ =>
+                    {
+                        confirmed = true;
+                        Application.RequestStop();
+                    };
 
-                if (confirmed)
-                {
-                    var idx = listView.SelectedItem;
-                    _solutionFilter = idx == 0 ? null : names[idx];
+                    Application.Run(dialog);
 
-                    // Persist updated filter state
-                    ErrorService.FireAndForget(
-                        Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
-                            new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
-                        "EnvironmentVariables.SaveState");
+                    if (confirmed)
+                    {
+                        var idx = listView.SelectedItem;
+                        _solutionFilter = idx == 0 ? null : names[idx];
 
-                    ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
+                        // Persist updated filter state
+                        ErrorService.FireAndForget(
+                            Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
+                                new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
+                            "EnvironmentVariables.SaveState");
+
+                        ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
+                    }
                 }
             });
         }
@@ -618,14 +620,16 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
             ErrorService.ReportError("No environment URL available");
             return;
         }
-        using var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        using (var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
         {
             Width = 60,
             Height = 7
-        };
-        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
-        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/environmentvariables" });
-        Application.Run(dialog);
+        })
+        {
+            dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+            dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/environmentvariables" });
+            Application.Run(dialog);
+        }
     }
 
     protected override void OnDispose()

--- a/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/EnvironmentVariablesScreen.cs
@@ -475,14 +475,13 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 var copyButton = new Button("Copy Path");
                 var closeButton = new Button("Close", is_default: true);
 
-                var dialog = new Dialog(
+                using (var dialog = new Dialog(
                     $"Export: {fileName}",
                     copyButton, closeButton)
                 {
                     Width = Dim.Percent(80),
                     Height = Dim.Percent(80)
-                };
-                try
+                })
                 {
                     dialog.Add(textView);
 
@@ -505,10 +504,6 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                     closeButton.Clicked += () => Application.RequestStop();
 
                     Application.Run(dialog);
-                }
-                finally
-                {
-                    dialog.Dispose();
                 }
 
                 // Restore status
@@ -569,47 +564,40 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
                 var selectButton = new Button("Select", is_default: true);
                 var cancelButton = new Button("Cancel");
 
-                var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
+                using var dialog = new Dialog("Filter by Solution", selectButton, cancelButton)
                 {
                     Width = Dim.Percent(60),
                     Height = Dim.Percent(70)
                 };
-                try
+                dialog.Add(listView);
+
+                var confirmed = false;
+                selectButton.Clicked += () =>
                 {
-                    dialog.Add(listView);
-
-                    var confirmed = false;
-                    selectButton.Clicked += () =>
-                    {
-                        confirmed = true;
-                        Application.RequestStop();
-                    };
-                    cancelButton.Clicked += () => Application.RequestStop();
-                    listView.OpenSelectedItem += _ =>
-                    {
-                        confirmed = true;
-                        Application.RequestStop();
-                    };
-
-                    Application.Run(dialog);
-
-                    if (confirmed)
-                    {
-                        var idx = listView.SelectedItem;
-                        _solutionFilter = idx == 0 ? null : names[idx];
-
-                        // Persist updated filter state
-                        ErrorService.FireAndForget(
-                            Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
-                                new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
-                            "EnvironmentVariables.SaveState");
-
-                        ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
-                    }
-                }
-                finally
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+                cancelButton.Clicked += () => Application.RequestStop();
+                listView.OpenSelectedItem += _ =>
                 {
-                    dialog.Dispose();
+                    confirmed = true;
+                    Application.RequestStop();
+                };
+
+                Application.Run(dialog);
+
+                if (confirmed)
+                {
+                    var idx = listView.SelectedItem;
+                    _solutionFilter = idx == 0 ? null : names[idx];
+
+                    // Persist updated filter state
+                    ErrorService.FireAndForget(
+                        Session.GetTuiStateStore().SaveScreenStateAsync("EnvironmentVariables", EnvironmentUrl!,
+                            new SolutionFilterScreenState { SolutionFilter = _solutionFilter }),
+                        "EnvironmentVariables.SaveState");
+
+                    ErrorService.FireAndForget(LoadDataAsync(), "EnvironmentVariables.FilterApply");
                 }
             });
         }
@@ -630,21 +618,14 @@ internal sealed class EnvironmentVariablesScreen : TuiScreenBase
             ErrorService.ReportError("No environment URL available");
             return;
         }
-        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        using var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
         {
             Width = 60,
             Height = 7
         };
-        try
-        {
-            dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
-            dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/environmentvariables" });
-            Application.Run(dialog);
-        }
-        finally
-        {
-            dialog.Dispose();
-        }
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/environmentvariables" });
+        Application.Run(dialog);
     }
 
     protected override void OnDispose()

--- a/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/PluginTracesScreen.cs
@@ -205,7 +205,6 @@ internal sealed class PluginTracesScreen : TuiScreenBase
             return;
         }
 
-        var formatDialog = new Dialog("Export Format", 40, 8);
         var selectedFormat = "";
         var csvBtn = new Button("CSV") { X = 4, Y = 1 };
         var jsonBtn = new Button("JSON") { X = 14, Y = 1 };
@@ -215,36 +214,33 @@ internal sealed class PluginTracesScreen : TuiScreenBase
         Action jsonHandler = () => { selectedFormat = "json"; Application.RequestStop(); };
         Action cancelHandler = () => Application.RequestStop();
 
-        try
+        using (var formatDialog = new Dialog("Export Format", 40, 8))
         {
-            csvBtn.Clicked += csvHandler;
-            jsonBtn.Clicked += jsonHandler;
-            cancelBtn.Clicked += cancelHandler;
+            try
+            {
+                csvBtn.Clicked += csvHandler;
+                jsonBtn.Clicked += jsonHandler;
+                cancelBtn.Clicked += cancelHandler;
 
-            formatDialog.Add(csvBtn, jsonBtn, cancelBtn);
-            Application.Run(formatDialog);
-        }
-        finally
-        {
-            // R3: explicitly unsubscribe before disposing.
-            csvBtn.Clicked -= csvHandler;
-            jsonBtn.Clicked -= jsonHandler;
-            cancelBtn.Clicked -= cancelHandler;
-            formatDialog.Dispose();
+                formatDialog.Add(csvBtn, jsonBtn, cancelBtn);
+                Application.Run(formatDialog);
+            }
+            finally
+            {
+                // R3: explicitly unsubscribe before disposing.
+                csvBtn.Clicked -= csvHandler;
+                jsonBtn.Clicked -= jsonHandler;
+                cancelBtn.Clicked -= cancelHandler;
+            }
         }
 
         if (string.IsNullOrEmpty(selectedFormat)) return;
 
         string? filePath = null;
-        var saveDialog = new SaveDialog("Export Traces", $"traces.{selectedFormat}");
-        try
+        using (var saveDialog = new SaveDialog("Export Traces", $"traces.{selectedFormat}"))
         {
             Application.Run(saveDialog);
             filePath = saveDialog.FilePath?.ToString();
-        }
-        finally
-        {
-            saveDialog.Dispose();
         }
 
         if (string.IsNullOrEmpty(filePath)) return;

--- a/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/WebResourcesScreen.cs
@@ -381,12 +381,6 @@ internal sealed class WebResourcesScreen : TuiScreenBase
                     Height = Dim.Fill()
                 };
 
-                var dialog = new Dialog("Filter by Solution", new Button("Cancel"))
-                {
-                    Width = Dim.Percent(60),
-                    Height = Dim.Percent(60)
-                };
-
                 Action<ListViewItemEventArgs> openHandler = (args) =>
                 {
                     if (args.Item == 0)
@@ -405,19 +399,25 @@ internal sealed class WebResourcesScreen : TuiScreenBase
                     Application.RequestStop();
                 };
 
-                try
+                using (var dialog = new Dialog("Filter by Solution", new Button("Cancel"))
                 {
-                    dialog.Add(listView);
-
-                    listView.OpenSelectedItem += openHandler;
-
-                    Application.Run(dialog);
-                }
-                finally
+                    Width = Dim.Percent(60),
+                    Height = Dim.Percent(60)
+                })
                 {
-                    // R3: explicitly unsubscribe before disposing.
-                    listView.OpenSelectedItem -= openHandler;
-                    dialog.Dispose();
+                    try
+                    {
+                        dialog.Add(listView);
+
+                        listView.OpenSelectedItem += openHandler;
+
+                        Application.Run(dialog);
+                    }
+                    finally
+                    {
+                        // R3: explicitly unsubscribe before disposing.
+                        listView.OpenSelectedItem -= openHandler;
+                    }
                 }
 
                 // Persist updated filter state
@@ -463,21 +463,14 @@ internal sealed class WebResourcesScreen : TuiScreenBase
             ErrorService.ReportError("No environment URL available");
             return;
         }
-        var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
+        using var dialog = new Dialog("Open in Maker", new Button("OK", is_default: true))
         {
             Width = 60,
             Height = 7
         };
-        try
-        {
-            dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
-            dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/WebResources" });
-            Application.Run(dialog);
-        }
-        finally
-        {
-            dialog.Dispose();
-        }
+        dialog.Add(new Label { X = 1, Y = 1, Text = "Open this URL in your browser:" });
+        dialog.Add(new Label { X = 1, Y = 2, Text = EnvironmentUrl + "/WebResources" });
+        Application.Run(dialog);
     }
 
     protected override void OnDispose()

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Raw Web API passthrough + draft-app sitemap resolution** — new public `IDataverseClient.GetRawWebApiAsync(queryString, ct)` returns the raw Web API JSON for a relative query, and model-driven-app sitemap resolution now handles draft (unpublished) apps ([#1242](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1242)).
 - **Metadata-authoring support for status reasons and local option sets** — `AddStatusReasonRequest`/`UpdateStatusReasonRequest`/`RemoveStatusReasonRequest`/`StatusReasonInfo` for entity status-reason management, and `AddOptionValueRequest`/`UpdateOptionValueRequest`/`DeleteOptionValueRequest` plus the shared `OptionValueDeriver` (publisher-prefix-based option value derivation) for column-scoped (local) Choice option sets ([#1167](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1167), [#1159](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1159), [#1160](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1160), [#1161](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1161)).
 - **`DeleteOptionValueRequest` targets by value or label** — `Value` is now nullable and a `Label` selector was added (exactly one required); the service resolves the target against unpublished metadata and throws `OPTION_NOT_FOUND` when unresolved ([#1169](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1169)).
 - **`UpdateOptionValueRequest` aligned with `UpdateColumnOptionRequest`** — `Value`/`Label` are now the (exactly-one) target selectors, `NewLabel` carries the updated label (current label preserved when omitted), and `Color` is now forwarded to the SDK ([#1170](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1170)).
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Actionable environment-lock errors on publish** — `PooledClientExtensions` re-throws in-progress import/publish faults as an `InvalidOperationException` with remediation guidance instead of surfacing the opaque platform fault ([#1245](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1245)).
 - **M:N relationship create** — populate `IntersectEntitySchemaName` on the create request (defaulting to the relationship schema name) so many-to-many relationship creation no longer fails with `Required field 'IntersectEntitySchemaName' is missing` ([#1018](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1018)).
 
 ## [1.0.0] - 2026-04-18
@@ -52,5 +54,5 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **Default `AcquireTimeout` of 120 s** — Connection acquisition from the pool waits up to 120 s, accommodating queuing on the DOP semaphore during large imports.
 - **Pool-managed concurrency** — Batch parallelism is capped at pool capacity via pool-queue blocking at `GetClientAsync()`, preventing oversubscription during throttling.
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.1.0...HEAD
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Dataverse-v1.0.0

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - **Plugin Traces "Status" Advanced filter is now honored** — the conditions switch had no `Status` case, so `Status = Exception`/`Success` silently fell through and the daemon returned all rows regardless of the selection; it now maps Equals/Not Equals against `Exception`/`Success` to the `hasException` filter. Also guards against an invalid `Created On` date (#1006, #1040).
+- **Command palette grouping** — 17 commands that previously appeared ungrouped now group under the **PPDS** category in the command palette, matching the other commands (#1263).
 
 ## [1.2.0] - 2026-04-26
 
@@ -143,3 +144,6 @@ Complete ground-up rebuild of the extension. The new architecture uses a thin VS
 ## [0.3.4] - 2026-01-01
 
 _Last stable release of the legacy architecture. See [archived repository](https://github.com/joshsmithxrm/power-platform-developer-suite/tree/archived) for full history._
+
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...HEAD
+[1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Extension-v1.2.0

--- a/src/PPDS.Extension/package-lock.json
+++ b/src/PPDS.Extension/package-lock.json
@@ -4366,9 +4366,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -649,6 +649,9 @@
     "typecheck:all": "npm run typecheck && npm run typecheck:webview",
     "prepare": "cd ../.. && git config core.hooksPath scripts/hooks"
   },
+  "overrides": {
+    "dompurify": "^3.4.9"
+  },
   "dependencies": {
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "monaco-editor": "0.55.1",

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Publish requirement surfaced on metadata column updates** — `MetadataUpdateColumnResult` now carries `RequiresPublish` and `PublishHint`, so MCP clients are told when a column change must be published and given the exact `ppds metadata publish <entity>` command ([#1016](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1016)).
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. Consolidates features developed across `1.0.0-beta.1` and `1.0.0-beta.2`.

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -44,5 +44,6 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **DI integration** — `AddDataverseMigration()` extension method.
 - **Security-first design** — Connection string redaction, no PII in logs.
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.1.0...HEAD
+[1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0...Migration-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Migration-v1.0.0

--- a/src/PPDS.Migration/Import/RelationshipProcessor.cs
+++ b/src/PPDS.Migration/Import/RelationshipProcessor.cs
@@ -147,6 +147,22 @@ namespace PPDS.Migration.Import
                         else if (isRoleTarget)
                         {
                             mappedId = await LookupRoleByIdAsync(targetId, ct).ConfigureAwait(false);
+
+                            // F4: surface role mapping skips so users can detect silent drops
+                            // (cross-environment role mapping is a documented limitation).
+                            // Emitted here, on the role lookup path, so the guard tracks the
+                            // actual failure rather than re-testing isRoleTarget in the shared
+                            // else branch below (which CodeQL flags as a constant condition).
+                            if (!mappedId.HasValue)
+                            {
+                                context.Warnings.AddWarning(new ImportWarning
+                                {
+                                    Code = ImportWarningCodes.RoleMappingSkipped,
+                                    Entity = entityName,
+                                    Message = $"Role {targetId} could not be mapped in target environment for relationship '{m2mData.RelationshipName}' — association skipped. Cross-environment role mapping by ID requires matching role IDs; export role names to enable mapping by name.",
+                                    Impact = $"1 role association skipped for {entityName}:{m2mData.SourceId}"
+                                });
+                            }
                         }
 
                         if (mappedId.HasValue)
@@ -157,19 +173,6 @@ namespace PPDS.Migration.Import
                         {
                             _logger?.LogDebug("Could not map target {Entity}:{Id} for relationship {Relationship}",
                                 m2mData.TargetEntityName, targetId, m2mData.RelationshipName);
-
-                            // F4: surface role mapping skips so users can detect silent drops
-                            // (cross-environment role mapping is a documented limitation).
-                            if (isRoleTarget)
-                            {
-                                context.Warnings.AddWarning(new ImportWarning
-                                {
-                                    Code = ImportWarningCodes.RoleMappingSkipped,
-                                    Entity = entityName,
-                                    Message = $"Role {targetId} could not be mapped in target environment for relationship '{m2mData.RelationshipName}' — association skipped. Cross-environment role mapping by ID requires matching role IDs; export role names to enable mapping by name.",
-                                    Impact = $"1 role association skipped for {entityName}:{m2mData.SourceId}"
-                                });
-                            }
                         }
                     }
 

--- a/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Services/Metadata/Authoring/MetadataAuthoringServiceTests.cs
@@ -476,7 +476,8 @@ public class MetadataAuthoringServiceTests
         capturedRequest.Should().NotBeNull();
         var dtAttr = capturedRequest!.Attribute as DateTimeAttributeMetadata;
         dtAttr.Should().NotBeNull();
-        dtAttr!.Format.Should().Be(DateTimeFormat.DateOnly);
+        Assert.NotNull(dtAttr);
+        dtAttr.Format.Should().Be(DateTimeFormat.DateOnly);
     }
 
     // Issue #1009: UpdateColumnAsync executes UpdateAttributeRequest but never publishes,
@@ -678,7 +679,8 @@ public class MetadataAuthoringServiceTests
         capturedRequest.Should().NotBeNull();
         var updatedRel = capturedRequest!.Relationship as OneToManyRelationshipMetadata;
         updatedRel.Should().NotBeNull("because UpdateRelationship should send a OneToManyRelationshipMetadata");
-        updatedRel!.CascadeConfiguration.Should().NotBeNull();
+        Assert.NotNull(updatedRel);
+        updatedRel.CascadeConfiguration.Should().NotBeNull();
         updatedRel.CascadeConfiguration.Delete.Should().Be(CascadeType.Restrict);
         updatedRel.CascadeConfiguration.Assign.Should().Be(CascadeType.Cascade);
     }

--- a/tests/PPDS.LiveTests/Metadata/OptionColorPersistenceLiveTests.cs
+++ b/tests/PPDS.LiveTests/Metadata/OptionColorPersistenceLiveTests.cs
@@ -48,8 +48,9 @@ public sealed class OptionColorPersistenceLiveTests : LiveTestBase
         var setName = $"{prefix}_clr{Guid.NewGuid():N}".Substring(0, Math.Min(48, prefix.Length + 12));
         var ct = CancellationToken.None;
 
-        _source = await LiveTestHelpers.CreateConnectionSourceAsync(Configuration, "OptionColorTest", maxPoolSize: 3);
-        _pool = LiveTestHelpers.CreateConnectionPool(new[] { _source });
+        var source = await LiveTestHelpers.CreateConnectionSourceAsync(Configuration, "OptionColorTest", maxPoolSize: 3);
+        _source = source;
+        _pool = LiveTestHelpers.CreateConnectionPool(new[] { source });
 
         await using var client = await _pool.GetClientAsync(cancellationToken: ct);
 

--- a/tests/PPDS.LiveTests/Metadata/OptionColorPersistenceLiveTests.cs
+++ b/tests/PPDS.LiveTests/Metadata/OptionColorPersistenceLiveTests.cs
@@ -49,7 +49,7 @@ public sealed class OptionColorPersistenceLiveTests : LiveTestBase
         var ct = CancellationToken.None;
 
         _source = await LiveTestHelpers.CreateConnectionSourceAsync(Configuration, "OptionColorTest", maxPoolSize: 3);
-        _pool = LiveTestHelpers.CreateConnectionPool(new[] { (IConnectionSource)_source });
+        _pool = LiveTestHelpers.CreateConnectionPool(new[] { _source });
 
         await using var client = await _pool.GetClientAsync(cancellationToken: ct);
 


### PR DESCRIPTION
Pre-release cleanup for the v1.2 wave. **No user-facing behavior changes** (so no per-change changelog entries beyond documenting already-merged 1.2 work).

## Security/quality alerts — clears all 29
- **15 Dependabot** (`dompurify` XSS advisories, transitive via `monaco-editor`): added `overrides: { dompurify: ^3.4.9 }` → resolves to 3.4.11. Verified: extension build + 469 unit tests pass.
- **14 CodeQL** (no behavior change, 4316 .NET tests pass on net8/9/10):
  - 10× `missed-using-statement` → `using` in TUI dialog flows (disposal scope + handler-unsubscribe order preserved)
  - 1× `constant-condition` (Migration `RelationshipProcessor`) → guard moved onto the role-lookup path; behavior identical
  - 2× `dereferenced-value-may-be-null` → `Assert.NotNull` guards in tests
  - 1× `useless-upcast` → dropped redundant cast in a live test

## Changelog gaps (documenting already-merged 1.2 work)
- Backfilled **Mcp #1016**, **Dataverse #1242 (new public `GetRawWebApiAsync`) + #1245**
- Extension: command-palette grouping entry (#1263) + footer compare-links
- Fixed stale compare-link bases (Cli/Migration/Dataverse `v1.0.0`→`v1.1.0`); added root index Extension row + fixed fake Plugins example

## `/release` skill fix (real landmine)
- **§3 rewritten**: versions are MinVer-derived from per-surface tags — the old `sed <Version> into Directory.Build.props` step no-ops (no such element) or would override MinVer. Documents the tag mechanism + publish dependency order.
- REFERENCE signing matrix corrected (removed false `WINSIGN_*`/`publish.yml` claims; CLI `.exe` ships unsigned).

## Hygiene
- `PPDS.Analyzers` `IsPackable=false` (consumed only as an analyzer ProjectReference).

The 15 Dependabot alerts auto-resolve on merge; the 14 CodeQL alerts close when CodeQL re-scans main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)