### PR TITLE
fix(cli): match plugin steps by functional identity instead of display name (#1295)

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/CleanCommand.cs
@@ -168,7 +168,13 @@ public static class CleanCommand
         }
     }
 
-    private static async Task<CleanResult> CleanAssemblyAsync(
+    /// <summary>
+    /// Removes orphaned steps (and now-empty types) for a single assembly. Orphans are identified by
+    /// functional identity (<see cref="PluginStepMatcher"/>) rather than by display name, so a
+    /// same-named step of a different stage/mode is correctly detected as an orphan.
+    /// </summary>
+    /// <remarks><c>internal</c> for direct unit-test access (InternalsVisibleTo PPDS.Cli.Tests).</remarks>
+    internal static async Task<CleanResult> CleanAssemblyAsync(
         IPluginRegistrationService service,
         PluginAssemblyConfig assemblyConfig,
         bool dryRun,
@@ -192,28 +198,48 @@ public static class CleanCommand
         if (!globalOptions.IsJsonMode)
             Console.Error.WriteLine($"Checking assembly: {assemblyConfig.Name}");
 
-        // Build set of configured step names
-        var configuredStepNames = new HashSet<string>();
-        foreach (var typeConfig in assemblyConfig.Types)
+        // Get existing types and steps once, keeping a per-type list for the type-orphan pass.
+        var existingTypes = await service.ListTypesForAssemblyAsync(assembly.Id);
+        var stepsByType = new Dictionary<Guid, List<PluginStepInfo>>();
+        var existingPairs = new List<(PluginTypeInfo Type, PluginStepInfo Step)>();
+        foreach (var existingType in existingTypes)
         {
-            foreach (var stepConfig in typeConfig.Steps)
-            {
-                var stepName = stepConfig.Name ?? $"{typeConfig.TypeName}: {stepConfig.Message} of {stepConfig.Entity}";
-                configuredStepNames.Add(stepName);
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+            var typeSteps = await service.ListStepsForTypeAsync(existingType.Id, cancellationToken: cancellationToken);
+            stepsByType[existingType.Id] = typeSteps;
+            foreach (var step in typeSteps)
+                existingPairs.Add((existingType, step));
         }
 
-        // Get existing types and steps
-        var existingTypes = await service.ListTypesForAssemblyAsync(assembly.Id);
+        // Configured (type, step) pairs.
+        var configuredPairs = new List<(PluginTypeConfig Type, PluginStepConfig Step)>();
+        foreach (var typeConfig in assemblyConfig.Types)
+            foreach (var stepConfig in typeConfig.Steps)
+                configuredPairs.Add((typeConfig, stepConfig));
+
+        // Match by identity; orphans are the environment steps with no configured counterpart.
+        var matches = PluginStepMatcher.Match(
+            configuredPairs,
+            existingPairs,
+            onResidualCollision: (id, configCount, envCount) =>
+                result.Warnings.Add(PluginStepMatcher.DescribeResidualCollision(id, configCount, envCount)));
+
+        if (!globalOptions.IsJsonMode)
+        {
+            foreach (var warning in result.Warnings)
+                Console.Error.WriteLine($"  [!] Warning: {warning}");
+        }
+
+        var orphanStepIds = matches.Where(m => m.IsOrphaned).Select(m => m.Env!.Id).ToHashSet();
 
         foreach (var existingType in existingTypes)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var steps = await service.ListStepsForTypeAsync(existingType.Id);
+            var steps = stepsByType[existingType.Id];
 
             // Find orphaned steps and track count for type cleanup
-            var orphanedStepsInType = steps.Where(s => !configuredStepNames.Contains(s.Name)).ToList();
+            var orphanedStepsInType = steps.Where(s => orphanStepIds.Contains(s.Id)).ToList();
 
             foreach (var step in orphanedStepsInType)
             {
@@ -231,7 +257,7 @@ public static class CleanCommand
                 }
                 else
                 {
-                    await service.DeleteStepAsync(step.Id);
+                    await service.DeleteStepAsync(step.Id, cancellationToken);
                     result.StepsDeleted++;
                     if (!globalOptions.IsJsonMode)
                         Console.Error.WriteLine($"  Deleted step: {step.Name}");
@@ -286,7 +312,7 @@ public static class CleanCommand
 
     #region Result Models
 
-    private sealed class CleanResult
+    internal sealed class CleanResult
     {
         [JsonPropertyName("assemblyName")]
         public string AssemblyName { get; set; } = string.Empty;
@@ -302,9 +328,15 @@ public static class CleanCommand
 
         [JsonPropertyName("typesDeleted")]
         public int TypesDeleted { get; set; }
+
+        /// <summary>
+        /// Advisory messages (e.g., residual functional-identity collisions).
+        /// </summary>
+        [JsonPropertyName("warnings")]
+        public List<string> Warnings { get; set; } = [];
     }
 
-    private sealed class OrphanedStep
+    internal sealed class OrphanedStep
     {
         [JsonPropertyName("typeName")]
         public string TypeName { get; set; } = string.Empty;
@@ -316,7 +348,7 @@ public static class CleanCommand
         public Guid StepId { get; set; }
     }
 
-    private sealed class OrphanedType
+    internal sealed class OrphanedType
     {
         [JsonPropertyName("typeName")]
         public string TypeName { get; set; } = string.Empty;

--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -497,6 +497,28 @@ public static class DeployCommand
                     }
                 }
             }
+            else
+            {
+                // Without --clean we must not delete anything. But because a stage/mode change is now
+                // delete+create, the old step lingers in the environment and STILL fires — with no other
+                // signal. Surface orphans loudly so the operator knows to re-run with --clean.
+                var orphanedSteps = matches.Where(m => m.IsOrphaned).Select(m => m.Env!).ToList();
+
+                if (orphanedSteps.Count > 0)
+                {
+                    var descriptions = string.Join(
+                        ", ",
+                        orphanedSteps.Select(o => $"{o.Name} ({o.Stage}, {o.Mode})"));
+                    var warning =
+                        $"{orphanedSteps.Count} step(s) in the environment no longer match the configuration and were " +
+                        $"left in place (they remain active): {descriptions}. Re-run with --clean to remove them.";
+
+                    result.Warnings.Add(warning);
+
+                    if (!globalOptions.IsJsonMode)
+                        Console.Error.WriteLine($"  [!] Warning: {warning}");
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -203,7 +203,14 @@ public static class DeployCommand
         }
     }
 
-    private static async Task<DeploymentResult> DeployAssemblyAsync(
+    /// <summary>
+    /// Deploys a single assembly's types, steps, and images. Steps are matched to the environment by
+    /// functional identity (<see cref="PluginStepMatcher"/>) rather than by mutable display name, so an
+    /// environment holding two same-named steps is disambiguated instead of aborting, and each write
+    /// targets the correct row.
+    /// </summary>
+    /// <remarks><c>internal</c> for direct unit-test access (InternalsVisibleTo PPDS.Cli.Tests).</remarks>
+    internal static async Task<DeploymentResult> DeployAssemblyAsync(
         IPluginRegistrationService service,
         PluginAssemblyConfig assemblyConfig,
         string configDir,
@@ -288,10 +295,6 @@ public static class DeployCommand
                 }
             }
 
-            // Track existing steps for orphan detection - use dictionary for O(1) lookup during cleanup
-            var existingStepsMap = new Dictionary<string, PluginStepInfo>();
-            var configuredStepNames = new HashSet<string>();
-
             // Get existing types and steps
             var existingTypes = await service.ListTypesForAssemblyAsync(assemblyId);
 
@@ -328,24 +331,41 @@ public static class DeployCommand
                     $"Please disambiguate manually before re-deploying. Conflicts: {details}");
             }
 
+            // Gather existing (type, step) pairs and match them to configuration by functional
+            // identity rather than by mutable display name. Two same-named steps (e.g., a PreOp/PostOp
+            // pair the Plugin Registration Tool auto-named identically) no longer collapse or abort.
+            var existingPairs = new List<(PluginTypeInfo Type, PluginStepInfo Step)>();
             foreach (var existingType in existingTypes)
             {
-                var steps = await service.ListStepsForTypeAsync(existingType.Id);
+                var steps = await service.ListStepsForTypeAsync(existingType.Id, cancellationToken: cancellationToken);
                 foreach (var step in steps)
-                {
-                    // Collision check: two existing steps in the environment sharing the same
-                    // name would silently collapse in this dictionary, causing cleanup to drop
-                    // one of them and deploy diffs to misreport existence. Surface the conflict.
-                    if (existingStepsMap.TryGetValue(step.Name, out var existingSameName))
-                    {
-                        throw new PpdsException(
-                            ErrorCodes.Operation.Duplicate,
-                            $"Environment contains duplicate plugin step name '{step.Name}' " +
-                            $"(ids: {existingSameName.Id}, {step.Id}) under assembly '{assemblyConfig.Name}'. " +
-                            "Rename or delete one of the conflicting steps in the environment before re-deploying.");
-                    }
-                    existingStepsMap[step.Name] = step;
-                }
+                    existingPairs.Add((existingType, step));
+            }
+
+            var configuredPairs = new List<(PluginTypeConfig Type, PluginStepConfig Step)>();
+            foreach (var typeConfigForPair in assemblyConfig.Types)
+                foreach (var stepConfigForPair in typeConfigForPair.Steps)
+                    configuredPairs.Add((typeConfigForPair, stepConfigForPair));
+
+            var matches = PluginStepMatcher.Match(
+                configuredPairs,
+                existingPairs,
+                onResidualCollision: (id, configCount, envCount) =>
+                    result.Warnings.Add(PluginStepMatcher.DescribeResidualCollision(id, configCount, envCount)));
+
+            if (!globalOptions.IsJsonMode)
+            {
+                foreach (var warning in result.Warnings)
+                    Console.Error.WriteLine($"  [!] Warning: {warning}");
+            }
+
+            // Map each configured step (by reference identity) to its matched environment step, if any.
+            // A configured step with no match is force-created; a paired step updates that exact row.
+            var envForConfigStep = new Dictionary<PluginStepConfig, PluginStepInfo?>(StepConfigReferenceComparer.Instance);
+            foreach (var match in matches)
+            {
+                if (match.Config is not null)
+                    envForConfigStep[match.Config] = match.Env;
             }
 
             // Deploy each type
@@ -373,10 +393,10 @@ public static class DeployCommand
                 // Deploy each step
                 foreach (var stepConfig in typeConfig.Steps)
                 {
-                    // Resolve auto-generated name if not specified
-                    stepConfig.Name ??= $"{typeConfig.TypeName}: {stepConfig.Message} of {stepConfig.Entity}";
+                    // Resolve auto-generated name if not specified. Deploy writes this name to the
+                    // matched row, so a renamed environment step converges back to the configured name.
+                    stepConfig.Name ??= PluginStepMatcher.ResolveConfigName(typeConfig, stepConfig);
                     var stepName = stepConfig.Name;
-                    configuredStepNames.Add(stepName);
 
                     // Lookup message and filter
                     var messageId = await service.GetSdkMessageIdAsync(stepConfig.Message);
@@ -392,12 +412,17 @@ public static class DeployCommand
                         stepConfig.Entity,
                         stepConfig.SecondaryEntity);
 
-                    var isNew = !existingStepsMap.ContainsKey(stepName);
+                    var matchedEnvStep = envForConfigStep.TryGetValue(stepConfig, out var env) ? env : null;
+                    var isNew = matchedEnvStep is null;
+
+                    // Identity-based resolution: paired -> update that exact GUID; missing -> force-create
+                    // (a null id skips the name lookup so a same-named different-identity row is never hijacked).
+                    var resolution = new StepIdentityResolution(matchedEnvStep?.Id);
 
                     Guid stepId;
                     if (dryRun)
                     {
-                        stepId = Guid.NewGuid();
+                        stepId = matchedEnvStep?.Id ?? Guid.NewGuid();
                         if (!globalOptions.IsJsonMode)
                             Console.Error.WriteLine($"    [Dry-Run] Would {(isNew ? "create" : "update")} step: {stepName}");
 
@@ -406,7 +431,7 @@ public static class DeployCommand
                     }
                     else
                     {
-                        stepId = await service.UpsertStepAsync(typeId, "pluginType", stepConfig, messageId.Value, filterId, solution);
+                        stepId = await service.UpsertStepAsync(typeId, "pluginType", stepConfig, messageId.Value, filterId, solution, resolution, cancellationToken);
                         if (!globalOptions.IsJsonMode)
                             Console.Error.WriteLine($"    Step {(isNew ? "created" : "updated")}: {stepName}");
 
@@ -443,34 +468,31 @@ public static class DeployCommand
                 }
             }
 
