### PR TITLE
fix(mcp): report MinVer package version in serverInfo instead of AssemblyVersion (#1273)

### DIFF
--- a/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
+++ b/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
@@ -61,12 +61,13 @@ internal static class ServerVersion
     {
         if (!string.IsNullOrWhiteSpace(informationalVersion))
         {
-            var metadataIndex = informationalVersion.IndexOf('+');
+            var trimmed = informationalVersion.Trim();
+            var metadataIndex = trimmed.IndexOf('+');
             return metadataIndex >= 0
-                ? informationalVersion[..metadataIndex]
-                : informationalVersion;
+                ? trimmed[..metadataIndex]
+                : trimmed;
         }
 
-        return string.IsNullOrWhiteSpace(fileVersion) ? Unknown : fileVersion;
+        return string.IsNullOrWhiteSpace(fileVersion) ? Unknown : fileVersion.Trim();
     }
 }

--- a/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
+++ b/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+
+namespace PPDS.Mcp.Infrastructure;
+
+/// <summary>
+/// Resolves the version PPDS reports as <c>serverInfo.version</c> in the MCP
+/// <c>initialize</c> handshake.
+/// </summary>
+/// <remarks>
+/// PPDS.Mcp is versioned with MinVer (<c>MinVerTagPrefix=Mcp-v</c> in
+/// <c>PPDS.Mcp.csproj</c>). MinVer stamps <see cref="AssemblyInformationalVersionAttribute"/>
+/// and <see cref="AssemblyFileVersionAttribute"/> from git tags/describe, but it deliberately
+/// leaves the classic <see cref="AssemblyName.Version"/> (AssemblyVersion) fixed at
+/// <c>{major}.0.0.0</c> for binding-compatibility reasons. The ModelContextProtocol SDK
+/// (v0.2.0-preview.3) falls back to the entry assembly's AssemblyVersion whenever
+/// <c>McpServerOptions.ServerInfo</c> is left unset, so without this helper the handshake
+/// always reports "1.0.0.0" regardless of the real package version. See #1273.
+/// </remarks>
+internal static class ServerVersion
+{
+    /// <summary>Reported when no version metadata is available at all.</summary>
+    internal const string Unknown = "0.0.0";
+
+    /// <summary>
+    /// Resolves the reportable version from the given assembly's version attributes.
+    /// </summary>
+    /// <param name="assembly">
+    /// The assembly to read version metadata from — pass <c>Assembly.GetExecutingAssembly()</c>
+    /// from Program.cs to resolve ppds-mcp-server's own MinVer-stamped version.
+    /// </param>
+    public static string Resolve(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        var fileVersion = assembly
+            .GetCustomAttribute<AssemblyFileVersionAttribute>()?
+            .Version;
+
+        return Resolve(informationalVersion, fileVersion);
+    }
+
+    /// <summary>
+    /// Pure resolution logic, separated from assembly reflection so it is directly unit
+    /// testable. Strips MinVer's '+&lt;metadata&gt;' build-metadata suffix (e.g. a git SHA)
+    /// from the informational version — e.g. "1.0.2-alpha.0.5+abc1234" becomes
+    /// "1.0.2-alpha.0.5" — since build metadata is not meaningful to MCP clients. Falls back
+    /// to <paramref name="fileVersion"/>, then <see cref="Unknown"/>, when the informational
+    /// version is missing or blank.
+    /// </summary>
+    /// <param name="informationalVersion">
+    /// The assembly's <see cref="AssemblyInformationalVersionAttribute"/> value, if present.
+    /// </param>
+    /// <param name="fileVersion">
+    /// The assembly's <see cref="AssemblyFileVersionAttribute"/> value, if present.
+    /// </param>
+    internal static string Resolve(string? informationalVersion, string? fileVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            var metadataIndex = informationalVersion.IndexOf('+');
+            return metadataIndex >= 0
+                ? informationalVersion[..metadataIndex]
+                : informationalVersion;
+        }
+
+        return string.IsNullOrWhiteSpace(fileVersion) ? Unknown : fileVersion;
+    }
+}

--- a/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
+++ b/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
@@ -28,7 +28,7 @@ internal static class ServerVersion
     /// The assembly to read version metadata from — pass <c>Assembly.GetExecutingAssembly()</c>
     /// from Program.cs to resolve ppds-mcp-server's own MinVer-stamped version.
     /// </param>
