### PR TITLE
fix(auth-tests): serialize interop test TFMs to fix parallel credential-vault race (#1047)

### DIFF
--- a/tests/PPDS.Auth.IntegrationTests/PPDS.Auth.IntegrationTests.csproj
+++ b/tests/PPDS.Auth.IntegrationTests/PPDS.Auth.IntegrationTests.csproj
@@ -7,6 +7,21 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!--
+      Run the per-TFM test hosts sequentially, not in parallel. The .NET 9+ SDK runs
+      `dotnet test` on a multi-TFM project with all target frameworks in parallel by
+      default (introduced in .NET 9 Preview 2). NativeCredentialStoreInteropTests
+      exercises the real per-user OS credential vault (Windows Credential Manager,
+      macOS Keychain, libsecret), and Get/Remove enumerate the *entire* vault via
+      CredEnumerate before filtering. Three TFM host processes mutating and enumerating
+      the same shared vault concurrently race: a CredRead can observe null while a
+      concurrent CredWrite from another TFM is in flight, failing the round-trip
+      (issue #1047). Per-appId GUIDs do not prevent this — the contention is at the
+      vault/enumeration level, not on the key. Forcing sequential TFM execution removes
+      the concurrency entirely without weakening coverage: every TFM still runs its
+      platform-native round-trip, just one at a time. See #1047.
+    -->
+    <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The `Credential Store Interop` workflow fails intermittently on the **windows-latest** leg (and, less often, ubuntu-latest) whenever a PR touches its path filter (`Directory.Packages.props`, `Directory.Build.props`, `src/PPDS.Auth/**`). This makes unrelated dependency bumps get a spurious red X.

This serializes the per-TFM test hosts so the interop round-trip stops racing on the shared OS credential vault.

`Fixes #1047`

## Root cause

`NativeCredentialStoreInteropTests` round-trips a secret through the **real per-user OS credential vault** (Windows Credential Manager / macOS Keychain / libsecret). The test project multi-targets `net8.0;net9.0;net10.0`.

The **.NET 9+ SDK runs `dotnet test` on a multi-TFM project with all target frameworks in parallel by default** (introduced in .NET 9 Preview 2). This workflow installs the 10.0.x SDK, so it silently opted into that behavior. Three TFM host processes then hit the *same* per-user vault concurrently. `NativeCredentialStore.GetAsync`/`RemoveAsync` resolve an entry via `WindowsCredentialManager.Get` → `Enumerate` → `CredEnumerate(null, AllCredentials)` — a **full-vault enumeration** filtered in-process. A `CredRead`/enumeration can observe `null` for a just-written entry while a concurrent `CredWrite` from another TFM host is in flight, so `Windows_RoundTripsSecret` fails at `retrieved.Should().NotBeNull()`.

Evidence from run [29164790261](https://github.com/joshsmithxrm/power-platform-developer-suite/actions/runs/29164790261) (windows-latest), where two TFM hosts finished ~milliseconds apart with interleaved output — one passing, one failing at `NativeCredentialStoreInteropTests.cs:53`:

```
Windows_RoundTripsSecret [FAIL]   ...NativeCredentialStoreInteropTests.cs:line 53
Test Run Failed. Total tests: 3  Failed: 1  Skipped: 2
```

### Not the skip reporting

The `MacOS_/Linux_RoundTripsSecret [SKIP] — Exception of type 'Xunit.SkipException' was thrown` lines are a **red herring**: in the same logs those tests are correctly tallied as `Skipped`, and TFM hosts that don't hit the race pass green (`Passed: 1, Skipped: 2`). `Xunit.SkippableFact` is working. The only red is the parallel-vault race on `Windows_RoundTripsSecret` — exactly the bug #1047 documents.

### Why not "namespace the appId per TFM" (issue's option 1)

The appId is already globally unique per test instance (`ppds-interop-test-{Guid.NewGuid():N}`). The contention is **not a key collision** — it's at the vault/enumeration level (`CredEnumerate` over the whole vault, plus a shared `_manifest` entry every write updates). Adding the TFM to an already-unique key would not reduce concurrent vault mutations, so it would not fix the race.

## Fix

Set `<TestTfmsInParallel>false</TestTfmsInParallel>` on `PPDS.Auth.IntegrationTests.csproj` — the documented, first-class opt-out for the SDK's parallel multi-TFM behavior. The three TFM hosts now run one at a time, eliminating concurrent access to the shared vault. This fixes the Windows Credential Manager race and the identical libsecret race noted on the issue.

Placing it in the csproj (rather than the workflow command line) makes the constraint travel with the project across CI, local `dotnet test`, and IDE runs — so no future invocation can silently reintroduce the race.

**Coverage is unchanged:** every TFM still runs its platform-native round-trip; they just run sequentially.

## Verification

- `dotnet build PPDS.sln` — 0 errors.
- `dotnet test PPDS.sln --filter "Category!=Integration"` — 0 failures (full unit suite via pre-commit hook).
- Interop tests run the workflow's way on Windows (SDK 10.0.109, parallel-by-default regime):
  - All 3 TFM hosts run **sequentially** (74/64/52 ms, no interleaving), exit 0.
  - `Windows_RoundTripsSecret` runs and **passes**; `MacOS_/Linux_RoundTripsSecret` report **Skipped**, not Failed.
  - `dotnet build ... -getProperty:TestTfmsInParallel` → `false`, confirming the property is honored.

## Scope

Independent of #1305 (plugins-extract); this only changes the interop test project's build property. A separate latent concern — that two concurrent `ppds` processes could hit the same full-vault enumeration race in product code — is out of scope for this test-hardening fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test execution to run target frameworks sequentially, improving reliability for credential store interoperability tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->