### PR TITLE
fix(dependabot): three classifier correctness fixes (auth-critical patch, multi-package titles, stylelint tooling)

### DIFF
--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -360,6 +360,8 @@ def _classify_member_set(
     descriptor: str,
     members: list[tuple[str, str, str]],
     ecosystem: str,
+    body: str,
+    files: list[str],
 ) -> Classification:
     """Classify a multi-member dependabot PR (grouped or multi-package title).
 
@@ -370,6 +372,12 @@ def _classify_member_set(
     in the reason, preferring an auth-critical member in the chosen group so its
     override is surfaced. ``descriptor`` is the leading phrase of the reason
     (e.g. "grouped bump 'group:npm_and_yarn'" or "multi-package bump").
+
+    ``body`` and ``files`` are consulted so the member-set path applies the same
+    two safety guards as the single-package path: a ``BREAKING CHANGE`` marker in
+    the body forces Group C, and an auth-critical-path diff (e.g. src/PPDS.Auth)
+    escalates to at least Group B. Without this, a member-set PR could skip both
+    guards and auto-merge despite them (regression flagged in review of #1311).
     """
     # Resolve each member's update type and individual group. Null/None update
     # types are coalesced to "unknown" by resolve_member_group, which itself
@@ -408,9 +416,25 @@ def _classify_member_set(
             f"; auth-critical override "
             f"({trigger[0]} {trigger[1]} -> {trigger[2]}, {trigger[3]})"
         )
+
+    # Safety guards the single-package path also applies — a member-set PR must
+    # not skip them. Take the most conservative of the member-set group and
+    # these two signals: an auth-critical-path diff escalates to at least Group
+    # B, and a BREAKING CHANGE marker in the body forces Group C.
+    group = chosen
+    if touches_auth_critical_path(files) and _GROUP_RANK[group] < _GROUP_RANK["B"]:
+        group = "B"
+        reason += "; escalated to Group B — diff touches auth-critical path (e.g. src/PPDS.Auth)"
+    if changelog_signals_breaking(body):
+        reason += (
+            "; PR body signals BREAKING CHANGE"
+            if group == "C"
+            else "; escalated to Group C — PR body signals BREAKING CHANGE"
+        )
+        group = "C"
     return Classification(
         pr_number=number,
-        group=chosen,
+        group=group,
         reason=reason,
         ecosystem=ecosystem,
         update_type=trigger_type,
@@ -459,7 +483,7 @@ def classify_pr(pr: dict) -> Classification:
                 to_version=None,
             )
         return _classify_member_set(
-            number, pkg, f"grouped bump '{pkg}'", members, ecosystem
+            number, pkg, f"grouped bump '{pkg}'", members, ecosystem, body, files
         )
 
     # Multi-package title (e.g. "Bump X and Y", no version in the title) —
