### PR TITLE
fix(cli): self-heal corrupted/empty net462 reference-assembly cache (#1326)

### DIFF
--- a/specs/plugins.md
+++ b/specs/plugins.md
@@ -523,6 +523,7 @@ ppds plugins extract MyPlugin.1.0.0.nupkg -o registrations.json
 | `-o, --output` | Output JSON file path |
 | `-s, --solution` | Solution unique name for registration |
 | `-f, --force` | Overwrite existing output file |
+| `--reference-dir` | Additional directory to search for referenced assemblies (repeatable) |
 
 ### ppds plugins deploy
 

--- a/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
+++ b/src/PPDS.Cli/Plugins/Extraction/AssemblyExtractor.cs
@@ -22,6 +22,14 @@ public sealed class AssemblyExtractor : IDisposable
     private const string Net462ResourceName = "PPDS.Cli.Resources.Net462ReferenceAssemblies.zip";
 
     /// <summary>
+    /// Zero-byte marker written into the cache directory as the very last extraction step.
+    /// Its presence is the cache-validity contract: the cache key is fixed per CLI version,
+    /// so a cache partially deleted by a temp cleaner would otherwise pass an "any DLL"
+    /// check forever and could never self-heal. See #1326.
+    /// </summary>
+    internal const string CompletionSentinelFileName = ".complete";
+
+    /// <summary>
     /// Directory of embedded .NET Framework 4.6.2 reference assemblies, extracted once per
     /// process on first use. Null when the embedded resource is unavailable or extraction
     /// failed — in which case the resolver falls back to runtime-directory seeding.
@@ -147,6 +155,14 @@ public sealed class AssemblyExtractor : IDisposable
     /// seeding, so the fix can never make extraction worse than before. See #1294.
     /// </summary>
     internal static string? GetNet462ReferenceAssemblyDirectory()
+        => GetNet462ReferenceAssemblyDirectory(cacheBaseDirOverride: null);
+
+    /// <summary>
+    /// Overload that redirects the cache base directory so tests can exercise cache
+    /// corruption and self-healing against an isolated location instead of the real
+    /// per-user cache in the temp directory. See #1326.
+    /// </summary>
+    internal static string? GetNet462ReferenceAssemblyDirectory(string? cacheBaseDirOverride)
     {
         try
         {
@@ -165,20 +181,32 @@ public sealed class AssemblyExtractor : IDisposable
             // resource (new CLI version) lands in a fresh directory, so there is no stale cache.
             var hash = Convert.ToHexString(SHA256.HashData(zipBytes))[..16].ToLowerInvariant();
 
-            // Scope the cache to the current user. On multi-user systems Path.GetTempPath() can be
-            // a shared directory (e.g. /tmp on Linux), so a fixed "ppds/net462-ref" path would be
-            // created by the first user and then throw UnauthorizedAccessException for every other
-            // account — which the outer catch swallows, silently disabling the fix for them.
-            // Isolating by user name gives each account its own cache. See #1294.
-            var rawUser = Environment.UserName;
-            var userScope = string.IsNullOrWhiteSpace(rawUser)
-                ? "default"
-                : string.Join("_", rawUser.Split(Path.GetInvalidFileNameChars()));
-            var baseDir = Path.Combine(Path.GetTempPath(), $"ppds-{userScope}", "net462-ref");
+            var baseDir = cacheBaseDirOverride;
+            if (baseDir == null)
+            {
+                // Scope the cache to the current user. On multi-user systems Path.GetTempPath() can be
+                // a shared directory (e.g. /tmp on Linux), so a fixed "ppds/net462-ref" path would be
+                // created by the first user and then throw UnauthorizedAccessException for every other
+                // account — which the outer catch swallows, silently disabling the fix for them.
+                // Isolating by user name gives each account its own cache. See #1294.
+                var rawUser = Environment.UserName;
+                var userScope = string.IsNullOrWhiteSpace(rawUser)
+                    ? "default"
+                    : string.Join("_", rawUser.Split(Path.GetInvalidFileNameChars()));
+                baseDir = Path.Combine(Path.GetTempPath(), $"ppds-{userScope}", "net462-ref");
+            }
+
             var cacheDir = Path.Combine(baseDir, hash);
 
             if (IsPopulated(cacheDir))
                 return cacheDir;
+
+            // Self-heal: a cache directory that exists but fails validation is corrupt — e.g. a
+            // temp cleaner deleted the sentinel or some DLLs but kept the directory. The cache key
+            // is fixed per CLI version, so without deleting it here the corrupt directory would
+            // never recover (and Directory.Move below would throw on the existing destination on
+            // every run). See #1326.
+            TryDeleteDirectory(cacheDir);
 
             // Extract to a unique staging directory, then atomically move it into place so a
             // concurrent extraction never observes a half-populated cache directory.
@@ -192,6 +220,10 @@ public sealed class AssemblyExtractor : IDisposable
                     archive.ExtractToDirectory(stagingDir);
                 }
 
+                // Completion sentinel, written only after every entry extracted: validation
+                // treats any cache directory without it as incomplete.
+                File.WriteAllBytes(Path.Combine(stagingDir, CompletionSentinelFileName), []);
+
                 if (IsPopulated(cacheDir))
                     return cacheDir; // Another process won the race while we were extracting.
 
@@ -202,8 +234,23 @@ public sealed class AssemblyExtractor : IDisposable
                 }
                 catch (IOException) when (IsPopulated(cacheDir))
                 {
-                    // Race: another process created the cache dir between our check and move.
+                    // Race: another process created a complete cache between our check and move.
                     return cacheDir;
+                }
+                catch (IOException)
+                {
+                    // The destination exists but is invalid (e.g. re-created mid-run by a temp
+                    // cleaner or a concurrent loser): delete it and retry the move once. If the
+                    // retry loses to a concurrent winner, its cache is complete — use it.
+                    TryDeleteDirectory(cacheDir);
+                    try
+                    {
+                        Directory.Move(stagingDir, cacheDir);
+                    }
+                    catch (IOException) when (IsPopulated(cacheDir))
+                    {
+                        return cacheDir;
+                    }
                 }
 
                 return cacheDir;
@@ -213,15 +260,28 @@ public sealed class AssemblyExtractor : IDisposable
                 TryDeleteDirectory(stagingDir);
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Never make things worse — fall back to runtime-directory seeding.
+            // Never make things worse — fall back to runtime-directory seeding. But say so
+            // (stderr — stdout is reserved for data): in a single-file install that fallback
+            // has no loose BCL DLLs, so extraction will likely fail downstream with the
+            // confusing "could not find core assembly" error. See #1326.
+            Console.Error.WriteLine(
+                "Warning: failed to extract embedded .NET Framework 4.6.2 reference assemblies; " +
+                $"plugin extraction may fail for single-file installs: {ex.Message}");
             return null;
         }
     }
 