-    public static string Resolve(Assembly assembly)
+    internal static string Resolve(Assembly assembly)
     {
         ArgumentNullException.ThrowIfNull(assembly);
 

--- a/src/PPDS.Mcp/Program.cs
+++ b/src/PPDS.Mcp/Program.cs
@@ -1,6 +1,8 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using PPDS.Cli.Services;
 using PPDS.Dataverse.DependencyInjection;
@@ -30,7 +32,17 @@ builder.Logging.SetMinimumLevel(logLevel);
 
 // Register MCP server with stdio transport.
 // WithToolsFromAssembly() discovers all [McpServerToolType] classes automatically.
-builder.Services.AddMcpServer()
+// ServerInfo is set explicitly because the SDK's default falls back to the entry
+// assembly's AssemblyVersion, which MinVer leaves fixed at "{major}.0.0.0" — see
+// ServerVersion and #1273 for why that misreports the real package version.
+builder.Services.AddMcpServer(options =>
+{
+    options.ServerInfo = new Implementation
+    {
+        Name = "ppds-mcp-server",
+        Version = ServerVersion.Resolve(Assembly.GetExecutingAssembly())
+    };
+})
     .WithStdioServerTransport()
     .WithToolsFromAssembly();
 

--- a/src/PPDS.Mcp/Program.cs
+++ b/src/PPDS.Mcp/Program.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -40,7 +39,9 @@ builder.Services.AddMcpServer(options =>
     options.ServerInfo = new Implementation
     {
         Name = "ppds-mcp-server",
-        Version = ServerVersion.Resolve(Assembly.GetExecutingAssembly())
+        // typeof(ServerVersion).Assembly is the ppds-mcp-server assembly itself, resolved
+        // statically at compile time rather than via GetExecutingAssembly() inside this lambda.
+        Version = ServerVersion.Resolve(typeof(ServerVersion).Assembly)
     };
 })
     .WithStdioServerTransport()

--- a/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using FluentAssertions;
 using PPDS.Mcp.Infrastructure;
 using Xunit;