@@ -474,7 +498,7 @@ def classify_pr(pr: dict) -> Classification:
         members = parse_group_members(body)
         if members:
             return _classify_member_set(
-                number, None, "multi-package bump", members, ecosystem
+                number, None, "multi-package bump", members, ecosystem, body, files
             )
 
     # Hard exclusion — major bumps are always Group C, no exceptions (v1-prelaunch retro).

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -59,6 +59,7 @@ TOOLING_PACKAGES = frozenset({
     "@playwright/test",
     "playwright",
     "prettier",
+    "stylelint",
     "typescript",
     "typescript-eslint",
     "@typescript-eslint/parser",
@@ -353,6 +354,72 @@ def changelog_signals_breaking(body: str) -> bool:
     return any(n in body for n in needles)
 
 
+def _classify_member_set(
+    number: int,
+    package: Optional[str],
+    descriptor: str,
+    members: list[tuple[str, str, str]],
+    ecosystem: str,
+) -> Classification:
+    """Classify a multi-member dependabot PR (grouped or multi-package title).
+
+    ``members`` is a non-empty list of (package, from_version, to_version)
+    tuples parsed from the PR body. Each member is resolved to an individual
+    group via ``resolve_member_group``; the most-conservative (C > B > A) wins
+    per docs/MERGE-POLICY.md "Grouped Dependabot PRs". A trigger member is cited
+    in the reason, preferring an auth-critical member in the chosen group so its
+    override is surfaced. ``descriptor`` is the leading phrase of the reason
+    (e.g. "grouped bump 'group:npm_and_yarn'" or "multi-package bump").
+    """
+    # Resolve each member's update type and individual group. Null/None update
+    # types are coalesced to "unknown" by resolve_member_group, which itself
+    # maps "unknown" -> Group C.
+    member_records = []
+    for p, fv, tv in members:
+        t = classify_update_type(fv, tv) or "unknown"
+        g = resolve_member_group(p, t)
+        member_records.append((p, fv, tv, t, g))
+
+    chosen = max(
+        (r[4] for r in member_records),
+        key=lambda g: _GROUP_RANK.get(g, _GROUP_RANK["C"]),
+    )
+
+    # Pick a trigger member to cite in the reason string. Prefer a member whose
+    # individual group matches the chosen group; among those, prefer an
+    # auth-critical package (so its override is named explicitly per
+    # MERGE-POLICY.md "Auth-Critical Packages").
+    chosen_members = [r for r in member_records if r[4] == chosen]
+    auth_critical_in_chosen = next(
+        (r for r in chosen_members if is_auth_critical_package(r[0])),
+        None,
+    )
+    trigger = auth_critical_in_chosen or chosen_members[0]
+    trigger_type = trigger[3]
+
+    reason = (
+        f"{descriptor} — {len(members)} members; most-conservative={trigger_type} "
+        f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
+    )
+    # When the trigger is an auth-critical package, surface that explicitly so
+    # the operator knows why the override applied.
+    if is_auth_critical_package(trigger[0]):
+        reason += (
+            f"; auth-critical override "
+            f"({trigger[0]} {trigger[1]} -> {trigger[2]}, {trigger[3]})"
+        )
+    return Classification(
+        pr_number=number,
+        group=chosen,
+        reason=reason,
+        ecosystem=ecosystem,
+        update_type=trigger_type,
+        package=package,
+        from_version=None,
+        to_version=None,
+    )
+
+
 def classify_pr(pr: dict) -> Classification:
     """Classify a single dependabot PR.
 
@@ -391,54 +458,24 @@ def classify_pr(pr: dict) -> Classification:
                 from_version=None,
                 to_version=None,
             )
-
-        # Resolve each member's update type and individual group. Null/None
-        # update types are coalesced to "unknown" by resolve_member_group,
-        # which itself maps "unknown" -> Group C.
-        member_records = []
-        for p, fv, tv in members:
-            t = classify_update_type(fv, tv) or "unknown"
-            g = resolve_member_group(p, t)
-            member_records.append((p, fv, tv, t, g))
-
-        chosen = max(
-            (r[4] for r in member_records),
-            key=lambda g: _GROUP_RANK.get(g, _GROUP_RANK["C"]),
+        return _classify_member_set(
+            number, pkg, f"grouped bump '{pkg}'", members, ecosystem
         )
 
-        # Pick a trigger member to cite in the reason string. Prefer a member
-        # whose individual group matches the chosen group; among those, prefer
-        # an auth-critical package (so its override is named explicitly per
-        # MERGE-POLICY.md "Auth-Critical Packages").
-        chosen_members = [r for r in member_records if r[4] == chosen]
-        auth_critical_in_chosen = next(
-            (r for r in chosen_members if is_auth_critical_package(r[0])),
-            None,
-        )
-        trigger = auth_critical_in_chosen or chosen_members[0]
-        trigger_type = trigger[3]
-
-        reason = (
-            f"grouped bump '{pkg}' — {len(members)} members; most-conservative={trigger_type} "
-            f"({trigger[0]} {trigger[1]} -> {trigger[2]})"
-        )
-        # When the trigger is an auth-critical package, surface that explicitly
-        # so the operator knows why the override applied.
-        if is_auth_critical_package(trigger[0]):
-            reason += (
-                f"; auth-critical override "
-                f"({trigger[0]} {trigger[1]} -> {trigger[2]}, {trigger[3]})"
+    # Multi-package title (e.g. "Bump X and Y", no version in the title) —
+    # parse_title yields no package, so a single-package classification is
+    # impossible, but dependabot still enumerates each member in the body.
+    # Route those members through the same per-member most-conservative-wins
+    # logic as grouped PRs so auth-critical members aren't lost to the Group-C
+    # "could not classify" default (real case: PR #1299 bumping two auth-critical
+    # packages). A genuinely unparseable PR (no members) falls through to that
+    # default below.
+    if pkg is None:
+        members = parse_group_members(body)
+        if members:
+            return _classify_member_set(
+                number, None, "multi-package bump", members, ecosystem
             )
-        return Classification(
-            pr_number=number,
-            group=chosen,
-            reason=reason,
-            ecosystem=ecosystem,
-            update_type=trigger_type,
-            package=pkg,
-            from_version=None,
-            to_version=None,
-        )
 
     # Hard exclusion — major bumps are always Group C, no exceptions (v1-prelaunch retro).
     if update_type == "major":

--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -479,12 +479,16 @@ def classify_pr(pr: dict) -> Classification:
             to_version=to_v,
         )
 
-    # Auth-critical package at minor — Group B.
-    if is_auth_critical_package(pkg) and update_type == "minor":
+    # Auth-critical package at any non-major version (patch OR minor) — Group B.
+    # Per docs/MERGE-POLICY.md "Auth-Critical Packages": bumps to these packages
+    # at any non-major version go through verify-then-merge. Major bumps already
+    # returned Group C above; an "unknown" update_type falls through to the final
+    # Group-C default (manual review).
+    if is_auth_critical_package(pkg) and update_type in ("patch", "minor"):
         return Classification(
             pr_number=number,
             group="B",
-            reason=f"auth-critical package {pkg} minor bump ({from_v} -> {to_v}) — verify-then-merge",
+            reason=f"auth-critical package {pkg} {update_type} bump ({from_v} -> {to_v}) — verify-then-merge",
             ecosystem=ecosystem,
             update_type=update_type,
             package=pkg,

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -591,6 +591,68 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "C")
         self.assertIn("could not classify", c.reason)
 
+    # Member-set safety guards — the grouped/multi-package path must apply the
+    # same body/path checks as the single-package path (regression from #1311
+    # review: _classify_member_set() returned before these guards ran).
+
+    def test_grouped_breaking_marker_forces_group_c(self):
+        # An all-patch group (would be Group A) whose body carries a BREAKING
+        # CHANGE marker must be forced to Group C, exactly like a single PR.
+        pr = make_pr(
+            number=1310,
+            title="Bump the npm_and_yarn group across 1 directory with 2 updates",
+            body=(
+                "Bumps the npm_and_yarn group with 2 updates:\n\n"
+                "Updates `foo` from 1.0.0 to 1.0.1\n"
+                "Updates `bar` from 2.3.4 to 2.3.5\n\n"
+                "> BREAKING CHANGE: the foo API was removed.\n"
+            ),
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/group-update",
+            files=["src/PPDS.Extension/package.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertIn("BREAKING CHANGE", c.reason)
+
+    def test_multi_package_breaking_marker_forces_group_c(self):
+        # Same guard on the multi-package ("Bump X and Y") path.
+        pr = make_pr(
+            number=1311,
+            title="Bump Foo and Bar",
+            body=(
+                "Bumps Foo and Bar.\n\n"
+                "Updated [Foo](https://example.com/foo) from 1.0.0 to 1.0.1.\n"
+                "Updated [Bar](https://example.com/bar) from 2.3.4 to 2.3.5.\n\n"
+                "Includes a BREAKING CHANGE in Foo.\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/foo-and-bar",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertIn("BREAKING CHANGE", c.reason)
+
+    def test_member_set_auth_critical_path_escalates_to_group_b(self):
+        # An all-patch, non-critical group (would be Group A) whose diff touches
+        # an auth-critical path (src/PPDS.Auth/**) must escalate to at least B.
+        pr = make_pr(
+            number=1312,
+            title="Bump the nuget group across 1 directory with 2 updates",
+            body=(
+                "Bumps the nuget group with 2 updates:\n\n"
+                "Updates `Foo` from 1.0.0 to 1.0.1\n"
+                "Updates `Bar` from 2.3.4 to 2.3.5\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/group-update",
+            files=["Directory.Packages.props", "src/PPDS.Auth/Credentials/Foo.cs"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertIn("auth-critical path", c.reason)
+
     # Group C — manual review
 
     def test_major_npm_is_group_c(self):

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -248,6 +248,28 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.update_type, "minor")
         self.assertIn("auth-critical", c.reason)
 
+    def test_patch_auth_critical_is_group_b(self):
+        # Regression for real PR #1288: an auth-critical PATCH bump
+        # (System.Security.Cryptography.Pkcs 10.0.5 -> 10.0.9) must go through
+        # verify-then-merge (Group B), NOT auto-merge (Group A). Per
+        # docs/MERGE-POLICY.md, auth-critical packages route to Group B at any
+        # non-major version — patch included. Before the fix this fell through
+        # to the generic "patch bump on non-critical path" branch and became A.
+        pr = make_pr(
+            number=1288,
+            title="Bump System.Security.Cryptography.Pkcs from 10.0.5 to 10.0.9",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/System.Security.Cryptography.Pkcs-10.0.9",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertEqual(c.update_type, "patch")
+        self.assertIn("auth-critical", c.reason)
+        # Reason should reflect the actual update type, not be hard-coded to "minor".
+        self.assertIn("patch", c.reason)
+        self.assertNotIn("minor", c.reason)
+
     def test_minor_azure_identity_is_group_b(self):
         pr = make_pr(
             number=841,
@@ -498,6 +520,22 @@ class TestClassifyPR(unittest.TestCase):
         )
         c = classify.classify_pr(pr)
         self.assertEqual(c.group, "C")
+
+    def test_major_auth_critical_is_group_c(self):
+        # An auth-critical MAJOR bump must still be Group C (universal major
+        # exclusion outranks the auth-critical Group-B override). Guards against
+        # the patch/minor override broadening to swallow majors.
+        pr = make_pr(
+            number=1289,
+            title="Bump Microsoft.Identity.Client from 4.56.0 to 5.0.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Microsoft.Identity.Client-5.0.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("major", c.reason)
 
     def test_major_github_actions_is_group_c(self):
         # actions/checkout v3 -> v4 is a major and should be Group C

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -186,6 +186,21 @@ class TestClassifyPR(unittest.TestCase):
         # but knip is tooling, so it's still A
         self.assertIn("tooling", c.reason)
 
+    def test_minor_stylelint_is_group_a(self):
+        # stylelint is a dev-time CSS linter (same class as eslint/knip/prettier)
+        # — a minor bump must be Group A (tooling), not Group B. Real case: PR #1279.
+        pr = make_pr(
+            number=1279,
+            title="Bump stylelint from 17.11.1 to 17.14.0",
+            labels=["npm", "dependencies"],
+            head_ref="dependabot/npm_and_yarn/stylelint-17.14.0",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
     def test_patch_nuget_test_sdk_is_group_a(self):
         pr = make_pr(
             number=824,
@@ -493,6 +508,88 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.group, "B")
         self.assertIn("auth-critical", c.reason)
         self.assertIn("Azure.Identity", c.reason)
+
+    # Multi-package "Bump X and Y" titles (no version in title) — issue #1299.
+    # parse_title yields no package; members are recovered from the body and run
+    # through the same most-conservative-wins logic as grouped PRs.
+
+    def test_multi_package_auth_critical_minor_is_group_b(self):
+        # Real PR #1299: title bumps two auth-critical packages with no version;
+        # the body enumerates both as minor bumps. Must classify Group B
+        # (auth-critical), NOT default to Group C "could not classify".
+        pr = make_pr(
+            number=1299,
+            title="deps: Bump Microsoft.Identity.Client and Microsoft.Identity.Client.Extensions.Msal",
+            body=(
+                "Bumps Microsoft.Identity.Client and Microsoft.Identity.Client.Extensions.Msal.\n\n"
+                "Updated [Microsoft.Identity.Client](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) from 4.84.2 to 4.85.2.\n"
+                "Updated [Microsoft.Identity.Client.Extensions.Msal](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet) from 4.84.2 to 4.85.2.\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/microsoft.identity.client-and-msal",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "B")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("multi-package", c.reason)
+        self.assertIn("auth-critical", c.reason)
+        self.assertIn("Microsoft.Identity.Client", c.reason)
+
+    def test_multi_package_with_major_member_is_group_c(self):
+        # A multi-package title where one member is a major bump — most
+        # conservative wins, so the whole PR is Group C.
+        pr = make_pr(
+            number=1300,
+            title="Bump Foo and Bar",
+            body=(
+                "Bumps Foo and Bar.\n\n"
+                "Updated [Foo](https://example.com/foo) from 1.0.0 to 1.0.1.\n"
+                "Updated [Bar](https://example.com/bar) from 2.0.0 to 3.0.0.\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/foo-and-bar",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("most-conservative=major", c.reason)
+
+    def test_multi_package_all_patch_non_critical_is_group_a(self):
+        # Two non-critical patch members via a multi-package title — Group A.
+        pr = make_pr(
+            number=1301,
+            title="Bump Foo and Bar",
+            body=(
+                "Bumps Foo and Bar.\n\n"
+                "Updated [Foo](https://example.com/foo) from 1.0.0 to 1.0.1.\n"
+                "Updated [Bar](https://example.com/bar) from 2.3.4 to 2.3.5.\n"
+            ),
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/foo-and-bar",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "patch")
+        self.assertIn("multi-package", c.reason)
+
+    def test_multi_package_unparseable_body_is_group_c(self):
+        # A title that parse_title can't resolve AND a body with no parseable
+        # member lines must still fall through to the Group-C "could not
+        # classify" default (guards the multi-package path from over-reaching).
+        pr = make_pr(
+            number=1302,
+            title="Bump Foo and Bar",
+            body="This body has no dependabot 'Updated pkg from A to B' lines.",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/foo-and-bar",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "C")
+        self.assertIn("could not classify", c.reason)
 
     # Group C — manual review
 


### PR DESCRIPTION
Three dependabot-classifier correctness fixes, all surfaced by the same `/dependabot-triage` run. `docs/MERGE-POLICY.md` is authoritative and unchanged — these are code-catches-up-to-doc fixes.

---

## Fix 1 — auth-critical PATCH bumps wrongly auto-merge-eligible (real PR #1288)

**Policy:** auth-critical packages (`Microsoft.Identity.Client`, `Azure.Identity`, `System.Security.Cryptography.Pkcs`, …) go through **Group B (verify-then-merge)** at **any non-major version** — patch included.

**Bug:** the single-PR path in `classify_pr()` gated the override on `update_type == "minor"` only, so an auth-critical **patch** bump fell through to the generic `patch → Group A` branch (auto-merge). Caught on PR #1288 (`System.Security.Cryptography.Pkcs` 10.0.5→10.0.9).

**Fix:** `is_auth_critical_package(pkg) and update_type in ("patch", "minor")`, and the reason string now interpolates the actual `update_type`. `major` already returns Group C earlier; auth-critical `unknown` still falls through to the Group-C manual-review default. The grouped-PR path was already correct and is untouched.

## Fix 2 — multi-package "Bump X and Y" titles not parsed (real PR #1299)

**Bug:** a title like `Bump Microsoft.Identity.Client and Microsoft.Identity.Client.Extensions.Msal` carries no version, so `parse_title()` returned `(None, None, None)`, `update_type` became `"unknown"`, and `classify_pr()` fell through to the Group-C "could not classify" default — even though the body enumerates both members as auth-critical **minor** bumps that should be **Group B**.

**Fix:** when the single-title parse yields no package and the title is not a `group:` title, attempt `parse_group_members(body)`; if it finds ≥1 members, route them through the **same** per-member most-conservative-wins logic the grouped path uses. That block was factored out of the grouped branch into a shared `_classify_member_set()` helper, so the `group:` path and the new multi-package path reuse it (no duplication). A genuinely unparseable PR (no title parse **and** no body members) still hits the Group-C default. Normal single-package and `group:` PRs are unchanged.

## Fix 3 — `stylelint` missing from `TOOLING_PACKAGES` (real PR #1279)

**Bug:** `stylelint` is a dev-time CSS linter (same class as eslint/knip/prettier), but its absence routed a stylelint minor bump to Group B instead of Group A.

**Fix:** added `"stylelint"` to the `TOOLING_PACKAGES` frozenset.

---

## Tests

Added regression coverage in `tests/scripts/dependabot/test_classify.py`:
- auth-critical **PATCH** (`Pkcs` 10.0.5→10.0.9) → **B**; auth-critical **MAJOR** (`Identity.Client` 4→5) still → **C**
- multi-package auth-critical minor (#1299) → **B** (reason names the auth-critical package); multi-package with a major member → **C**; two non-critical patch members → **A**; unparseable body → **C** "could not classify"
- `stylelint` minor (#1279) → **A** (tooling)

Existing auth-critical minor → B, non-auth-critical patch → A, all `group:` cases, and `TestAuthCriticalDocCodeDrift` remain green (no change touches the auth-critical list). Full suite: **64 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency update classification for multi-package PRs by evaluating each member and applying the most-conservative A/B/C outcome, with consistent safety guards.
  * Enhanced auth-critical handling: auth-critical patch/minor bumps now map to Group B (major remains Group C) with bump-specific reasons.
  * Expanded tooling attribution allowlist to include `stylelint`.
* **Tests**
  * Added regression coverage for tooling-style packages, auth-critical patch/minor/major, multi-package edge cases (including BREAKING CHANGE forcing Group C), and reason-message assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->