+    /// <summary>
+    /// A cache directory is valid only when the completion sentinel (written as the last
+    /// extraction step) and the core assembly are both present. Checking mscorlib rather
+    /// than "any DLL" lets a partially deleted cache fail validation and self-heal instead
+    /// of passing forever. See #1326.
+    /// </summary>
     private static bool IsPopulated(string directory)
-        => Directory.Exists(directory) && Directory.EnumerateFiles(directory, "*.dll").Any();
+        => File.Exists(Path.Combine(directory, CompletionSentinelFileName))
+           && File.Exists(Path.Combine(directory, "mscorlib.dll"));
 
     private static void TryDeleteDirectory(string directory)
     {

--- a/tests/PPDS.Cli.Tests/Plugins/Extraction/AssemblyExtractorTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Extraction/AssemblyExtractorTests.cs
@@ -117,6 +117,19 @@ public sealed class AssemblyExtractorTests : IDisposable
         return tempPath;
     }
 
+    /// <summary>
+    /// Creates a unique, tracked cache base directory so self-heal tests never touch the
+    /// real per-user reference-assembly cache in the temp directory and never observe
+    /// state left behind by other tests. See #1326.
+    /// </summary>
+    private string CreateIsolatedCacheBaseDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ppds-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        _tempFiles.Add(dir);
+        return dir;
+    }
+
     #endregion
 
     #region Deployment extraction tests
