### PR TITLE
fix(cli): embed net462 reference assemblies so plugins extract works in single-file builds (#1294)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,6 +64,11 @@
 
   <ItemGroup Label="Dataverse SDK (Plugins)">
     <PackageVersion Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.60" />
+    <!-- Build-asset-only: supplies .NET Framework 4.6.2 reference assemblies that PPDS.Cli
+         embeds so `plugins extract` can resolve the core assembly (mscorlib) and BCL facades
+         when running as a single-file self-contained binary (no loose BCL DLLs on disk).
+         See #1294. Consumed via GeneratePathProperty + ExcludeAssets in PPDS.Cli.csproj. -->
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="Testing">

--- a/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
@@ -45,12 +45,24 @@ public static class ExtractCommand
             Description = "Overwrite existing file without merging"
         };
 
-        var command = new Command("extract", "Extract plugin step/image attributes from assembly to JSON configuration")
+        var referenceDirOption = new Option<DirectoryInfo[]>("--reference-dir")
+        {
+            Description = "Additional directory to search for referenced assemblies (repeatable). " +
+                          "Use when a plugin's dependencies live outside the input assembly's own folder.",
+            AllowMultipleArgumentsPerToken = true
+        };
+
+        var command = new Command(
+            "extract",
+            "Extract plugin step/image attributes from an assembly (.dll) or plugin package (.nupkg) to " +
+            "JSON configuration. Works against .NET Framework 4.6.2 plugin assemblies regardless of how " +
+            "the CLI is packaged (single-file, self-contained, or framework-dependent).")
         {
             inputOption,
             outputOption,
             solutionOption,
-            forceOption
+            forceOption,
+            referenceDirOption
         };
 
         // Add global options including output format
@@ -62,9 +74,12 @@ public static class ExtractCommand
             var output = parseResult.GetValue(outputOption);
             var solution = parseResult.GetValue(solutionOption);
             var force = parseResult.GetValue(forceOption);
+            var referenceDirs = parseResult.GetValue(referenceDirOption)
+                ?.Select(d => d.FullName)
+                .ToArray();
             var globalOptions = GlobalOptions.GetValues(parseResult);
 
-            return await ExecuteAsync(input, output, solution, force, globalOptions, cancellationToken);
+            return await ExecuteAsync(input, output, solution, force, referenceDirs, globalOptions, cancellationToken);
         });
 
         return command;
@@ -75,6 +90,7 @@ public static class ExtractCommand
         FileInfo? output,
         string? solution,
         bool force,
+        IReadOnlyList<string>? referenceDirs,
         GlobalOptionValues globalOptions,
         CancellationToken cancellationToken)
     {
@@ -90,14 +106,14 @@ public static class ExtractCommand
                 if (!globalOptions.IsJsonMode)
                     Console.Error.WriteLine($"Extracting from NuGet package: {input.Name}");
 
-                assemblyConfig = NupkgExtractor.Extract(input.FullName);
+                assemblyConfig = NupkgExtractor.Extract(input.FullName, referenceDirs);
             }
             else if (extension == ".dll")
             {
                 if (!globalOptions.IsJsonMode)
                     Console.Error.WriteLine($"Extracting from assembly: {input.Name}");
 
-                using var extractor = AssemblyExtractor.Create(input.FullName);
+                using var extractor = AssemblyExtractor.Create(input.FullName, referenceDirs);
                 assemblyConfig = extractor.Extract();
             }
             else

--- a/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/ExtractCommand.cs
@@ -50,7 +50,7 @@ public static class ExtractCommand
             Description = "Additional directory to search for referenced assemblies (repeatable). " +
                           "Use when a plugin's dependencies live outside the input assembly's own folder.",
             AllowMultipleArgumentsPerToken = true
