### PR TITLE
docs(release): trigger ppds-skills re-capture on stable release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -103,14 +103,31 @@ curl -s https://api.nuget.org/v3-flatcontainer/ppds.auth/index.json | jq '.versi
 ppds --version  # should match the new tag
 ```
 
-### 8. Workflow State
+### 8. Hand off to the skills package (stable releases only)
+
+The [PPDS Skills](https://github.com/joshsmithxrm/ppds-skills) package pins its
+captured CLI/MCP surface to a specific release. Once §7 confirms the new
+**stable** `PPDS.Cli` is live on NuGet, trigger its re-capture so the published
+flag tables track the released CLI:
+
+```bash
+gh workflow run recapture-on-release.yml --repo joshsmithxrm/ppds-skills
+```
+
+This opens a re-capture PR in `ppds-skills` (it never auto-merges, and no-ops if
+the latest stable isn't newer than what's pinned). **Skip for prereleases** — the
+workflow only acts on stable. Follow-up happens in that repo: review the capture
+diff + the PR's manual-prose checklist, resolve any review threads, and
+**close/reopen the PR** to fire its CI before merging.
+
+### 9. Workflow State
 
 ```bash
 python scripts/workflow-state.py set release.published now
 python scripts/workflow-state.py set release.version <X.Y.Z>
 ```
 
-### 9. Announce
+### 10. Announce
 
 Update GitHub release notes with CHANGELOG content. Optional: short post-mortem in the release commit if anything was tricky (file under `.retros/release-X.Y.Z.md`).
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -108,7 +108,7 @@ captured CLI/MCP surface to a specific release. Once §7 confirms the new
 flag tables track the released CLI:
 
 ```bash
-gh workflow run recapture-on-release.yml --repo joshsmithxrm/ppds-skills
+gh workflow run recapture-on-release.yml --repo joshsmithxrm/ppds-skills -r main
 ```
 
 This opens a re-capture PR in `ppds-skills` (it never auto-merges, and no-ops if


### PR DESCRIPTION
Adds a step to the `release` skill so a stable PPDS release closes the loop with the [PPDS Skills](https://github.com/joshsmithxrm/ppds-skills) package automatically, instead of relying on the skills repo's weekly cron or someone remembering.

## What

New **§8 — Hand off to the skills package (stable releases only)**, placed right after §7 Post-publish Verification (where NuGet is already confirmed live). It dispatches the skills package's re-capture workflow:

```bash
gh workflow run recapture-on-release.yml --repo joshsmithxrm/ppds-skills
```

Following steps renumbered (Workflow State → §9, Announce → §10).

## Notes

- **Stable-only**, and the workflow itself no-ops if the latest stable isn't newer than what's pinned — so an accidental run during an rc is harmless.
- It's a *trigger*, not an inline re-capture: the actual work and its review gate live in `ppds-skills`. The step notes the follow-up there (review capture diff + manual-prose checklist, resolve review threads, close/reopen the PR to fire CI).
- Docs-only change to the skill instructions; no pipeline behavior changes.