### PR TITLE
refactor(version): extract shared AssemblyInformationalVersion read into AssemblyVersionInfo

### DIFF
--- a/src/PPDS.Cli/Commands/ErrorOutput.cs
+++ b/src/PPDS.Cli/Commands/ErrorOutput.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using PPDS.Cli.Infrastructure;
 
 namespace PPDS.Cli.Commands;
 
@@ -56,8 +57,9 @@ public static class ErrorOutput
     /// </summary>
     private static string GetInformationalVersion(Assembly assembly)
     {
-        // InformationalVersion includes pre-release suffix and commit hash (e.g., "1.2.3-beta.1+abc1234")
-        var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        // InformationalVersion includes pre-release suffix and commit hash (e.g., "1.2.3-beta.1+abc1234").
+        // The CLI intentionally keeps the '+<sha>' build-metadata suffix for diagnostics.
+        var infoVersion = AssemblyVersionInfo.GetInformationalVersion(assembly);
         if (!string.IsNullOrEmpty(infoVersion))
         {
             return infoVersion;

--- a/src/PPDS.Cli/Infrastructure/AssemblyVersionInfo.cs
+++ b/src/PPDS.Cli/Infrastructure/AssemblyVersionInfo.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+
+namespace PPDS.Cli.Infrastructure;
+
+/// <summary>
+/// Shared reflection primitive for reading an assembly's MinVer-stamped informational version.
+/// Both the CLI diagnostics header (<see cref="Commands.ErrorOutput"/>) and the MCP
+/// <c>serverInfo.version</c> resolver read <see cref="AssemblyInformationalVersionAttribute"/>
+/// off an assembly; this centralizes that one raw read.
+/// </summary>
+/// <remarks>
+/// Callers apply their own formatting on top: the CLI intentionally keeps the
+/// '+&lt;sha&gt;' build-metadata suffix for diagnostics, while MCP strips it. This helper
+/// therefore returns the raw attribute value verbatim — no trimming, stripping, or fallback.
+/// </remarks>
+public static class AssemblyVersionInfo
+{
+    /// <summary>
+    /// Reads the raw <see cref="AssemblyInformationalVersionAttribute.InformationalVersion"/>
+    /// from the given assembly, or <c>null</c> when the attribute is absent.
+    /// </summary>
+    /// <param name="assembly">The assembly to read version metadata from.</param>
+    public static string? GetInformationalVersion(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+    }
+}

--- a/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
+++ b/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using PPDS.Cli.Infrastructure;
 
 namespace PPDS.Mcp.Infrastructure;
 
@@ -32,9 +33,7 @@ internal static class ServerVersion
     {
         ArgumentNullException.ThrowIfNull(assembly);
 
-        var informationalVersion = assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-            .InformationalVersion;
+        var informationalVersion = AssemblyVersionInfo.GetInformationalVersion(assembly);
 
         var fileVersion = assembly
             .GetCustomAttribute<AssemblyFileVersionAttribute>()?

--- a/tests/PPDS.Cli.Tests/Infrastructure/AssemblyVersionInfoTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/AssemblyVersionInfoTests.cs
@@ -25,6 +25,7 @@ public class AssemblyVersionInfoTests
         // helper must return exactly that value — no trimming, stripping, or normalization.
         var assembly = typeof(AssemblyVersionInfoTests).Assembly;
         var expected = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        Assert.NotNull(expected); // guard against a vacuous null == null pass if the attribute is absent
 
         var actual = AssemblyVersionInfo.GetInformationalVersion(assembly);
 

--- a/tests/PPDS.Cli.Tests/Infrastructure/AssemblyVersionInfoTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/AssemblyVersionInfoTests.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using PPDS.Cli.Infrastructure;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Infrastructure;
+
+/// <summary>
+/// Tests for <see cref="AssemblyVersionInfo"/> — the shared raw read of an assembly's
+/// <see cref="AssemblyInformationalVersionAttribute"/> used by both the CLI diagnostics
+/// header and the MCP serverInfo.version resolver.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AssemblyVersionInfoTests
+{
+    [Fact]
+    public void GetInformationalVersion_NullAssembly_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => AssemblyVersionInfo.GetInformationalVersion(null!));
+    }
+
+    [Fact]
+    public void GetInformationalVersion_ReturnsRawAttributeValueVerbatim()
+    {
+        // The test assembly is stamped with an AssemblyInformationalVersionAttribute, so the
+        // helper must return exactly that value — no trimming, stripping, or normalization.
+        var assembly = typeof(AssemblyVersionInfoTests).Assembly;
+        var expected = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        var actual = AssemblyVersionInfo.GetInformationalVersion(assembly);
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the one duplicated reflection read of `AssemblyInformationalVersionAttribute` into a shared helper, `PPDS.Cli.Infrastructure.AssemblyVersionInfo.GetInformationalVersion(Assembly)`. Behavior-preserving cleanup.

Before, two surfaces independently performed the same raw attribute read:
- `ErrorOutput.GetInformationalVersion` (CLI diagnostics header)
- `ServerVersion.Resolve` (MCP `serverInfo.version`)

## What changed

- **New:** `src/PPDS.Cli/Infrastructure/AssemblyVersionInfo.cs` — a single public static that returns the raw `InformationalVersion` verbatim (no trimming, stripping, or fallback).
- `ErrorOutput` and `ServerVersion` now call the helper for the raw read; **each keeps its own formatting and fallback**:
  - CLI intentionally **keeps** the `+<sha>` build-metadata suffix and falls back to `AssemblyName.Version` (`{Major}.{Minor}.{Build}`).
  - MCP intentionally **strips** the `+<sha>` suffix and falls back to `AssemblyFileVersion`, then `"0.0.0"`.
- **New test:** `AssemblyVersionInfoTests` (null-arg throws; returns the raw attribute value verbatim).

The helper lives in PPDS.Cli because PPDS.Mcp already references PPDS.Cli (never the reverse) and there is no shared Core/Common project; PPDS.Cli has no `PublicAPI.*.txt` tracking, so `public` adds no API-surface bookkeeping.

## Why

Removes a small duplication flagged as a non-blocking nit during the #1273 self-review and deliberately deferred to keep that PR surgical. Done now that both callers coexist on `main`.

## Testing

- Full non-integration suite green on net8.0/net9.0/net10.0 (incl. `ServerVersionTests` 9/9 and new `AssemblyVersionInfoTests` 2/2); pre-commit hook re-ran build + tests.
- `ServerVersionTests.Resolve_RealPpdsMcpAssembly_...` exercises the real MinVer-stamped assembly through the new helper, confirming MCP `serverInfo.version` still resolves to a real, suffix-stripped, non-`1.0.0.0` value.
- Interactive CLI/MCP exe smoke test was not run — blocked by the env-safety hook (active env outside the allowlist); not bypassed. No surface behavior changes.

## Context

Follow-up to #1273 (no separate tracking issue). Pre-PR self-review: 0 must-fix, 0 should-fix, 2 nits (both acceptable as shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved informational version reporting across CLI and server components.
  * CLI and server now consistently read informational versions via a shared helper, preserving `+<sha>` build metadata for diagnostics.

* **Tests**
  * Added unit tests for the new informational-version helper, including null-argument validation and verbatim retrieval of informational-version values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->