@@ -107,7 +106,7 @@ public sealed class ServerVersionTests
     public void Resolve_NullAssembly_ThrowsArgumentNullException()
     {
         // Act
-        var act = () => ServerVersion.Resolve((Assembly)null!);
+        var act = () => ServerVersion.Resolve(null!);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();

--- a/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using FluentAssertions;
+using PPDS.Mcp.Infrastructure;
+using Xunit;
+
+namespace PPDS.Mcp.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="ServerVersion"/>.
+/// Verifies fix for #1273: MCP <c>serverInfo.version</c> must reflect MinVer's stamped
+/// package version, not the SDK's default AssemblyVersion fallback (always "1.0.0.0").
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class ServerVersionTests
+{
+    #region Resolve(string?, string?) — informational version present
+
+    [Fact]
+    public void Resolve_InformationalVersionWithBuildMetadata_StripsMetadataSuffix()
+    {
+        // Arrange — MinVer's non-tag-build format: "{version}-{prerelease}+{sha}"
+        var informational = "1.0.2-alpha.0.5+abc1234def5678";
+
+        // Act
+        var result = ServerVersion.Resolve(informational, fileVersion: "1.0.2.0");
+
+        // Assert
+        result.Should().Be("1.0.2-alpha.0.5");
+    }
+
+    [Fact]
+    public void Resolve_InformationalVersionWithoutBuildMetadata_ReturnsUnchanged()
+    {
+        // Arrange — MinVer's tag-build format has no '+' suffix.
+        var informational = "1.0.1";
+
+        // Act
+        var result = ServerVersion.Resolve(informational, fileVersion: "1.0.1.0");
+
+        // Assert
+        result.Should().Be("1.0.1");
+    }
+
+    [Fact]
+    public void Resolve_InformationalVersionWithMultiplePlusSigns_StripsFromFirstPlus()
+    {
+        // Arrange — defensive: only the first '+' should demarcate build metadata,
+        // matching semver (everything after the first '+' is metadata).
+        var informational = "1.0.2-alpha.0.5+abc+def";
+
+        // Act
+        var result = ServerVersion.Resolve(informational, fileVersion: null);
+
+        // Assert
+        result.Should().Be("1.0.2-alpha.0.5");
+    }
+
+    #endregion
+
+    #region Resolve(string?, string?) — informational version missing or blank
+
+    [Fact]
+    public void Resolve_MissingInformationalVersion_FallsBackToFileVersion()
+    {
+        // Act
+        var result = ServerVersion.Resolve(informationalVersion: null, fileVersion: "1.0.2.0");
+
+        // Assert
+        result.Should().Be("1.0.2.0");
+    }
+
+    [Fact]
+    public void Resolve_BlankInformationalVersion_FallsBackToFileVersion()
+    {
+        // Act
+        var result = ServerVersion.Resolve(informationalVersion: "   ", fileVersion: "1.0.2.0");
+
+        // Assert
+        result.Should().Be("1.0.2.0");
+    }
+
+    [Fact]
+    public void Resolve_MissingBothInformationalAndFileVersion_FallsBackToUnknown()
+    {
+        // Act
+        var result = ServerVersion.Resolve(informationalVersion: null, fileVersion: null);
+
+        // Assert
+        result.Should().Be(ServerVersion.Unknown);
+        result.Should().Be("0.0.0");
+    }
+
+    [Fact]
+    public void Resolve_BlankInformationalAndBlankFileVersion_FallsBackToUnknown()
+    {
+        // Act
+        var result = ServerVersion.Resolve(informationalVersion: "", fileVersion: "  ");
+
+        // Assert
+        result.Should().Be(ServerVersion.Unknown);
+    }
+
+    #endregion
+
+    #region Resolve(Assembly)
+
+    [Fact]
+    public void Resolve_NullAssembly_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => ServerVersion.Resolve((Assembly)null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Resolve_RealPpdsMcpAssembly_ReturnsMinVerVersionNotFixedAssemblyVersion()
+    {
+        // Arrange — ServerVersion itself lives in the MinVer-versioned ppds-mcp-server
+        // assembly, so this exercises the real attributes MinVer stamps at build time
+        // without needing a live handshake.
+        var assembly = typeof(ServerVersion).Assembly;
+
+        // Act
+        var result = ServerVersion.Resolve(assembly);
+
+        // Assert — must never be blank, never carry build metadata, and must never
+        // collapse to the fixed "{major}.0.0.0" AssemblyVersion the bug reported.
+        result.Should().NotBeNullOrWhiteSpace();
+        result.Should().NotContain("+");
+        result.Should().NotBe("1.0.0.0");
+    }
+
+    #endregion
+}

--- a/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs
@@ -87,7 +87,6 @@ public sealed class ServerVersionTests
 
         // Assert
         result.Should().Be(ServerVersion.Unknown);
-        result.Should().Be("0.0.0");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

The MCP server reports `serverInfo.version` = `1.0.0.0` in the MCP `initialize` handshake regardless of the actual published package version (currently 1.0.1).

**Root cause:** `AddMcpServer()` was called with no explicit `ServerInfo`, so the ModelContextProtocol SDK (v0.2.0-preview.3) falls back to the entry assembly's `AssemblyVersion`. The repo versions `PPDS.Mcp` with MinVer (`MinVerTagPrefix=Mcp-v`), which stamps `AssemblyInformationalVersion`/`FileVersion` from git tags but deliberately leaves `AssemblyVersion` fixed at `{major}.0.0.0`. So the package version moves while the self-reported version never does.

## Fix

- New `src/PPDS.Mcp/Infrastructure/ServerVersion.cs` — resolves the reportable version from `AssemblyInformationalVersionAttribute`, stripping MinVer's `+<build-metadata>` suffix (e.g. `1.0.2-alpha.0.5+abc1234` → `1.0.2-alpha.0.5`), with a `FileVersion` → `0.0.0` fallback. Pure `Resolve(string?, string?)` overload separated for unit testing.
- `Program.cs` now sets `options.ServerInfo` with the correct name and `ServerVersion.Resolve(Assembly.GetExecutingAssembly())`.

## Tests

New `tests/PPDS.Mcp.Tests/Infrastructure/ServerVersionTests.cs` covering: metadata-suffix stripping, tag-build (no `+`), multiple `+` (semver: strip from first), missing/blank informational → `FileVersion` fallback, and both-missing → `0.0.0`. Full non-integration suite green (verified by the pre-commit gate).

Fixes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server handshakes now report a fixed, consistent server name and an accurate build version.

* **Bug Fixes**
  * Improved version detection by preferring informational version details and falling back when unavailable.
  * Build metadata suffixes are removed for cleaner, user-facing version reporting.
  * When version info is missing, a clear default “unknown” version is used instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->