-            // Handle orphan cleanup if requested
+            // Handle orphan cleanup if requested. Orphans are the environment steps the matcher could
+            // not pair to any configured step; delete exactly those rows by GUID.
             if (clean)
             {
-                var orphanedStepNames = existingStepsMap.Keys.Except(configuredStepNames).ToList();
+                var orphanedSteps = matches.Where(m => m.IsOrphaned).Select(m => m.Env!).ToList();
 
-                if (orphanedStepNames.Count > 0)
+                if (orphanedSteps.Count > 0)
                 {
                     if (!globalOptions.IsJsonMode)
-                        Console.Error.WriteLine($"  Cleaning {orphanedStepNames.Count} orphaned step(s)...");
+                        Console.Error.WriteLine($"  Cleaning {orphanedSteps.Count} orphaned step(s)...");
 
-                    foreach (var orphanName in orphanedStepNames)
+                    foreach (var orphanStep in orphanedSteps)
                     {
-                        // Use dictionary lookup instead of re-querying
-                        if (existingStepsMap.TryGetValue(orphanName, out var orphanStep))
+                        if (dryRun)
                         {
-                            if (dryRun)
-                            {
-                                if (!globalOptions.IsJsonMode)
-                                    Console.Error.WriteLine($"    [Dry-Run] Would delete step: {orphanName}");
-                                result.StepsDeleted++;
-                            }
-                            else
-                            {
-                                await service.DeleteStepAsync(orphanStep.Id);
-                                if (!globalOptions.IsJsonMode)
-                                    Console.Error.WriteLine($"    Deleted step: {orphanName}");
-                                result.StepsDeleted++;
-                            }
+                            if (!globalOptions.IsJsonMode)
+                                Console.Error.WriteLine($"    [Dry-Run] Would delete step: {orphanStep.Name}");
+                            result.StepsDeleted++;
+                        }
+                        else
+                        {
+                            await service.DeleteStepAsync(orphanStep.Id, cancellationToken);
+                            if (!globalOptions.IsJsonMode)
+                                Console.Error.WriteLine($"    Deleted step: {orphanStep.Name}");
+                            result.StepsDeleted++;
                         }
                     }
                 }
@@ -610,7 +632,7 @@ public static class DeployCommand
 
     #region Result Models
 
-    private sealed class DeploymentResult
+    internal sealed class DeploymentResult
     {
         [JsonPropertyName("assemblyName")]
         public string AssemblyName { get; set; } = string.Empty;
@@ -638,6 +660,28 @@ public static class DeployCommand
 
         [JsonPropertyName("imagesDeleted")]
         public int ImagesDeleted { get; set; }
+
+        /// <summary>
+        /// Advisory messages (e.g., residual functional-identity collisions). Deployment still
+        /// proceeds; these surface ambiguity for the operator to resolve.
+        /// </summary>
+        [JsonPropertyName("warnings")]
+        public List<string> Warnings { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Reference-identity comparer for mapping a specific <see cref="PluginStepConfig"/> instance to its
+    /// matched environment step. Two distinct config objects with identical values must remain distinct
+    /// keys (the matcher already zipped them positionally), so value equality would be wrong here.
+    /// </summary>
+    private sealed class StepConfigReferenceComparer : IEqualityComparer<PluginStepConfig>
+    {
+        public static readonly StepConfigReferenceComparer Instance = new();
+
+        public bool Equals(PluginStepConfig? x, PluginStepConfig? y) => ReferenceEquals(x, y);
+
+        public int GetHashCode(PluginStepConfig obj) =>
+            System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
     }
 
     #endregion

--- a/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
@@ -120,7 +120,9 @@ public static class DiffCommand
             }
             else
             {
-                if (!hasDrift)
+                var hasWarnings = allDrifts.Any(d => d.Warnings.Count > 0);
+
+                if (!hasDrift && !hasWarnings)
                 {
                     Console.Error.WriteLine("No drift detected. Environment matches configuration.");
                     return ExitCodes.Success;
@@ -128,10 +130,13 @@ public static class DiffCommand
 
                 foreach (var drift in allDrifts)
                 {
-                    if (!drift.HasDrift)
+                    if (!drift.HasDrift && drift.Warnings.Count == 0)
                         continue;
 
                     Console.Error.WriteLine($"Assembly: {drift.AssemblyName}");
+
+                    foreach (var warning in drift.Warnings)
+                        Console.Error.WriteLine($"  [!] Warning: {warning}");
 
                     if (drift.AssemblyMissing)
                     {
@@ -193,7 +198,13 @@ public static class DiffCommand
         }
     }
 
-    private static async Task<AssemblyDrift> ComputeDriftAsync(
+    /// <summary>
+    /// Computes drift between the configured assembly and its environment state, matching steps by
+    /// functional identity (<see cref="PluginStepMatcher"/>) rather than by mutable display name so an
+    /// environment holding two same-named steps no longer aborts the diff.
+    /// </summary>
+    /// <remarks><c>internal</c> for direct unit-test access (InternalsVisibleTo PPDS.Cli.Tests).</remarks>
+    internal static async Task<AssemblyDrift> ComputeDriftAsync(
         IPluginRegistrationService service,
         PluginAssemblyConfig config)
     {
@@ -213,171 +224,152 @@ public static class DiffCommand
         // Get all types for this assembly
         var existingTypes = await service.ListTypesForAssemblyAsync(assembly.Id);
 
-        // Build a map of all configured steps. Duplicate resolved names within a config file
-        // are blocked earlier by PluginRegistrationConfig.Validate(); if we still hit one here
-        // (e.g., Validate() was skipped), throw a PpdsException so the mismatch is visible in
-        // diff output instead of silently collapsing.
-        var configuredSteps = new Dictionary<string, (PluginTypeConfig Type, PluginStepConfig Step)>();
+        // Configured (type, step) pairs. Config-side duplicate resolved names are already blocked by
+        // PluginRegistrationConfig.Validate() (per-type name uniqueness); the matcher's zip semantics
+        // handle any residual identity collision without collapsing entries.
+        var configured = new List<(PluginTypeConfig Type, PluginStepConfig Step)>();
         foreach (var typeConfig in config.Types)
         {
             foreach (var stepConfig in typeConfig.Steps)
-            {
-                var key = stepConfig.Name ?? $"{typeConfig.TypeName}: {stepConfig.Message} of {stepConfig.Entity}";
-                if (configuredSteps.ContainsKey(key))
-                {
-                    throw new PpdsException(
-                        ErrorCodes.Operation.Duplicate,
-                        $"Assembly '{config.Name}' has multiple configured steps resolving to name '{key}'. " +
-                        "Provide unique explicit Name values so the diff output reflects every step.");
-                }
-                configuredSteps[key] = (typeConfig, stepConfig);
-            }
+                configured.Add((typeConfig, stepConfig));
         }
 
-        // Get all existing steps. Duplicate names in the environment are a real (though rare)
-        // possibility — surface them rather than letting one silently overwrite the other.
-        var existingSteps = new Dictionary<string, (PluginTypeInfo Type, PluginStepInfo Step)>();
+        // Existing (type, step) pairs. The owning type name comes from the enclosing loop so identity
+        // is attributed to the correct type. Duplicate names in the environment no longer throw.
+        var existing = new List<(PluginTypeInfo Type, PluginStepInfo Step)>();
         foreach (var existingType in existingTypes)
         {
             var steps = await service.ListStepsForTypeAsync(existingType.Id);
             foreach (var step in steps)
-            {
-                if (existingSteps.TryGetValue(step.Name, out var priorEntry))
-                {
-                    throw new PpdsException(
-                        ErrorCodes.Operation.Duplicate,
-                        $"Environment contains duplicate plugin step name '{step.Name}' " +
-                        $"(ids: {priorEntry.Step.Id}, {step.Id}) under assembly '{config.Name}'. " +
-                        "Rename or delete one of the conflicting steps in the environment before diffing.");
-                }
-                existingSteps[step.Name] = (existingType, step);
-            }
+                existing.Add((existingType, step));
         }
 
-        // Find missing steps (in config, not in environment)
-        foreach (var (stepName, (typeConfig, stepConfig)) in configuredSteps)
+        var matches = PluginStepMatcher.Match(
+            configured,
+            existing,
+            onResidualCollision: (id, configCount, envCount) =>
+                drift.Warnings.Add(PluginStepMatcher.DescribeResidualCollision(id, configCount, envCount)));
+
+        foreach (var match in matches)
         {
-            if (!existingSteps.ContainsKey(stepName))
+            if (match.IsMissing)
             {
+                var typeConfig = match.TypeConfig!;
+                var stepConfig = match.Config!;
                 drift.MissingSteps.Add(new StepDrift
                 {
                     TypeName = typeConfig.TypeName,
-                    StepName = stepName,
+                    StepName = PluginStepMatcher.ResolveConfigName(typeConfig, stepConfig),
                     Message = stepConfig.Message,
                     Entity = stepConfig.Entity,
                     Stage = stepConfig.Stage,
                     Mode = stepConfig.Mode
                 });
             }
-        }
-
-        // Find orphaned steps (in environment, not in config)
-        foreach (var (stepName, (typeInfo, stepInfo)) in existingSteps)
-        {
-            if (!configuredSteps.ContainsKey(stepName))
+            else if (match.IsOrphaned)
             {
+                var typeInfo = match.EnvType!;
+                var stepInfo = match.Env!;
                 drift.OrphanedSteps.Add(new StepDrift
                 {
                     TypeName = typeInfo.TypeName,
-                    StepName = stepName,
+                    StepName = stepInfo.Name,
                     Message = stepInfo.Message,
                     Entity = stepInfo.PrimaryEntity,
                     Stage = stepInfo.Stage,
                     Mode = stepInfo.Mode
                 });
             }
-        }
-
-        // Find modified steps and check images
-        foreach (var (stepName, (typeConfig, stepConfig)) in configuredSteps)
-        {
-            if (!existingSteps.TryGetValue(stepName, out var existing))
-                continue;
-
-            var (_, stepInfo) = existing;
-
-            // Compare step properties
-            var changes = new List<PropertyChange>();
-
-            if (!string.Equals(stepConfig.Stage, stepInfo.Stage, StringComparison.OrdinalIgnoreCase))
-                changes.Add(new PropertyChange("stage", stepConfig.Stage, stepInfo.Stage));
-
-            if (!string.Equals(stepConfig.Mode, stepInfo.Mode, StringComparison.OrdinalIgnoreCase))
-                changes.Add(new PropertyChange("mode", stepConfig.Mode, stepInfo.Mode));
-
-            if (stepConfig.ExecutionOrder != stepInfo.ExecutionOrder)
-                changes.Add(new PropertyChange("executionOrder", stepConfig.ExecutionOrder.ToString(), stepInfo.ExecutionOrder.ToString()));
-
-            var configFiltering = NormalizeAttributes(stepConfig.FilteringAttributes);
-            var envFiltering = NormalizeAttributes(stepInfo.FilteringAttributes);
-            if (!string.Equals(configFiltering, envFiltering, StringComparison.OrdinalIgnoreCase))
-                changes.Add(new PropertyChange("filteringAttributes", configFiltering ?? "(none)", envFiltering ?? "(none)"));
-
-            if (changes.Count > 0)
+            else
             {
-                drift.ModifiedSteps.Add(new ModifiedStepDrift
-                {
-                    TypeName = typeConfig.TypeName,
-                    StepName = stepName,
-                    Changes = changes
-                });
-            }
+                var typeConfig = match.TypeConfig!;
+                var stepConfig = match.Config!;
+                var stepInfo = match.Env!;
+                var resolvedName = PluginStepMatcher.ResolveConfigName(typeConfig, stepConfig);
 
-            // Compare images
-            var existingImages = await service.ListImagesForStepAsync(stepInfo.Id);
-            var existingImageMap = existingImages.ToDictionary(i => i.Name, i => i);
-            var configImageMap = stepConfig.Images.ToDictionary(i => i.Name, i => i);
+                // Compare step properties. Stage and mode are part of the identity now — a paired step
+                // shares them by construction, so they can never differ here and are no longer compared.
+                var changes = new List<PropertyChange>();
 
-            // Missing images
-            foreach (var imageConfig in stepConfig.Images)
-            {
-                if (!existingImageMap.ContainsKey(imageConfig.Name))
+                // Name is no longer identity: a rename leaves behavior intact but should still surface,
+                // and a deploy would converge the environment name to the configured one.
+                if (!string.Equals(resolvedName, stepInfo.Name, StringComparison.Ordinal))
+                    changes.Add(new PropertyChange("name", resolvedName, stepInfo.Name));
+
+                if (stepConfig.ExecutionOrder != stepInfo.ExecutionOrder)
+                    changes.Add(new PropertyChange("executionOrder", stepConfig.ExecutionOrder.ToString(), stepInfo.ExecutionOrder.ToString()));
+
+                var configFiltering = NormalizeAttributes(stepConfig.FilteringAttributes);
+                var envFiltering = NormalizeAttributes(stepInfo.FilteringAttributes);
+                if (!string.Equals(configFiltering, envFiltering, StringComparison.OrdinalIgnoreCase))
+                    changes.Add(new PropertyChange("filteringAttributes", configFiltering ?? "(none)", envFiltering ?? "(none)"));
+
+                if (changes.Count > 0)
                 {
-                    drift.MissingImages.Add(new ImageDrift
+                    drift.ModifiedSteps.Add(new ModifiedStepDrift
                     {
-                        StepName = stepName,
-                        ImageName = imageConfig.Name
+                        TypeName = typeConfig.TypeName,
+                        StepName = resolvedName,
+                        Changes = changes
                     });
                 }
-            }
 
-            // Orphaned images
-            foreach (var imageInfo in existingImages)
-            {
-                if (!configImageMap.ContainsKey(imageInfo.Name))
+                // Compare images
+                var existingImages = await service.ListImagesForStepAsync(stepInfo.Id);
+                var existingImageMap = existingImages.ToDictionary(i => i.Name, i => i);
+                var configImageMap = stepConfig.Images.ToDictionary(i => i.Name, i => i);
+
+                // Missing images
+                foreach (var imageConfig in stepConfig.Images)
                 {
-                    drift.OrphanedImages.Add(new ImageDrift
+                    if (!existingImageMap.ContainsKey(imageConfig.Name))
                     {
-                        StepName = stepName,
-                        ImageName = imageInfo.Name
-                    });
+                        drift.MissingImages.Add(new ImageDrift
+                        {
+                            StepName = resolvedName,
+                            ImageName = imageConfig.Name
+                        });
+                    }
                 }
-            }
 
-            // Modified images
-            foreach (var imageConfig in stepConfig.Images)
-            {
-                if (!existingImageMap.TryGetValue(imageConfig.Name, out var imageInfo))
-                    continue;
-
-                var imageChanges = new List<PropertyChange>();
-
-                if (!string.Equals(imageConfig.ImageType, imageInfo.ImageType, StringComparison.OrdinalIgnoreCase))
-                    imageChanges.Add(new PropertyChange("imageType", imageConfig.ImageType, imageInfo.ImageType));
-
-                var configAttrs = NormalizeAttributes(imageConfig.Attributes);
-                var envAttrs = NormalizeAttributes(imageInfo.Attributes);
-                if (!string.Equals(configAttrs, envAttrs, StringComparison.OrdinalIgnoreCase))
-                    imageChanges.Add(new PropertyChange("attributes", configAttrs ?? "(all)", envAttrs ?? "(all)"));
-
-                if (imageChanges.Count > 0)
+                // Orphaned images
+                foreach (var imageInfo in existingImages)
                 {
-                    drift.ModifiedImages.Add(new ModifiedImageDrift
+                    if (!configImageMap.ContainsKey(imageInfo.Name))
                     {
-                        StepName = stepName,
-                        ImageName = imageConfig.Name,
-                        Changes = imageChanges
-                    });
+                        drift.OrphanedImages.Add(new ImageDrift
+                        {
+                            StepName = resolvedName,
+                            ImageName = imageInfo.Name
+                        });
+                    }
+                }
+
+                // Modified images
+                foreach (var imageConfig in stepConfig.Images)
+                {
+                    if (!existingImageMap.TryGetValue(imageConfig.Name, out var imageInfo))
+                        continue;
+
+                    var imageChanges = new List<PropertyChange>();
+
+                    if (!string.Equals(imageConfig.ImageType, imageInfo.ImageType, StringComparison.OrdinalIgnoreCase))
+                        imageChanges.Add(new PropertyChange("imageType", imageConfig.ImageType, imageInfo.ImageType));
+
+                    var configAttrs = NormalizeAttributes(imageConfig.Attributes);
+                    var envAttrs = NormalizeAttributes(imageInfo.Attributes);
+                    if (!string.Equals(configAttrs, envAttrs, StringComparison.OrdinalIgnoreCase))
+                        imageChanges.Add(new PropertyChange("attributes", configAttrs ?? "(all)", envAttrs ?? "(all)"));
+
+                    if (imageChanges.Count > 0)
+                    {
+                        drift.ModifiedImages.Add(new ModifiedImageDrift
+                        {
+                            StepName = resolvedName,
+                            ImageName = imageConfig.Name,
+                            Changes = imageChanges
+                        });
+                    }
                 }
             }
         }
@@ -402,7 +394,7 @@ public static class DiffCommand
 
     #region Drift Models
 
-    private sealed class AssemblyDrift
+    internal sealed class AssemblyDrift
     {
         [JsonPropertyName("assemblyName")]
         public string AssemblyName { get; set; } = string.Empty;
@@ -428,6 +420,13 @@ public static class DiffCommand
         [JsonPropertyName("modifiedImages")]
         public List<ModifiedImageDrift> ModifiedImages { get; set; } = [];
 
+        /// <summary>
+        /// Advisory messages (e.g., residual functional-identity collisions where multiple steps
+        /// share an identity). Warnings do not by themselves constitute drift.
+        /// </summary>
+        [JsonPropertyName("warnings")]
+        public List<string> Warnings { get; set; } = [];
+
         [JsonIgnore]
         public bool HasDrift => AssemblyMissing ||
                                 MissingSteps.Count > 0 ||
@@ -438,7 +437,7 @@ public static class DiffCommand
                                 ModifiedImages.Count > 0;
     }
 
-    private sealed class StepDrift
+    internal sealed class StepDrift
     {
         [JsonPropertyName("typeName")]
         public string TypeName { get; set; } = string.Empty;
@@ -459,7 +458,7 @@ public static class DiffCommand
         public string Mode { get; set; } = string.Empty;
     }
 
-    private sealed class ModifiedStepDrift
+    internal sealed class ModifiedStepDrift
     {
         [JsonPropertyName("typeName")]
         public string TypeName { get; set; } = string.Empty;
@@ -471,7 +470,7 @@ public static class DiffCommand
         public List<PropertyChange> Changes { get; set; } = [];
     }
 
-    private sealed class ImageDrift
+    internal sealed class ImageDrift
     {
         [JsonPropertyName("stepName")]
         public string StepName { get; set; } = string.Empty;
@@ -480,7 +479,7 @@ public static class DiffCommand
         public string ImageName { get; set; } = string.Empty;
     }
 
-    private sealed class ModifiedImageDrift
+    internal sealed class ModifiedImageDrift
     {
         [JsonPropertyName("stepName")]
         public string StepName { get; set; } = string.Empty;
@@ -492,7 +491,7 @@ public static class DiffCommand
         public List<PropertyChange> Changes { get; set; } = [];
     }
 
-    private sealed class PropertyChange
+    internal sealed class PropertyChange
     {
         [JsonPropertyName("property")]
         public string Property { get; set; }

--- a/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
@@ -551,7 +551,7 @@ public static class RegisterCommand
                 SecureConfiguration = secureConfig
             };
 
-            var stepId = await registrationService.UpsertStepAsync(pluginType.Id, eventHandlerType, stepConfig, messageId.Value, filterId, solution, cancellationToken);
+            var stepId = await registrationService.UpsertStepAsync(pluginType.Id, eventHandlerType, stepConfig, messageId.Value, filterId, solution, cancellationToken: cancellationToken);
 
             var result = new RegisterStepResult
             {

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
@@ -324,7 +324,7 @@ public partial class RpcMethodHandler
                 SecondaryEntity = secondaryEntity
             };
 
-            var stepId = await registrationService.UpsertStepAsync(typeId, eventHandlerType, stepConfig, messageId, filterId, solutionName, ct);
+            var stepId = await registrationService.UpsertStepAsync(typeId, eventHandlerType, stepConfig, messageId, filterId, solutionName, cancellationToken: ct);
 
             return new PluginsRegisterResponse { Id = stepId.ToString() };
         }, cancellationToken);

--- a/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/IPluginRegistrationService.cs
@@ -287,6 +287,13 @@ public interface IPluginRegistrationService
     /// <param name="messageId">The SDK message ID.</param>
     /// <param name="filterId">Optional SDK message filter ID.</param>
     /// <param name="solutionName">Optional solution name.</param>
+    /// <param name="identity">
+    /// Optional identity-based resolution from <see cref="PluginStepMatcher"/>. When <c>null</c> the
+    /// step is located by <c>(EventHandler, Name)</c> (the legacy path used by ad-hoc registration and
+    /// RPC). When non-null with a step id, that exact row is updated; when non-null with a null id, the
+    /// step is force-created without any name lookup so a same-named-but-different-identity row is never
+    /// hijacked.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<Guid> UpsertStepAsync(
         Guid eventHandlerId,
@@ -295,6 +302,7 @@ public interface IPluginRegistrationService
         Guid messageId,
         Guid? filterId,
         string? solutionName = null,
+        StepIdentityResolution? identity = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -1248,29 +1248,63 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         Guid messageId,
         Guid? filterId,
         string? solutionName = null,
+        StepIdentityResolution? identity = null,
         CancellationToken cancellationToken = default)
     {
         _guard.EnsureCanMutate("plugins.step.upsert");
-        // Check if step exists by name
-        var query = new QueryExpression(SdkMessageProcessingStep.EntityLogicalName)
-        {
-            ColumnSet = new ColumnSet(
-                SdkMessageProcessingStep.Fields.SdkMessageProcessingStepId,
-                SdkMessageProcessingStep.Fields.StateCode,
-                SdkMessageProcessingStep.Fields.SdkMessageProcessingStepSecureConfigId),
-            Criteria = new FilterExpression
-            {
-                Conditions =
-                {
-                    new ConditionExpression(SdkMessageProcessingStep.Fields.EventHandler, ConditionOperator.Equal, eventHandlerId),
-                    new ConditionExpression(SdkMessageProcessingStep.Fields.Name, ConditionOperator.Equal, stepConfig.Name)
-                }
-            }
-        };
 
         await using var client = await _pool.GetClientAsync(cancellationToken: cancellationToken);
-        var results = await RetrieveMultipleAsync(query, client, cancellationToken);
-        var existing = results.Entities.FirstOrDefault();
+
+        // Resolve the row to write:
+        //  - identity == null                    -> legacy behavior: locate by (EventHandler, Name).
+        //  - identity with a non-null step id     -> update exactly that GUID (never a same-named sibling).
+        //  - identity with a null step id         -> force-create: skip the lookup entirely.
+        var columns = new ColumnSet(
+            SdkMessageProcessingStep.Fields.SdkMessageProcessingStepId,
+            SdkMessageProcessingStep.Fields.StateCode,
+            SdkMessageProcessingStep.Fields.SdkMessageProcessingStepSecureConfigId);
+
+        Entity? existing;
+        if (identity is null)
+        {
+            // Check if step exists by name
+            var query = new QueryExpression(SdkMessageProcessingStep.EntityLogicalName)
+            {
+                ColumnSet = columns,
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression(SdkMessageProcessingStep.Fields.EventHandler, ConditionOperator.Equal, eventHandlerId),
+                        new ConditionExpression(SdkMessageProcessingStep.Fields.Name, ConditionOperator.Equal, stepConfig.Name)
+                    }
+                }
+            };
+
+            var results = await RetrieveMultipleAsync(query, client, cancellationToken);
+            existing = results.Entities.FirstOrDefault();
+        }
+        else if (identity.ExistingStepId is { } existingStepId)
+        {
+            var query = new QueryExpression(SdkMessageProcessingStep.EntityLogicalName)
+            {
+                ColumnSet = columns,
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression(SdkMessageProcessingStep.Fields.SdkMessageProcessingStepId, ConditionOperator.Equal, existingStepId)
+                    }
+                }
+            };
+
+            var results = await RetrieveMultipleAsync(query, client, cancellationToken);
+            existing = results.Entities.FirstOrDefault();
+        }
+        else
+        {
+            existing = null;
+        }
 
         var entity = new SdkMessageProcessingStep
         {

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -2329,7 +2329,9 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         return response.id;
     }
 