-        };
+        }.AcceptExistingOnly();
 
         var command = new Command(
             "extract",

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -98,7 +98,7 @@
        the EmbeddedResource item is re-added on every build so an incremental recompile that
        skips zip generation still embeds the resource. -->
   <Target Name="_GenerateNet462ReferenceAssembliesZip"
-          Inputs="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net462)\build\.NETFramework\v4.6.2\mscorlib.dll"
+          Inputs="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net462)\build\.NETFramework\v4.6.2\mscorlib.dll;$(MSBuildProjectFullPath)"
           Outputs="$(IntermediateOutputPath)Net462ReferenceAssemblies.zip">
 
     <PropertyGroup>

--- a/src/PPDS.Cli/PPDS.Cli.csproj
+++ b/src/PPDS.Cli/PPDS.Cli.csproj
@@ -75,5 +75,83 @@
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
+    <!-- Build-asset-only. ExcludeAssets="all" stops the package's own build props/targets
+         from injecting these net462 reference assemblies as compile references (which would
+         break our net8.0+ compilation); GeneratePathProperty exposes the package location so
+         the EmbedNet462ReferenceAssemblies target below can zip the needed assemblies into an
+         embedded resource. Fixes single-file `plugins extract` (#1294). -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net462"
+                      PrivateAssets="all"
+                      ExcludeAssets="all"
+                      GeneratePathProperty="true" />
   </ItemGroup>
+
+  <!-- Embed .NET Framework 4.6.2 reference assemblies (mscorlib + BCL facades) into the CLI
+       assembly. Dataverse plugin assemblies target net462; when `plugins extract` runs from a
+       single-file self-contained binary there are no loose BCL DLLs on disk, so the
+       MetadataLoadContext resolver cannot find a core assembly (mscorlib). Shipping these as an
+       embedded zip (extracted lazily at runtime) makes extraction work regardless of how the
+       CLI is packaged. Zip only the assemblies needed to resolve typical Dataverse plugin
+       references to keep the binary lean. See #1294 and AssemblyExtractor.cs.
+
+       Split into two targets on purpose: zip generation is incremental (Inputs/Outputs), while
+       the EmbeddedResource item is re-added on every build so an incremental recompile that
+       skips zip generation still embeds the resource. -->
+  <Target Name="_GenerateNet462ReferenceAssembliesZip"
+          Inputs="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net462)\build\.NETFramework\v4.6.2\mscorlib.dll"
+          Outputs="$(IntermediateOutputPath)Net462ReferenceAssemblies.zip">
+
+    <PropertyGroup>
+      <_Net462RefRoot>$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net462)\build\.NETFramework\v4.6.2</_Net462RefRoot>
+      <_Net462StageDir>$(IntermediateOutputPath)net462-ref\</_Net462StageDir>
+    </PropertyGroup>
+
+    <Error Condition="'$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net462)' == '' Or !Exists('$(_Net462RefRoot)\mscorlib.dll')"
+           Text="Cannot locate the Microsoft.NETFramework.ReferenceAssemblies.net462 reference assemblies at '$(_Net462RefRoot)'. Ensure the package is restored with GeneratePathProperty=&quot;true&quot;." />
+
+    <ItemGroup>
+      <!-- Core + commonly-referenced BCL assemblies (metadata-only reference assemblies). -->
+      <_Net462RefFile Include="$(_Net462RefRoot)\mscorlib.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Core.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Data.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Xml.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Xml.Linq.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Runtime.Serialization.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.ServiceModel.dll" />
+      <_Net462RefFile Include="$(_Net462RefRoot)\System.Net.Http.dll" />
+      <!-- Facades hold System.Runtime.dll and the other type-forwarding contract shims that
+           net462 assemblies reference; they are tiny and prevent resolution gaps. -->
+      <_Net462RefFile Include="$(_Net462RefRoot)\Facades\*.dll" />
+    </ItemGroup>
+
+    <!-- Rebuild the stage dir deterministically each time the zip is (re)generated. -->
+    <RemoveDir Directories="$(_Net462StageDir)" />
+    <MakeDir Directories="$(_Net462StageDir)" />
+    <Copy SourceFiles="@(_Net462RefFile)"
+          DestinationFolder="$(_Net462StageDir)"
+          SkipUnchangedFiles="false" />
+
+    <ZipDirectory SourceDirectory="$(_Net462StageDir)"
+                  DestinationFile="$(IntermediateOutputPath)Net462ReferenceAssemblies.zip"
+                  Overwrite="true" />
+  </Target>
+
+  <!-- Hook AssignTargetPaths (not PrepareResourceNames): CreateManifestResourceNames, which
+       assigns each EmbeddedResource its manifest name, is a *dependency* of PrepareResourceNames
+       and therefore runs before a BeforeTargets="PrepareResourceNames" target. AssignTargetPaths
+       is the first link in that dependency chain, so adding the item here guarantees it is named
+       and embedded. No Inputs/Outputs so the item is re-added on every (incremental) build. -->
+  <Target Name="_EmbedNet462ReferenceAssemblies"
+          DependsOnTargets="_GenerateNet462ReferenceAssembliesZip"
+          BeforeTargets="AssignTargetPaths">
+    <Error Condition="!Exists('$(IntermediateOutputPath)Net462ReferenceAssemblies.zip')"
+           Text="Net462ReferenceAssemblies.zip was not generated before resource names were assigned." />
+    <ItemGroup>
+      <EmbeddedResource Include="$(IntermediateOutputPath)Net462ReferenceAssemblies.zip">
+        <LogicalName>PPDS.Cli.Resources.Net462ReferenceAssemblies.zip</LogicalName>
+        <Visible>false</Visible>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
@@ -1,7 +1,9 @@
+using System.IO.Compression;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using PPDS.Cli.Plugins.Models;
 using PPDS.Plugins;
 
@@ -12,6 +14,21 @@ namespace PPDS.Cli.Plugins.Extraction;
 /// </summary>
 public sealed class AssemblyExtractor : IDisposable
 {
+    /// <summary>
+    /// Logical name of the embedded resource holding the zipped .NET Framework 4.6.2
+    /// reference assemblies. Must stay in sync with the <c>EmbedNet462ReferenceAssemblies</c>
+    /// target in <c>PPDS.Cli.csproj</c>.
+    /// </summary>
+    private const string Net462ResourceName = "PPDS.Cli.Resources.Net462ReferenceAssemblies.zip";
+
+    /// <summary>
+    /// Directory of embedded .NET Framework 4.6.2 reference assemblies, extracted once per
+    /// process on first use. Null when the embedded resource is unavailable or extraction
+    /// failed — in which case the resolver falls back to runtime-directory seeding.
+    /// </summary>
+    private static readonly Lazy<string?> Net462ReferenceDirectory =
+        new(GetNet462ReferenceAssemblyDirectory);
+
     private readonly MetadataLoadContext _metadataLoadContext;
     private readonly string _assemblyPath;
     private bool _disposed;
@@ -26,27 +43,186 @@ public sealed class AssemblyExtractor : IDisposable
     /// Creates an extractor for the specified assembly.
     /// </summary>
     /// <param name="assemblyPath">Path to the assembly DLL.</param>
+    /// <param name="referenceDirs">
+    /// Optional additional directories to search for referenced assemblies, seeded ahead of the
+    /// embedded reference assemblies and the process runtime directory. Supplied via the
+    /// <c>--reference-dir</c> option for plugins whose dependencies live outside the target
+    /// assembly's own directory.
+    /// </param>
     /// <returns>An extractor instance that must be disposed.</returns>
-    public static AssemblyExtractor Create(string assemblyPath)
+    public static AssemblyExtractor Create(string assemblyPath, IReadOnlyList<string>? referenceDirs = null)
+        => Create(assemblyPath, referenceDirs, includeRuntimeDirectory: true);
+
+    /// <summary>
+    /// Internal factory that allows suppressing runtime-directory seeding so tests can
+    /// reproduce the single-file packaging environment — where no loose BCL DLLs exist on
+    /// disk — and prove the embedded reference assemblies alone are sufficient. See #1294.
+    /// </summary>
+    internal static AssemblyExtractor Create(
+        string assemblyPath,
+        IReadOnlyList<string>? referenceDirs,
+        bool includeRuntimeDirectory)
     {
-        var directory = Path.GetDirectoryName(assemblyPath) ?? ".";
-
-        // Collect assemblies for the resolver:
-        // 1. All DLLs in the same directory as the target assembly
-        // 2. .NET runtime assemblies for core types
-        var assemblyPaths = new List<string>();
-
-        // Add assemblies from target directory
-        assemblyPaths.AddRange(Directory.GetFiles(directory, "*.dll"));
-
-        // Add .NET runtime assemblies
-        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
-        assemblyPaths.AddRange(Directory.GetFiles(runtimeDir, "*.dll"));
-
+        var assemblyPaths = BuildResolverPaths(assemblyPath, referenceDirs, includeRuntimeDirectory);
         var resolver = new PathAssemblyResolver(assemblyPaths);
+
+        // Leave coreAssemblyName null so MetadataLoadContext infers the core assembly from the
+        // target assembly's references (it probes "mscorlib", "System.Runtime", ... in order).
+        // For a net462 plugin that resolves to mscorlib — now always available via the embedded
+        // reference assemblies — and for a net8-targeted assembly it resolves via the runtime
+        // directory. Passing an explicit "mscorlib" would force the net462 core even for net8
+        // targets, so null is the safer choice that keeps both scenarios working.
         var mlc = new MetadataLoadContext(resolver);
 
         return new AssemblyExtractor(mlc, assemblyPath);
+    }
+
+    /// <summary>
+    /// Builds the ordered, de-duplicated list of assembly paths used to seed the
+    /// <see cref="PathAssemblyResolver"/>. Ordering encodes priority (earlier wins):
+    /// <list type="number">
+    /// <item>the target assembly's own directory — user-local assemblies win;</item>
+    /// <item>caller-supplied <paramref name="referenceDirs"/> (<c>--reference-dir</c>);</item>
+    /// <item>the embedded .NET Framework 4.6.2 reference assemblies (fixes single-file
+    /// packaging, where no loose BCL DLLs exist on disk — #1294);</item>
+    /// <item>the process runtime directory — helps framework-dependent dev runs and
+    /// net8-targeted assemblies; empty of loose DLLs in single-file publishes.</item>
+    /// </list>
+    /// De-duping by simple assembly name (keeping the first occurrence) preserves that priority
+    /// and keeps resolution deterministic. <see cref="PathAssemblyResolver"/> tolerates
+    /// duplicate simple names, but de-duping guarantees the ordering above wins.
+    /// </summary>
+    internal static List<string> BuildResolverPaths(
+        string assemblyPath,
+        IReadOnlyList<string>? referenceDirs,
+        bool includeRuntimeDirectory)
+    {
+        var candidates = new List<string>();
+
+        // 1. Target assembly's own directory.
+        var directory = Path.GetDirectoryName(assemblyPath);
+        if (string.IsNullOrEmpty(directory))
+            directory = ".";
+        candidates.AddRange(Directory.GetFiles(directory, "*.dll"));
+
+        // 2. Caller-supplied reference directories.
+        if (referenceDirs != null)
+        {
+            foreach (var dir in referenceDirs)
+            {
+                if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+                    candidates.AddRange(Directory.GetFiles(dir, "*.dll"));
+            }
+        }
+
+        // 3. Embedded .NET Framework 4.6.2 reference assemblies.
+        var net462Dir = Net462ReferenceDirectory.Value;
+        if (net462Dir != null)
+            candidates.AddRange(Directory.GetFiles(net462Dir, "*.dll"));
+
+        // 4. Process runtime directory (empty of loose DLLs in single-file publishes).
+        if (includeRuntimeDirectory)
+        {
+            var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+            if (!string.IsNullOrEmpty(runtimeDir) && Directory.Exists(runtimeDir))
+                candidates.AddRange(Directory.GetFiles(runtimeDir, "*.dll"));
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>(candidates.Count);
+        foreach (var path in candidates)
+        {
+            if (seen.Add(Path.GetFileNameWithoutExtension(path)))
+                result.Add(path);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extracts the embedded .NET Framework 4.6.2 reference assemblies to a stable, content-
+    /// addressed cache directory and returns its path, or <c>null</c> if the resource is
+    /// unavailable or extraction fails. Never throws — callers fall back to runtime-directory
+    /// seeding, so the fix can never make extraction worse than before. See #1294.
+    /// </summary>
+    internal static string? GetNet462ReferenceAssemblyDirectory()
+    {
+        try
+        {
+            var assembly = typeof(AssemblyExtractor).Assembly;
+            using var resourceStream = assembly.GetManifestResourceStream(Net462ResourceName);
+            if (resourceStream == null)
+                return null;
+
+            using var buffer = new MemoryStream();
+            resourceStream.CopyTo(buffer);
+            var zipBytes = buffer.ToArray();
+            if (zipBytes.Length == 0)
+                return null;
+
+            // Content-addressed cache key: identical content reuses the cache, while a rebuilt
+            // resource (new CLI version) lands in a fresh directory, so there is no stale cache.
+            var hash = Convert.ToHexString(SHA256.HashData(zipBytes))[..16].ToLowerInvariant();
+            var cacheDir = Path.Combine(Path.GetTempPath(), "ppds", "net462-ref", hash);
+
+            if (IsPopulated(cacheDir))
+                return cacheDir;
+
+            // Extract to a unique staging directory, then atomically move it into place so a
+            // concurrent extraction never observes a half-populated cache directory.
+            var stagingDir = Path.Combine(
+                Path.GetTempPath(), "ppds", "net462-ref", $".staging-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(stagingDir);
+            try
+            {
+                using (var zipStream = new MemoryStream(zipBytes, writable: false))
+                using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Read))
+                {
+                    archive.ExtractToDirectory(stagingDir);
+                }
+
+                if (IsPopulated(cacheDir))
+                    return cacheDir; // Another process won the race while we were extracting.
+
+                Directory.CreateDirectory(Path.GetDirectoryName(cacheDir)!);
+                try
+                {
+                    Directory.Move(stagingDir, cacheDir);
+                }
+                catch (IOException) when (IsPopulated(cacheDir))
+                {
+                    // Race: another process created the cache dir between our check and move.
+                    return cacheDir;
+                }
+
+                return cacheDir;
+            }
+            finally
+            {
+                TryDeleteDirectory(stagingDir);
+            }
+        }
+        catch
+        {
+            // Never make things worse — fall back to runtime-directory seeding.
+            return null;
+        }
+    }
+
+    private static bool IsPopulated(string directory)
+        => Directory.Exists(directory) && Directory.EnumerateFiles(directory, "*.dll").Any();
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup; a leftover staging dir is harmless.
+        }
     }
 
     /// <summary>

--- a/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
@@ -164,15 +164,25 @@ public sealed class AssemblyExtractor : IDisposable
             // Content-addressed cache key: identical content reuses the cache, while a rebuilt
             // resource (new CLI version) lands in a fresh directory, so there is no stale cache.
             var hash = Convert.ToHexString(SHA256.HashData(zipBytes))[..16].ToLowerInvariant();
-            var cacheDir = Path.Combine(Path.GetTempPath(), "ppds", "net462-ref", hash);
+
+            // Scope the cache to the current user. On multi-user systems Path.GetTempPath() can be
+            // a shared directory (e.g. /tmp on Linux), so a fixed "ppds/net462-ref" path would be
+            // created by the first user and then throw UnauthorizedAccessException for every other
+            // account — which the outer catch swallows, silently disabling the fix for them.
+            // Isolating by user name gives each account its own cache. See #1294.
+            var rawUser = Environment.UserName;
+            var userScope = string.IsNullOrWhiteSpace(rawUser)
+                ? "default"
+                : string.Join("_", rawUser.Split(Path.GetInvalidFileNameChars()));
+            var baseDir = Path.Combine(Path.GetTempPath(), $"ppds-{userScope}", "net462-ref");
+            var cacheDir = Path.Combine(baseDir, hash);
 
             if (IsPopulated(cacheDir))
                 return cacheDir;
 
             // Extract to a unique staging directory, then atomically move it into place so a
             // concurrent extraction never observes a half-populated cache directory.
-            var stagingDir = Path.Combine(
-                Path.GetTempPath(), "ppds", "net462-ref", $".staging-{Guid.NewGuid():N}");
+            var stagingDir = Path.Combine(baseDir, $".staging-{Guid.NewGuid():N}");
             Directory.CreateDirectory(stagingDir);
             try
             {

--- a/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
@@ -66,12 +66,13 @@ public sealed class AssemblyExtractor : IDisposable
         var assemblyPaths = BuildResolverPaths(assemblyPath, referenceDirs, includeRuntimeDirectory);
         var resolver = new PathAssemblyResolver(assemblyPaths);
 
-        // Leave coreAssemblyName null so MetadataLoadContext infers the core assembly from the
-        // target assembly's references (it probes "mscorlib", "System.Runtime", ... in order).
-        // For a net462 plugin that resolves to mscorlib — now always available via the embedded
-        // reference assemblies — and for a net8-targeted assembly it resolves via the runtime
-        // directory. Passing an explicit "mscorlib" would force the net462 core even for net8
-        // targets, so null is the safer choice that keeps both scenarios working.
+        // Leave coreAssemblyName null: MetadataLoadContext infers the core assembly from the
+        // target assembly's own references. Dataverse plugin assemblies target .NET Framework
+        // 4.6.2, so the core resolves to mscorlib — which BuildResolverPaths seeds from the
+        // embedded reference assemblies, ordered ahead of the runtime directory so it is found
+        // even in a single-file publish (where no loose BCL DLLs exist on disk). Forcing an
+        // explicit "mscorlib" would over-constrain the core for any non-net462 input, so null
+        // is the more general choice — MLC binds whatever core the target actually references.
         var mlc = new MetadataLoadContext(resolver);
 
         return new AssemblyExtractor(mlc, assemblyPath);

--- a/src/PPDS.Cli/Plugins/Extraction/NupkgExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/NupkgExtractor.cs
@@ -13,8 +13,17 @@ public static class NupkgExtractor
     /// Extracts plugin configuration from a NuGet package.
     /// </summary>
     /// <param name="nupkgPath">Path to the .nupkg file.</param>
+    /// <param name="referenceDirs">
+    /// Optional additional directories to search for referenced assemblies, forwarded to
+    /// <see cref="AssemblyExtractor.Create(string, IReadOnlyList{string})"/> for each candidate
+    /// assembly (the <c>--reference-dir</c> option).
+    /// </param>
     /// <returns>Assembly configuration from the package.</returns>
-    public static PluginAssemblyConfig Extract(string nupkgPath)
+    /// <exception cref="PpdsException">
+    /// Thrown when no plugin types could be extracted and at least one candidate assembly failed
+    /// to load, so the failure is surfaced instead of silently returning an empty configuration.
+    /// </exception>
+    public static PluginAssemblyConfig Extract(string nupkgPath, IReadOnlyList<string>? referenceDirs = null)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ppds-extract-{Guid.NewGuid():N}");
 
@@ -66,12 +75,13 @@ public static class NupkgExtractor
             var allTypes = new List<PluginTypeConfig>();
             var allTypeNames = new List<string>();
             string? primaryAssemblyName = null;
+            var failures = new List<(string Assembly, Exception Error)>();
 
             foreach (var dllPath in dlls)
             {
                 try
                 {
-                    using var extractor = AssemblyExtractor.Create(dllPath);
+                    using var extractor = AssemblyExtractor.Create(dllPath, referenceDirs);
                     var assemblyConfig = extractor.Extract();
 
                     if (assemblyConfig.Types.Count > 0)
@@ -82,10 +92,37 @@ public static class NupkgExtractor
                         allTypeNames.AddRange(assemblyConfig.AllTypeNames);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Skip DLLs that can't be loaded (dependencies, native, etc.)
+                    // Some DLLs legitimately can't be loaded as plugin assemblies (native,
+                    // resource-only, or unrelated dependencies). Collect the failure so we can
+                    // decide whether it is fatal (nothing extracted) or merely worth a warning.
+                    failures.Add((Path.GetFileName(dllPath), ex));
                 }
+            }
+
+            // If nothing was extracted AND at least one assembly failed to load, surface the
+            // failure instead of silently returning an empty config. This is exactly the
+            // single-file "could not find core assembly" symptom that the embedded reference
+            // assemblies fix (#1294) addresses — should it recur for any reason, the user must
+            // see the cause rather than a misleading "0 plugin types" result.
+            if (allTypes.Count == 0 && failures.Count > 0)
+            {
+                var first = failures[0];
+                throw new PpdsException(
+                    ErrorCodes.Operation.Dependency,
+                    $"Could not extract plugin registrations from '{Path.GetFileName(nupkgPath)}': " +
+                    $"{failures.Count} of {dlls.Length} assembl{(dlls.Length == 1 ? "y" : "ies")} failed to " +
+                    $"load and no plugin types were found. First failure ({first.Assembly}): {first.Error.Message}",
+                    first.Error);
+            }
+
+            // Partial failure: at least one assembly yielded plugins, but others failed to load.
+            // Warn per failed assembly (stderr — stdout is reserved for data) and continue.
+            foreach (var (assemblyName, error) in failures)
+            {
+                Console.Error.WriteLine(
+                    $"Warning: skipped assembly '{assemblyName}' during extraction: {error.Message}");
             }
 
             // Build the combined config

--- a/tests/PPDS.Cli.Tests/Plugins/Extraction/AssemblyExtractorTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Extraction/AssemblyExtractorTests.cs
@@ -46,6 +46,14 @@ public sealed class AssemblyExtractorTests : IDisposable
     /// PPDS.Plugins.dll into the same temp directory as the compiled test DLL.
     /// </summary>
     private string CompileTestAssembly(string pluginClassSource)
+        => CompileTestAssembly(pluginClassSource, copyPluginsAssemblyToOutputDir: true);
+
+    /// <summary>
+    /// Overload that controls whether PPDS.Plugins.dll is copied alongside the compiled test
+    /// DLL. Pass <c>false</c> to leave the dependency out of the target directory so a test can
+    /// prove it is resolved from an explicit <c>--reference-dir</c> seed instead. See #1294.
+    /// </summary>
+    private string CompileTestAssembly(string pluginClassSource, bool copyPluginsAssemblyToOutputDir)
     {
         var pluginsAssemblyPath = typeof(PPDS.Plugins.PluginStepAttribute).Assembly.Location;
 
@@ -87,8 +95,11 @@ public sealed class AssemblyExtractorTests : IDisposable
         _tempFiles.Add(tempDir);
 
         // Copy PPDS.Plugins.dll alongside our test DLL so the MetadataLoadContext resolver finds it
-        var pluginsFileName = Path.GetFileName(pluginsAssemblyPath);
-        File.Copy(pluginsAssemblyPath, Path.Combine(tempDir, pluginsFileName), overwrite: true);
+        if (copyPluginsAssemblyToOutputDir)
+        {
+            var pluginsFileName = Path.GetFileName(pluginsAssemblyPath);
+            File.Copy(pluginsAssemblyPath, Path.Combine(tempDir, pluginsFileName), overwrite: true);
+        }
 
         var tempPath = Path.Combine(tempDir, "TestPlugin.dll");
 
@@ -760,6 +771,82 @@ public sealed class AssemblyExtractorTests : IDisposable
         Assert.NotNull(config.CustomApis);
         Assert.Single(config.CustomApis);
         Assert.Single(config.Types);
+    }
+
+    #endregion
+
+    #region Single-file / embedded reference assembly tests (#1294)
+
+    [Fact]
+    public void GetNet462ReferenceAssemblyDirectory_ReturnsPopulatedDirectory()
+    {
+        // The embedded reference assemblies must extract to a real directory containing the
+        // core assembly (mscorlib) and the System.Runtime facade — the assemblies a net462
+        // plugin needs and that a single-file publish does not carry as loose DLLs on disk.
+        var dir = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory();
+
+        Assert.NotNull(dir);
+        Assert.True(Directory.Exists(dir));
+        Assert.True(File.Exists(Path.Combine(dir!, "mscorlib.dll")),
+            "Embedded net462 reference assemblies must include mscorlib.dll (the core assembly).");
+        Assert.True(File.Exists(Path.Combine(dir!, "System.Runtime.dll")),
+            "Embedded net462 reference assemblies must include the System.Runtime facade.");
+    }
+
+    [Fact]
+    public void Extract_WithoutRuntimeDirectory_SucceedsViaEmbeddedReferenceAssemblies()
+    {
+        // Reproduces the single-file packaging bug (#1294): a self-contained single-file CLI has
+        // no loose BCL DLLs in its runtime directory, so seeding the resolver from that directory
+        // alone cannot find the core assembly. Suppressing runtime-directory seeding here proves
+        // the embedded net462 reference assemblies (plus the target directory) are sufficient on
+        // their own to extract a net462-referencing plugin assembly.
+        var dllPath = CompileTestAssembly("""
+            [PluginStep(Message = "Create", EntityLogicalName = "account", Stage = PluginStage.PostOperation)]
+            public class TestPlugin { }
+            """);
+
+        using var extractor = AssemblyExtractor.Create(
+            dllPath, referenceDirs: null, includeRuntimeDirectory: false);
+        var config = extractor.Extract();
+
+        Assert.Single(config.Types);
+        var step = config.Types[0].Steps[0];
+        Assert.Equal("Create", step.Message);
+        Assert.Equal("account", step.Entity);
+        Assert.Equal("PostOperation", step.Stage);
+    }
+
+    [Fact]
+    public void Extract_WithReferenceDir_ResolvesDependencyFromSeedDirectory()
+    {
+        // The plugin's dependency (PPDS.Plugins.dll) is deliberately NOT placed in the target
+        // assembly's directory. With runtime-directory seeding suppressed, extraction can only
+        // succeed if the explicit --reference-dir seed is honored.
+        var pluginsDir = Path.GetDirectoryName(
+            typeof(PPDS.Plugins.PluginStepAttribute).Assembly.Location)!;
+
+        var dllPath = CompileTestAssembly("""
+            [PluginStep(Message = "Update", EntityLogicalName = "contact", Stage = PluginStage.PreOperation)]
+            public class TestPlugin { }
+            """,
+            copyPluginsAssemblyToOutputDir: false);
+
+        // Sanity check: without the reference dir, the dependency is unresolvable and extraction
+        // fails — proving the success below is due to the seed, not incidental resolution.
+        Assert.ThrowsAny<Exception>(() =>
+        {
+            using var withoutSeed = AssemblyExtractor.Create(
+                dllPath, referenceDirs: null, includeRuntimeDirectory: false);
+            withoutSeed.Extract();
+        });
+
+        using var extractor = AssemblyExtractor.Create(
+            dllPath, referenceDirs: new[] { pluginsDir }, includeRuntimeDirectory: false);
+        var config = extractor.Extract();
+
+        Assert.Single(config.Types);
+        Assert.Equal("Update", config.Types[0].Steps[0].Message);
     }
 
     #endregion

--- a/tests/PPDS.Cli.Tests/Plugins/Extraction/NupkgExtractorTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Extraction/NupkgExtractorTests.cs
@@ -90,4 +90,37 @@ public class NupkgExtractorTests : IDisposable
             caught is PpdsException or IOException or InvalidDataException or UnauthorizedAccessException,
             $"Expected containment-related exception, got {caught.GetType().FullName}: {caught.Message}");
     }
+
+    [Fact]
+    public void Extract_NupkgWithUnloadableAssembly_ThrowsInsteadOfReturningEmpty()
+    {
+        // A lib/net462 folder whose only DLL is not a valid assembly. Previously every
+        // per-assembly load failure was swallowed and Extract returned an empty config (a
+        // misleading "0 plugin types" result). The extractor now surfaces the failure so the
+        // user sees the real cause instead of a silent no-op (#1294).
+        var nupkgPath = Path.Combine(_scratch, "broken.nupkg");
+        using (var stream = File.Create(nupkgPath))
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+        {
+            var nuspec = archive.CreateEntry("broken.nuspec");
+            using (var entryStream = nuspec.Open())
+            {
+                var xml = Encoding.UTF8.GetBytes("""
+                    <?xml version="1.0"?>
+                    <package><metadata><id>broken</id></metadata></package>
+                    """);
+                entryStream.Write(xml, 0, xml.Length);
+            }
+
+            // Not a valid PE image — LoadFromAssemblyPath fails for this "assembly".
+            var dll = archive.CreateEntry("lib/net462/Broken.dll");
+            using var dllStream = dll.Open();
+            var payload = Encoding.UTF8.GetBytes("this is not a PE file");
+            dllStream.Write(payload, 0, payload.Length);
+        }
+
+        var ex = Assert.Throws<PpdsException>(() => NupkgExtractor.Extract(nupkgPath));
+        Assert.Equal(ErrorCodes.Operation.Dependency, ex.ErrorCode);
+        Assert.Contains("Broken.dll", ex.Message);
+    }
 }


