### PR TITLE
chore(deps): rely on central Pkcs pin, drop redundant VersionOverride (#1328)

### DIFF
--- a/src/PPDS.Auth/PPDS.Auth.csproj
+++ b/src/PPDS.Auth/PPDS.Auth.csproj
@@ -84,7 +84,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
 
     <!-- JSON serialization -->
-    <PackageReference Include="System.Security.Cryptography.Pkcs" VersionOverride="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="System.Text.Json" />
 
     <!-- JWT token parsing for extracting claims -->

--- a/src/PPDS.Migration/PPDS.Migration.csproj
+++ b/src/PPDS.Migration/PPDS.Migration.csproj
@@ -45,7 +45,7 @@ dependency-aware tiered import, and CMT format compatibility for automated pipel
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" VersionOverride="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />


### PR DESCRIPTION
Closes #1328

## What

Removes two `VersionOverride` attributes that duplicated the exact central pin in `Directory.Packages.props` (this repo uses Central Package Management). The `PackageReference` items are kept; only the local version override is dropped, so both projects now follow the central pin.

- `src/PPDS.Auth/PPDS.Auth.csproj`: `System.Security.Cryptography.Pkcs` — override `10.0.9` == central `10.0.9`
- `src/PPDS.Migration/PPDS.Migration.csproj`: `Microsoft.Data.SqlClient` — override `6.1.4` == central `6.1.4`

## Why (drift trap)

Both overrides were mechanical dependabot edits (Pkcs: #1288 / `1c42ea1c6`; SqlClient: `c638e1630`) that bumped the central `PackageVersion` and injected a same-version `VersionOverride` reference in the same commit. Redundant today, but they silently defeat central management: a future security bump that edits only `Directory.Packages.props` — exactly how dependabot and humans bump CPM repos — would strand the overriding project on the old version with no warning. For Pkcs that means PPDS.Auth, the crypto consumer, silently staying on a superseded patch.

Not hypothetical: the third override in the repo has already sprung this trap — `PPDS.Auth.csproj` pins `Microsoft.Extensions.Logging` at `10.0.5` while central moved to `10.0.9`. That one differs from central (removing it changes resolved versions), so it is deliberately left untouched here and tracked in #1330.

Deliberateness check: no comments, commit rationale, or PR discussion mark either removed override as intentional; sibling projects (`PPDS.Dataverse`, `PPDS.Cli`) already consume the same packages via the central pin with no override, and CodeRabbit's review on #1288 flagged the Pkcs line with this exact suggestion before merge.

## Provenance

Post-merge weekend review of dependabot #1288.

## Evidence: resolved versions unchanged

`dotnet list <proj> package` (requested/resolved), identical before and after on all TFMs (net8.0 / net9.0 / net10.0):

| Project | Package | Before | After |
|---|---|---|---|
| PPDS.Auth | System.Security.Cryptography.Pkcs | 10.0.9 / 10.0.9 | 10.0.9 / 10.0.9 |
| PPDS.Migration | Microsoft.Data.SqlClient | 6.1.4 / 6.1.4 | 6.1.4 / 6.1.4 |
| PPDS.Auth | Microsoft.Extensions.Logging (untouched, see #1330) | 10.0.5 / 10.0.5 | 10.0.5 / 10.0.5 |

## Gates

- `dotnet build PPDS.sln -v q`: 0 errors (warnings are pre-existing xUnit analyzer nits in test projects; no RS/NU diagnostics)
- `dotnet test tests/PPDS.Auth.Tests --filter "Category!=Integration" -v q --no-build`: 592 passed, 0 failed, 1 skipped on each of net8.0/net9.0/net10.0
- `dotnet test tests/PPDS.Migration.Tests --filter "Category!=Integration" -v q --no-build`: 565 passed, 0 failed on each TFM
- Pre-commit hook re-ran the full solution build plus the entire unit-test suite: all green
- No `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` changes (version alignment does not alter API surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version management for authentication and migration components.
  * Improved consistency with the project’s centralized versioning configuration.
  * No user-facing feature or behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->