### PR TITLE
fix(ext): pin @types/vscode to ^1.116.0 (unblock Extension v1.4.0 publish)

### DIFF
--- a/src/PPDS.Extension/package-lock.json
+++ b/src/PPDS.Extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "power-platform-developer-suite",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "power-platform-developer-suite",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.4.0",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@types/node": "^25.9.3",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.116.0",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.1",
         "esbuild": "^0.28.1",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -660,7 +660,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.3",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.116.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.28.1",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
-  "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
+  "description": "Power Platform and Dataverse developer suite for VS Code \u00e2\u20ac\u201d SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
   "version": "1.4.0",
   "publisher": "JoshSmithXRM",
   "preview": false,
@@ -660,7 +660,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.3",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.116.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.28.1",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
-  "description": "Power Platform and Dataverse developer suite for VS Code \u00e2\u20ac\u201d SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
+  "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
   "version": "1.4.0",
   "publisher": "JoshSmithXRM",
   "preview": false,
@@ -660,7 +660,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.3",
-    "@types/vscode": "^1.116.0",
+    "@types/vscode": "^1.120.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
The `Extension-v1.4.0` Marketplace publish failed: vsce rejects `@types/vscode ^1.120.0 > engines.vscode ^1.116.0`. `@types/vscode` was dependabot-bumped to 1.120 while `engines.vscode` stayed at 1.116. Verified the extension **typechecks clean against `@types/vscode ^1.116.0`** (no 1.117+ API used), so pinning it back is intent-preserving and keeps the supported VS Code minimum unchanged. After merge I'll move the `Extension-v1.4.0` tag to this commit to re-trigger the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)