### PR TITLE
fix(ext): pin @types/vscode to ^1.116.0 (unblock Extension v1.4.0 publish)

### DIFF
--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -660,7 +660,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.3",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.116.0",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.28.1",


### PR DESCRIPTION
`Extension-v1.4.0` Marketplace publish failed: `vsce` rejects `@types/vscode ^1.120.0 > engines.vscode ^1.116.0` (dependabot drifted @types above engines). Verified the extension typechecks clean against `@types/vscode ^1.116.0` (no 1.117+ API used), so pinning it back is intent-preserving and keeps the supported VS Code minimum unchanged. Lock left as-is (resolved 1.120.0 satisfies ^1.116.0; vsce checks the declared range). After merge I'll move `Extension-v1.4.0` to this commit to re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)