@@ -847,6 +860,81 @@ public sealed class AssemblyExtractorTests : IDisposable
 
         Assert.Single(config.Types);
         Assert.Equal("Update", config.Types[0].Steps[0].Message);
+    }
+
+    #endregion
+
+    #region Cache self-healing tests (#1326)
+
+    [Fact]
+    public void GetNet462ReferenceAssemblyDirectory_CacheMissingSentinel_SelfHealsAndReExtracts()
+    {
+        // A temp cleaner can delete individual cache files while leaving the directory and
+        // other DLLs behind. The cache key is fixed per CLI version, so a corrupt directory
+        // that still passed validation would break every subsequent run. A cache without the
+        // completion sentinel must be treated as invalid, deleted, and re-extracted.
+        var baseDir = CreateIsolatedCacheBaseDir();
+
+        var first = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+        Assert.NotNull(first);
+        Assert.True(File.Exists(Path.Combine(first!, AssemblyExtractor.CompletionSentinelFileName)),
+            "A freshly extracted cache must contain the completion sentinel.");
+
+        File.Delete(Path.Combine(first!, AssemblyExtractor.CompletionSentinelFileName));
+        File.Delete(Path.Combine(first!, "mscorlib.dll"));
+        Assert.True(Directory.EnumerateFiles(first!, "*.dll").Any(),
+            "Corruption setup must leave at least one DLL so the old any-DLL check would have passed.");
+
+        var healed = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+
+        Assert.Equal(first, healed);
+        Assert.True(File.Exists(Path.Combine(healed!, "mscorlib.dll")),
+            "Self-healed cache must contain the core assembly again.");
+        Assert.True(File.Exists(Path.Combine(healed!, AssemblyExtractor.CompletionSentinelFileName)),
+            "Self-healed cache must contain the completion sentinel.");
+    }
+
+    [Fact]
+    public void GetNet462ReferenceAssemblyDirectory_CacheMissingCoreAssembly_SelfHealsAndReExtracts()
+    {
+        // Failure mode 1 of #1326: a cleaner deletes mscorlib.dll but leaves other DLLs (and
+        // even the sentinel). The old "any *.dll" validation accepted such a cache forever,
+        // permanently reproducing the #1294 "could not find core assembly" failure.
+        var baseDir = CreateIsolatedCacheBaseDir();
+
+        var first = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+        Assert.NotNull(first);
+
+        File.Delete(Path.Combine(first!, "mscorlib.dll"));
+
+        var healed = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+
+        Assert.Equal(first, healed);
+        Assert.True(File.Exists(Path.Combine(healed!, "mscorlib.dll")),
+            "Self-healed cache must contain the core assembly again.");
+    }
+
+    [Fact]
+    public void GetNet462ReferenceAssemblyDirectory_EmptyCacheDirectory_SelfHealsAndReExtracts()
+    {
+        // Failure mode 2 of #1326: a cleaner deletes every file but keeps the directory.
+        // Before self-healing, Directory.Move into the existing-but-empty destination threw
+        // IOException on every run, silently disabling the embedded reference assemblies.
+        var baseDir = CreateIsolatedCacheBaseDir();
+
+        var first = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+        Assert.NotNull(first);
+
+        Directory.Delete(first!, recursive: true);
+        Directory.CreateDirectory(first!);
+
+        var healed = AssemblyExtractor.GetNet462ReferenceAssemblyDirectory(baseDir);
+
+        Assert.Equal(first, healed);
+        Assert.True(File.Exists(Path.Combine(healed!, "mscorlib.dll")),
+            "Self-healed cache must contain the core assembly.");
+        Assert.True(File.Exists(Path.Combine(healed!, AssemblyExtractor.CompletionSentinelFileName)),
+            "Self-healed cache must contain the completion sentinel.");
     }
 
     #endregion