### PR DESCRIPTION
## Problem

`ppds plugins extract -i X.dll` fails with:

```
Could not find core assembly. Either specify a valid core assembly name in the
MetadataLoadContext constructor or provide a MetadataAssemblyResolver that can load the core assembly.
```

**The reporter's stated root cause (net462 / `GetRuntimeDirectory()` missing mscorlib) is not correct** — on a framework-dependent install that directory *does* contain the BCL facades, which is why the existing tests pass. The real trigger is **packaging**: the shipped CLI is published `-p:PublishSingleFile=true --self-contained` (`.github/workflows/release-cli.yml`), and the VS Code extension bundles it the same way (`bundle-cli.mjs`). In a single-file bundle the managed BCL DLLs are embedded, not present as loose files on disk, so `AssemblyExtractor.Create()` seeding its `PathAssemblyResolver` from `Directory.GetFiles(RuntimeEnvironment.GetRuntimeDirectory(), "*.dll")` finds no core assembly and `MetadataLoadContext` throws. `dotnet tool install` (framework-dependent) users are unaffected; single-file CLI **and** extension users are affected.

## Fix (machine-independent, survives single-file publishing)

- **`Directory.Packages.props` / `PPDS.Cli.csproj`** — add `Microsoft.NETFramework.ReferenceAssemblies.net462` as a **build-only** package (`PrivateAssets=all ExcludeAssets=all GeneratePathProperty=true`, so it never becomes a compile reference for our net8+ build), and an MSBuild target that zips the net462 reference assemblies (mscorlib + BCL + `Facades/*.dll`) into a single compressed `EmbeddedResource`.
- **`AssemblyExtractor.cs`** — extract the embedded reference assemblies lazily to a content-addressed cache dir on first use and seed the resolver from them. Seed priority (earlier wins, de-duped by simple name): target-assembly dir → `--reference-dir` → embedded net462 refs → runtime dir. `coreAssemblyName` is left **null** so `MetadataLoadContext` infers the core from the target's references — net462 resolves to the embedded mscorlib, net8-targeted assemblies still resolve via the runtime dir (forcing `"mscorlib"` would break the net8 case). Extraction never throws; on any failure it falls back to the prior behavior, so it can't make things worse.
- **`ExtractCommand.cs`** — new optional repeatable `--reference-dir` escape hatch for plugins whose dependencies live elsewhere.
- **`NupkgExtractor.cs`** — stop silently swallowing per-assembly extraction failures (previously surfaced as "Found 0 plugin type(s)" with exit 0).

