### PR TITLE
fix(mcp): implement documented --version flag (#1324)

### DIFF
--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ppds-mcp-server --version` prints the package version and exits** — previously the flag was documented in the README's bug-report instructions but unhandled: the server started normally and blocked silently waiting for MCP protocol messages on stdin. `--version` anywhere in the argument list now short-circuits startup, prints the MinVer-resolved version to stdout, and exits 0 ([#1273](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1273), [#1324](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1324)).
+
 ## [1.0.1] - 2026-06-17
 
 ### Added

--- a/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
+++ b/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
@@ -48,8 +48,12 @@ public sealed class McpSessionOptions
     /// server startup entirely: Program.cs prints the resolved version to stdout and
     /// exits instead of hosting, so <see cref="Parse"/> semantics never apply.
     /// </summary>
-    public static bool IsVersionRequested(string[] args) =>
-        args.Contains("--version", StringComparer.Ordinal);
+    public static bool IsVersionRequested(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        return args.Contains("--version", StringComparer.Ordinal);
+    }
 
     /// <summary>
     /// Parses command-line arguments into session options.

--- a/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
+++ b/src/PPDS.Mcp/Infrastructure/McpSessionOptions.cs
@@ -43,6 +43,15 @@ public sealed class McpSessionOptions
     }
 
     /// <summary>
+    /// Checks whether the arguments request version output (<c>--version</c> anywhere in
+    /// the argument list, regardless of other flags). A version request short-circuits
+    /// server startup entirely: Program.cs prints the resolved version to stdout and
+    /// exits instead of hosting, so <see cref="Parse"/> semantics never apply.
+    /// </summary>
+    public static bool IsVersionRequested(string[] args) =>
+        args.Contains("--version", StringComparer.Ordinal);
+
+    /// <summary>
     /// Parses command-line arguments into session options.
     /// Unknown args are passed through to the host builder.
     /// </summary>

--- a/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
+++ b/src/PPDS.Mcp/Infrastructure/ServerVersion.cs
@@ -26,8 +26,10 @@ internal static class ServerVersion
     /// Resolves the reportable version from the given assembly's version attributes.
     /// </summary>
     /// <param name="assembly">
-    /// The assembly to read version metadata from — pass <c>Assembly.GetExecutingAssembly()</c>
-    /// from Program.cs to resolve ppds-mcp-server's own MinVer-stamped version.
+    /// The assembly to read version metadata from — pass <c>typeof(ServerVersion).Assembly</c>
+    /// to resolve ppds-mcp-server's own MinVer-stamped version, independent of which entry
+    /// assembly is executing (this is what Program.cs does for both the MCP handshake and
+    /// <c>--version</c>).
     /// </param>
     internal static string Resolve(Assembly assembly)
     {

--- a/src/PPDS.Mcp/Program.cs
+++ b/src/PPDS.Mcp/Program.cs
@@ -7,6 +7,16 @@ using PPDS.Cli.Services;
 using PPDS.Dataverse.DependencyInjection;
 using PPDS.Mcp.Infrastructure;
 
+// --version short-circuits startup entirely: print the resolved package version and exit
+// instead of hosting. This must run before the stdout redirect below — version output is
+// data, and stdout is only reserved for the protocol once the server actually runs.
+// Documented in the README's "Report a Bug" section; see #1273/#1324.
+if (McpSessionOptions.IsVersionRequested(args))
+{
+    Console.WriteLine(ServerVersion.Resolve(typeof(ServerVersion).Assembly));
+    return 0;
+}
+
 // MCP servers MUST NOT write to stdout (reserved for protocol).
 // Redirect all console output to stderr before any logging occurs.
 Console.SetOut(Console.Error);
@@ -65,6 +75,7 @@ builder.Services.AddCliApplicationServices();
 
 var host = builder.Build();
 await host.RunAsync();
+return 0;
 
 // --- helpers -----------------------------------------------------------------
 

--- a/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
@@ -170,6 +170,16 @@ public sealed class McpSessionOptionsTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public void IsVersionRequested_NullArgs_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => McpSessionOptions.IsVersionRequested(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
     #endregion
 
     #region IsEnvironmentAllowed Tests

--- a/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
+++ b/tests/PPDS.Mcp.Tests/Infrastructure/McpSessionOptionsTests.cs
@@ -115,6 +115,63 @@ public sealed class McpSessionOptionsTests
 
     #endregion
 
+    #region IsVersionRequested Tests
+
+    [Fact]
+    public void IsVersionRequested_WithVersionFlag_ReturnsTrue()
+    {
+        // Arrange
+        var args = new[] { "--version" };
+
+        // Act
+        var result = McpSessionOptions.IsVersionRequested(args);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsVersionRequested_VersionAmongOtherArgs_ReturnsTrue()
+    {
+        // Arrange — --version must short-circuit no matter where it appears
+        // (e.g. `ppds-mcp-server --profile Dev --version`).
+        var args = new[] { "--profile", "Dev", "--version", "--read-only" };
+
+        // Act
+        var result = McpSessionOptions.IsVersionRequested(args);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsVersionRequested_WithoutVersionFlag_ReturnsFalse()
+    {
+        // Arrange — ordinary session args must take the normal startup path.
+        var args = new[] { "--profile", "Dev", "--read-only" };
+
+        // Act
+        var result = McpSessionOptions.IsVersionRequested(args);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsVersionRequested_EmptyArgs_ReturnsFalse()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+
+        // Act
+        var result = McpSessionOptions.IsVersionRequested(args);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
     #region IsEnvironmentAllowed Tests
 
     [Fact]


### PR DESCRIPTION
## Problem

`ppds-mcp-server --version` is documented in the package README (the "Report a Bug" section tells users to include its output) and was explicitly promised in #1273's Expected section — but the flag was never handled. `McpSessionOptions.Parse` ignores it and `Program.cs` unconditionally builds and runs the stdio host, so the command produces no output and blocks silently waiting for MCP protocol messages on stdin.

#1304 delivered the `serverInfo.version` half of #1273; this PR completes the second expectation (the CLI flag). Found during post-merge weekend review of #1304.

Closes #1324

## Fix

- **`McpSessionOptions.IsVersionRequested(string[] args)`** — small pure static helper: `--version` anywhere in the argument list requests version output, so it works regardless of other session flags (`--profile x --version` still short-circuits). Program.cs keeps only the I/O.
- **`Program.cs`** — on a version request, print `ServerVersion.Resolve(typeof(ServerVersion).Assembly)` to stdout and exit 0, *before* the `Console.SetOut(Console.Error)` redirect and before building the host. Version output is data, so stdout is correct; stdout is only protocol-reserved once the server actually runs. (Top-level statements now return an exit code, so the normal path gained an explicit trailing `return 0;`.)
- **`ServerVersion.cs`** — fixed stale xmldoc that still said to pass `Assembly.GetExecutingAssembly()`; the actual pattern (chosen during #1304 review) is `typeof(ServerVersion).Assembly`, which is host-independent.
- **`CHANGELOG.md`** — `[Unreleased]` > `### Added` entry.

## Tests

4 new unit tests in `McpSessionOptionsTests` covering `IsVersionRequested`: flag alone, flag among other args, args without the flag (normal startup path), and empty args.

```
Passed!  - Failed:     0, Passed:   165, Skipped:     3, Total:   168, Duration: 1 s - PPDS.Mcp.Tests.dll (net8.0)
Passed!  - Failed:     0, Passed:   165, Skipped:     3, Total:   168, Duration: 1 s - PPDS.Mcp.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:   165, Skipped:     3, Total:   168, Duration: 1 s - PPDS.Mcp.Tests.dll (net10.0)
```

Full-solution build clean (0 errors); the pre-commit gate's full .NET suite passed. Smoke-tested the built binary: `--version` prints `1.0.2-alpha.0.32` to stdout with exit code 0 and nothing on stderr; `--profile x --version` behaves identically.

> **Note:** the `[Unreleased]` changelog entry may trivially conflict with a pending changelog backfill PR touching the same section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--version` command-line option that displays the resolved server version and exits immediately.
  - Version checks work when combined with other command-line options.

- **Bug Fixes**
  - Normal server shutdown now returns a successful exit code.

- **Tests**
  - Added coverage for version detection, empty arguments, mixed options, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->