### PR TITLE
docs(skill): keep /release §10 timeless (drop v1.2 narration)

### DIFF
--- a/.claude/skills/release/REFERENCE.md
+++ b/.claude/skills/release/REFERENCE.md
@@ -114,7 +114,7 @@ If any smoke check fails, file a hotfix issue and prepare a patch release. Do no
 
 ## §8 - GitHub Releases
 
-Only the CLI gets an automatic GitHub Release (`release-cli.yml`, with binaries attached). Every other released surface (NuGet libraries + Extension) needs one created by hand from its CHANGELOG section — this was forgotten in v1.2 and the Releases page showed only the CLI until backfilled.
+Only the CLI gets an automatic GitHub Release (`release-cli.yml`, with binaries attached). Every other released surface (NuGet libraries + Extension) needs one created by hand from its CHANGELOG section.
 
 For each released `<Prefix>-vX.Y.Z` **except `Cli`**:
 
@@ -130,7 +130,7 @@ gh release create <Prefix>-vX.Y.Z \
 
 `--latest=false` keeps the per-surface library releases from hijacking the "Latest" badge on a multi-package repo. Pass the notes via `--notes-file` (not inline) — CHANGELOG bodies contain `ppds ...` command examples that trip the stdout/env safety hooks when placed directly in a shell command.
 
-Then verify nothing was missed:
+Then verify every released tag has a release:
 
 ```bash
 for t in <every tag you pushed>; do

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -126,7 +126,7 @@ python scripts/workflow-state.py set release.version <X.Y.Z>
 
 ### 10. GitHub Releases (per surface — REQUIRED, easy to forget)
 
-The CLI's GitHub Release is auto-created by `release-cli.yml`; **the NuGet libraries and the Extension are NOT** — create one per released surface from its CHANGELOG `[X.Y.Z]` section, then verify each tag has a release (missed in v1.2). Recipe: REFERENCE.md §8 "GitHub Releases". Optional: post-mortem under `.retros/release-X.Y.Z.md`.
+The CLI's GitHub Release is auto-created by `release-cli.yml`; **the NuGet libraries and the Extension are NOT** — create one per released surface from its CHANGELOG `[X.Y.Z]` section, then verify each tag has a release. Recipe: REFERENCE.md §8 "GitHub Releases". Optional: post-mortem under `.retros/release-X.Y.Z.md`.
 
 ## Continue with
 


### PR DESCRIPTION
Removes session/release-specific history ("missed in v1.2", "forgotten in v1.2 ... until backfilled") from the /release skill — instructions should be timeless. No behavior change to the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)