## Why not the reporter's suggestion

Auto-adding the machine's `.NETFramework\v4.6.2` reference directory depends on those assemblies being installed (a VS/build-tools artifact) and is net462-only. Embedding is required anyway because the release uploads **only the single binary** — loose companion files would not ship.

## Tests & validation

`AssemblyExtractorTests.cs` gains a regression test that suppresses runtime-directory seeding (`includeRuntimeDirectory: false`) to reproduce the single-file environment and proves a net462 plugin extracts from the embedded reference assemblies alone; plus a `--reference-dir` test and an embedded-resource presence test. `NupkgExtractorTests.cs` covers the error-surfacing change. Full non-integration suite green across net8/9/10 (`PPDS.Cli.Tests`: 4320 passed).

A real single-file `dotnet publish -p:PublishSingleFile=true --self-contained` was run during triage and produced the 52 MB single-file binary with the embedded resource compiled in. The end-to-end live `extract` run against that binary is best exercised as a **release-QA step on a safe environment** (a repo safety hook gates local `ppds` invocations by active environment); the resolution mechanism itself is already proven by the runtime-directory-suppressed unit test above.

Fixes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `--reference-dir` option to supply extra directories for resolving plugin dependencies during extraction.
  * Enhanced extraction for .NET Framework 4.6.2 plugins, including support for single-file deployments by using embedded reference assemblies.
* **Bug Fixes**
  * Extraction now reports dependency-loading failures: it throws when nothing can be extracted, and logs warnings when only some assemblies fail.
* **Tests**
  * Added coverage for embedded .NET 4.6.2 references, custom dependency directories, and `.nupkg` entries containing invalid assemblies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->