### PR TITLE
feat(pr-monitor): reviewer-optional mode (gemini|none) ahead of Gemini sunset

### DIFF
--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -64,6 +64,11 @@ def main():
     except (json.JSONDecodeError, OSError):
         sys.exit(0)
 
+    # A non-dict root (e.g. JSON ``null`` or an array) is as unusable as a
+    # corrupt file — allow stop rather than crashing on state.get(...) below.
+    if not isinstance(state, dict):
+        sys.exit(0)
+
     # Bypass: pipeline orchestrator is actively running (AC-197)
     if state.get("pipeline", {}).get("in_flight"):
         sys.exit(0)

--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -88,7 +88,7 @@ def main():
     # When phase=pr, require pr.monitor_launched to be set (timestamp or
     # "fallback: <reason>"). Both truthy values allow exit.
     if phase == "pr":
-        monitor_launched = state.get("pr", {}).get("monitor_launched")
+        monitor_launched = (state.get("pr") or {}).get("monitor_launched")
         if monitor_launched:
             sys.exit(0)
         output = {
@@ -132,7 +132,7 @@ def main():
         except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
             commits_ahead = 0
 
-        if commits_ahead > 0 and not state.get("pr", {}).get("invoked_via_skill"):
+        if commits_ahead > 0 and not (state.get("pr") or {}).get("invoked_via_skill"):
             output = {
                 "decision": "block",
                 "reason": (
@@ -260,7 +260,7 @@ def main():
     # Reviewer-optional mode: pr.reviewer == "none" means no external reviewer
     # is configured for this PR — nothing to triage, gate skipped. Absent key
     # = state written before reviewer modes existed = legacy gemini run.
-    pr = state.get("pr", {})
+    pr = state.get("pr") or {}  # tolerate explicit "pr": null (not just missing key)
     pr_created = pr and pr.get("url")
     pr_reviewer = pr.get("reviewer") or "gemini"
     if pr_created and pr_reviewer != "none" and not pr.get("gemini_triaged"):

--- a/.claude/hooks/session-stop-workflow.py
+++ b/.claude/hooks/session-stop-workflow.py
@@ -256,10 +256,14 @@ def main():
     if not review.get("passed"):
         missing.append("/review")
 
-    # PR Gemini triage — if PR exists but gemini_triaged is false
+    # PR review triage — if PR exists but gemini_triaged is false.
+    # Reviewer-optional mode: pr.reviewer == "none" means no external reviewer
+    # is configured for this PR — nothing to triage, gate skipped. Absent key
+    # = state written before reviewer modes existed = legacy gemini run.
     pr = state.get("pr", {})
     pr_created = pr and pr.get("url")
-    if pr_created and not pr.get("gemini_triaged"):
+    pr_reviewer = pr.get("reviewer") or "gemini"
+    if pr_created and pr_reviewer != "none" and not pr.get("gemini_triaged"):
         missing.append("Gemini review triage (PR created but comments not triaged)")
 
     # Uncommitted changes
@@ -282,9 +286,12 @@ def main():
         + (f" ({review.get('findings', 0)} findings)" if review.get("passed") else "")
     )
     if pr_created:
-        triaged = "✓" if pr.get("gemini_triaged") else "✗"
         lines.append(f"  ✓ PR: {pr['url']}")
-        lines.append(f"  {triaged} Gemini review triaged")
+        if pr_reviewer == "none":
+            lines.append("  - Reviewer: none (triage gate skipped)")
+        else:
+            triaged = "✓" if pr.get("gemini_triaged") else "✗"
+            lines.append(f"  {triaged} Gemini review triaged")
     else:
         lines.append("  ⚠ PR not created")
 

--- a/.claude/skills/pr/REFERENCE.md
+++ b/.claude/skills/pr/REFERENCE.md
@@ -54,9 +54,11 @@ The monitor handles: CI polling, Gemini review wait (overload detection + retry)
 
 **Why the monitor exists:** Gemini review timing is unpredictable (2–10+ minutes). Inline polling with a fixed timeout creates a gap where late-arriving comments go untriaged.
 
+**Reviewer mode:** the external reviewer is configurable — values `gemini | none`. Precedence: `--reviewer` flag > `PPDS_PR_REVIEWER` env > the prior run's persisted mode (on `--resume`) > the committed default (`DEFAULT_REVIEWER` in `scripts/pr_monitor.py`, currently **`none`** ahead of the Gemini Code Assist sunset on July 17, 2026 — export `PPDS_PR_REVIEWER=gemini` to ride the last Gemini days). Mode `none` skips the review wait, triage dispatch, and the review dimension of the ready-flip gate, and never produces a `gemini-timeout` terminal state; the unreplied-bot-comments gate (CodeQL / github-advanced-security) and the CI gate always apply. `--gemini-timeout-sec` / `PPDS_PR_MONITOR_GEMINI_TIMEOUT` are still parsed but never consulted when mode is `none`. The resolved mode is recorded in `.workflow/pr-monitor-result.json` (`reviewer`) and `.workflow/state.json` (`pr.reviewer`) so the session-stop hook skips the triage gate for reviewer-less PRs. Resolve it once with `python scripts/pr_monitor.py --print-reviewer` (stdout = the mode only, Constitution I1).
+
 > **Retro-enforced (PR #868):** Agent skipped the monitor, manually replied to 3 of 9 comments via `gh api`, missed all CodeQL comments. Manual comment triage is never an acceptable substitute.
 
-Launch command: `python scripts/pr_monitor.py --worktree "$(pwd)" --pr {pr-number}`
+Launch command: `python scripts/pr_monitor.py --worktree "$(pwd)" --pr {pr-number} --reviewer "$REVIEWER"` (resolve `$REVIEWER` first — see **Reviewer mode** above)
 
 - **Windows:** `subprocess.Popen(..., creationflags=subprocess.CREATE_BREAKAWAY_FROM_JOB | subprocess.CREATE_NEW_PROCESS_GROUP)`
 - **Unix:** `subprocess.Popen(..., start_new_session=True)`

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr
-description: Create PR, wait for Gemini review, triage every comment, and present summary. Use when work is ready to ship — after gates, verify, QA, and review are complete.
+description: Create PR, wait for the configured reviewer (Gemini or none), triage every comment, and present summary. Use when work is ready to ship — after gates, verify, QA, and review are complete.
 ---
 
 # PR
 
-End-to-end PR lifecycle: rebase, create, wait for Gemini review, triage comments, and present a summary to the user.
+End-to-end PR lifecycle: rebase, create, wait for the configured external review, triage comments, and present a summary to the user.
 
 This skill is the ONLY sanctioned path for automated PR creation. <!-- enforcement: T1 hook:pr-gate --> See REFERENCE.md §1.
 
@@ -66,30 +66,38 @@ python scripts/workflow-state.py set pr.created now
 ### Step 5: Launch Background Monitor (MANDATORY) <!-- enforcement: T1 hook:session-stop-workflow -->
 
 ```bash
-python scripts/pr_monitor.py --worktree "$(pwd)" --pr {pr-number}
+REVIEWER=$(python scripts/pr_monitor.py --print-reviewer)
+python scripts/workflow-state.py set pr.reviewer "$REVIEWER"
+python scripts/pr_monitor.py --worktree "$(pwd)" --pr {pr-number} --reviewer "$REVIEWER"
 ```
 
-Launch as detached background process (see REFERENCE.md §4). Then:
+Reviewer mode resolves `--reviewer` flag > `PPDS_PR_REVIEWER` env > repo default; `none` disables the external-review wait and triage. Launch as detached background process (see REFERENCE.md §4). Then:
 ```bash
 cat .workflow/pr-monitor.pid
 python scripts/workflow-state.py set pr.monitor_launched now
 ```
 
-On failure: inline fallback — record reason per REFERENCE.md §4. <!-- enforcement: T2 hook:pr-monitor-fallback-record -->
+On failure: inline fallback — record reason per REFERENCE.md §4. When `$REVIEWER` is `none`, skip the "wait + triage yourself" fallback steps (there is no external reviewer); still record `pr.monitor_launched "fallback: <reason>"` and `pr.reviewer`. <!-- enforcement: T2 hook:pr-monitor-fallback-record -->
 
 ### Step 6: Completion Gate (MANDATORY) <!-- since: PR#956 rationale --> <!-- enforcement: T1 hook:session-stop-workflow -->
 
 1. **Monitor**: confirm `.workflow/pr-monitor.pid` exists and process running (`kill -0`). If missing AND no fallback recorded → fail: `"⚠ Monitor PID file missing"`.
-2. **Gemini review**: poll `gh pr view {N} --json reviews,comments` every 30s for 5 min. If absent → fail. Bypass with `--skip-gemini-check`.
+2. **Review received** — *skip this check when `$REVIEWER` is `none`* (note "Reviewer: none" in the summary instead). Otherwise poll `gh pr view {N} --json reviews,comments` every 30s for 5 min. If absent → fail. Bypass with `--skip-gemini-check`.
 
 ### Step 7: Present Summary
 
+Gemini mode:
 ```
 PR created (draft): {url}
 Monitor launched (PID {pid}) — handling CI, Gemini, CodeQL, triage, ready-flip, retro
 Gemini review: ✅ verified
 
 Check: /status   Log: .workflow/pr-monitor.log
+```
+
+When `$REVIEWER` is `none`, replace the "Gemini review" line with:
+```
+Reviewer: none — monitor gates on CI + unreplied bot comments only
 ```
 
 ### Step 8: Post-Merge Cleanup

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1360,7 +1360,12 @@ def _persist_reviewer_state(worktree, mode, logger):
                 state = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             state = {}
-        state.setdefault("pr", {})["reviewer"] = mode
+        # Tolerate an explicit ``"pr": null`` (setdefault returns None for a
+        # present-but-null key, which would then TypeError on item assignment).
+        pr_sec = state.get("pr")
+        pr_sec = pr_sec if isinstance(pr_sec, dict) else {}
+        pr_sec["reviewer"] = mode
+        state["pr"] = pr_sec
         with open(state_path, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
             f.write("\n")
@@ -2446,7 +2451,11 @@ def main():
     args = parser.parse_args()
 
     if args.print_reviewer:
-        mode, _ = _resolve_reviewer_mode(args.reviewer)
+        # Honor the resume tier too: --resume --print-reviewer must reflect the
+        # prior run's persisted mode (args.worktree may be None — the resolver
+        # guards on `resume and worktree`).
+        mode, _ = _resolve_reviewer_mode(
+            args.reviewer, worktree=args.worktree, resume=args.resume)
         print(mode)          # stdout = data only (Constitution I1)
         sys.exit(0)
     if not args.worktree or args.pr is None:

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -51,6 +51,16 @@ MAX_TRIAGE_ITERATIONS = 3   # max triage -> CI re-check cycles
 
 MAX_CI_FIX_ROUNDS = int(os.environ.get("PPDS_MAX_CI_FIX_ROUNDS", "3"))
 
+VALID_REVIEWERS = ("gemini", "none")
+# Committed default for real runs (resolved in main()). Flipped to "none"
+# ahead of the Gemini Code Assist sunset (July 17, 2026) — issue #1177.
+# Ride the last Gemini days with PPDS_PR_REVIEWER=gemini if desired.
+DEFAULT_REVIEWER = "none"
+# Module-import value = legacy behavior for direct-function callers and the
+# existing test suite (which is the gemini-mode regression guarantee).
+# main() overwrites this via _resolve_reviewer_mode() for every real run.
+REVIEWER_MODE = "gemini"
+
 
 def _resolve_ci_timeout_sec(flag_value):
     """Return (effective_seconds, source) with flag > env > default precedence."""
@@ -76,6 +86,20 @@ def _resolve_gemini_timeout_sec(flag_value):
         except ValueError:
             pass
     return GEMINI_MAX_WAIT, "default"
+
+
+def _resolve_reviewer_mode(flag_value, worktree=None, resume=False):
+    """Return (mode, source): flag > env > prior run (resume only) > default."""
+    if flag_value is not None:
+        return flag_value, "flag"
+    env_val = os.environ.get("PPDS_PR_REVIEWER", "").strip().lower()
+    if env_val in VALID_REVIEWERS:
+        return env_val, "env"
+    if resume and worktree:
+        prev = read_result(worktree).get("reviewer")
+        if prev in VALID_REVIEWERS:
+            return prev, "resume"
+    return DEFAULT_REVIEWER, "default"
 
 
 KNOWN_FLAKE_PATTERNS = [
@@ -304,6 +328,8 @@ def _empty_result():
         # ready-flip gate can distinguish clean-approval / declined reviews
         # from reviews that flagged issues needing replies.
         "gemini_review_body": "",
+        # Effective reviewer mode; set by run_monitor.
+        "reviewer": None,
         "timestamp": _timestamp(),
     }
 
@@ -493,6 +519,12 @@ def poll_gemini_comments(worktree, pr_number, logger):
     """
     if SHAKEDOWN:
         logger.log("gemini", "SHAKEDOWN_SKIPPED")
+        return []
+
+    if REVIEWER_MODE == "none":
+        logger.log("gemini", "SKIPPED_REVIEWER_NONE")
+        logger.last_gemini_status = "reviewer_none"
+        logger.last_gemini_review_body = ""
         return []
 
     pr_created_at = _get_pr_created_at(worktree, pr_number)
@@ -1311,6 +1343,32 @@ def _set_terminal_state_marker(worktree, terminal_state, reason, logger):
         logger.log("escalation", "STATE_MARKER_ERROR", error=str(e))
 
 
+def _persist_reviewer_state(worktree, mode, logger):
+    """Record the effective reviewer mode into ``.workflow/state.json``
+    under ``pr.reviewer`` (cross-process contract for the session-stop hook).
+
+    Direct state.json write — same pattern as ``_set_terminal_state_marker``
+    — rather than a ``workflow-state.py`` subprocess, so it works from the
+    detached monitor regardless of branch (that script blocks writes on the
+    main branch).
+    """
+    state_path = os.path.join(worktree, ".workflow", "state.json")
+    try:
+        os.makedirs(os.path.join(worktree, ".workflow"), exist_ok=True)
+        try:
+            with open(state_path, "r", encoding="utf-8") as f:
+                state = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            state = {}
+        state.setdefault("pr", {})["reviewer"] = mode
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+            f.write("\n")
+        logger.log("monitor", "REVIEWER_STATE_SET", reviewer=mode)
+    except OSError as e:
+        logger.log("monitor", "REVIEWER_STATE_ERROR", error=str(e))
+
+
 def _notify_terminal(worktree, pr_number, logger, message):
     """Best-effort notification + escalation visibility on any non-clean exit.
 
@@ -1669,7 +1727,8 @@ def _parse_github_repo(remote_url):
 
 
 def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
-                ci_timeout_source="default", gemini_timeout_source="default"):
+                ci_timeout_source="default", gemini_timeout_source="default",
+                reviewer_source="default"):
     """Main monitor loop — state-machine orchestrator (v9.1).
 
     Args:
@@ -1697,12 +1756,15 @@ def run_monitor(worktree, pr_number, resume=False, repo=None, mode=None,
 
     result = read_result(worktree) if resume else _empty_result()
     result["status"] = "running"
+    result["reviewer"] = REVIEWER_MODE
     result["timestamp"] = _timestamp()
     write_result(worktree, result)
 
     logger.log("monitor", "START", pr=pr_number, resume=resume, pid=os.getpid())
     logger.log("monitor", "CI_TIMEOUT", ci_timeout_sec=CI_MAX_WAIT, source=ci_timeout_source)
     logger.log("monitor", "GEMINI_TIMEOUT", gemini_timeout_sec=GEMINI_MAX_WAIT, source=gemini_timeout_source)
+    logger.log("monitor", "REVIEWER", reviewer=REVIEWER_MODE, source=reviewer_source)
+    _persist_reviewer_state(worktree, REVIEWER_MODE, logger)
 
     ci_fix_rounds_used = 0
     triage_rounds_used = 0
@@ -2200,24 +2262,30 @@ def _ready_flip_gates(worktree, pr_number, result, logger):
 
     Returns (ok, failing_reasons). ok is True only when all gates pass:
       - CI green, AND
-      - Gemini dimension is satisfied — either the latest review body
-        matches a clean-approval / declined pattern
+      - the reviewer dimension is satisfied UNLESS ``REVIEWER_MODE`` is
+        ``"none"`` (in which case the review gate is skipped entirely and
+        ``gemini_review_not_posted`` is never appended). When a reviewer is
+        configured, the dimension is satisfied — either the latest review
+        body matches a clean-approval / declined pattern
         (see ``_gemini_effectively_done``), OR Gemini posted a review, AND
       - no unreplied bot comments remain from ANY reviewer (Gemini,
         CodeQL / github-advanced-security, or other aggregated sources
         returned by ``get_unreplied_comments``). A Gemini clean/declined
         review satisfies the "Gemini reviewed" dimension but does NOT
         bypass unreplied comments from other reviewers — see PR #846
-        review (gemini-code-assist HIGH, 2026-04-20).
+        review (gemini-code-assist HIGH, 2026-04-20). The unreplied-bot
+        gate is mode-independent: CodeQL findings still block the flip
+        even when ``REVIEWER_MODE`` is ``"none"``.
     """
     reasons = []
     if result.get("ci_result") != "pass":
         reasons.append(f"ci_result={result.get('ci_result')!r}")
 
-    review_body = result.get("gemini_review_body") or ""
-    gemini_done_clean = _gemini_effectively_done(review_body)
-    if not gemini_done_clean and not result.get("gemini_review_posted"):
-        reasons.append("gemini_review_not_posted")
+    if REVIEWER_MODE != "none":
+        review_body = result.get("gemini_review_body") or ""
+        gemini_done_clean = _gemini_effectively_done(review_body)
+        if not gemini_done_clean and not result.get("gemini_review_posted"):
+            reasons.append("gemini_review_not_posted")
 
     try:
         unreplied = get_unreplied_comments(
@@ -2352,9 +2420,9 @@ def main():
     parser = argparse.ArgumentParser(
         description="Background PR monitor — CI, Gemini triage, retro, notify"
     )
-    parser.add_argument("--worktree", required=True,
+    parser.add_argument("--worktree", required=False,
                         help="Path to the git worktree")
-    parser.add_argument("--pr", required=True, type=int,
+    parser.add_argument("--pr", required=False, type=int,
                         help="Pull request number")
     parser.add_argument("--resume", action="store_true",
                         help="Resume from last completed step")
@@ -2369,7 +2437,20 @@ def main():
     parser.add_argument("--gemini-timeout-sec", type=int, default=None,
                         help="Gemini review polling timeout in seconds (default: 1800). "
                              "Env: PPDS_PR_MONITOR_GEMINI_TIMEOUT. Flag takes precedence over env.")
+    parser.add_argument("--reviewer", choices=VALID_REVIEWERS, default=None,
+                        help="External reviewer mode. 'none' skips the review wait, triage, "
+                             "and review gate (CI + unreplied bot comments still gate ready-flip). "
+                             "Env: PPDS_PR_REVIEWER. Flag > env > prior run (--resume) > default.")
+    parser.add_argument("--print-reviewer", action="store_true",
+                        help="Print the effective reviewer mode to stdout and exit.")
     args = parser.parse_args()
+
+    if args.print_reviewer:
+        mode, _ = _resolve_reviewer_mode(args.reviewer)
+        print(mode)          # stdout = data only (Constitution I1)
+        sys.exit(0)
+    if not args.worktree or args.pr is None:
+        parser.error("--worktree and --pr are required")
 
     global CI_MAX_WAIT
     ci_timeout_sec, ci_timeout_source = _resolve_ci_timeout_sec(args.ci_timeout_sec)
@@ -2386,9 +2467,15 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
+    global REVIEWER_MODE
+    reviewer_mode, reviewer_source = _resolve_reviewer_mode(
+        args.reviewer, worktree=worktree, resume=args.resume)
+    REVIEWER_MODE = reviewer_mode
+
     exit_code = run_monitor(worktree, args.pr, resume=args.resume, repo=args.repo,
                             mode=args.mode, ci_timeout_source=ci_timeout_source,
-                            gemini_timeout_source=gemini_timeout_source)
+                            gemini_timeout_source=gemini_timeout_source,
+                            reviewer_source=reviewer_source)
     sys.exit(exit_code)
 
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -1360,6 +1360,10 @@ def _persist_reviewer_state(worktree, mode, logger):
                 state = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             state = {}
+        # Tolerate a non-dict root (``null`` or an array parse to a non-dict,
+        # on which ``state.get(...)`` would AttributeError and abort startup).
+        if not isinstance(state, dict):
+            state = {}
         # Tolerate an explicit ``"pr": null`` (setdefault returns None for a
         # present-but-null key, which would then TypeError on item assignment).
         pr_sec = state.get("pr")

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -3309,3 +3309,368 @@ class TestPrMonitorBypassPermissions:
             "run_retro must spawn with permission_mode='bypassPermissions'"
         assert "dangerous" not in captured or not captured.get("dangerous"), \
             "run_retro must not pass legacy dangerous=True"
+
+
+# ---------------------------------------------------------------------------
+# #1177 — reviewer-optional mode (gemini | none) ahead of Gemini sunset
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerModeConfig:
+    """#1177: reviewer mode resolves flag > env > prior run (--resume) >
+    default. Mirrors TestGeminiTimeoutConfig."""
+
+    def test_default_reviewer_is_none(self):
+        """Operator flip switch (#1177): the committed default is 'none' ahead
+        of the Gemini Code Assist sunset (July 17, 2026). Change deliberately
+        only — ride the last Gemini days with PPDS_PR_REVIEWER=gemini."""
+        assert pr_monitor.DEFAULT_REVIEWER == "none"
+
+    def test_module_global_initializes_gemini(self):
+        """Import-time REVIEWER_MODE stays 'gemini' so direct-call tests (the
+        gemini-mode regression suite) keep legacy behavior. main() overwrites
+        it via _resolve_reviewer_mode() for every real run."""
+        assert pr_monitor.REVIEWER_MODE == "gemini"
+
+    def test_resolve_default_when_no_override(self):
+        """No flag, no env → (DEFAULT_REVIEWER, 'default')."""
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        with patch.dict(os.environ, env, clear=True):
+            mode, source = pr_monitor._resolve_reviewer_mode(None)
+        assert mode == "none"
+        assert source == "default"
+
+    def test_resolve_env_wins_over_default(self):
+        """PPDS_PR_REVIEWER resolves when the flag is absent."""
+        with patch.dict(os.environ, {"PPDS_PR_REVIEWER": "none"}):
+            mode, source = pr_monitor._resolve_reviewer_mode(None)
+        assert mode == "none"
+        assert source == "env"
+
+    def test_resolve_flag_wins_over_env(self):
+        """--reviewer flag beats PPDS_PR_REVIEWER env."""
+        with patch.dict(os.environ, {"PPDS_PR_REVIEWER": "gemini"}):
+            mode, source = pr_monitor._resolve_reviewer_mode("none")
+        assert mode == "none"
+        assert source == "flag"
+
+    def test_resolve_invalid_env_ignored(self):
+        """Unknown env value falls through to the default (mirrors the int()
+        ValueError fall-through in the timeout resolvers)."""
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        env["PPDS_PR_REVIEWER"] = "coderabbit"
+        with patch.dict(os.environ, env, clear=True):
+            mode, source = pr_monitor._resolve_reviewer_mode(None)
+        assert mode == "none"
+        assert source == "default"
+
+    def test_resolve_resume_uses_persisted_mode(self, tmp_path):
+        """On --resume with no flag/env, the prior run's persisted reviewer
+        (from result JSON) beats the committed default. Persist 'gemini' so
+        the resolved value (not just the source) proves persistence drove it."""
+        wt = _make_worktree(tmp_path)
+        r = pr_monitor._empty_result()
+        r["reviewer"] = "gemini"
+        pr_monitor.write_result(wt, r)
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        with patch.dict(os.environ, env, clear=True):
+            mode, source = pr_monitor._resolve_reviewer_mode(
+                None, worktree=wt, resume=True)
+        assert mode == "gemini"
+        assert source == "resume"
+
+    def test_resolve_env_beats_resume_persistence(self, tmp_path):
+        """Explicit current intent (env) beats persisted history on resume."""
+        wt = _make_worktree(tmp_path)
+        r = pr_monitor._empty_result()
+        r["reviewer"] = "none"
+        pr_monitor.write_result(wt, r)
+        with patch.dict(os.environ, {"PPDS_PR_REVIEWER": "gemini"}):
+            mode, source = pr_monitor._resolve_reviewer_mode(
+                None, worktree=wt, resume=True)
+        assert mode == "gemini"
+        assert source == "env"
+
+    def test_resolve_fresh_run_ignores_persisted_mode(self, tmp_path):
+        """A fresh (non-resume) run never consults the persisted mode — the
+        persisted 'gemini' is ignored and the value falls to the default."""
+        wt = _make_worktree(tmp_path)
+        r = pr_monitor._empty_result()
+        r["reviewer"] = "gemini"
+        pr_monitor.write_result(wt, r)
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        with patch.dict(os.environ, env, clear=True):
+            mode, source = pr_monitor._resolve_reviewer_mode(
+                None, worktree=wt, resume=False)
+        assert mode == "none"
+        assert source == "default"
+
+
+class TestReviewerNoneSkipsPoll:
+    """#1177: REVIEWER_MODE='none' short-circuits poll_gemini_comments with
+    zero network I/O. Mirrors TestGeminiTimeout."""
+
+    def test_poll_gemini_comments_short_circuits(self, tmp_path):
+        """none mode returns [] immediately, makes no subprocess calls, and
+        stashes last_gemini_status='reviewer_none' on the logger."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        def _fail(*args, **kwargs):
+            pytest.fail(
+                "subprocess.run must not be called in reviewer=none mode")
+
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.subprocess.run", side_effect=_fail), \
+             patch("triage_common.subprocess.run", side_effect=_fail):
+            result = pr_monitor.poll_gemini_comments(wt, 5, logger)
+
+        assert result == []
+        assert logger.last_gemini_status == "reviewer_none"
+        assert logger.last_gemini_review_body == ""
+
+    def test_shakedown_guard_still_first(self, tmp_path):
+        """SHAKEDOWN guard precedes the reviewer guard — shakedown logging is
+        byte-for-byte unchanged even when the mode is none."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+
+        with patch("pr_monitor.SHAKEDOWN", "1"), \
+             patch("pr_monitor.REVIEWER_MODE", "none"):
+            result = pr_monitor.poll_gemini_comments(wt, 5, logger)
+
+        assert result == []
+        logger.close()
+        log_text = (tmp_path / "test.log").read_text(encoding="utf-8")
+        assert "SHAKEDOWN_SKIPPED" in log_text
+        assert "SKIPPED_REVIEWER_NONE" not in log_text
+
+
+class TestReviewerNoneEndToEnd:
+    """#1177: full run_monitor flow in none mode — ready-flips on CI green,
+    never escalates gemini-timeout, and CodeQL still blocks the flip."""
+
+    def test_none_mode_flips_ready_on_ci_green(self, tmp_path):
+        """CI green + no unreplied comments → ready flip, no triage dispatch."""
+        wt = _make_worktree(tmp_path)
+        mock_triage = MagicMock()
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.poll_ci", return_value="pass"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]), \
+             patch("pr_monitor._rebase_source_branch", return_value=True), \
+             patch("pr_monitor.mark_pr_ready", return_value=True) as mock_ready, \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"), \
+             patch("pr_monitor.run_triage", mock_triage):
+            rc = pr_monitor.run_monitor(wt, 1, resume=False)
+
+        assert rc == 0
+        result = pr_monitor.read_result(wt)
+        assert result["status"] == "ready"
+        assert result["reviewer"] == "none"
+        mock_ready.assert_called_once()
+        assert result["steps_completed"]["ready"]["status"] == "done"
+        mock_triage.assert_not_called()
+
+    def test_none_mode_never_raises_gemini_timeout(self, tmp_path):
+        """gemini_review_posted stays False all run, yet no _GeminiTimeoutError
+        and no 'gemini-timeout' notification."""
+        wt = _make_worktree(tmp_path)
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.poll_ci", return_value="pass"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]), \
+             patch("pr_monitor._rebase_source_branch", return_value=True), \
+             patch("pr_monitor.mark_pr_ready", return_value=True), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify") as mock_notify:
+            rc = pr_monitor.run_monitor(wt, 1, resume=False)
+
+        assert rc == 0
+        result = pr_monitor.read_result(wt)
+        assert result["status"] == "ready"
+        assert result.get("gemini_review_posted") is False
+        notify_args = " ".join(str(c) for c in mock_notify.call_args_list)
+        assert "gemini-timeout" not in notify_args
+
+    def test_none_mode_unreplied_codeql_blocks_flip(self, tmp_path):
+        """A CodeQL (github-advanced-security) unreplied comment blocks the
+        flip in none mode — no mark_pr_ready, no escalation, exit 0."""
+        wt = _make_worktree(tmp_path)
+        codeql = [{"id": 1, "user": "github-advanced-security[bot]",
+                   "path": "scripts/pr_monitor.py", "line": 1,
+                   "body": "Potential issue"}]
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.poll_ci", return_value="pass"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=codeql), \
+             patch("pr_monitor._rebase_source_branch") as mock_rebase, \
+             patch("pr_monitor.mark_pr_ready") as mock_ready, \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"):
+            rc = pr_monitor.run_monitor(wt, 1, resume=False)
+
+        assert rc == 0
+        mock_ready.assert_not_called()
+        mock_rebase.assert_not_called()
+        result = pr_monitor.read_result(wt)
+        assert result["steps_completed"]["ready"]["status"] == "skipped"
+        assert any("unreplied_comments" in r
+                   for r in result["ready_skip_reasons"])
+
+    def test_none_mode_records_reviewer_in_state_json(self, tmp_path):
+        """The monitor self-persists pr.reviewer into .workflow/state.json."""
+        wt = _make_worktree(tmp_path)
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.poll_ci", return_value="pass"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]), \
+             patch("pr_monitor._rebase_source_branch", return_value=True), \
+             patch("pr_monitor.mark_pr_ready", return_value=True), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"):
+            pr_monitor.run_monitor(wt, 1, resume=False)
+
+        state_path = os.path.join(wt, ".workflow", "state.json")
+        with open(state_path, encoding="utf-8") as f:
+            state = json.load(f)
+        assert state["pr"]["reviewer"] == "none"
+
+    def test_gemini_mode_records_reviewer(self, tmp_path):
+        """Additive-schema regression: gemini-mode runs record
+        result['reviewer'] == 'gemini'."""
+        wt = _make_worktree(tmp_path)
+        with patch("pr_monitor.REVIEWER_MODE", "gemini"), \
+             patch("pr_monitor.poll_ci", return_value="pass"), \
+             patch("pr_monitor.poll_gemini_comments", return_value=[]), \
+             patch("pr_monitor._ready_flip_gates", return_value=(True, [])), \
+             patch("pr_monitor.mark_pr_ready", return_value=True), \
+             patch("pr_monitor.run_retro", return_value="done"), \
+             patch("pr_monitor.run_notify"):
+            pr_monitor.run_monitor(wt, 1, resume=False)
+
+        result = pr_monitor.read_result(wt)
+        assert result["reviewer"] == "gemini"
+
+
+class TestReviewerNoneReadyFlipGates:
+    """#1177: _ready_flip_gates skips the review dimension in none mode but
+    still enforces the CI and unreplied-bot gates. Mirrors TestReadyFlipGates."""
+
+    def _base_result(self, **overrides):
+        r = pr_monitor._empty_result()
+        r["ci_result"] = "pass"
+        r.update(overrides)
+        return r
+
+    def test_gates_pass_without_review_when_none(self, tmp_path):
+        """CI pass, no review posted, empty body, no unreplied → (True, [])."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(gemini_review_posted=False,
+                                   gemini_review_body="")
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+        assert ok is True
+        assert reasons == []
+
+    def test_gates_still_block_on_ci_fail_when_none(self, tmp_path):
+        """CI is still a gate in none mode."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(ci_result="fail",
+                                   gemini_review_posted=False)
+        with patch("pr_monitor.REVIEWER_MODE", "none"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+        assert ok is False
+        assert "ci_result='fail'" in reasons
+
+    def test_gemini_mode_gate_unchanged(self, tmp_path):
+        """Gemini mode still appends gemini_review_not_posted when no review."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        result = self._base_result(gemini_review_posted=False,
+                                   gemini_review_body="")
+        with patch("pr_monitor.REVIEWER_MODE", "gemini"), \
+             patch("pr_monitor.get_unreplied_comments", return_value=[]):
+            ok, reasons = pr_monitor._ready_flip_gates(wt, 42, result, logger)
+        assert ok is False
+        assert "gemini_review_not_posted" in reasons
+
+
+class TestPrMonitorReviewerCli:
+    """#1177: --reviewer / --print-reviewer CLI surface. Mirrors
+    TestPrMonitorModeFlag."""
+
+    SCRIPT = os.path.join(REPO_ROOT, "scripts", "pr_monitor.py")
+
+    def test_help_advertises_reviewer(self):
+        """--help documents --reviewer, PPDS_PR_REVIEWER, and --print-reviewer."""
+        import io
+        argv = ["pr_monitor.py", "--help"]
+        buf = io.StringIO()
+        with patch("sys.argv", argv), patch("sys.stdout", buf):
+            with pytest.raises(SystemExit):
+                pr_monitor.main()
+        out = buf.getvalue()
+        assert "--reviewer" in out
+        assert "PPDS_PR_REVIEWER" in out
+        assert "--print-reviewer" in out
+
+    def test_print_reviewer_stdout_is_mode_only(self):
+        """PPDS_PR_REVIEWER=none → stdout is exactly the mode, one line
+        (Constitution I1: stdout = data only)."""
+        env = dict(os.environ, PPDS_PR_REVIEWER="none")
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT, "--print-reviewer"],
+            capture_output=True, text=True, env=env,
+            stdin=subprocess.DEVNULL,  # pytest replaces stdin w/ non-inheritable handle (WinError 6)
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "none"
+        assert len(proc.stdout.strip().splitlines()) == 1
+
+    def test_print_reviewer_env_gemini(self):
+        """PPDS_PR_REVIEWER=gemini → stdout 'gemini' (env-resolution path)."""
+        env = dict(os.environ, PPDS_PR_REVIEWER="gemini")
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT, "--print-reviewer"],
+            capture_output=True, text=True, env=env,
+            stdin=subprocess.DEVNULL,  # pytest replaces stdin w/ non-inheritable handle (WinError 6)
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "gemini"
+
+    def test_print_reviewer_needs_no_worktree(self):
+        """--print-reviewer resolves and exits 0 without --worktree/--pr."""
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT, "--print-reviewer"],
+            capture_output=True, text=True, env=env,
+            stdin=subprocess.DEVNULL,  # pytest replaces stdin w/ non-inheritable handle (WinError 6)
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "none"
+
+    def test_missing_worktree_still_usage_error(self):
+        """No flags at all → exit 2 (guards the required=False refactor)."""
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            capture_output=True, text=True,
+            stdin=subprocess.DEVNULL,
+        )
+        assert proc.returncode == 2
+
+    def test_reviewer_flag_rejects_unknown_value(self):
+        """--reviewer with an unknown value → argparse usage error, exit 2."""
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT,
+             "--reviewer", "coderabbit", "--print-reviewer"],
+            capture_output=True, text=True,
+            stdin=subprocess.DEVNULL,
+        )
+        assert proc.returncode == 2

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -3572,6 +3572,22 @@ class TestReviewerNoneEndToEnd:
         assert state["pr"] == {"reviewer": "none"}
         assert state["phase"] == "pr"  # unrelated top-level keys preserved
 
+    def test_persist_reviewer_state_handles_non_dict_root(self, tmp_path):
+        """Regression (CodeRabbit review of #1308): a non-dict state.json root
+        (JSON null or an array) must not AttributeError in
+        _persist_reviewer_state — it resets to {} and writes a clean
+        {"pr": {"reviewer": <mode>}}."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        state_path = os.path.join(wt, ".workflow", "state.json")
+        for raw in ("null", "[]"):
+            with open(state_path, "w", encoding="utf-8") as f:
+                f.write(raw)
+            pr_monitor._persist_reviewer_state(wt, "none", logger)
+            with open(state_path, encoding="utf-8") as f:
+                state = json.load(f)
+            assert state == {"pr": {"reviewer": "none"}}
+
 
 class TestReviewerNoneReadyFlipGates:
     """#1177: _ready_flip_gates skips the review dimension in none mode but

--- a/tests/test_pr_monitor.py
+++ b/tests/test_pr_monitor.py
@@ -3553,6 +3553,25 @@ class TestReviewerNoneEndToEnd:
         result = pr_monitor.read_result(wt)
         assert result["reviewer"] == "gemini"
 
+    def test_persist_reviewer_state_handles_null_pr(self, tmp_path):
+        """Regression (Gemini review of #1308): _persist_reviewer_state must
+        tolerate an explicit "pr": null in state.json — setdefault("pr", {})
+        returns None for a present-but-null key, which would then TypeError on
+        item assignment. It replaces null with a fresh dict and preserves other
+        top-level keys."""
+        wt = _make_worktree(tmp_path)
+        logger = _make_logger(tmp_path)
+        state_path = os.path.join(wt, ".workflow", "state.json")
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump({"pr": None, "phase": "pr"}, f)
+
+        pr_monitor._persist_reviewer_state(wt, "none", logger)
+
+        with open(state_path, encoding="utf-8") as f:
+            state = json.load(f)
+        assert state["pr"] == {"reviewer": "none"}
+        assert state["phase"] == "pr"  # unrelated top-level keys preserved
+
 
 class TestReviewerNoneReadyFlipGates:
     """#1177: _ready_flip_gates skips the review dimension in none mode but
@@ -3674,3 +3693,22 @@ class TestPrMonitorReviewerCli:
             stdin=subprocess.DEVNULL,
         )
         assert proc.returncode == 2
+
+    def test_print_reviewer_resume_uses_persisted_mode(self, tmp_path):
+        """Regression (CodeRabbit review of #1308): --resume --print-reviewer
+        must consult the prior run's persisted mode. Persist 'gemini' so the
+        printed value proves the resume tier was used (not flag/env/default)."""
+        wt = _make_worktree(tmp_path)
+        r = pr_monitor._empty_result()
+        r["reviewer"] = "gemini"
+        pr_monitor.write_result(wt, r)
+        env = {k: v for k, v in os.environ.items()
+               if k != "PPDS_PR_REVIEWER"}
+        proc = subprocess.run(
+            [sys.executable, self.SCRIPT, "--print-reviewer",
+             "--resume", "--worktree", wt],
+            capture_output=True, text=True, env=env,
+            stdin=subprocess.DEVNULL,
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "gemini"

--- a/tests/test_session_stop_workflow.py
+++ b/tests/test_session_stop_workflow.py
@@ -149,7 +149,8 @@ def _base_state():
     }
 
 
-def _run_hook(tmp_path, state, monkeypatch, capsys, branch="feat/x"):
+def _run_hook(tmp_path, state, monkeypatch, capsys, branch="feat/x",
+              commits_ahead="1"):
     """Drive session_stop_workflow.main() end-to-end against a temp worktree.
 
     Mocks git so the hook sees a feature branch with one code commit ahead of
@@ -174,7 +175,7 @@ def _run_hook(tmp_path, state, monkeypatch, capsys, branch="feat/x"):
         elif argv[:2] == ["git", "rev-parse"]:
             out = "abc123"
         elif argv[:3] == ["git", "rev-list", "--count"]:
-            out = "1"
+            out = commits_ahead
         elif argv[:3] == ["git", "diff", "--name-only"]:
             out = "scripts/x.py\n"
         elif argv[:3] == ["git", "status", "--porcelain"]:
@@ -232,3 +233,28 @@ class TestReviewerOptionalTriageGate:
         code, out = _run_hook(tmp_path, state, monkeypatch, capsys)
         assert code == 0
         assert "Gemini review triaged" in out
+
+    def test_pr_explicit_null_does_not_crash_triage_block(
+            self, tmp_path, monkeypatch, capsys):
+        """Regression (Gemini review of #1308): an explicit "pr": null in
+        state.json must NOT AttributeError the triage/summary block. With no
+        commits ahead the hook treats it as 'no PR' and exits cleanly."""
+        state = _base_state()
+        state["pr"] = None
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys,
+                              commits_ahead="0")
+        assert code == 0
+        assert "AttributeError" not in out and "Traceback" not in out
+        assert "PR not created" in out
+
+    def test_pr_explicit_null_does_not_crash_pr_invocation_gate(
+            self, tmp_path, monkeypatch, capsys):
+        """Regression: the pr-invocation gate (commits ahead + no
+        invoked_via_skill) must also tolerate "pr": null — it blocks (exit 2)
+        rather than crashing."""
+        state = _base_state()
+        state["pr"] = None
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys,
+                              commits_ahead="1")
+        assert code == 2
+        assert "AttributeError" not in out and "Traceback" not in out

--- a/tests/test_session_stop_workflow.py
+++ b/tests/test_session_stop_workflow.py
@@ -128,3 +128,107 @@ class TestWorkflowSurface:
                             assert "workflow" in elements, (
                                 "'workflow' must be in pr-gate valid_surfaces"
                             )
+
+
+# ---------------------------------------------------------------------------
+# #1177 — reviewer-optional mode: the triage gate respects pr.reviewer
+# ---------------------------------------------------------------------------
+
+
+def _base_state():
+    """Workflow state that passes every gate EXCEPT (optionally) PR triage."""
+    return {
+        "gates": {"passed": True, "commit_ref": "abc123"},
+        "verify": {"workflow": "x"},
+        "qa": {"workflow": "x"},
+        "review": {"passed": True},
+        "pr": {
+            "url": "https://github.com/o/r/pull/1",
+            "invoked_via_skill": True,
+        },
+    }
+
+
+def _run_hook(tmp_path, state, monkeypatch, capsys, branch="feat/x"):
+    """Drive session_stop_workflow.main() end-to-end against a temp worktree.
+
+    Mocks git so the hook sees a feature branch with one code commit ahead of
+    main and a clean tree (HEAD == gates.commit_ref), so the block/allow
+    decision is driven purely by the provided state.json. Returns
+    (exit_code, combined_stdout+stderr).
+    """
+    import io as _io
+
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("PPDS_PIPELINE", raising=False)
+    monkeypatch.delenv("PPDS_SHAKEDOWN", raising=False)
+
+    wf = tmp_path / ".workflow"
+    wf.mkdir(parents=True, exist_ok=True)
+    (wf / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    def _fake_git(*args, **kwargs):
+        argv = args[0] if args else kwargs.get("args", [])
+        if argv[:2] == ["git", "rev-parse"] and "--abbrev-ref" in argv:
+            out = branch
+        elif argv[:2] == ["git", "rev-parse"]:
+            out = "abc123"
+        elif argv[:3] == ["git", "rev-list", "--count"]:
+            out = "1"
+        elif argv[:3] == ["git", "diff", "--name-only"]:
+            out = "scripts/x.py\n"
+        elif argv[:3] == ["git", "status", "--porcelain"]:
+            out = ""
+        else:
+            out = ""
+        return subprocess.CompletedProcess(argv, 0, out, "")
+
+    with patch.object(hook.subprocess, "run", side_effect=_fake_git), \
+         patch("sys.stdin", _io.StringIO("{}")):
+        with pytest.raises(SystemExit) as exc:
+            hook.main()
+
+    captured = capsys.readouterr()
+    code = exc.value.code if exc.value.code is not None else 0
+    return code, captured.out + captured.err
+
+
+class TestReviewerOptionalTriageGate:
+    """#1177: the session-stop triage gate reads pr.reviewer.
+
+    reviewer == "none"  → no external reviewer → triage gate skipped.
+    reviewer == "gemini" or ABSENT (legacy) → gate enforced.
+    """
+
+    def test_reviewer_none_allows_stop_without_triage(
+            self, tmp_path, monkeypatch, capsys):
+        state = _base_state()
+        state["pr"]["reviewer"] = "none"
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys)
+        assert code == 0
+        assert "Reviewer: none" in out
+
+    def test_reviewer_gemini_blocks_without_triage(
+            self, tmp_path, monkeypatch, capsys):
+        state = _base_state()
+        state["pr"]["reviewer"] = "gemini"
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys)
+        assert code == 2
+        assert "triage" in out.lower()
+
+    def test_reviewer_absent_defaults_to_gemini_gate(
+            self, tmp_path, monkeypatch, capsys):
+        # No reviewer key at all — legacy state written before reviewer modes.
+        state = _base_state()
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys)
+        assert code == 2
+        assert "triage" in out.lower()
+
+    def test_reviewer_gemini_triaged_allows_stop(
+            self, tmp_path, monkeypatch, capsys):
+        state = _base_state()
+        state["pr"]["reviewer"] = "gemini"
+        state["pr"]["gemini_triaged"] = True
+        code, out = _run_hook(tmp_path, state, monkeypatch, capsys)
+        assert code == 0
+        assert "Gemini review triaged" in out

--- a/tests/test_session_stop_workflow.py
+++ b/tests/test_session_stop_workflow.py
@@ -258,3 +258,14 @@ class TestReviewerOptionalTriageGate:
                               commits_ahead="1")
         assert code == 2
         assert "AttributeError" not in out and "Traceback" not in out
+
+    def test_non_dict_state_root_does_not_crash(
+            self, tmp_path, monkeypatch, capsys):
+        """Regression (CodeRabbit review of #1308): a non-dict JSON root in
+        state.json (null or an array) must not crash the hook on the
+        state.get(...) that immediately follows the load — treat it like a
+        corrupt file and allow stop (exit 0)."""
+        for raw_root in (None, []):
+            code, out = _run_hook(tmp_path, raw_root, monkeypatch, capsys)
+            assert code == 0
+            assert "AttributeError" not in out and "Traceback" not in out


### PR DESCRIPTION
## Summary
- Add reviewer-optional mode to `scripts/pr_monitor.py` — resolvable to `gemini | none` via `--reviewer` flag > `PPDS_PR_REVIEWER` env > persisted prior-run mode (on `--resume`) > committed default (`none`, ahead of the Gemini Code Assist sunset on July 17, 2026).
- Mode `none` skips the external-review wait, triage dispatch, and the review dimension of the ready-flip gate; CI and unreplied-bot (CodeQL / advanced-security) gates always apply.
- Persist resolved mode to `.workflow/pr-monitor-result.json` and `.workflow/state.json` (`pr.reviewer`); session-stop hook skips the triage gate for reviewer-less PRs (absent `pr.reviewer` treated as legacy `gemini`).
- `/pr` skill + REFERENCE.md updated to resolve and record the reviewer mode; new tests in `test_pr_monitor.py` and `test_session_stop_workflow.py`.

Closes #1177

## Test Plan
- [x] `test_pr_monitor.py` — reviewer-mode precedence, `none`-mode short-circuit, unreplied-CodeQL-blocks-flip
- [x] `test_session_stop_workflow.py` — triage-gate skip for `none`, legacy-`gemini` default when `pr.reviewer` absent

## Self-review notes (non-blocking)
- CONCERN: the detached monitor and the foreground skill both read-modify-write the same worktree `state.json` without locking; interleaving could drop `pr.monitor_launched`/`pr.reviewer`. Low probability; pre-existing pattern applied to a new writer.
- CONCERN: in `none` mode, CodeQL/advanced-security comments are surfaced via the ready-flip gate (blocks draft→ready) but not auto-triaged — documented in REFERENCE.md §4 and intentional for the new default.

## Verification
- [x] Pre-PR self-review completed (findings: 0 DEFECT / 2 CONCERN / 1 NIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PR reviewer mode: **Gemini** or **none** to optionally skip the external review/triage step.

* **Workflow Updates**
  * Ready-flip and end-of-session enforcement now adapt to the selected reviewer mode.
  * Workflow status summaries reflect whether triage was skipped (none) or Gemini triage status (Gemini).
  * Session stop is more resilient to missing or malformed PR state (no crashes; appropriate exit behavior maintained).

* **Documentation**
  * Updated PR monitor and skill documentation to explain reviewer-mode selection precedence and the “none” gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->