### PR DESCRIPTION
## What

Makes the embedded net462 reference-assembly cache (introduced by #1305 for #1294) self-healing and observable. The cache key is content-addressed and fixed per CLI version, so before this change any damage to the cache directory was permanent.

Closes #1326.

## Why — three failure modes in `AssemblyExtractor.cs`

1. **Partially deleted cache passed validation forever.** `IsPopulated` was `Directory.Exists && any *.dll`. A temp cleaner deleting SOME files (e.g. `mscorlib.dll`) while leaving one DLL produced a cache that validated forever, so every single-file `plugins extract` failed permanently with the original #1294 "Could not find core assembly" error.
2. **Empty-but-existing cache dir disabled embedded refs on every run.** With all files deleted but the directory kept, `IsPopulated` was false, extraction proceeded, and `Directory.Move(stagingDir, cacheDir)` threw `IOException` (destination exists). The `when (IsPopulated(cacheDir))` filter was false, so the exception fell to the outer catch and the method returned null — every run.
3. **Zero observability.** The outer `catch { return null; }` emitted nothing; users only saw the downstream "Could not find core assembly" with no hint why.

## How

- **Completion sentinel:** a zero-byte `.complete` marker is written into the staging directory as the last step before the atomic `Directory.Move`. Cache validity is now sentinel + `mscorlib.dll` present (two cheap `File.Exists` stats) — a partially deleted cache fails validation instead of passing forever.
- **Self-heal:** an existing-but-invalid cache directory is deleted (`TryDeleteDirectory`) and re-extracted. The Move-destination-exists case gets the same treatment with a single retry, while the existing race-tolerant `when (IsPopulated(...))` semantics for a concurrent winner are preserved — with sentinel-based validation a winner is now genuinely complete.
- **Observability:** when the whole embedded-reference path fails, one warning line goes to stderr (matching the `Warning: ...: {ex.Message}` phrasing #1305 used in `NupkgExtractor`), including the exception message. stdout stays data-only; `GetNet462ReferenceAssemblyDirectory` keeps its never-throws contract, and the `Lazy` wrapper means at most one warning per process, only when the embedded path was actually attempted and failed.
- **Spec reconciliation:** adds the shipped `--reference-dir` option (from #1305) to the `plugins extract` option table in `specs/plugins.md`.

No CHANGELOG entry: #1305 is itself unreleased, so this amends unreleased behavior and the pending backfill entry stays accurate.

## Tests

Three regression tests in `AssemblyExtractorTests.cs`, each against an isolated per-test cache base directory (new internal `cacheBaseDirOverride` seam — no dependence on real %TEMP% state):

- cache missing the sentinel (DLLs still present, i.e. the old check would have passed) → re-extracts and succeeds
- cache missing `mscorlib.dll` (sentinel present) → re-extracts and succeeds
- empty-but-existing cache directory → re-extracts and succeeds

Evidence:

- `dotnet build PPDS.sln -v q` — 0 errors
- `dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration&FullyQualifiedName~Extraction" -v q` — 43/43 passed on net8.0, net9.0, net10.0
- `dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration" -v q --no-build` — 4407/4407 passed on net8.0, net9.0, net10.0

## Provenance

Found during post-merge weekend review of #1305 (#1294).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the repeatable `--reference-dir` option to `ppds plugins extract`, allowing additional directories to be searched for referenced assemblies.

* **Bug Fixes**
  * Improved reference assembly cache recovery when cached files are incomplete, missing, or corrupted.
  * Prevented cache conflicts during concurrent extraction.
  * Extraction failures now display a warning with the relevant error message instead of failing silently.

* **Documentation**
  * Updated the plugin extraction command documentation with the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->