### PR TITLE
release: v1.2

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-17
+
 ### Added
 - **`ppds webresources create <file>`** — create a brand-new web resource directly from a local file: type inferred from the file extension (`--type` single-type override), `--display-name`, optional atomic `--solution` binding (SDK equivalent of the `MSCRM.SolutionUniqueName` header), and `--publish`. Fails with `WebResource.AlreadyExists` (hinting at `update`) when the name is taken (#1207).
 - **`ppds webresources update <name|id> <file>`** — replace an existing web resource's content from a local file (binary types allowed — this is file replacement, not text editing), with optional `--publish`. Resolves by exact name or GUID only, so a fuzzy match can never overwrite the wrong resource; warns when the file extension implies a different type than the stored resource (#1207).
@@ -111,6 +113,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **`ppds flows get|url` accept GUID or unique name** — The `name` argument resolves by workflow ID (GUID) when provided, falling back to unique-name lookup ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Extension panel UX** — Unified panel navigation and filtering, 300 ms filter debouncing, and race-condition prevention across 8 VS Code panels ([#633](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/633)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.2.0...HEAD
+[1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...Cli-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0...Cli-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Cli-v1.0.0

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-17
+
 ### Added
 
 - **Raw Web API passthrough + draft-app sitemap resolution** — new public `IDataverseClient.GetRawWebApiAsync(queryString, ct)` returns the raw Web API JSON for a relative query, and model-driven-app sitemap resolution now handles draft (unpublished) apps ([#1242](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1242)).
@@ -58,6 +60,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **Default `AcquireTimeout` of 120 s** — Connection acquisition from the pool waits up to 120 s, accommodating queuing on the DOP semaphore during large imports.
 - **Pool-managed concurrency** — Batch parallelism is capped at pool capacity via pool-queue blocking at `GetClientAsync()`, preventing oversubscription during throttling.
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.1.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.2.0...HEAD
+[1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.1.0...Dataverse-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0...Dataverse-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Dataverse-v1.0.0

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-17
+
 ### Added
 - **Connection picker for connection-reference binding** — the Connection References panel detail card gains a Change/Bind button (disabled for managed CRs) that opens a modal picker filtered by connector id and supports unbind via the empty option. Backed by new `connectionReferences/bind` and `connections/list` daemon RPC endpoints and `IConnectionReferenceService.BindAsync`, which writes `connectionid` on the Dataverse `connectionreference` entity (#592, #1058).
 
@@ -145,5 +147,6 @@ Complete ground-up rebuild of the extension. The new architecture uses a thin VS
 
 _Last stable release of the legacy architecture. See [archived repository](https://github.com/joshsmithxrm/power-platform-developer-suite/tree/archived) for full history._
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.0...HEAD
+[1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...Extension-v1.4.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Extension-v1.2.0

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -2,7 +2,7 @@
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
   "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "publisher": "JoshSmithXRM",
   "preview": false,
   "qna": false,

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-17
+
 ### Added
 
 - **Publish requirement surfaced on metadata column updates** — `MetadataUpdateColumnResult` now carries `RequiresPublish` and `PublishHint`, so MCP clients are told when a column change must be published and given the exact `ppds metadata publish <entity>` command ([#1016](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1016)).
@@ -32,5 +34,6 @@ First stable release. Consolidates features developed across `1.0.0-beta.1` and 
 - **Structured MCP error responses** — All tool exceptions now surface `errorCode`, `userMessage`, and `context`, giving MCP clients machine-readable failure details ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Configurable log level** — `--log-level` flag and `PPDS_MCP_LOG_LEVEL` environment variable let operators adjust server verbosity without rebuilding ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.1...HEAD
+[1.0.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0...Mcp-v1.0.1
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Mcp-v1.0.0

--- a/src/PPDS.Migration/CHANGELOG.md
+++ b/src/PPDS.Migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-17
+
 ### Added
 - **JSON data export format** — `ExportDataFormat.Json` on `ExportOptions` alongside the default CMT XML. `JsonDataWriter` (streaming `Utf8JsonWriter`) emits a single-file PPDS-native payload mirroring the CMT structure (schema metadata, per-entity typed field values, M2M associations), with `AliasedValue` unwrapping for FetchXML-joined attributes. `ParallelExporter` selects the writer from `options.Format`. File-column binaries are not serialized in JSON v1; use CMT format for binary round-trip (#147, #1059).
 
@@ -44,6 +46,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **DI integration** — `AddDataverseMigration()` extension method.
 - **Security-first design** — Connection string redaction, no PII in logs.
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.1.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.2.0...HEAD
+[1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.1.0...Migration-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Migration-v1.0.0...Migration-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Migration-v1.0.0


### PR DESCRIPTION
Stamps the v1.2 release. **Merging is safe — no publish happens from this commit; publishing triggers on the tags pushed afterward.**

## Versions
| Surface | Version |
|---|---|
| PPDS.Dataverse | 1.2.0 |
| PPDS.Migration | 1.2.0 |
| PPDS.Cli (incl. TUI) | 1.2.0 |
| PPDS.Mcp | 1.0.1 |
| PPDS.Extension | 1.4.0 (stable, even minor) |

Auth / Query / Plugins / Analyzers: no unreleased changes → not released.

## Changes
- Each surface's `[Unreleased]` → `[version] - 2026-06-17` + compare-link footer.
- `src/PPDS.Extension/package.json` version → 1.4.0 (vsce reads this; not cosmetic).

## After merge — tags in dependency order (ProjectReference floors):
`Dataverse-v1.2.0` → `Migration-v1.2.0` → `Cli-v1.2.0` → `Mcp-v1.0.1`; `Extension-v1.4.0` independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)