### PR TITLE
fix(pipeline): record failed stage on blocked path, guard stage=None, classify rate limits (#1166)

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -104,8 +104,19 @@ MODEL_OVERRIDE = None
 
 
 class PipelineFailure(Exception):
-    """Raised by _pipeline_fail to exit the stage loop without sys.exit."""
-    pass
+    """Raised by _pipeline_fail (and the run_claude blocked path) to exit
+    the stage loop without sys.exit.
+
+    ``stage`` carries the failing stage name on the exception itself so the
+    ``except PipelineFailure`` handler in main() can recover it even on
+    paths (like the blocked/rate-limit path in run_claude) that don't go
+    through the ``_pipeline_fail`` closure and its nonlocal assignment
+    (#1166).
+    """
+
+    def __init__(self, message, stage=None):
+        super().__init__(message)
+        self.stage = stage
 
 
 def timestamp():
@@ -303,7 +314,14 @@ def should_converge(state):
 
 
 def compute_resume_stage(failed_stage):
-    """Map a failed stage name to a valid ``--from`` stage for resume."""
+    """Map a failed stage name to a valid ``--from`` stage for resume.
+
+    ``failed_stage`` should always be set by the time this is called (#1166),
+    but a missing stage defaults to the first stage rather than crashing —
+    the safest fallback when we genuinely don't know where to resume.
+    """
+    if not failed_stage:
+        return "worktree"
     if failed_stage in STAGES:
         return failed_stage
     if "reconverge" in failed_stage:
@@ -480,7 +498,15 @@ def auto_commit_stranded(worktree_path, stage, logger, *,
             capture_output=True, text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
-        scope = stage.split("-")[0] if "-" in stage else stage
+        # stage may be None on failure paths that couldn't resolve a stage
+        # name (#1166) — fall back to a generic "pipeline" scope rather
+        # than crashing on `"-" in None`.
+        if not stage:
+            scope = "pipeline"
+        elif "-" in stage:
+            scope = stage.split("-")[0]
+        else:
+            scope = stage
         msg = f"chore({scope}): auto-commit {reason}"
         commit = subprocess.run(
             ["git", "commit", "-m", msg],
@@ -966,6 +992,19 @@ def run_stack(stack_path, *, repo_root, worktree_path, dry_run=False,
 from bg_transcript import extract_text_from_jsonl, parse_outcome  # noqa: E402,F401
 
 
+# Substrings (checked case-insensitively) that mark a blocked-state ``needs``
+# string as a rate/session/usage limit rather than a genuine clarifying
+# question from the worker (#1166, #1175).
+_RATE_LIMIT_MARKERS = ("rate limit", "session limit", "usage limit", "resets")
+
+
+def _classify_blocked_needs(needs):
+    """True if ``needs`` (from ``handle.needs()`` on a blocked poll) looks
+    like a rate/session/usage limit rather than a genuine question."""
+    lowered = str(needs).lower()
+    return any(marker in lowered for marker in _RATE_LIMIT_MARKERS)
+
+
 def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
                agent=None, ceiling=None, mode=None):
     """Run a claude stage via claude_dispatch.spawn. Returns (exit_code, logger).
@@ -1052,8 +1091,12 @@ def run_claude(worktree_path, prompt, logger, stage, dry_run=False,
                 needs = handle.needs() if hasattr(handle, "needs") else ""
                 log(logger, stage, "BLOCKED", needs=str(needs)[:200])
                 handle.terminate()
+                if _classify_blocked_needs(needs):
+                    raise PipelineFailure(
+                        f"{stage}: rate limited: {needs}", stage=stage
+                    )
                 raise PipelineFailure(
-                    f"{stage}: stage asked question: {needs}"
+                    f"{stage}: stage asked question: {needs}", stage=stage
                 )
             if state == "error":
                 exit_code = 1
@@ -2371,7 +2414,18 @@ def main():
         if pr_url:
             print(f"PR: {pr_url}", file=sys.stderr)
 
-    except PipelineFailure:
+    except PipelineFailure as exc:
+        # Resolve stage/reason once, up front, so every downstream consumer
+        # below (auto_commit_stranded, compute_resume_stage,
+        # _read_last_lines, write_result, and the finally safety net) sees
+        # real values even on paths that raise PipelineFailure without going
+        # through the _pipeline_fail closure — e.g. the run_claude blocked
+        # path, which attaches the stage to the exception itself (#1166).
+        _failed_stage = _failed_stage or getattr(exc, "stage", None)
+        _failed_log_stage = _failed_log_stage or _failed_stage
+        if _failed_reason is None:
+            _failed_reason = str(exc)
+
         duration = int(time.time() - pipeline_start)
         log(logger, "pipeline", "FAILED",
             failed_stage=_failed_stage, reason=_failed_reason,

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -330,6 +330,27 @@ def compute_resume_stage(failed_stage):
     return base if base in STAGES else failed_stage
 
 
+def _resolve_failure_context(failed_stage, failed_log_stage, failed_reason, exc):
+    """Resolve (stage, log_stage, reason) for main()'s ``except
+    PipelineFailure`` handler.
+
+    Only backfills from the exception when ``failed_stage`` is still
+    ``None`` — i.e. ``_pipeline_fail`` never ran, so the exception must
+    have come from a path that bypasses its nonlocal assignment (the
+    run_claude blocked path, #1166). This is deliberately narrower than
+    guarding on ``failed_reason is None`` alone: most ``_pipeline_fail``
+    call sites pass no ``reason`` (e.g. ``_pipeline_fail("pr")``), which
+    legitimately leaves ``failed_reason`` as ``None`` — backfilling those
+    from ``str(exc)`` would turn a clean "no reason" into a misleading
+    "pr: None" in pipeline-result.json and /status output (review finding).
+    """
+    if failed_stage is None:
+        failed_stage = getattr(exc, "stage", None)
+        failed_log_stage = failed_stage
+        failed_reason = str(exc)
+    return failed_stage, failed_log_stage, failed_reason
+
+
 def find_last_completed_stage(log_path):
     """Parse pipeline.log to find the last completed stage for --resume."""
     if not os.path.exists(log_path):
@@ -995,7 +1016,15 @@ from bg_transcript import extract_text_from_jsonl, parse_outcome  # noqa: E402,F
 # Substrings (checked case-insensitively) that mark a blocked-state ``needs``
 # string as a rate/session/usage limit rather than a genuine clarifying
 # question from the worker (#1166, #1175).
-_RATE_LIMIT_MARKERS = ("rate limit", "session limit", "usage limit", "resets")
+#
+# Deliberately excludes a bare "resets" marker: it's a generic word that can
+# appear in a genuine clarifying question unrelated to rate limiting (e.g.
+# "the staging environment resets nightly — should I account for that?").
+# The real-world session-limit message ("You've hit your session limit ...
+# resets 1:50am") already matches on "session limit" alone, so a standalone
+# "resets" marker only widens the false-positive surface without adding
+# necessary coverage (review finding, #1166).
+_RATE_LIMIT_MARKERS = ("rate limit", "session limit", "usage limit")
 
 
 def _classify_blocked_needs(needs):
@@ -2194,7 +2223,13 @@ def main():
             _failed_stage = stage_name
             _failed_log_stage = log_stage or stage_name
             _failed_reason = reason
-            raise PipelineFailure(f"{stage_name}: {reason}")
+            # stage= is redundant today (the nonlocal assignment above
+            # already sets _failed_stage before this raises, so the except
+            # handler's _resolve_failure_context short-circuits past
+            # exc.stage), but attaching it keeps every PipelineFailure
+            # self-describing and avoids a latent trap if this pairing is
+            # ever refactored (review finding, #1166).
+            raise PipelineFailure(f"{stage_name}: {reason}", stage=stage_name)
 
         for i, stage in enumerate(STAGES):
             if i < start_idx:
@@ -2421,10 +2456,9 @@ def main():
         # real values even on paths that raise PipelineFailure without going
         # through the _pipeline_fail closure — e.g. the run_claude blocked
         # path, which attaches the stage to the exception itself (#1166).
-        _failed_stage = _failed_stage or getattr(exc, "stage", None)
-        _failed_log_stage = _failed_log_stage or _failed_stage
-        if _failed_reason is None:
-            _failed_reason = str(exc)
+        _failed_stage, _failed_log_stage, _failed_reason = _resolve_failure_context(
+            _failed_stage, _failed_log_stage, _failed_reason, exc
+        )
 
         duration = int(time.time() - pipeline_start)
         log(logger, "pipeline", "FAILED",

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -21,6 +21,7 @@ from pipeline import (
     _classify_blocked_needs,
     _finding_key,
     _get_direct_children,
+    _resolve_failure_context,
     auto_commit_stranded,
     classify_activity,
     compute_resume_stage,
@@ -211,6 +212,67 @@ class TestClassifyBlockedNeeds(unittest.TestCase):
 
     def test_empty_needs_not_classified_as_rate_limit(self):
         self.assertFalse(_classify_blocked_needs(""))
+
+    def test_bare_resets_word_not_classified_as_rate_limit(self):
+        """Review finding (#1166): a genuine question containing the word
+        "resets" but no rate/session/usage-limit qualifier must NOT be
+        misclassified — "resets" alone is too generic a signal. The real
+        session-limit message ("... session limit ... resets 1:50am")
+        already matches on "session limit"; a bare "resets" only adds
+        false-positive risk."""
+        needs = ("the staging environment resets nightly — should I "
+                 "account for that in the migration?")
+        self.assertFalse(_classify_blocked_needs(needs))
+
+
+class TestResolveFailureContext(unittest.TestCase):
+    """#1166 review fix: the except PipelineFailure handler must only
+    backfill stage/log_stage/reason from the exception when
+    _pipeline_fail never ran (failed_stage is None) — not merely when
+    reason is None, since most _pipeline_fail call sites pass no reason
+    and that "no reason" state must survive unchanged."""
+
+    def test_backfills_from_exception_when_pipeline_fail_bypassed(self):
+        """Blocked path: _pipeline_fail never ran, so failed_stage is None
+        going in. Must recover stage/log_stage/reason from the exception."""
+        exc = pipeline.PipelineFailure(
+            "implement: rate limited: session limit hit", stage="implement")
+        stage, log_stage, reason = _resolve_failure_context(
+            None, None, None, exc)
+        self.assertEqual(stage, "implement")
+        self.assertEqual(log_stage, "implement")
+        self.assertEqual(reason, "implement: rate limited: session limit hit")
+
+    def test_preserves_none_reason_when_pipeline_fail_ran_with_no_reason(self):
+        """_pipeline_fail("pr") sets failed_stage="pr", failed_reason=None
+        (no reason supplied) before raising PipelineFailure("pr: None").
+        The handler must NOT backfill reason from str(exc) here — that
+        would turn a clean "no reason" into a misleading "pr: None"."""
+        exc = pipeline.PipelineFailure("pr: None", stage="pr")
+        stage, log_stage, reason = _resolve_failure_context(
+            "pr", "pr", None, exc)
+        self.assertEqual(stage, "pr")
+        self.assertEqual(log_stage, "pr")
+        self.assertIsNone(reason)
+
+    def test_preserves_explicit_reason_when_pipeline_fail_ran(self):
+        """_pipeline_fail("implement", "outcome verification failed") sets
+        a real reason before raising — must pass through unchanged."""
+        exc = pipeline.PipelineFailure(
+            "implement: outcome verification failed", stage="implement")
+        stage, log_stage, reason = _resolve_failure_context(
+            "implement", "implement", "outcome verification failed", exc)
+        self.assertEqual(stage, "implement")
+        self.assertEqual(log_stage, "implement")
+        self.assertEqual(reason, "outcome verification failed")
+
+    def test_log_stage_backfill_uses_resolved_stage_not_original_none(self):
+        """log_stage must come from the resolved stage, not stay None,
+        when _pipeline_fail was bypassed."""
+        exc = pipeline.PipelineFailure("verify: stage asked question: x",
+                                       stage="verify")
+        _, log_stage, _ = _resolve_failure_context(None, None, None, exc)
+        self.assertEqual(log_stage, "verify")
 
 
 class TestWriteResultResumeCommand(unittest.TestCase):

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -18,6 +18,7 @@ import pipeline
 from pipeline import (
     STAGE_MODELS,
     _FILED_FINDING_KEYS,
+    _classify_blocked_needs,
     _finding_key,
     _get_direct_children,
     auto_commit_stranded,
@@ -143,6 +144,22 @@ class TestAutoCommitStranded(unittest.TestCase):
             logger, "converge", "AUTO_COMMIT_FAILED",
             reason="subprocess error")
 
+    @patch("pipeline.subprocess.run")
+    @patch("pipeline.log")
+    def test_none_stage_defaults_to_pipeline_scope(self, mock_log, mock_run):
+        """#1166: stage=None on a dirty worktree must not crash — it falls
+        back to a generic 'pipeline' commit scope instead of raising
+        TypeError on `"-" in None`."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M file.py\n", stderr=""),
+            MagicMock(returncode=0),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        result = auto_commit_stranded("/tmp/wt", None, self._logger())
+        self.assertTrue(result)
+        commit_msg = mock_run.call_args_list[2][0][0][-1]
+        self.assertTrue(commit_msg.startswith("chore(pipeline):"))
+
 
 class TestComputeResumeStage(unittest.TestCase):
 
@@ -163,6 +180,37 @@ class TestComputeResumeStage(unittest.TestCase):
 
     def test_unknown_stage_returned_as_is(self):
         self.assertEqual(compute_resume_stage("unknown-stage"), "unknown-stage")
+
+    def test_none_stage_defaults_to_worktree(self):
+        """#1166: a missing failed_stage must not crash — defaults to the
+        first stage rather than raising TypeError on `"reconverge" in None`."""
+        self.assertEqual(compute_resume_stage(None), "worktree")
+
+    def test_empty_string_stage_defaults_to_worktree(self):
+        self.assertEqual(compute_resume_stage(""), "worktree")
+
+
+class TestClassifyBlockedNeeds(unittest.TestCase):
+    """#1166/#1175: blocked-state ``needs`` text must be classified as a
+    rate limit (not a generic "asked question") when it looks like one."""
+
+    def test_rate_limit_message_detected(self):
+        needs = ("You've hit your session limit for this account. "
+                 "It resets 1:50am (America/Chicago).")
+        self.assertTrue(_classify_blocked_needs(needs))
+
+    def test_usage_limit_message_detected(self):
+        self.assertTrue(_classify_blocked_needs("usage limit reached"))
+
+    def test_rate_limit_marker_case_insensitive(self):
+        self.assertTrue(_classify_blocked_needs("RATE LIMIT exceeded"))
+
+    def test_genuine_question_not_classified_as_rate_limit(self):
+        needs = "what environment should I deploy to?"
+        self.assertFalse(_classify_blocked_needs(needs))
+
+    def test_empty_needs_not_classified_as_rate_limit(self):
+        self.assertFalse(_classify_blocked_needs(""))
 
 
 class TestWriteResultResumeCommand(unittest.TestCase):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3364,7 +3364,10 @@ class TestPipelineModeFlag:
 class TestPipelineBlockedLoudFail:
     def test_pipeline_fails_loud_on_blocked(self, tmp_path):
         """AC-18: when poll() returns blocked, run_claude calls terminate
-        and raises PipelineFailure with the needs text in the reason."""
+        and raises PipelineFailure with the needs text in the reason.
+
+        #1166: the exception must also carry the failing stage as
+        ``exc.stage`` so main()'s except handler never sees stage=None."""
         import pipeline
         import claude_dispatch
 
@@ -3390,5 +3393,42 @@ class TestPipelineBlockedLoudFail:
         msg = str(exc_info.value)
         assert "stage asked question" in msg
         assert "what environment should I deploy to?" in msg
+        assert exc_info.value.stage == "test-stage"
+        stub.terminate.assert_called_once()
+        logger.close()
+
+    def test_pipeline_fails_loud_on_rate_limit_block(self, tmp_path):
+        """#1166/#1175: a rate-limited bg session surfaces as state==blocked
+        with a session-limit ``needs`` message. It must be classified as a
+        rate limit (not mislabeled "stage asked question"), and the raised
+        PipelineFailure must carry the stage so it never resolves to None."""
+        import pipeline
+        import claude_dispatch
+
+        wf_dir = tmp_path / ".workflow" / "stages"
+        wf_dir.mkdir(parents=True)
+        logger = pipeline.open_logger(str(tmp_path / ".workflow" / "pipeline.log"))
+
+        class _RateLimitedStub(_DispatchHandleStub):
+            def needs(self):
+                return ("You've hit your session limit · "
+                         "resets 1:50am (America/Chicago)")
+
+        stub = _RateLimitedStub(transcript_path=tmp_path / "x.jsonl",
+                                poll_sequence=["blocked"])
+
+        with unittest.mock.patch.object(claude_dispatch, "spawn", return_value=stub):
+            with unittest.mock.patch("subprocess.run",
+                                     return_value=unittest.mock.MagicMock(returncode=0,
+                                                                          stdout="0",
+                                                                          stderr="")):
+                with pytest.raises(pipeline.PipelineFailure) as exc_info:
+                    pipeline.run_claude(str(tmp_path), "t", logger, "test-stage")
+
+        msg = str(exc_info.value)
+        assert "rate limited" in msg
+        assert "asked question" not in msg
+        assert "session limit" in msg
+        assert exc_info.value.stage == "test-stage"
         stub.terminate.assert_called_once()
         logger.close()


### PR DESCRIPTION
## Summary

`scripts/pipeline.py`'s blocked-state failure path never recorded which stage failed, so `main()`'s `except PipelineFailure` handler fed `stage=None` into `auto_commit_stranded`, which crashed with `TypeError: argument of type 'NoneType' is not iterable` on `"-" in None` whenever the worktree was dirty. That crash buried the real failure reason (often a Claude session rate limit) under a raw traceback, skipped writing `pipeline-result.json`, and left stranded work uncommitted.

- `PipelineFailure` now carries an optional `stage`, attached on the blocked-path raise in `run_claude` so it survives independently of the `_pipeline_fail` closure's `nonlocal` assignment.
- `main()`'s except handler resolves `_failed_stage`/`_failed_log_stage`/`_failed_reason` via a new `_resolve_failure_context()` helper, scoped to fire only when `_pipeline_fail` never ran (`failed_stage is None`) — so every downstream consumer (`auto_commit_stranded`, `compute_resume_stage`, `_read_last_lines`, `write_result`, the `finally` safety net) sees real values on the previously-crashing path, **without** disturbing the legitimate "no reason supplied" case that most `_pipeline_fail` call sites rely on (e.g. `_pipeline_fail("pr")`).
- `auto_commit_stranded` and `compute_resume_stage` now tolerate `stage=None` defensively (belt-and-braces) instead of crashing.
- Blocked-state `needs` text is now classified: rate/session/usage-limit markers produce a `"rate limited: ..."` `PipelineFailure` instead of being mislabeled `"stage asked question: ..."` (#1175, folded into this issue).

Closes #1166

## Test Plan

- `TestResolveFailureContext` (new): backfills stage/log_stage/reason from the exception only when `_pipeline_fail` was bypassed; leaves a legitimate `reason=None` untouched when `_pipeline_fail` ran without an explicit reason (regression test for a bug caught in review — see below).
- `TestClassifyBlockedNeeds`: rate/session/usage-limit markers detected case-insensitively; a genuine question containing the bare word "resets" (no limit qualifier) is correctly NOT classified as a rate limit (regression test for a false-positive caught in review — see below).
- `TestComputeResumeStage`: `None` and `""` default to `"worktree"` without crashing.
- `TestAutoCommitStranded.test_none_stage_defaults_to_pipeline_scope`: `stage=None` on a dirty worktree commits under `chore(pipeline):` instead of raising.
- `TestPipelineBlockedLoudFail`: the blocked path raises `PipelineFailure` carrying `exc.stage`; the rate-limit variant is labeled `"rate limited"` (not `"asked question"`) and still carries the stage.
- `python -m pytest scripts/test_pipeline.py tests/test_pipeline.py -q`: green except 3 pre-existing failures in `TestFindDuplicateIssue` (unrelated — confirmed present on `main` via `git show`, calling `_find_duplicate_issue` with the wrong arity; flagged separately, not touched here).

## Verification

- [x] `/gates` passed (workflow-only diff: AC-verification + enforcement-audit gates; `.NET`/TS gates N/A — no `.cs`/`.ts` files touched)
- [x] `/verify` completed (surface: `workflow` — all 10 checks passed, including the empirical shakedown gate against the allowlisted `scripts/pipeline.py`)
- QA: not required — workflow-only diff skips QA per the PR gate
- [x] `/review` completed (bias-isolated, fresh-context: 0 critical, 2 important, 2 suggestion — **both important findings fixed** in a follow-up commit: (1) the reason-backfill guard was too broad and would have leaked `"pr: None"`-style text into `/status` for ordinary stage failures, now scoped to the actual `_pipeline_fail`-bypass case; (2) the `"resets"` rate-limit marker was too generic and risked mislabeling genuine questions, now dropped since `"session limit"` alone already covers the real-world message)
- [x] Pre-PR self-review completed (0 defects; 2 concerns flagged as follow-up — a resume-hint precision edge case for round-suffixed converge-round stage names hitting the blocked path, and the pre-existing unrelated `TestFindDuplicateIssue` failures; 1 nit noted, not actioned)

## Follow-up (non-blocking, flagged separately)

- `compute_resume_stage` doesn't recognize raw round-suffixed stage names (`gates-r2`, etc.) the way it recognizes the `-reconverge` suffix, so a blocked/rate-limited failure mid-converge-round can produce a less-precise `--from` resume hint than an exit-code failure at the same point. Low severity (hint quality, not a crash), tracked separately.
- `specs/dispatch-routing.md` AC-18's prose predates both the `stage=` mechanism and the rate-limit sub-classification this PR adds — worth a documentation refresh, tracked separately.
- Pre-existing, unrelated test breakage on `main` (`TestFindDuplicateIssue` arity mismatch, `test_workflow_state_bump_rejects_non_integer` stderr text mismatch) — confirmed present before this PR via `git show origin/main`, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline failure reporting with more accurate stage and reason details.
  * Added clearer handling for rate-limit and session-limit interruptions.
  * Improved resume behavior when failure stage information is unavailable.
  * Prevented stranded-worktree recovery from failing when stage details are missing.
  * Ensured blocked processes are properly terminated and cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->