-    private static string MapStageFromValue(int value) => value switch
+    // internal (not private) so PluginStepIdentity can canonicalize config-side stage/mode tokens
+    // through the exact same mapping the write path uses — see PluginStepIdentity.Normalize.
+    internal static string MapStageFromValue(int value) => value switch
     {
         StagePreValidation => "PreValidation",
         StagePreOperation => "PreOperation",
@@ -2338,7 +2340,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         _ => value.ToString()
     };
 
-    private static string MapModeFromValue(int value) => value switch
+    internal static string MapModeFromValue(int value) => value switch
     {
         0 => "Synchronous",
         1 => "Asynchronous",
@@ -2353,7 +2355,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         _ => value.ToString()
     };
 
-    private static int MapStageToValue(string stage) => stage switch
+    internal static int MapStageToValue(string stage) => stage switch
     {
         "PreValidation" => StagePreValidation,
         "PreOperation" => StagePreOperation,
@@ -2362,7 +2364,7 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         _ => int.TryParse(stage, out var v) ? v : StagePostOperation
     };
 
-    private static int MapModeToValue(string mode) => mode switch
+    internal static int MapModeToValue(string mode) => mode switch
     {
         "Synchronous" => 0,
         "Asynchronous" => 1,

--- a/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
@@ -1,0 +1,288 @@
+using PPDS.Cli.Plugins.Models;
+
+namespace PPDS.Cli.Plugins.Registration;
+
+/// <summary>
+/// The functional identity of a plugin processing step — the tuple of immutable coordinates
+/// that determines which real Dataverse behavior a step represents, independent of its mutable
+/// display name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A Dataverse step <c>name</c> is a mutable display label; only the <c>SdkMessageProcessingStepId</c>
+/// GUID is unique. Two steps can legitimately share a name — commonly when the Plugin Registration
+/// Tool auto-names steps <c>"{TypeName}: {Message} of {Entity}"</c> (omitting stage and mode), so a
+/// PreOperation/PostOperation pair on the same message and entity collide on name. Matching
+/// configuration to the environment by name therefore either mis-classifies steps or aborts. Keying
+/// on this functional identity instead is stable across renames and unambiguous for distinct
+/// behaviors.
+/// </para>
+/// <para>
+/// Rank/ExecutionOrder and FilteringAttributes are deliberately NOT part of the identity: they are
+/// mutable properties that deploy updates in place. Keying on them would turn a rank tweak into a
+/// delete+create, breaking idempotent redeploys. Name is likewise NOT part of the identity.
+/// </para>
+/// </remarks>
+public readonly record struct PluginStepIdentity(
+    string PluginTypeName,
+    string Message,
+    string PrimaryEntity,
+    string SecondaryEntity,
+    string Stage,
+    string Mode)
+{
+    /// <summary>Sentinel for an absent primary/secondary entity (global messages).</summary>
+    public const string NoEntity = "none";
+
+    /// <summary>
+    /// Builds an identity from a configured step under the given plugin type.
+    /// </summary>
+    public static PluginStepIdentity FromConfig(string pluginTypeName, PluginStepConfig step) =>
+        Normalize(pluginTypeName, step.Message, step.Entity, step.SecondaryEntity, step.Stage, step.Mode);
+
+    /// <summary>
+    /// Builds an identity from an existing environment step under the given plugin type.
+    /// </summary>
+    public static PluginStepIdentity FromEnvironment(string pluginTypeName, PluginStepInfo step) =>
+        Normalize(pluginTypeName, step.Message, step.PrimaryEntity, step.SecondaryEntity, step.Stage, step.Mode);
+
+    /// <summary>
+    /// The single normalizer both factories funnel through: trims and lower-cases every component so
+    /// casing/whitespace differences between config and environment never split an identity, and
+    /// collapses null/empty/"none" entities to <see cref="NoEntity"/>.
+    /// </summary>
+    private static PluginStepIdentity Normalize(
+        string? pluginTypeName,
+        string? message,
+        string? primaryEntity,
+        string? secondaryEntity,
+        string? stage,
+        string? mode) =>
+        new(
+            NormalizeComponent(pluginTypeName),
+            NormalizeComponent(message),
+            NormalizeEntity(primaryEntity),
+            NormalizeEntity(secondaryEntity),
+            NormalizeComponent(stage),
+            NormalizeComponent(mode));
+
+    private static string NormalizeComponent(string? value) =>
+        (value ?? string.Empty).Trim().ToLowerInvariant();
+
+    private static string NormalizeEntity(string? value)
+    {
+        var normalized = NormalizeComponent(value);
+        return normalized.Length == 0 || normalized == NoEntity ? NoEntity : normalized;
+    }
+
+    /// <summary>
+    /// Human-readable rendering for warnings and drift reporting, e.g.
+    /// <c>myplugin.type: update of account (postoperation, synchronous)</c>. Components are shown in
+    /// their normalized (lower-cased) form because that is what identity is compared on.
+    /// </summary>
+    public override string ToString()
+    {
+        var entity = SecondaryEntity == NoEntity
+            ? PrimaryEntity
+            : $"{PrimaryEntity} -> {SecondaryEntity}";
+        return $"{PluginTypeName}: {Message} of {entity} ({Stage}, {Mode})";
+    }
+}
+
+/// <summary>
+/// Resolution for how <see cref="IPluginRegistrationService.UpsertStepAsync"/> should locate the row
+/// to write when identity-based matching has already been performed by the caller.
+/// </summary>
+/// <param name="ExistingStepId">
+/// The GUID of the environment step this configured step was matched to, or <c>null</c> to force a
+/// create (the matcher found no counterpart). A non-null value updates exactly that row; a null value
+/// skips the lookup entirely so a same-named-but-different-identity row can never be hijacked.
+/// </param>
+public sealed record StepIdentityResolution(Guid? ExistingStepId);
+
+/// <summary>
+/// Matches configured plugin steps to existing environment steps by functional identity
+/// (<see cref="PluginStepIdentity"/>) rather than by mutable display name.
+/// </summary>
+/// <remarks>
+/// Both sides are grouped by identity. Within each identity group both sides are ordered
+/// deterministically and zipped into pairs; a surplus on the configured side becomes
+/// <see cref="StepMatch.IsMissing"/> (needs create) and a surplus on the environment side becomes
+/// <see cref="StepMatch.IsOrphaned"/> (candidate for --clean). Whenever either side of a group holds
+/// more than one member the optional <c>onResidualCollision</c> callback fires: the zip still
+/// converges (extras only ever add or delete), so a residual collision warns rather than aborts.
+/// </remarks>
+public static class PluginStepMatcher
+{
+    /// <summary>
+    /// The pairing of at most one configured step and at most one environment step that share a
+    /// functional identity.
+    /// </summary>
+    /// <remarks>
+    /// Named <c>StepMatch</c> (not <c>Match</c>) to avoid colliding with the <see cref="Match"/> entry
+    /// method on the enclosing type.
+    /// </remarks>
+    public sealed record StepMatch(
+        PluginTypeConfig? TypeConfig,
+        PluginStepConfig? Config,
+        PluginTypeInfo? EnvType,
+        PluginStepInfo? Env)
+    {
+        /// <summary>Both a configured step and an environment step are present (update in place).</summary>
+        public bool IsPaired => Config is not null && Env is not null;
+
+        /// <summary>Configured but absent from the environment (needs create).</summary>
+        public bool IsMissing => Config is not null && Env is null;
+
+        /// <summary>Present in the environment but not configured (orphan; delete under --clean).</summary>
+        public bool IsOrphaned => Config is null && Env is not null;
+    }
+
+    /// <summary>
+    /// Pairs configured steps with existing environment steps by functional identity.
+    /// </summary>
+    /// <param name="configured">Configured (type, step) pairs.</param>
+    /// <param name="existing">Existing environment (type, step) pairs.</param>
+    /// <param name="onResidualCollision">
+    /// Invoked as <c>(identity, configuredCount, environmentCount)</c> whenever an identity group has
+    /// more than one member on either side. The classification still proceeds.
+    /// </param>
+    public static IReadOnlyList<StepMatch> Match(
+        IEnumerable<(PluginTypeConfig Type, PluginStepConfig Step)> configured,
+        IEnumerable<(PluginTypeInfo Type, PluginStepInfo Step)> existing,
+        Action<PluginStepIdentity, int, int>? onResidualCollision = null)
+    {
+        var configByIdentity = configured
+            .GroupBy(c => PluginStepIdentity.FromConfig(c.Type.TypeName, c.Step))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var envByIdentity = existing
+            .GroupBy(e => PluginStepIdentity.FromEnvironment(e.Type.TypeName, e.Step))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // Deterministic set of identities: configured first (config order preserved by GroupBy),
+        // then any environment-only identities.
+        var identities = new List<PluginStepIdentity>();
+        var seen = new HashSet<PluginStepIdentity>();
+        foreach (var identity in configByIdentity.Keys.Concat(envByIdentity.Keys))
+        {
+            if (seen.Add(identity))
+                identities.Add(identity);
+        }
+
+        var results = new List<StepMatch>();
+
+        foreach (var identity in identities)
+        {
+            var configList = configByIdentity.TryGetValue(identity, out var cfg)
+                ? cfg
+                : new List<(PluginTypeConfig Type, PluginStepConfig Step)>();
+            var envList = envByIdentity.TryGetValue(identity, out var env)
+                ? env
+                : new List<(PluginTypeInfo Type, PluginStepInfo Step)>();
+
+            if (configList.Count > 1 || envList.Count > 1)
+                onResidualCollision?.Invoke(identity, configList.Count, envList.Count);
+
+            configList.Sort(CompareConfig);
+            envList.Sort(CompareEnv);
+
+            var max = Math.Max(configList.Count, envList.Count);
+            for (var i = 0; i < max; i++)
+            {
+                PluginTypeConfig? typeConfig = null;
+                PluginStepConfig? stepConfig = null;
+                PluginTypeInfo? envType = null;
+                PluginStepInfo? envStep = null;
+
+                if (i < configList.Count)
+                {
+                    typeConfig = configList[i].Type;
+                    stepConfig = configList[i].Step;
+                }
+
+                if (i < envList.Count)
+                {
+                    envType = envList[i].Type;
+                    envStep = envList[i].Step;
+                }
+
+                results.Add(new StepMatch(typeConfig, stepConfig, envType, envStep));
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Resolves the display name a configured step deploys as: its explicit <c>Name</c>, or the
+    /// auto-name convention <c>"{TypeName}: {Message} of {Entity}"</c> when none is set. Kept identical
+    /// to the convention used by <c>PluginRegistrationConfig.Validate()</c>.
+    /// </summary>
+    public static string ResolveConfigName(PluginTypeConfig typeConfig, PluginStepConfig stepConfig) =>
+        stepConfig.Name ?? $"{typeConfig.TypeName}: {stepConfig.Message} of {stepConfig.Entity}";
+
+    /// <summary>
+    /// Formats a consistent warning describing a residual identity collision for surfacing to users.
+    /// </summary>
+    public static string DescribeResidualCollision(PluginStepIdentity identity, int configuredCount, int environmentCount) =>
+        $"Multiple plugin steps share the functional identity [{identity}] " +
+        $"(configured: {configuredCount}, environment: {environmentCount}). " +
+        "They were paired positionally and any surplus is treated as add/remove; " +
+        "give them distinct stage/mode/message/entity, or delete the redundant environment step, to disambiguate.";
+
+    private static int CompareConfig(
+        (PluginTypeConfig Type, PluginStepConfig Step) a,
+        (PluginTypeConfig Type, PluginStepConfig Step) b)
+    {
+        var byOrder = a.Step.ExecutionOrder.CompareTo(b.Step.ExecutionOrder);
+        if (byOrder != 0)
+            return byOrder;
+
+        var byFiltering = string.CompareOrdinal(
+            NormalizeFiltering(a.Step.FilteringAttributes),
+            NormalizeFiltering(b.Step.FilteringAttributes));
+        if (byFiltering != 0)
+            return byFiltering;
+
+        return string.CompareOrdinal(ResolveConfigName(a.Type, a.Step), ResolveConfigName(b.Type, b.Step));
+    }
+
+    private static int CompareEnv(
+        (PluginTypeInfo Type, PluginStepInfo Step) a,
+        (PluginTypeInfo Type, PluginStepInfo Step) b)
+    {
+        var byOrder = a.Step.ExecutionOrder.CompareTo(b.Step.ExecutionOrder);
+        if (byOrder != 0)
+            return byOrder;
+
+        var byFiltering = string.CompareOrdinal(
+            NormalizeFiltering(a.Step.FilteringAttributes),
+            NormalizeFiltering(b.Step.FilteringAttributes));
+        if (byFiltering != 0)
+            return byFiltering;
+
+        var byName = string.CompareOrdinal(a.Step.Name ?? string.Empty, b.Step.Name ?? string.Empty);
+        if (byName != 0)
+            return byName;
+
+        return a.Step.Id.CompareTo(b.Step.Id);
+    }
+
+    /// <summary>
+    /// Normalizes a comma-separated filtering-attributes string for stable ordering: trims, lower-cases,
+    /// drops empties, and sorts the tokens.
+    /// </summary>
+    private static string NormalizeFiltering(string? attributes)
+    {
+        if (string.IsNullOrWhiteSpace(attributes))
+            return string.Empty;
+
+        return string.Join(
+            ",",
+            attributes.Split(',')
+                .Select(a => a.Trim().ToLowerInvariant())
+                .Where(a => a.Length > 0)
+                .OrderBy(a => a, StringComparer.Ordinal));
+    }
+}

--- a/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
@@ -51,6 +51,14 @@ public readonly record struct PluginStepIdentity(
     /// casing/whitespace differences between config and environment never split an identity, and
     /// collapses null/empty/"none" entities to <see cref="NoEntity"/>.
     /// </summary>
+    /// <remarks>
+    /// Stage and Mode are additionally canonicalized through the exact mappers the deploy write path
+    /// uses (<see cref="PluginRegistrationService.MapStageToValue"/> → <see cref="PluginRegistrationService.MapStageFromValue"/>,
+    /// likewise for Mode). The environment side is always canonical ("PostOperation"/"Synchronous"),
+    /// but a hand-authored config may use variant tokens ("sync", "40", or an omitted stage). Without
+    /// this, such a config would never match its environment counterpart and deploy would force-create
+    /// a duplicate step on every run.
+    /// </remarks>
     private static PluginStepIdentity Normalize(
         string? pluginTypeName,
         string? message,
@@ -63,11 +71,46 @@ public readonly record struct PluginStepIdentity(
             NormalizeComponent(message),
             NormalizeEntity(primaryEntity),
             NormalizeEntity(secondaryEntity),
-            NormalizeComponent(stage),
-            NormalizeComponent(mode));
+            NormalizeComponent(CanonicalizeStage(stage)),
+            NormalizeComponent(CanonicalizeMode(mode)));
 
     private static string NormalizeComponent(string? value) =>
         (value ?? string.Empty).Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Canonicalizes a stage token to the form the write path persists and reads back (e.g. "40" or an
+    /// omitted stage → "PostOperation"), by round-tripping through the write path's own mappers. Never
+    /// throws — an unmappable token falls back to its raw (trimmed/lower-cased) form.
+    /// </summary>
+    private static string CanonicalizeStage(string? stage)
+    {
+        var token = (stage ?? string.Empty).Trim();
+        try
+        {
+            return PluginRegistrationService.MapStageFromValue(PluginRegistrationService.MapStageToValue(token));
+        }
+        catch
+        {
+            return token;
+        }
+    }
+
+    /// <summary>
+    /// Canonicalizes a mode token the same way as <see cref="CanonicalizeStage"/> (e.g. "sync" or an
+    /// omitted mode → "Synchronous"). Never throws.
+    /// </summary>
+    private static string CanonicalizeMode(string? mode)
+    {
+        var token = (mode ?? string.Empty).Trim();
+        try
+        {
+            return PluginRegistrationService.MapModeFromValue(PluginRegistrationService.MapModeToValue(token));
+        }
+        catch
+        {
+            return token;
+        }
+    }
 
     private static string NormalizeEntity(string? value)
     {

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/CleanCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/CleanCommandTests.cs
@@ -1,6 +1,11 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using Moq;
+using PPDS.Cli.Commands;
 using PPDS.Cli.Commands.Plugins;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
 using PPDS.Cli.Tests.TestHelpers;
 using Xunit;
 
@@ -151,6 +156,62 @@ public class CleanCommandTests : IDisposable
             "--dry-run " +
             "--output-format Json");
         Assert.Empty(result.Errors);
+    }
+
+    #endregion
+
+    #region Clean Matching Tests (#1295)
+
+    // The environment has two same-named steps differing only in stage; the config declares the
+    // PostOperation one. The PreOperation step must be detected as an orphan (previously the name-set
+    // check saw its name as "configured" and skipped it).
+    [Fact]
+    public async Task CleanAssemblyAsync_SameNamedOrphanOfDifferentStage_IsDetected()
+    {
+        var typeId = Guid.NewGuid();
+        var postId = Guid.NewGuid();
+        var preId = Guid.NewGuid();
+        const string sharedName = "MyPlugin.Handler: Update of account";
+
+        var mock = new Mock<IPluginRegistrationService>();
+        mock.Setup(s => s.GetAssemblyByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PluginAssemblyInfo { Id = Guid.NewGuid(), Name = "MyPlugin" });
+        mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+        mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PluginStepInfo>
+            {
+                new() { Id = postId, Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PostOperation", Mode = "Synchronous" },
+                new() { Id = preId, Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PreOperation", Mode = "Synchronous" }
+            });
+
+        var assemblyConfig = new PluginAssemblyConfig
+        {
+            Name = "MyPlugin",
+            Types =
+            {
+                new PluginTypeConfig
+                {
+                    TypeName = "MyPlugin.Handler",
+                    Steps =
+                    {
+                        new PluginStepConfig { Name = sharedName, Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous" }
+                    }
+                }
+            }
+        };
+
+        var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+        // Act - dry run so no real delete is issued.
+        var result = await CleanCommand.CleanAssemblyAsync(
+            mock.Object, assemblyConfig, dryRun: true, globalOptions, CancellationToken.None);
+
+        // Assert - exactly the PreOperation step is flagged orphaned; the configured PostOperation is not.
+        var orphan = Assert.Single(result.OrphanedSteps);
+        Assert.Equal(preId, orphan.StepId);
+        Assert.DoesNotContain(result.OrphanedSteps, o => o.StepId == postId);
+        mock.Verify(s => s.DeleteStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
@@ -319,7 +319,7 @@ public class DeployCommandTests : IDisposable
             mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Guid.NewGuid());
             mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Guid?)Guid.NewGuid());
+                .ReturnsAsync(Guid.NewGuid());
             mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<PluginImageInfo>());
             mock.Setup(s => s.UpsertStepAsync(
@@ -417,7 +417,7 @@ public class DeployCommandTests : IDisposable
             mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Guid.NewGuid());
             mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Guid?)Guid.NewGuid());
+                .ReturnsAsync(Guid.NewGuid());
             mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<PluginImageInfo>());
             mock.Setup(s => s.UpsertStepAsync(

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
@@ -1,6 +1,11 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using Moq;
+using PPDS.Cli.Commands;
 using PPDS.Cli.Commands.Plugins;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Commands.Plugins;
@@ -181,6 +186,109 @@ public class DeployCommandTests : IDisposable
             "--dry-run " +
             "--output-format Json");
         Assert.Empty(result.Errors);
+    }
+
+    #endregion
+
+    #region Deployment Matching Tests (#1295)
+
+    // Environment holds two same-named steps (PreOp + PostOp); config declares the PostOp step plus a
+    // brand-new Create step. Deploy must update the exact PostOp row by GUID, force-create the new
+    // step, and (with --clean) delete the orphaned PreOp row by GUID — never abort on the duplicate name.
+    [Fact]
+    public async Task DeployAssemblyAsync_SameNamedSteps_UpdatesPaired_ForceCreatesNew_AndCleansOrphan()
+    {
+        var assemblyId = Guid.NewGuid();
+        var typeId = Guid.NewGuid();
+        var postId = Guid.NewGuid();
+        var preId = Guid.NewGuid();
+        const string sharedName = "MyPlugin.Handler: Update of account";
+
+        // A real (empty) file so File.Exists passes for the classic-assembly path.
+        var dummyAssembly = Path.Combine(Path.GetTempPath(), $"deploy-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(dummyAssembly, new byte[] { 0x4D, 0x5A });
+
+        try
+        {
+            var mock = new Mock<IPluginRegistrationService>();
+            mock.Setup(s => s.UpsertAssemblyAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(assemblyId);
+            mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+            mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginStepInfo>
+                {
+                    new() { Id = postId, Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PostOperation", Mode = "Synchronous" },
+                    new() { Id = preId, Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PreOperation", Mode = "Synchronous" }
+                });
+            mock.Setup(s => s.UpsertPluginTypeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(typeId);
+            mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginImageInfo>());
+            mock.Setup(s => s.UpsertStepAsync(
+                    It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<PluginStepConfig>(), It.IsAny<Guid>(),
+                    It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.DeleteStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var assemblyConfig = new PluginAssemblyConfig
+            {
+                Name = "MyPlugin",
+                Type = "Assembly",
+                Path = dummyAssembly,
+                Types =
+                {
+                    new PluginTypeConfig
+                    {
+                        TypeName = "MyPlugin.Handler",
+                        Steps =
+                        {
+                            new PluginStepConfig { Name = sharedName, Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous" },
+                            new PluginStepConfig { Message = "Create", Entity = "account", Stage = "PostOperation", Mode = "Synchronous" }
+                        }
+                    }
+                }
+            };
+
+            var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+            // Act
+            var result = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, assemblyConfig, Path.GetTempPath(),
+                solutionOverride: null, clean: true, dryRun: false, globalOptions, CancellationToken.None);
+
+            // Assert - the assembly deployed successfully.
+            Assert.True(result.Success);
+
+            // Paired Update step updates the exact PostOperation row by GUID.
+            mock.Verify(s => s.UpsertStepAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(),
+                It.Is<PluginStepConfig>(c => c.Message == "Update"),
+                It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string?>(),
+                It.Is<StepIdentityResolution?>(r => r != null && r.ExistingStepId == postId),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            // New Create step is force-created (null step id).
+            mock.Verify(s => s.UpsertStepAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(),
+                It.Is<PluginStepConfig>(c => c.Message == "Create"),
+                It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string?>(),
+                It.Is<StepIdentityResolution?>(r => r != null && r.ExistingStepId == null),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            // The orphaned PreOperation row is deleted by its GUID.
+            mock.Verify(s => s.DeleteStepAsync(preId, It.IsAny<CancellationToken>()), Times.Once);
+            mock.Verify(s => s.DeleteStepAsync(postId, It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            File.Delete(dummyAssembly);
+        }
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
@@ -291,5 +291,176 @@ public class DeployCommandTests : IDisposable
         }
     }
 
+    // Fix (#1295 follow-up): a config authored with variant stage/mode tokens ("40"/"sync") must be
+    // idempotent — the second deploy updates the existing step in place rather than force-creating a
+    // duplicate. The stateful mock stores canonical stage/mode on create (as Dataverse reads them back).
+    [Fact]
+    public async Task DeployAssemblyAsync_VariantStageModeTokens_IsIdempotent_NoDuplicateOnSecondRun()
+    {
+        var assemblyId = Guid.NewGuid();
+        var typeId = Guid.NewGuid();
+
+        var dummyAssembly = Path.Combine(Path.GetTempPath(), $"deploy-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(dummyAssembly, new byte[] { 0x4D, 0x5A });
+
+        try
+        {
+            var envSteps = new List<PluginStepInfo>();
+
+            var mock = new Mock<IPluginRegistrationService>();
+            mock.Setup(s => s.UpsertAssemblyAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(assemblyId);
+            mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+            mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => envSteps.ToList());
+            mock.Setup(s => s.UpsertPluginTypeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(typeId);
+            mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid?)Guid.NewGuid());
+            mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginImageInfo>());
+            mock.Setup(s => s.UpsertStepAsync(
+                    It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<PluginStepConfig>(), It.IsAny<Guid>(),
+                    It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid _, string _, PluginStepConfig cfg, Guid _, Guid? _, string? _, StepIdentityResolution? res, CancellationToken _) =>
+                {
+                    if (res?.ExistingStepId is { } existingId)
+                        return existingId; // update in place
+
+                    var id = Guid.NewGuid();
+                    envSteps.Add(new PluginStepInfo
+                    {
+                        Id = id,
+                        Name = cfg.Name!,
+                        Message = cfg.Message,
+                        PrimaryEntity = cfg.Entity,
+                        // Dataverse stores an int and reads back the canonical string — mirror that.
+                        Stage = PluginRegistrationService.MapStageFromValue(PluginRegistrationService.MapStageToValue(cfg.Stage)),
+                        Mode = PluginRegistrationService.MapModeFromValue(PluginRegistrationService.MapModeToValue(cfg.Mode)),
+                        ExecutionOrder = cfg.ExecutionOrder
+                    });
+                    return id;
+                });
+
+            PluginAssemblyConfig BuildConfig() => new()
+            {
+                Name = "MyPlugin",
+                Type = "Assembly",
+                Path = dummyAssembly,
+                Types =
+                {
+                    new PluginTypeConfig
+                    {
+                        TypeName = "MyPlugin.Handler",
+                        Steps =
+                        {
+                            new PluginStepConfig { Message = "Update", Entity = "account", Stage = "40", Mode = "sync", ExecutionOrder = 1 }
+                        }
+                    }
+                }
+            };
+
+            var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+            // First deploy creates the step.
+            var first = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, BuildConfig(), Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+            Assert.True(first.Success);
+            Assert.Equal(1, first.StepsCreated);
+            Assert.Equal(0, first.StepsUpdated);
+            Assert.Single(envSteps);
+
+            // Second deploy of the SAME variant-token config must update in place — no duplicate.
+            var second = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, BuildConfig(), Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+            Assert.True(second.Success);
+            Assert.Equal(0, second.StepsCreated);
+            Assert.Equal(1, second.StepsUpdated);
+            Assert.Single(envSteps);
+        }
+        finally
+        {
+            File.Delete(dummyAssembly);
+        }
+    }
+
+    // Fix (#1295 follow-up): a plain deploy (no --clean) must not silently leave the old step active
+    // after a stage/mode change (now delete+create). Orphans are surfaced as warnings, not deleted.
+    [Fact]
+    public async Task DeployAssemblyAsync_WithoutClean_ReportsOrphanedStepsAsWarnings()
+    {
+        var assemblyId = Guid.NewGuid();
+        var typeId = Guid.NewGuid();
+        var orphanId = Guid.NewGuid();
+
+        var dummyAssembly = Path.Combine(Path.GetTempPath(), $"deploy-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(dummyAssembly, new byte[] { 0x4D, 0x5A });
+
+        try
+        {
+            var mock = new Mock<IPluginRegistrationService>();
+            mock.Setup(s => s.UpsertAssemblyAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(assemblyId);
+            mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+            // Env holds the OLD PreOperation step; config declares the PostOperation step -> PreOp is orphaned.
+            mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginStepInfo>
+                {
+                    new() { Id = orphanId, Name = "MyPlugin.Handler: Update of account", Message = "Update", PrimaryEntity = "account", Stage = "PreOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+                });
+            mock.Setup(s => s.UpsertPluginTypeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(typeId);
+            mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid?)Guid.NewGuid());
+            mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginImageInfo>());
+            mock.Setup(s => s.UpsertStepAsync(
+                    It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<PluginStepConfig>(), It.IsAny<Guid>(),
+                    It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.DeleteStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var assemblyConfig = new PluginAssemblyConfig
+            {
+                Name = "MyPlugin",
+                Type = "Assembly",
+                Path = dummyAssembly,
+                Types =
+                {
+                    new PluginTypeConfig
+                    {
+                        TypeName = "MyPlugin.Handler",
+                        Steps =
+                        {
+                            new PluginStepConfig { Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+                        }
+                    }
+                }
+            };
+
+            var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+            // Act - deploy WITHOUT --clean.
+            var result = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, assemblyConfig, Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+
+            // Assert - the orphaned PreOperation step is surfaced as a warning, and nothing is deleted.
+            Assert.True(result.Success);
+            Assert.Contains(result.Warnings, w => w.Contains("--clean") && w.Contains("PreOperation"));
+            mock.Verify(s => s.DeleteStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            File.Delete(dummyAssembly);
+        }
+    }
+
     #endregion
 }

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DiffCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DiffCommandTests.cs
@@ -1,6 +1,9 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using Moq;
 using PPDS.Cli.Commands.Plugins;
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Commands.Plugins;
@@ -133,6 +136,107 @@ public class DiffCommandTests : IDisposable
             "--environment https://org.crm.dynamics.com " +
             "--output-format Json");
         Assert.Empty(result.Errors);
+    }
+
+    #endregion
+
+    #region Drift Computation Tests (#1295)
+
+    private static Mock<IPluginRegistrationService> MockServiceWithSteps(
+        Guid assemblyId,
+        Guid typeId,
+        string typeName,
+        List<PluginStepInfo> envSteps)
+    {
+        var mock = new Mock<IPluginRegistrationService>();
+        mock.Setup(s => s.GetAssemblyByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PluginAssemblyInfo { Id = assemblyId, Name = "MyPlugin" });
+        mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = typeName } });
+        mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(envSteps);
+        mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PluginImageInfo>());
+        return mock;
+    }
+
+    // Previously this threw "Environment contains duplicate plugin step name ..." — the reported bug.
+    [Fact]
+    public async Task ComputeDriftAsync_EnvHasTwoSameNamedDifferentStage_ClassifiesInsteadOfThrowing()
+    {
+        var typeId = Guid.NewGuid();
+        const string sharedName = "MyPlugin.Handler: Update of account";
+
+        // Env ranks aligned with the config default (ExecutionOrder = 1) so the paired step shows no
+        // rank drift; rank is a drift-tracked property, not part of identity.
+        var mock = MockServiceWithSteps(Guid.NewGuid(), typeId, "MyPlugin.Handler", new List<PluginStepInfo>
+        {
+            new() { Id = Guid.NewGuid(), Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PostOperation", Mode = "Synchronous", ExecutionOrder = 1 },
+            new() { Id = Guid.NewGuid(), Name = sharedName, Message = "Update", PrimaryEntity = "account", Stage = "PreOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+        });
+
+        var config = new PluginAssemblyConfig
+        {
+            Name = "MyPlugin",
+            Types =
+            {
+                new PluginTypeConfig
+                {
+                    TypeName = "MyPlugin.Handler",
+                    Steps =
+                    {
+                        new PluginStepConfig { Name = sharedName, Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+                    }
+                }
+            }
+        };
+
+        // Act - must complete rather than throw.
+        var drift = await DiffCommand.ComputeDriftAsync(mock.Object, config);
+
+        // Assert - the PostOperation step is paired (clean); the PreOperation step is orphaned.
+        Assert.Empty(drift.MissingSteps);
+        Assert.Empty(drift.ModifiedSteps);
+        var orphan = Assert.Single(drift.OrphanedSteps);
+        Assert.Equal("PreOperation", orphan.Stage);
+    }
+
+    [Fact]
+    public async Task ComputeDriftAsync_RenamedPairedStep_ReportsNameDrift()
+    {
+        var typeId = Guid.NewGuid();
+
+        var mock = MockServiceWithSteps(Guid.NewGuid(), typeId, "MyPlugin.Handler", new List<PluginStepInfo>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Old Display Name", Message = "Update", PrimaryEntity = "account", Stage = "PostOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+        });
+
+        var config = new PluginAssemblyConfig
+        {
+            Name = "MyPlugin",
+            Types =
+            {
+                new PluginTypeConfig
+                {
+                    TypeName = "MyPlugin.Handler",
+                    Steps =
+                    {
+                        new PluginStepConfig { Name = "New Display Name", Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous", ExecutionOrder = 1 }
+                    }
+                }
+            }
+        };
+
+        var drift = await DiffCommand.ComputeDriftAsync(mock.Object, config);
+
+        Assert.Empty(drift.MissingSteps);
+        Assert.Empty(drift.OrphanedSteps);
+        // The only drift on the paired step is the name change (behavior is unchanged).
+        var modified = Assert.Single(drift.ModifiedSteps);
+        var change = Assert.Single(modified.Changes);
+        Assert.Equal("name", change.Property);
+        Assert.Equal("New Display Name", change.Expected);
+        Assert.Equal("Old Display Name", change.Actual);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceGuardTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceGuardTests.cs
@@ -66,7 +66,7 @@ public class PluginRegistrationServiceGuardTests
             Guid.NewGuid(),
             null,
             null,
-            CancellationToken.None),
+            cancellationToken: CancellationToken.None),
         "UpsertImageAsync" => svc.UpsertImageAsync(
             Guid.NewGuid(),
             new PluginImageConfig { Name = "img", ImageType = "PostImage" },

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginRegistrationServiceTests.cs
@@ -2921,4 +2921,141 @@ public class PluginRegistrationServiceTests
     }
 
     #endregion
+
+    #region UpsertStepAsync Identity Resolution Tests (#1295)
+
+    [Fact]
+    public async Task UpsertStepAsync_WithMatchedExistingStepId_UpdatesThatExactRowByGuid()
+    {
+        // Arrange
+        var pluginTypeId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var filterId = Guid.NewGuid();
+        var matchedStepId = Guid.NewGuid();
+
+        QueryExpression? capturedQuery = null;
+        _mockPooledClient
+            .Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()))
+            .Callback<QueryBase, CancellationToken>((q, _) => capturedQuery = q as QueryExpression)
+            .ReturnsAsync(() => _retrieveMultipleResult);
+
+        // The identity-based lookup (by GUID) returns the matched row.
+        var existingStep = new SdkMessageProcessingStep { Id = matchedStepId };
+        existingStep[SdkMessageProcessingStep.Fields.StateCode] =
+            new OptionSetValue((int)sdkmessageprocessingstep_statecode.Enabled);
+        _retrieveMultipleResult = new EntityCollection();
+        _retrieveMultipleResult.Entities.Add(existingStep);
+
+        var stepConfig = new PluginStepConfig
+        {
+            Name = "MyPlugin: Update of account",
+            Message = "Update",
+            Entity = "account",
+            Stage = "PostOperation",
+            Mode = "Synchronous",
+            Enabled = true
+        };
+
+        // Act - identity carries the matched GUID.
+        var result = await _sut.UpsertStepAsync(
+            pluginTypeId, "pluginType", stepConfig, messageId, filterId,
+            identity: new StepIdentityResolution(matchedStepId));
+
+        // Assert - updated the exact row, resolved by SdkMessageProcessingStepId (not by Name).
+        Assert.Equal(matchedStepId, result);
+        Assert.NotNull(_updatedEntity);
+        Assert.Equal(matchedStepId, _updatedEntity!.Id);
+
+        Assert.NotNull(capturedQuery);
+        Assert.Contains(capturedQuery!.Criteria.Conditions, c =>
+            c.AttributeName == SdkMessageProcessingStep.Fields.SdkMessageProcessingStepId
+            && c.Operator == ConditionOperator.Equal
+            && c.Values.Contains(matchedStepId));
+        Assert.DoesNotContain(capturedQuery.Criteria.Conditions, c =>
+            c.AttributeName == SdkMessageProcessingStep.Fields.Name);
+    }
+
+    [Fact]
+    public async Task UpsertStepAsync_WithNullExistingStepId_ForceCreatesWithoutLookup()
+    {
+        // Arrange
+        var pluginTypeId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var filterId = Guid.NewGuid();
+        var newStepId = Guid.NewGuid();
+
+        // A same-named row "exists" in the environment; force-create must ignore it and never
+        // issue the lookup, so a same-named-but-different-identity row can't be hijacked.
+        var sameNamed = new SdkMessageProcessingStep { Id = Guid.NewGuid() };
+        _retrieveMultipleResult = new EntityCollection();
+        _retrieveMultipleResult.Entities.Add(sameNamed);
+        _createResult = newStepId;
+        _updatedEntity = null;
+
+        var stepConfig = new PluginStepConfig
+        {
+            Name = "MyPlugin: Update of account",
+            Message = "Update",
+            Entity = "account",
+            Stage = "PostOperation",
+            Mode = "Synchronous"
+        };
+
+        // Act - identity with a null step id forces a create.
+        var result = await _sut.UpsertStepAsync(
+            pluginTypeId, "pluginType", stepConfig, messageId, filterId,
+            identity: new StepIdentityResolution(null));
+
+        // Assert - created a new row, with no existence lookup and no update.
+        Assert.Equal(newStepId, result);
+        Assert.Null(_updatedEntity);
+        _mockPooledClient.Verify(
+            s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockPooledClient.Verify(
+            s => s.CreateAsync(
+                It.Is<Entity>(e => e.LogicalName == SdkMessageProcessingStep.EntityLogicalName),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpsertStepAsync_LegacyNullIdentity_ResolvesByEventHandlerAndName()
+    {
+        // Arrange
+        var pluginTypeId = Guid.NewGuid();
+        var messageId = Guid.NewGuid();
+        var filterId = Guid.NewGuid();
+
+        QueryExpression? capturedQuery = null;
+        _mockPooledClient
+            .Setup(s => s.RetrieveMultipleAsync(It.IsAny<QueryBase>(), It.IsAny<CancellationToken>()))
+            .Callback<QueryBase, CancellationToken>((q, _) => capturedQuery = q as QueryExpression)
+            .ReturnsAsync(() => _retrieveMultipleResult);
+        _retrieveMultipleResult = new EntityCollection(); // none existing -> create path
+        _createResult = Guid.NewGuid();
+
+        var stepConfig = new PluginStepConfig
+        {
+            Name = "MyPlugin: Update of account",
+            Message = "Update",
+            Entity = "account",
+            Stage = "PostOperation",
+            Mode = "Synchronous"
+        };
+
+        // Act - identity omitted (defaults to null) preserves the legacy name-based resolution.
+        await _sut.UpsertStepAsync(pluginTypeId, "pluginType", stepConfig, messageId, filterId);
+
+        // Assert - resolved by (EventHandler, Name), unchanged from prior behavior.
+        Assert.NotNull(capturedQuery);
+        Assert.Contains(capturedQuery!.Criteria.Conditions, c =>
+            c.AttributeName == SdkMessageProcessingStep.Fields.EventHandler
+            && c.Values.Contains(pluginTypeId));
+        Assert.Contains(capturedQuery.Criteria.Conditions, c =>
+            c.AttributeName == SdkMessageProcessingStep.Fields.Name
+            && c.Values.Contains("MyPlugin: Update of account"));
+    }
+
+    #endregion
 }

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
@@ -1,0 +1,156 @@
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Plugins.Registration;
+
+[Trait("Category", "Unit")]
+public class PluginStepIdentityTests
+{
+    private static PluginStepConfig Config(
+        string message = "Update",
+        string entity = "account",
+        string? secondaryEntity = null,
+        string stage = "PostOperation",
+        string mode = "Synchronous",
+        string? name = null,
+        int executionOrder = 1,
+        string? filteringAttributes = null) => new()
+    {
+        Name = name,
+        Message = message,
+        Entity = entity,
+        SecondaryEntity = secondaryEntity,
+        Stage = stage,
+        Mode = mode,
+        ExecutionOrder = executionOrder,
+        FilteringAttributes = filteringAttributes
+    };
+
+    private static PluginStepInfo Env(
+        string message = "Update",
+        string primaryEntity = "account",
+        string? secondaryEntity = null,
+        string stage = "PostOperation",
+        string mode = "Synchronous",
+        string name = "env-name",
+        int executionOrder = 1,
+        string? filteringAttributes = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Message = message,
+        PrimaryEntity = primaryEntity,
+        SecondaryEntity = secondaryEntity,
+        Stage = stage,
+        Mode = mode,
+        ExecutionOrder = executionOrder,
+        FilteringAttributes = filteringAttributes
+    };
+
+    [Fact]
+    public void FromConfig_And_FromEnvironment_Agree_AcrossCasingAndWhitespace()
+    {
+        var config = Config(message: "Update", entity: "account", stage: "PostOperation", mode: "Synchronous");
+        // Same behavior, but every component differs in casing/whitespace, plus a different name/rank/filter.
+        var env = Env(
+            message: "  update ",
+            primaryEntity: "ACCOUNT",
+            stage: "postoperation",
+            mode: "SYNCHRONOUS",
+            name: "a totally different display name",
+            executionOrder: 42,
+            filteringAttributes: "irrelevant");
+
+        var idConfig = PluginStepIdentity.FromConfig("MyPlugin.Handler", config);
+        var idEnv = PluginStepIdentity.FromEnvironment("  myplugin.HANDLER  ", env);
+
+        Assert.Equal(idConfig, idEnv);
+        Assert.Equal(idConfig.GetHashCode(), idEnv.GetHashCode());
+    }
+
+    [Fact]
+    public void PrimaryEntity_EmptyNoneAndWhitespace_NormalizeEqual()
+    {
+        var fromEmpty = PluginStepIdentity.FromConfig("T", Config(entity: ""));
+        var fromNone = PluginStepIdentity.FromEnvironment("T", Env(primaryEntity: "none"));
+        var fromWhitespace = PluginStepIdentity.FromEnvironment("T", Env(primaryEntity: "  "));
+
+        Assert.Equal(fromEmpty, fromNone);
+        Assert.Equal(fromEmpty, fromWhitespace);
+        Assert.Equal(PluginStepIdentity.NoEntity, fromEmpty.PrimaryEntity);
+    }
+
+    [Fact]
+    public void SecondaryEntity_NullEmptyAndNone_NormalizeEqual()
+    {
+        var fromNull = PluginStepIdentity.FromConfig("T", Config(secondaryEntity: null));
+        var fromEmpty = PluginStepIdentity.FromConfig("T", Config(secondaryEntity: ""));
+        var fromNone = PluginStepIdentity.FromEnvironment("T", Env(secondaryEntity: "none"));
+
+        Assert.Equal(fromNull, fromEmpty);
+        Assert.Equal(fromNull, fromNone);
+        Assert.Equal(PluginStepIdentity.NoEntity, fromNull.SecondaryEntity);
+    }
+
+    [Fact]
+    public void Stage_Change_ChangesIdentity()
+    {
+        var post = PluginStepIdentity.FromConfig("T", Config(stage: "PostOperation"));
+        var pre = PluginStepIdentity.FromConfig("T", Config(stage: "PreOperation"));
+
+        Assert.NotEqual(post, pre);
+    }
+
+    [Fact]
+    public void Mode_Change_ChangesIdentity()
+    {
+        var sync = PluginStepIdentity.FromConfig("T", Config(mode: "Synchronous"));
+        var async = PluginStepIdentity.FromConfig("T", Config(mode: "Asynchronous"));
+
+        Assert.NotEqual(sync, async);
+    }
+
+    [Fact]
+    public void PluginTypeName_Change_ChangesIdentity()
+    {
+        var a = PluginStepIdentity.FromConfig("Plugin.TypeA", Config());
+        var b = PluginStepIdentity.FromConfig("Plugin.TypeB", Config());
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void Message_Or_Entity_Change_ChangesIdentity()
+    {
+        var baseline = PluginStepIdentity.FromConfig("T", Config(message: "Update", entity: "account"));
+
+        Assert.NotEqual(baseline, PluginStepIdentity.FromConfig("T", Config(message: "Create", entity: "account")));
+        Assert.NotEqual(baseline, PluginStepIdentity.FromConfig("T", Config(message: "Update", entity: "contact")));
+    }
+
+    [Fact]
+    public void Rank_Filtering_And_Name_DoNotAffectIdentity()
+    {
+        var a = PluginStepIdentity.FromConfig("T", Config(name: "Alpha", executionOrder: 1, filteringAttributes: "name"));
+        var b = PluginStepIdentity.FromConfig("T", Config(name: "Omega", executionOrder: 999, filteringAttributes: "name,age,city"));
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void ToString_RendersReadableComponents()
+    {
+        var id = PluginStepIdentity.FromConfig(
+            "MyPlugin.Handler",
+            Config(message: "Update", entity: "account", stage: "PostOperation", mode: "Synchronous"));
+
+        var text = id.ToString();
+
+        Assert.Contains("myplugin.handler", text);
+        Assert.Contains("update", text);
+        Assert.Contains("account", text);
+        Assert.Contains("postoperation", text);
+        Assert.Contains("synchronous", text);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
@@ -138,6 +138,31 @@ public class PluginStepIdentityTests
         Assert.Equal(a, b);
     }
 
+    // Fix (#1295 follow-up): the environment side is always canonical, but a hand-authored config may
+    // use variant tokens the deploy write path accepts. These must canonicalize to the SAME identity so
+    // deploy updates in place instead of force-creating a duplicate every run.
+    [Theory]
+    [InlineData("40", "sync")]                 // numeric stage + short mode token
+    [InlineData("PostOperation", "Synchronous")] // canonical (sanity: canonicalization is a no-op here)
+    [InlineData("", "")]                        // omitted stage/mode default to PostOperation/Synchronous
+    public void VariantStageAndModeTokens_CanonicalizeToEnvironmentIdentity(string stageToken, string modeToken)
+    {
+        var env = PluginStepIdentity.FromEnvironment("T", Env(stage: "PostOperation", mode: "Synchronous"));
+        var config = PluginStepIdentity.FromConfig("T", Config(stage: stageToken, mode: modeToken));
+
+        Assert.Equal(env, config);
+    }
+
+    [Fact]
+    public void NumericStageToken_ForDifferentStage_StillDiffers()
+    {
+        // Guard against over-canonicalization collapsing everything to PostOperation: "20" is PreOperation.
+        var post = PluginStepIdentity.FromEnvironment("T", Env(stage: "PostOperation"));
+        var pre = PluginStepIdentity.FromConfig("T", Config(stage: "20"));
+
+        Assert.NotEqual(post, pre);
+    }
+
     [Fact]
     public void ToString_RendersReadableComponents()
     {

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepMatcherTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepMatcherTests.cs
@@ -179,6 +179,21 @@ public class PluginStepMatcherTests
             Assert.Equal(pair.Config!.ExecutionOrder, pair.Env!.ExecutionOrder);
     }
 
+    // Fix (#1295 follow-up): a config authored with variant stage/mode tokens must pair with the
+    // canonical environment step, not be misclassified as Missing (which would force-create a duplicate).
+    [Fact]
+    public void VariantStageModeTokens_PairWithCanonicalEnvStep()
+    {
+        var config = Config(stage: "40", mode: "sync");
+        var env = Env(stage: "PostOperation", mode: "Synchronous");
+
+        var matches = PluginStepMatcher.Match(new[] { Cfg(config) }, new[] { Ev(env) });
+
+        Assert.Single(matches.Where(m => m.IsPaired));
+        Assert.Empty(matches.Where(m => m.IsMissing));
+        Assert.Empty(matches.Where(m => m.IsOrphaned));
+    }
+
     [Fact]
     public void EmptyInputs_ReturnEmpty()
     {

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepMatcherTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepMatcherTests.cs
@@ -1,0 +1,191 @@
+using PPDS.Cli.Plugins.Models;
+using PPDS.Cli.Plugins.Registration;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Plugins.Registration;
+
+[Trait("Category", "Unit")]
+public class PluginStepMatcherTests
+{
+    private static readonly PluginTypeConfig TypeConfig = new() { TypeName = "MyPlugin.Handler" };
+    private static readonly PluginTypeInfo TypeInfo = new() { Id = Guid.NewGuid(), TypeName = "MyPlugin.Handler" };
+
+    private static PluginStepConfig Config(
+        string stage = "PostOperation",
+        string mode = "Synchronous",
+        string message = "Update",
+        string entity = "account",
+        string? name = null,
+        int executionOrder = 1,
+        string? filteringAttributes = null) => new()
+    {
+        Name = name,
+        Message = message,
+        Entity = entity,
+        Stage = stage,
+        Mode = mode,
+        ExecutionOrder = executionOrder,
+        FilteringAttributes = filteringAttributes
+    };
+
+    private static PluginStepInfo Env(
+        string stage = "PostOperation",
+        string mode = "Synchronous",
+        string message = "Update",
+        string primaryEntity = "account",
+        string name = "MyPlugin.Handler: Update of account",
+        int executionOrder = 1,
+        Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Name = name,
+        Message = message,
+        PrimaryEntity = primaryEntity,
+        Stage = stage,
+        Mode = mode,
+        ExecutionOrder = executionOrder
+    };
+
+    private static (PluginTypeConfig, PluginStepConfig) Cfg(PluginStepConfig step) => (TypeConfig, step);
+    private static (PluginTypeInfo, PluginStepInfo) Ev(PluginStepInfo step) => (TypeInfo, step);
+
+    // The reported issue (#1295): the environment holds two steps that share a display name but
+    // differ in stage, and the config declares a single step matching one of them. This must NOT
+    // throw; it must pair the matching stage and orphan the other.
+    [Fact]
+    public void SameNamedDifferentStage_PairsCorrectStage_OrphansTheOther()
+    {
+        var sharedName = "MyPlugin.Handler: Update of account";
+        var config = Config(stage: "PostOperation", name: sharedName);
+        var envPost = Env(stage: "PostOperation", name: sharedName);
+        var envPre = Env(stage: "PreOperation", name: sharedName);
+
+        var matches = PluginStepMatcher.Match(
+            new[] { Cfg(config) },
+            new[] { Ev(envPost), Ev(envPre) });
+
+        var paired = matches.Where(m => m.IsPaired).ToList();
+        var orphaned = matches.Where(m => m.IsOrphaned).ToList();
+        var missing = matches.Where(m => m.IsMissing).ToList();
+
+        Assert.Single(paired);
+        Assert.Single(orphaned);
+        Assert.Empty(missing);
+
+        // Paired with the PostOperation row (the one whose identity matches the config).
+        Assert.Equal(envPost.Id, paired[0].Env!.Id);
+        Assert.Same(config, paired[0].Config);
+
+        // The PreOperation row is the orphan.
+        Assert.Equal(envPre.Id, orphaned[0].Env!.Id);
+    }
+
+    [Fact]
+    public void ResidualCollision_TwoIdenticalEnvSteps_FiresCallback_And_StillClassifies()
+    {
+        var config = Config(stage: "PostOperation");
+        var envA = Env(stage: "PostOperation", id: Guid.NewGuid());
+        var envB = Env(stage: "PostOperation", id: Guid.NewGuid()); // identical functional identity
+
+        var collisions = new List<(PluginStepIdentity Identity, int ConfigCount, int EnvCount)>();
+
+        var matches = PluginStepMatcher.Match(
+            new[] { Cfg(config) },
+            new[] { Ev(envA), Ev(envB) },
+            onResidualCollision: (id, cc, ec) => collisions.Add((id, cc, ec)));
+
+        var collision = Assert.Single(collisions);
+        Assert.Equal(1, collision.ConfigCount);
+        Assert.Equal(2, collision.EnvCount);
+
+        // Still classifies: one pair, one orphan, no exception.
+        Assert.Single(matches.Where(m => m.IsPaired));
+        Assert.Single(matches.Where(m => m.IsOrphaned));
+        Assert.Empty(matches.Where(m => m.IsMissing));
+    }
+
+    [Fact]
+    public void ConfigSurplus_ProducesMissing()
+    {
+        // Two configured steps share an identity; only one environment step exists.
+        var cfgA = Config(name: "A");
+        var cfgB = Config(name: "B");
+        var env = Env();
+
+        var collisions = new List<(PluginStepIdentity Identity, int ConfigCount, int EnvCount)>();
+        var matches = PluginStepMatcher.Match(
+            new[] { Cfg(cfgA), Cfg(cfgB) },
+            new[] { Ev(env) },
+            onResidualCollision: (id, cc, ec) => collisions.Add((id, cc, ec)));
+
+        Assert.Single(matches.Where(m => m.IsPaired));
+        Assert.Single(matches.Where(m => m.IsMissing));
+        Assert.Empty(matches.Where(m => m.IsOrphaned));
+
+        var collision = Assert.Single(collisions);
+        Assert.Equal(2, collision.ConfigCount);
+        Assert.Equal(1, collision.EnvCount);
+    }
+
+    [Fact]
+    public void EnvSurplus_ProducesOrphaned()
+    {
+        var config = Config();
+        var env1 = Env(id: Guid.NewGuid());
+        var env2 = Env(id: Guid.NewGuid());
+
+        var matches = PluginStepMatcher.Match(
+            new[] { Cfg(config) },
+            new[] { Ev(env1), Ev(env2) });
+
+        Assert.Single(matches.Where(m => m.IsPaired));
+        Assert.Single(matches.Where(m => m.IsOrphaned));
+        Assert.Empty(matches.Where(m => m.IsMissing));
+    }
+
+    [Fact]
+    public void DisjointIdentities_ClassifyAsMissingAndOrphaned()
+    {
+        var config = Config(stage: "PostOperation", message: "Update", entity: "account");
+        var env = Env(stage: "PreOperation", message: "Create", primaryEntity: "contact");
+
+        var matches = PluginStepMatcher.Match(new[] { Cfg(config) }, new[] { Ev(env) });
+
+        Assert.Single(matches.Where(m => m.IsMissing));
+        Assert.Single(matches.Where(m => m.IsOrphaned));
+        Assert.Empty(matches.Where(m => m.IsPaired));
+        // No residual-collision expectation: each identity group has a single member.
+    }
+
+    [Fact]
+    public void WithinIdentityGroup_PairingIsDeterministic_ByExecutionOrder()
+    {
+        // Four members share one identity (rank is not part of identity). Config and env are supplied
+        // out of order; the matcher must sort both sides so rank-1 pairs with rank-1 and rank-5 with rank-5.
+        var cfgRank1 = Config(name: "zzz", executionOrder: 1);
+        var cfgRank5 = Config(name: "aaa", executionOrder: 5);
+        var envRank1 = Env(executionOrder: 1, id: Guid.NewGuid());
+        var envRank5 = Env(executionOrder: 5, id: Guid.NewGuid());
+
+        var matches = PluginStepMatcher.Match(
+            new[] { Cfg(cfgRank5), Cfg(cfgRank1) },
+            new[] { Ev(envRank5), Ev(envRank1) });
+
+        var paired = matches.Where(m => m.IsPaired).ToList();
+        Assert.Equal(2, paired.Count);
+
+        // Deterministic: each pair matches like-ranked config and env.
+        foreach (var pair in paired)
+            Assert.Equal(pair.Config!.ExecutionOrder, pair.Env!.ExecutionOrder);
+    }
+
+    [Fact]
+    public void EmptyInputs_ReturnEmpty()
+    {
+        var matches = PluginStepMatcher.Match(
+            Array.Empty<(PluginTypeConfig, PluginStepConfig)>(),
+            Array.Empty<(PluginTypeInfo, PluginStepInfo)>());
+
+        Assert.Empty(matches);
+    }
+}


### PR DESCRIPTION
Fixes #1295

## Root cause

`plugins diff` / `deploy` / `clean` aborted with **"Environment contains duplicate plugin step name ..."** whenever a Dataverse environment held two steps sharing a display **name**. This is common: the Plugin Registration Tool auto-names steps `"{TypeName}: {Message} of {Entity}"` and omits stage/mode, so a **PreOperation + PostOperation pair on the same message/entity collides on name**.

A Dataverse step `name` is a mutable display label; only the `SdkMessageProcessingStepId` GUID is unique. Name-as-identity was baked into **four** places:

1. **DiffCommand** (`ComputeDriftAsync`) — name-keyed config + env dictionaries, hard throw on env-name duplicates.
2. **DeployCommand** (`DeployAssemblyAsync`) — name-keyed `existingStepsMap`, duplicate throw, `isNew` by name, `--clean` orphan set by name.
3. **CleanCommand** (`CleanAssemblyAsync`) — orphan detection via a configured-name set (silently mis-detected orphans on duplicate names).
4. **Write path** (`PluginRegistrationService.UpsertStepAsync`) — resolved the target row by `(EventHandler == typeId AND Name == step name)` + `FirstOrDefault()`. With two same-named rows this updated an **arbitrary** one — silent data corruption, not just a diff failure.

## The design

New `PluginStepIdentity` (`src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs`) — a `readonly record struct` of `(PluginTypeName, Message, PrimaryEntity, SecondaryEntity, Stage, Mode)`, every component `Trim().ToLowerInvariant()` normalized, with primary/secondary entity null/empty/`"none"` all collapsed to `"none"`. `FromConfig` and `FromEnvironment` funnel through one normalizer so config and environment agree across casing/whitespace.

New `PluginStepMatcher.Match(...)` groups both sides by identity, orders each group deterministically, and **zips** them into `paired` / `missing` / `orphaned`. All three commands now build `(type, step)` lists and consume the matcher; the write path takes a `StepIdentityResolution`.

**Why rank/ExecutionOrder and FilteringAttributes are drift, not identity:** they are mutable properties deploy updates in place. Keying identity on them would turn a rank tweak into delete+create and break idempotent redeploys. So they stay in the drift comparison (rank change = modified step) but never split an identity. Name is likewise not identity.

**Why residual collisions warn instead of abort:** if two steps genuinely share the *same* identity, the zip still converges — surplus config becomes `Missing` (create), surplus environment becomes `Orphaned` (only ever deleted under `--clean`). Nothing is silently overwritten, so an abort is unwarranted; the matcher invokes an `onResidualCollision` callback and each command surfaces a warning (stderr + JSON `warnings`).

**Write path** (`UpsertStepAsync`, new `StepIdentityResolution? identity` param before the token):
- `identity == null` → exact legacy behavior (locate by `(EventHandler, Name)`) — unchanged for ad-hoc `RegisterCommand` and the RPC handler.
- `identity` with a step id → retrieve **that GUID** and update that row.
- `identity` with a null id → **force-create**, skipping the lookup entirely, so a same-named different-identity row can never be hijacked (used for `Missing`).

## Behavior changes a reviewer should know

- **Stage/mode change is now delete + create**, not an in-place update. Stage and mode are identity, so a step that changes stage no longer matches its old row: the new one is created and the old one is reported orphaned (deleted only under `--clean`). This matches Dataverse reality — you cannot re-stage a step in place via a name match without risking the wrong row.
- **Deploy converges display names.** A paired step is written with the configured (resolved) name, so an environment step that was renamed converges back. `diff` now reports this as a `name: <expected> -> <actual>` change (stage/mode are no longer compared on a paired step — they can't differ by construction).
- `diff`/`deploy`/`clean` **no longer throw** on duplicate environment step names.

## Scope notes

- The **plugin-TYPE** duplicate-collision guard in `DeployCommand` is intentionally kept (out of scope).
- `ComputeDriftAsync` / `DeployAssemblyAsync` / `CleanAssemblyAsync` were made `internal` (from `private`) for direct unit-test access; `InternalsVisibleTo PPDS.Cli.Tests` is already configured. PPDS.Cli has no PublicAPI analyzer file, so the interface change needed no PublicAPI edits.

## Test evidence

Env-side duplicate handling previously had **zero** coverage. Added:

- `PluginStepIdentityTests` — factory equivalence config↔env across casing/whitespace; `""` ≡ `"none"`; stage/mode/type change the key; rank/filtering/name do not.
- `PluginStepMatcherTests` — the reported scenario (two same-named env steps of different stage + one matching config ⇒ one paired + one orphaned, no throw); residual collision fires the callback and still classifies; count-aware surpluses both directions; deterministic order-based pairing.
- `DiffCommandTests` — `ComputeDriftAsync` completes (previously threw) and classifies; name-drift reported for a renamed paired step.
- `DeployCommandTests` — `DeployAssemblyAsync` succeeds; `UpsertStepAsync` called with `StepIdentityResolution.ExistingStepId` == the matched GUID for the paired step and a null id (force-create) for a new step; `--clean` deletes exactly the orphan GUID.
- `PluginRegistrationServiceTests` — `UpsertStepAsync` updates the exact row by GUID, force-creates on a null id without any lookup, and the legacy null-identity path still resolves by `(EventHandler, Name)`.
- `CleanCommandTests` — a same-named orphan of a different stage is now detected.

**Full suite green** (`dotnet test PPDS.sln --filter "Category!=Integration"`), all of net8.0/net9.0/net10.0. Key line: `PPDS.Cli.Tests.dll — Failed: 0, Passed: 4339`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin step matching now uses functional identity for deployment, cleanup, and diff, reducing issues with duplicate or renamed steps.
  * Deployment can target the exact matching step, avoid duplicates, and force-create new steps when truly different.
  * Deployment and diff reporting now surface warnings for residual identity collisions and for orphaned steps left undeleted.

* **Bug Fixes**
  * Fixed incorrect pairing/deletion when steps share names but differ by stage or mode.
  * Improved idempotency when stage/mode tokens are equivalent but formatted differently.

* **Tests**
  * Added coverage for identity matching, pairing/classification, warnings, drift behavior, cleanup behavior, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->