### PR TITLE
fix(cli): clean --output-format errors, reject unsupported Csv

### DIFF
--- a/.workflow/ci-fix-decisions/718128b9ca88f6dac5cac0be4e18cf9c64a31357.json
+++ b/.workflow/ci-fix-decisions/718128b9ca88f6dac5cac0be4e18cf9c64a31357.json
@@ -1,0 +1,12 @@
+{
+  "round": 1,
+  "timestamp": "2026-07-11T06:24:48Z",
+  "pr": 1303,
+  "failure_summary": "",
+  "files_touched": [],
+  "lines_added": 0,
+  "lines_removed": 0,
+  "action": "escalate",
+  "escalation_reason": "agent dispatch failed: ",
+  "scope_violation": false
+}

--- a/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Auth/AuthCommandGroup.cs
@@ -629,11 +629,7 @@ public static class AuthCommandGroup
 
     private static Command CreateListCommand()
     {
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var command = new Command("list", "List all authentication profiles")
         {
@@ -1248,11 +1244,7 @@ public static class AuthCommandGroup
 
     private static Command CreateWhoCommand()
     {
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var command = new Command("who", "Show the current active profile")
         {

--- a/src/PPDS.Cli/Commands/Data/AnalyzeCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/AnalyzeCommand.cs
@@ -23,11 +23,7 @@ public static class AnalyzeCommand
             Required = true
         }.AcceptExistingOnly();
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format: text or json",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Data/CopyCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/CopyCommand.cs
@@ -117,11 +117,7 @@ public static class CopyCommand
                 result.AddError($"User mapping file not found: {file.FullName}");
         });
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Data/ExportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ExportCommand.cs
@@ -81,11 +81,7 @@ public static class ExportCommand
                 result.AddError("--page-parallel-threshold must be at least 1");
         });
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var dataFormatOption = new Option<ExportDataFormat>("--format")
         {

--- a/src/PPDS.Cli/Commands/Data/ImportCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/ImportCommand.cs
@@ -93,11 +93,7 @@ public static class ImportCommand
             DefaultValueFactory = _ => false
         };
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Data/LoadCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/LoadCommand.cs
@@ -131,11 +131,7 @@ public static class LoadCommand
             DefaultValueFactory = _ => false
         };
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-o")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption(shortAlias: "-o");
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/SchemaCommand.cs
@@ -65,11 +65,7 @@ public static class SchemaCommand
             Description = "SQL-like filter per entity. Format: entity:expression (e.g., \"account:statecode = 0\"). Repeatable."
         };
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Data/UsersCommand.cs
+++ b/src/PPDS.Cli/Commands/Data/UsersCommand.cs
@@ -56,11 +56,7 @@ public static class UsersCommand
             DefaultValueFactory = _ => false
         };
 
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var verboseOption = new Option<bool>("--verbose", "-v")
         {

--- a/src/PPDS.Cli/Commands/Env/EnvCommandGroup.cs
+++ b/src/PPDS.Cli/Commands/Env/EnvCommandGroup.cs
@@ -54,11 +54,7 @@ public static class EnvCommandGroup
 
     private static Command CreateListCommand()
     {
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var filterOption = new Option<string?>("--filter", "-fl")
         {
@@ -321,11 +317,7 @@ public static class EnvCommandGroup
 
     private static Command CreateWhoCommand()
     {
-        var outputFormatOption = new Option<OutputFormat>("--output-format", "-f")
-        {
-            Description = "Output format",
-            DefaultValueFactory = _ => OutputFormat.Text
-        };
+        var outputFormatOption = GlobalOptions.CreateOutputFormatOption();
 
         var envOption = new Option<string?>("--environment", "-env")
         {

--- a/src/PPDS.Cli/Commands/PluginTraces/ListCommand.cs
+++ b/src/PPDS.Cli/Commands/PluginTraces/ListCommand.cs
@@ -158,7 +158,7 @@ public static class ListCommand
             orderByOption
         };
 
-        GlobalOptions.AddToCommand(command);
+        GlobalOptions.AddToCommand(command, supportsCsv: true);
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {

--- a/src/PPDS.Cli/Commands/Query/FetchCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/FetchCommand.cs
@@ -318,14 +318,17 @@ public static class FetchCommand
         return value.Substring(0, maxLength - 3) + "...";
     }
 
-    private static void WriteCsvOutput(QueryResult result)
+    internal static void WriteCsvOutput(QueryResult result)
     {
-        if (result.Count == 0)
+        // Nothing to emit without a schema. When columns are known the header is
+        // written even for zero rows, so CSV consumers still get column names
+        // rather than silent zero-byte output (#1078).
+        if (result.Columns.Count == 0)
         {
             return;
         }
 
-        // Header row
+        // Header row (emitted even when there are no records)
         var headers = result.Columns.Select(c => EscapeCsvField(c.Alias ?? c.LogicalName));
         Console.WriteLine(string.Join(",", headers));
 

--- a/src/PPDS.Cli/Commands/Query/FetchCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/FetchCommand.cs
@@ -46,7 +46,7 @@ public static class FetchCommand
             QueryCommandGroup.CountOption
         };
 
-        GlobalOptions.AddToCommand(command);
+        GlobalOptions.AddToCommand(command, supportsCsv: true);
 
         // Validate that exactly one input source is provided
         command.Validators.Add(result =>

--- a/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/History/ExecuteCommand.cs
@@ -39,7 +39,7 @@ public static class ExecuteCommand
             topOption
         };
 
-        GlobalOptions.AddToCommand(command);
+        GlobalOptions.AddToCommand(command, supportsCsv: true);
 
         command.SetAction(async (parseResult, cancellationToken) =>
         {

--- a/src/PPDS.Cli/Commands/Query/SqlCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/SqlCommand.cs
@@ -87,7 +87,7 @@ public static class SqlCommand
             QueryCommandGroup.CountOption
         };
 
-        GlobalOptions.AddToCommand(command);
+        GlobalOptions.AddToCommand(command, supportsCsv: true);
 
         // Validate that exactly one input source is provided
         command.Validators.Add(result =>

--- a/src/PPDS.Cli/Commands/Query/SqlCommand.cs
+++ b/src/PPDS.Cli/Commands/Query/SqlCommand.cs
@@ -110,6 +110,34 @@ public static class SqlCommand
             }
         });
 
+        // --explain and --show-fetchxml render a plan / FetchXML blob, not a result set,
+        // so CSV is not applicable. Reject it rather than silently emitting Text (#1078).
+        command.Validators.Add(result =>
+        {
+            if (!result.GetValue(showFetchXmlOption) && !result.GetValue(explainOption))
+            {
+                return;
+            }
+
+            // If --output-format itself failed to parse, that error is already reported by
+            // the option's parser; reading the value here would throw, so skip.
+            OutputFormat format;
+            try
+            {
+                format = result.GetValue(GlobalOptions.CsvCapableOutputFormat);
+            }
+            catch (InvalidOperationException)
+            {
+                return;
+            }
+
+            if (format == OutputFormat.Csv)
+            {
+                result.AddError(
+                    "CSV output is not supported with --explain or --show-fetchxml. Use --output-format Json or Text.");
+            }
+        });
+
         command.SetAction(async (parseResult, cancellationToken) =>
         {
             var sql = parseResult.GetValue(sqlArgument);

--- a/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
+++ b/src/PPDS.Cli/Commands/Schema/CompareCommand.cs
@@ -64,15 +64,6 @@ public static class CompareCommand
             var env = result.GetValue(EnvOption);
             var source = result.GetValue(SourceOption);
             var target = result.GetValue(TargetOption);
-            var format = result.GetValue(GlobalOptions.OutputFormat);
-
-            if (format == Commands.OutputFormat.Csv)
-            {
-                // CSV output is not implemented for schema compare. System-wide CSV
-                // support is tracked in #1078.
-                result.AddError("CSV output is not supported for 'schema compare'. Use --output-format Json or Text.");
-                return;
-            }
 
             var packageMode = data is not null || env is not null;
             var envMode = source is not null || target is not null;

--- a/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
+++ b/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
@@ -196,8 +196,9 @@ public static class GlobalOptions
     }
 
     /// <summary>
-    /// Reads the output format from whichever --output-format instance the command carries
-    /// (<see cref="OutputFormat"/> or <see cref="CsvCapableOutputFormat"/>).
+    /// Reads the output format from whichever --output-format instance the command carries:
+    /// the shared <see cref="OutputFormat"/>/<see cref="CsvCapableOutputFormat"/> statics, or a
+    /// command-local instance (resolved by option name so <see cref="GetValues"/> stays correct).
     /// </summary>
     private static OutputFormat GetOutputFormatValue(System.CommandLine.ParseResult parseResult)
     {
@@ -209,6 +210,17 @@ public static class GlobalOptions
         if (parseResult.GetResult(OutputFormat) is { } result)
         {
             return result.GetValueOrDefault<OutputFormat>();
+        }
+
+        // Fallback for commands that declare their own local --output-format option
+        // instead of the shared statics — resolve it by name so we never silently
+        // fall through to Text.
+        foreach (var option in parseResult.CommandResult.Command.Options)
+        {
+            if (option.Name == "--output-format" && parseResult.GetResult(option) is { } localResult)
+            {
+                return localResult.GetValueOrDefault<OutputFormat>();
+            }
         }
 
         return Commands.OutputFormat.Text;

--- a/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
+++ b/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using PPDS.Cli.Commands;
 
 namespace PPDS.Cli.Infrastructure;
@@ -44,12 +45,16 @@ public static class GlobalOptions
 
     /// <summary>
     /// Output format: text (human-readable) or json (machine-readable).
+    /// Rejects <see cref="Commands.OutputFormat.Csv"/> — most commands do not implement CSV rendering (#1078).
     /// </summary>
-    public static readonly Option<OutputFormat> OutputFormat = new("--output-format", "-f")
-    {
-        Description = "Output format",
-        DefaultValueFactory = _ => Commands.OutputFormat.Text
-    };
+    public static readonly Option<OutputFormat> OutputFormat = CreateOutputFormatOption();
+
+    /// <summary>
+    /// Output format variant for the commands that implement CSV rendering
+    /// (query sql, query fetch, query history execute, plugin traces list).
+    /// Added via <see cref="AddToCommand"/> with <c>supportsCsv: true</c>.
+    /// </summary>
+    public static readonly Option<OutputFormat> CsvCapableOutputFormat = CreateOutputFormatOption(supportsCsv: true);
 
     /// <summary>
     /// Correlation ID for distributed tracing. Auto-generated if not provided.
@@ -60,11 +65,88 @@ public static class GlobalOptions
     };
 
     /// <summary>
+    /// Creates an --output-format option with a clean parse error for invalid values (#1076)
+    /// and, unless <paramref name="supportsCsv"/> is set, a validator rejecting CSV (#1078).
+    /// </summary>
+    /// <param name="supportsCsv">Whether the owning command implements CSV rendering.</param>
+    /// <param name="shortAlias">Short alias — "-f" everywhere except data load, where -f belongs to --file.</param>
+    public static Option<OutputFormat> CreateOutputFormatOption(bool supportsCsv = false, string shortAlias = "-f")
+    {
+        var validValues = supportsCsv ? "Text, Json, Csv" : "Text, Json";
+
+        var option = new Option<OutputFormat>("--output-format", shortAlias)
+        {
+            Description = "Output format",
+            DefaultValueFactory = _ => Commands.OutputFormat.Text,
+            CustomParser = result =>
+            {
+                var token = result.Tokens[^1].Value;
+                if (Enum.TryParse<OutputFormat>(token, ignoreCase: true, out var format)
+                    && Enum.IsDefined(format))
+                {
+                    return format;
+                }
+
+                result.AddError($"Invalid value '{token}' for --output-format. Valid values: {validValues}.");
+                return Commands.OutputFormat.Text;
+            }
+        };
+
+        if (!supportsCsv)
+        {
+            option.Validators.Add(result =>
+            {
+                if (result.Tokens.Count == 0)
+                {
+                    return; // Default value (Text) — nothing to reject.
+                }
+
+                if (Enum.TryParse<OutputFormat>(result.Tokens[^1].Value, ignoreCase: true, out var format)
+                    && format == Commands.OutputFormat.Csv)
+                {
+                    result.AddError(
+                        $"CSV output is not supported for '{GetCommandPath(result)}'. Use --output-format Json or Text.");
+                }
+            });
+        }
+
+        return option;
+    }
+
+    /// <summary>
+    /// Builds the user-facing command path (e.g. "schema compare") from a parse result,
+    /// excluding the executable root.
+    /// </summary>
+    private static string GetCommandPath(OptionResult optionResult)
+    {
+        var names = new List<string>();
+        SymbolResult? current = optionResult.Parent;
+        while (current is CommandResult commandResult)
+        {
+            if (commandResult.Command is not RootCommand)
+            {
+                names.Add(commandResult.Command.Name);
+            }
+
+            current = commandResult.Parent;
+        }
+
+        if (names.Count == 0)
+        {
+            return "this command";
+        }
+
+        names.Reverse();
+        return string.Join(" ", names);
+    }
+
+    /// <summary>
     /// Adds the global options to a command.
     /// </summary>
     /// <param name="command">The command to add options to.</param>
     /// <param name="includeOutputFormat">Whether to include --output-format (skip if command has its own).</param>
-    public static void AddToCommand(Command command, bool includeOutputFormat = true)
+    /// <param name="supportsCsv">Whether the command implements CSV rendering for --output-format Csv.</param>
+    public static void AddToCommand(Command command, bool includeOutputFormat = true, bool supportsCsv = false)
     {
         command.Options.Add(Quiet);
         command.Options.Add(Verbose);
@@ -73,7 +155,7 @@ public static class GlobalOptions
 
         if (includeOutputFormat)
         {
-            command.Options.Add(OutputFormat);
+            command.Options.Add(supportsCsv ? CsvCapableOutputFormat : OutputFormat);
         }
 
         // Add validator for mutually exclusive verbosity options
@@ -103,9 +185,28 @@ public static class GlobalOptions
             Quiet = parseResult.GetValue(Quiet),
             Verbose = parseResult.GetValue(Verbose),
             Debug = parseResult.GetValue(Debug),
-            OutputFormat = parseResult.GetValue(OutputFormat),
+            OutputFormat = GetOutputFormatValue(parseResult),
             CorrelationId = parseResult.GetValue(CorrelationId)
         };
+    }
+
+    /// <summary>
+    /// Reads the output format from whichever --output-format instance the command carries
+    /// (<see cref="OutputFormat"/> or <see cref="CsvCapableOutputFormat"/>).
+    /// </summary>
+    private static OutputFormat GetOutputFormatValue(System.CommandLine.ParseResult parseResult)
+    {
+        if (parseResult.GetResult(CsvCapableOutputFormat) is { } csvCapableResult)
+        {
+            return csvCapableResult.GetValueOrDefault<OutputFormat>();
+        }
+
+        if (parseResult.GetResult(OutputFormat) is { } result)
+        {
+            return result.GetValueOrDefault<OutputFormat>();
+        }
+
+        return Commands.OutputFormat.Text;
     }
 }
 

--- a/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
+++ b/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
@@ -80,6 +80,11 @@ public static class GlobalOptions
             DefaultValueFactory = _ => Commands.OutputFormat.Text,
             CustomParser = result =>
             {
+                if (result.Tokens.Count == 0)
+                {
+                    return Commands.OutputFormat.Text; // Missing value is reported by arity enforcement.
+                }
+
                 var token = result.Tokens[^1].Value;
                 if (Enum.TryParse<OutputFormat>(token, ignoreCase: true, out var format)
                     && Enum.IsDefined(format))

--- a/src/PPDS.Cli/Infrastructure/Output/QueryResultFormatter.cs
+++ b/src/PPDS.Cli/Infrastructure/Output/QueryResultFormatter.cs
@@ -112,12 +112,15 @@ public static class QueryResultFormatter
     /// <param name="result">The query result to output as CSV.</param>
     public static void WriteCsvOutput(QueryResult result)
     {
-        if (result.Count == 0)
+        // Nothing to emit without a schema. When columns are known the header is
+        // written even for zero rows, so CSV consumers still get column names
+        // rather than silent zero-byte output (#1078).
+        if (result.Columns.Count == 0)
         {
             return;
         }
 
-        // Header row
+        // Header row (emitted even when there are no records)
         var headers = result.Columns.Select(c => EscapeCsvField(c.Alias ?? c.LogicalName));
         Console.WriteLine(string.Join(",", headers));
 

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -71,6 +71,17 @@ public class GlobalOptionsOutputFormatTests
         Assert.Contains("Invalid value '42' for --output-format", JoinedErrors(result));
     }
 
+    [Fact]
+    public void MissingValue_ReportsRequiredArgument_WithoutCrashing()
+    {
+        // --output-format with no value: arity enforcement reports the missing argument
+        // before the custom parser dereferences the (empty) token list. Must not throw.
+        var result = SolutionsCommandGroup.Create().Parse("list --output-format");
+
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains("Required argument missing", JoinedErrors(result));
+    }
+
     // ---- #1078: Csv is rejected on commands without CSV rendering ----
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -1,0 +1,234 @@
+using System.CommandLine;
+using PPDS.Cli.Commands;
+using PPDS.Cli.Commands.Data;
+using PPDS.Cli.Commands.Env;
+using PPDS.Cli.Commands.PluginTraces;
+using PPDS.Cli.Commands.Query;
+using PPDS.Cli.Commands.Schema;
+using PPDS.Cli.Commands.Solutions;
+using PPDS.Cli.Infrastructure;
+using PPDS.Cli.Infrastructure.Output;
+using PPDS.Dataverse.Query;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Infrastructure;
+
+/// <summary>
+/// Covers #1076 (invalid --output-format values produce a clean error instead of leaking
+/// the CLR enum type name) and #1078 (--output-format Csv is rejected on commands without
+/// CSV rendering and still accepted on the four commands that implement it).
+/// </summary>
+[Trait("Category", "Unit")]
+public class GlobalOptionsOutputFormatTests
+{
+    private static string JoinedErrors(ParseResult result) =>
+        string.Join(" | ", result.Errors.Select(e => e.Message));
+
+    // ---- #1076: invalid values produce a clean message ----
+
+    [Fact]
+    public void InvalidValue_OnSharedOption_ProducesCleanMessage()
+    {
+        var result = SolutionsCommandGroup.Create().Parse("list --output-format Yaml");
+
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains("Invalid value 'Yaml' for --output-format. Valid values: Text, Json.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void InvalidValue_DoesNotLeakClrTypeName()
+    {
+        var result = SolutionsCommandGroup.Create().Parse("list --output-format Yaml");
+
+        Assert.DoesNotContain("PPDS.Cli.Commands.OutputFormat", JoinedErrors(result));
+        Assert.DoesNotContain("Cannot parse argument", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void InvalidValue_OnLocalOption_ProducesCleanMessage()
+    {
+        // env list declares its own option instance (factory-created, not the shared one).
+        var result = EnvCommandGroup.Create().Parse("list -f Yaml");
+
+        Assert.Contains("Invalid value 'Yaml' for --output-format. Valid values: Text, Json.", JoinedErrors(result));
+        Assert.DoesNotContain("PPDS.Cli.Commands.OutputFormat", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void InvalidValue_OnCsvCapableCommand_ListsCsvAmongValidValues()
+    {
+        var result = QueryCommandGroup.Create().Parse("sql \"SELECT name FROM account\" --output-format Yaml");
+
+        Assert.Contains("Invalid value 'Yaml' for --output-format. Valid values: Text, Json, Csv.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void UndefinedNumericValue_IsRejected()
+    {
+        // Enum.TryParse would accept out-of-range numerics like 42; the parser must not.
+        var result = SolutionsCommandGroup.Create().Parse("list --output-format 42");
+
+        Assert.Contains("Invalid value '42' for --output-format", JoinedErrors(result));
+    }
+
+    // ---- #1078: Csv is rejected on commands without CSV rendering ----
+
+    [Fact]
+    public void Csv_OnSolutionsList_IsRejectedWithCommandPath()
+    {
+        var result = SolutionsCommandGroup.Create().Parse("list --output-format Csv");
+
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains("CSV output is not supported for 'solutions list'. Use --output-format Json or Text.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void Csv_OnEnvList_IsRejectedWithCommandPath()
+    {
+        var result = EnvCommandGroup.Create().Parse("list -f Csv");
+
+        Assert.Contains("CSV output is not supported for 'env list'. Use --output-format Json or Text.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void Csv_IsRejectedCaseInsensitively()
+    {
+        var result = EnvCommandGroup.Create().Parse("list -f CSV");
+
+        Assert.Contains("CSV output is not supported for 'env list'.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void Csv_OnDataLoad_IsRejected_ViaOAlias()
+    {
+        var result = DataCommandGroup.Create().Parse("load --entity account --file test.csv -o Csv");
+
+        Assert.Contains("CSV output is not supported for 'data load'. Use --output-format Json or Text.", JoinedErrors(result));
+    }
+
+    [Fact]
+    public void SchemaCompare_Csv_KeepsExistingRejectionMessage()
+    {
+        // The hand-rolled #1078 rejection in CompareCommand was subsumed by the shared
+        // option validator; the message must remain byte-identical.
+        var result = SchemaCommandGroup.Create().Parse("compare --data pkg.zip --environment https://x.crm.dynamics.com -f Csv");
+
+        Assert.Contains("CSV output is not supported for 'schema compare'. Use --output-format Json or Text.", JoinedErrors(result));
+    }
+
+    // ---- #1078: the four CSV-capable commands still accept Csv ----
+
+    [Fact]
+    public void Csv_OnQuerySql_ParsesAndBindsCsv()
+    {
+        var result = QueryCommandGroup.Create().Parse("sql \"SELECT name FROM account\" --output-format Csv");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Csv, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void Csv_OnQueryFetch_Parses()
+    {
+        var result = QueryCommandGroup.Create().Parse("fetch \"<fetch><entity name='account'/></fetch>\" -f Csv");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Csv, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void Csv_OnQueryHistoryExecute_Parses()
+    {
+        var result = QueryCommandGroup.Create().Parse("history execute 1 -f Csv");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Csv, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void Csv_OnPluginTracesList_Parses()
+    {
+        var result = PluginTracesCommandGroup.Create().Parse("list --output-format Csv");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Csv, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    // ---- valid values keep parsing (case-insensitive, defaults intact) ----
+
+    [Theory]
+    [InlineData("Text", OutputFormat.Text)]
+    [InlineData("text", OutputFormat.Text)]
+    [InlineData("Json", OutputFormat.Json)]
+    [InlineData("json", OutputFormat.Json)]
+    [InlineData("JSON", OutputFormat.Json)]
+    public void ValidValues_ParseCaseInsensitively(string token, OutputFormat expected)
+    {
+        var result = SolutionsCommandGroup.Create().Parse($"list --output-format {token}");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(expected, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void OmittedOption_DefaultsToText()
+    {
+        var result = SolutionsCommandGroup.Create().Parse("list");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Text, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void DataLoad_OutputFormatKeepsOAlias_FBelongsToFile()
+    {
+        var loadCommand = LoadCommand.Create();
+        var formatOption = loadCommand.Options.First(o => o.Name == "--output-format");
+
+        Assert.Contains("-o", formatOption.Aliases);
+        Assert.DoesNotContain("-f", formatOption.Aliases);
+    }
+
+    // ---- CSV emission still works for the shared query formatter ----
+
+    [Fact]
+    public void QueryResultFormatter_WriteCsvOutput_EmitsHeaderAndEscapedRows()
+    {
+        var queryResult = new QueryResult
+        {
+            EntityLogicalName = "account",
+            Columns =
+            [
+                new QueryColumn { LogicalName = "name" },
+                new QueryColumn { LogicalName = "revenue", Alias = "total" }
+            ],
+            Records =
+            [
+                new Dictionary<string, QueryValue>
+                {
+                    ["name"] = QueryValue.Simple("Contoso, Ltd \"HQ\""),
+                    ["total"] = QueryValue.WithFormatting(1000.50m, "$1,000.50")
+                }
+            ],
+            Count = 1,
+            MoreRecords = false
+        };
+
+        var originalOut = Console.Out;
+        var captured = new StringWriter();
+        Console.SetOut(captured);
+        try
+        {
+            QueryResultFormatter.WriteCsvOutput(queryResult);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        var csv = captured.ToString();
+        Assert.Contains("name,total", csv);
+        Assert.Contains("\"Contoso, Ltd \"\"HQ\"\"\"", csv);
+        Assert.Contains("\"$1,000.50\"", csv);
+    }
+}

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -269,4 +269,52 @@ public class GlobalOptionsOutputFormatTests
         Assert.Contains("\"Contoso, Ltd \"\"HQ\"\"\"", csv);
         Assert.Contains("\"$1,000.50\"", csv);
     }
+
+    // ---- #1078: empty CSV results emit the header, never silent zero bytes ----
+
+    [Fact]
+    public void QueryResultFormatter_WriteCsvOutput_EmptyResult_EmitsHeaderNotZeroBytes()
+    {
+        var csv = CaptureStdout(() => QueryResultFormatter.WriteCsvOutput(EmptyResultWithColumns()));
+
+        Assert.Equal("name,total", csv.TrimEnd('\r', '\n'));
+    }
+
+    [Fact]
+    public void FetchCommand_WriteCsvOutput_EmptyResult_EmitsHeaderNotZeroBytes()
+    {
+        var csv = CaptureStdout(() => FetchCommand.WriteCsvOutput(EmptyResultWithColumns()));
+
+        Assert.Equal("name,total", csv.TrimEnd('\r', '\n'));
+    }
+
+    private static QueryResult EmptyResultWithColumns() => new()
+    {
+        EntityLogicalName = "account",
+        Columns =
+        [
+            new QueryColumn { LogicalName = "name" },
+            new QueryColumn { LogicalName = "revenue", Alias = "total" }
+        ],
+        Records = [],
+        Count = 0,
+        MoreRecords = false
+    };
+
+    private static string CaptureStdout(Action action)
+    {
+        var originalOut = Console.Out;
+        var captured = new StringWriter();
+        Console.SetOut(captured);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        return captured.ToString();
+    }
 }

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -200,6 +200,33 @@ public class GlobalOptionsOutputFormatTests
         Assert.DoesNotContain("-f", formatOption.Aliases);
     }
 
+    [Fact]
+    public void GetValues_ResolvesCommandLocalOutputFormatInstance()
+    {
+        // Commands like `auth list` / `env list` declare their own --output-format instance
+        // (not the shared statics). GetValues must still resolve it — without the name-based
+        // fallback this returns the default Text (the bug Gemini flagged on GetOutputFormatValue).
+        var command = new Command("probe") { GlobalOptions.CreateOutputFormatOption() };
+        GlobalOptions.AddToCommand(command, includeOutputFormat: false);
+
+        var result = command.Parse("--output-format Json");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Json, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    [Fact]
+    public void GetValues_LocalInstanceOmitted_DefaultsToText()
+    {
+        var command = new Command("probe") { GlobalOptions.CreateOutputFormatOption() };
+        GlobalOptions.AddToCommand(command, includeOutputFormat: false);
+
+        var result = command.Parse("");
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(OutputFormat.Text, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
     // ---- CSV emission still works for the shared query formatter ----
 
     [Fact]

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -138,6 +138,29 @@ public class GlobalOptionsOutputFormatTests
         Assert.Equal(OutputFormat.Csv, GlobalOptions.GetValues(result).OutputFormat);
     }
 
+    [Theory]
+    [InlineData("--explain")]
+    [InlineData("--show-fetchxml")]
+    public void Csv_OnQuerySql_WithExplainOrShowFetchXml_IsRejected(string subMode)
+    {
+        // These sub-modes render a plan / FetchXML blob, not a result set, so Csv must be
+        // rejected rather than silently falling back to Text (#1078).
+        var result = QueryCommandGroup.Create().Parse($"sql \"SELECT name FROM account\" {subMode} --output-format Csv");
+
+        Assert.Contains(
+            "CSV output is not supported with --explain or --show-fetchxml. Use --output-format Json or Text.",
+            JoinedErrors(result));
+    }
+
+    [Fact]
+    public void InvalidValue_OnQuerySql_WithExplain_StillReportsCleanMessage_NoCrash()
+    {
+        // The sub-mode validator must not throw when --output-format itself failed to parse.
+        var result = QueryCommandGroup.Create().Parse("sql \"SELECT name FROM account\" --explain --output-format Yaml");
+
+        Assert.Contains("Invalid value 'Yaml' for --output-format", JoinedErrors(result));
+    }
+
     [Fact]
     public void Csv_OnQueryFetch_Parses()
     {
@@ -252,19 +275,8 @@ public class GlobalOptionsOutputFormatTests
             MoreRecords = false
         };
 
-        var originalOut = Console.Out;
-        var captured = new StringWriter();
-        Console.SetOut(captured);
-        try
-        {
-            QueryResultFormatter.WriteCsvOutput(queryResult);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var csv = CaptureStdout(() => QueryResultFormatter.WriteCsvOutput(queryResult));
 
-        var csv = captured.ToString();
         Assert.Contains("name,total", csv);
         Assert.Contains("\"Contoso, Ltd \"\"HQ\"\"\"", csv);
         Assert.Contains("\"$1,000.50\"", csv);
@@ -304,7 +316,7 @@ public class GlobalOptionsOutputFormatTests
     private static string CaptureStdout(Action action)
     {
         var originalOut = Console.Out;
-        var captured = new StringWriter();
+        using var captured = new StringWriter();
         Console.SetOut(captured);
         try
         {


### PR DESCRIPTION
## Summary

Fixes two related `--output-format` defects with one centralized mechanism in `GlobalOptions`.

**#1076 — parse errors leaked the CLR type name.** An invalid value produced
`Cannot parse argument 'Yaml' for option '--output-format' as expected type 'PPDS.Cli.Commands.OutputFormat'.` — System.CommandLine's default enum parse message, exposing an internal FQN. Root cause: the shared option (and 12 independent local `Option<OutputFormat>` declarations that bypassed it) had no `CustomParser`.

**#1078 — `--output-format Csv` silently rendered Text on most commands.** `ServiceFactory.CreateOutputWriter` maps any non-Json format to `TextOutputWriter`, so `Csv` fell through to Text with no error. Only four commands actually implement CSV; the rest silently produced wrong-format output. Root cause: `Csv` was accepted at the parse layer everywhere but implemented almost nowhere.

> History note: #1078's original "zero bytes" symptom was masked by commit `b5e71b6d3` (#1077's stderr→stdout move). The current symptom is silent wrong-format **Text on stdout**, not empty output — but the fix is the same: reject `Csv` where it isn't implemented.

## Design

New factory `GlobalOptions.CreateOutputFormatOption(bool supportsCsv, string shortAlias)`:
- **CustomParser** emits `Invalid value 'X' for --output-format. Valid values: Text, Json.` (no CLR type name). `Enum.IsDefined` rejects out-of-range numerics that `Enum.TryParse` would otherwise accept. The valid-values list gains `Csv` only when `supportsCsv`.
- **Validator** (only when `!supportsCsv`) rejects `Csv` with `CSV output is not supported for '<command>'. Use --output-format Json or Text.`, deriving `<command>` from the runtime parse tree — so one shared static instance names each command correctly.

`AddToCommand` gains `supportsCsv` (default `false`). The four CSV-capable commands opt in: `query sql`, `query fetch`, `query history execute`, `plugintraces list`. The 12 local declarations are repointed at the factory (data `load` keeps its `-o` alias, since `-f` is `--file` there). `schema compare`'s hand-rolled `Csv` rejection (which already cited #1078) is subsumed by the central validator — same message, byte-for-byte.

## Behavior change

**~160 command surfaces move from silent Text fallback to a clear error on `--output-format Csv`.** This is #1078's own acceptance criterion: every command either emits valid CSV or rejects the flag clearly — no silent wrong output. The four CSV-capable commands are unchanged. Valid `Text`/`Json` values (including case-insensitive `json`, `JSON`) parse exactly as before.

## Test Plan

New `tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs` (22 cases, all additive — nothing asserted the old leaky message):
- [x] Invalid value → clean message, and **explicitly asserts** the CLR type name `PPDS.Cli.Commands.OutputFormat` is absent
- [x] `Csv` rejected with non-zero exit on non-CSV commands (`solutions list`, `env list`, `data load` via `-o`), case-insensitive
- [x] `schema compare` keeps its exact pre-existing rejection wording
- [x] `Csv` still parses and binds on all four CSV-capable commands (`query sql`, `query fetch`, `query history execute`, `plugintraces list`)
- [x] Valid-values list adapts to `supportsCsv` (`...Text, Json` vs `...Text, Json, Csv`)
- [x] `Text`/`Json` parse case-insensitively; omitted option defaults to `Text`; `data load` keeps `-o` / not `-f`
- [x] `QueryResultFormatter.WriteCsvOutput` still emits header + CSV-escaped rows

## Verification

- [x] `dotnet build PPDS.sln` — 0 errors
- [x] `dotnet test PPDS.sln --filter "Category!=Integration"` — **0 failures** (CLI: 4338 passed × net8/9/10; full solution green)
- [x] `/verify cli` against a live environment: invalid value → clean message (no FQN); `Csv` rejected on `solutions list` / `env list` / `data load`; `schema compare` wording preserved; `query sql ... -f Csv` emits real CSV (`fullname,systemuserid\n...`); `-f Json` still emits JSON

Fixes #1076
Fixes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent CSV-capable `--output-format` support across supported query/history/trace commands (including correct `csv` parsing and rendering).
* **Bug Fixes**
  * Standardized `--output-format` validation and missing/invalid-value errors across commands (clean messages, no enum type leakage).
  * CSV is now allowed for `schema compare`.
  * CSV output now emits the header even when there are zero records (query/fetch).
  * `query sql` rejects CSV when using `--explain` or `--show-fetchxml`.
* **Tests**
  * Added automated coverage for output-format parsing/validation and CSV rendering behavior (including empty results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->