### PR TITLE
ci(dependabot): guard @types/vscode against drifting above engines.vscode (#1274)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,10 @@ updates:
       - "npm"
     commit-message:
       prefix: "deps(extension)"
+    ignore:
+      # @types/vscode must not exceed engines.vscode (vsce rejects it at publish).
+      # Bump both together, manually, when raising the supported VS Code minimum. (#1274)
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"


### PR DESCRIPTION
Prevents the recurrence of the v1.2 Extension publish failure (vsce rejected `@types/vscode ^1.120.0 > engines.vscode ^1.116.0`, caused by dependabot drift). Adds a dependabot `ignore` for `@types/vscode` minor+major bumps in the extension npm config — patch bumps still flow; the team bumps `@types/vscode` + `engines.vscode` together when raising the supported VS Code minimum. Closes #1274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)