### PR TITLE
docs(changelog): backfill [Unreleased] entries for 2026-07-11 weekend merges

### DIFF
--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--reference-dir` on `ppds plugins extract`** — repeatable option naming additional directories to search for a plugin's referenced assemblies when they live outside the input assembly's folder (#1294).
+
 ### Changed
 - **Kebab-case top-level command names** — `ppds plugintraces` → `ppds plugin-traces`, `ppds environmentvariables` → `ppds environment-variables`, `ppds connectionreferences` → `ppds connection-references`, and `ppds importjobs` → `ppds import-jobs` are now the canonical names, consistent with `deployment-settings`, `service-endpoints`, and `custom-apis`. The old run-together names still work as deprecated aliases (`command.Aliases`) and print a one-line `warning: '<old>' is deprecated; use '<new>'` to stderr; `webresources` is intentionally exempt as a platform compound term (#1246).
+- **`--output-format Csv` now fails with a clear error on commands that don't implement CSV rendering** — previously the flag was accepted everywhere but silently rendered Text on all but four commands (`schema compare` alone already rejected it). The CSV-capable commands (`query sql`, `query fetch`, `query history execute`, `plugin-traces list`) are unchanged; `query sql` additionally rejects Csv with `--explain`/`--show-fetchxml`. Scripts passing Csv to other commands now exit non-zero instead of succeeding with wrong-format output (#1076, #1078).
+
+### Fixed
+- **`ppds plugins diff|deploy|clean` no longer abort when the environment contains duplicate plugin step names** — steps are now matched by functional identity (plugin type, message, entity, stage, mode) instead of mutable display name, so a PreOperation/PostOperation pair sharing a Plugin Registration Tool auto-name is disambiguated and each write targets the exact row by GUID (previously `UpsertStepAsync` could update an arbitrary same-named row). Renamed environment steps converge back to the configured name on deploy and surface as `name` drift in `diff`. Behavior change: a stage/mode edit is now delete+create — the new step is created and the old one remains active until removed with `--clean`; deploy warns loudly (stderr and JSON `warnings`) about such leftover steps, and residual identity collisions warn instead of aborting (#1295).
+- **Invalid `--output-format` values no longer leak the internal CLR type name** — errors now read `Invalid value 'X' for --output-format. Valid values: Text, Json.`; empty query results with `-f Csv` emit the header row instead of zero bytes (#1076, #1078).
+- **`ppds plugins extract` now works from single-file/self-contained CLI builds** — the CLI embeds the .NET Framework 4.6.2 reference assemblies and seeds the metadata resolver from them, so extraction no longer fails with `Could not find core assembly` when run from the standalone binary; `.nupkg` extraction also surfaces assembly-load failures (an error when nothing could be extracted, per-assembly stderr warnings otherwise) instead of silently reporting 0 plugin types (#1294).
 
 ## [1.2.0] - 2026-06-17
 

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP `initialize` handshake now reports the real package version** — `serverInfo.version` previously reported the fixed `AssemblyVersion` (`1.0.0.0`) regardless of the installed package; it now reports the MinVer-stamped package version (e.g. `1.0.2-alpha.0.5`) with the `+<sha>` build-metadata suffix stripped ([#1273](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1273)).
+
 ## [1.0.1] - 2026-06-17
 
 ### Added


### PR DESCRIPTION
## Summary

Docs-only backfill of `[Unreleased]` changelog entries for the user-facing PRs merged in the 2026-07-11 weekend push. Four fix PRs shipped without self-documenting: #1302, #1303, #1304, #1305 (the kebab-case rename #1307 already carried its own entry, which is left untouched). No code changes.

### `src/PPDS.Cli/CHANGELOG.md`

- **Added** — `--reference-dir` on `ppds plugins extract`: repeatable option for referenced assemblies living outside the input assembly's folder (#1294, shipped in #1305).
- **Changed** — `--output-format Csv` now fails with a clear error on commands that don't implement CSV rendering, instead of silently emitting Text; the four CSV-capable commands are unchanged, and `query sql` rejects Csv with `--explain`/`--show-fetchxml` (#1076/#1078, shipped in #1303).
- **Fixed** — `plugins diff|deploy|clean` no longer abort on duplicate environment step names: functional-identity matching, GUID-targeted writes, name-drift reporting/convergence, stage/mode edits as delete+create with loud orphan warnings (#1295, shipped in #1302).
- **Fixed** — invalid `--output-format` values get a clean error without the internal CLR type name; empty query results with `-f Csv` emit the header row (#1076/#1078, shipped in #1303).
- **Fixed** — `plugins extract` works from single-file/self-contained builds via embedded net462 reference assemblies; `.nupkg` extraction surfaces assembly-load failures instead of silently reporting 0 plugin types (#1294, shipped in #1305).

### `src/PPDS.Mcp/CHANGELOG.md`

- **Fixed** — MCP `initialize` handshake reports the MinVer-stamped package version (build-metadata suffix stripped) instead of the fixed `AssemblyVersion` `1.0.0.0` (#1273, shipped in #1304).

## Verification

Every behavioral claim in every entry was checked against the implementing PR's actual diff (`gh pr view` + `gh pr diff` for #1302, #1303, #1304, #1305), not taken from PR descriptions: the option shape (`--reference-dir` repeatable via `AllowMultipleArgumentsPerToken`), the exact error-message strings, the warning destinations (stderr + JSON `warnings` — the deploy warning text itself says orphans "remain active" until `--clean`), the GUID-conditioned update in `UpsertStepAsync`, the `name` drift `PropertyChange`, the empty-CSV header guard (`Columns.Count` replacing `Count`), the nupkg error-vs-warning split, and the `+<metadata>`-stripping `ServerVersion.Resolve`. One correction surfaced by that pass: `schema compare` already rejected Csv before #1303 (the central validator preserves its message byte-for-byte, per that PR's regression test), so the Changed entry notes it as the one prior exception rather than claiming a universal silent-Text fallback.

## Coordination note

An in-flight fix PR (`fix/mcp-version-flag`) will add an `### Added` entry to the same PPDS.Mcp `[Unreleased]` section — whichever of the two merges second needs a trivial rebase of that section.

Not documented, per curation: dependency bumps (#1297/#1299/#1300 — user decision), #1323 (pure refactor, verified no observable change), and automation/infra/docs PRs (#1306, #1308, #1311, #1315, #1320, #1321 — not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--reference-dir` support to `ppds plugins extract`, enabling searches across additional assembly directories.

- **Changed**
  - Standardized top-level command names with kebab-case while retaining deprecated aliases and warnings.
  - Unsupported CSV output now reports a clear error.

- **Bug Fixes**
  - Improved plugin diff, deploy, clean, and extract reliability.
  - Invalid output formats no longer expose internal type details.
  - MCP initialization now reports the correct package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->