### PR TITLE
fix(cli): fail plugins deploy clearly when entity has no SDK message filter (#1332)

### DIFF
--- a/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DeployCommand.cs
@@ -368,6 +368,11 @@ public static class DeployCommand
                     envForConfigStep[match.Config] = match.Env;
             }
 
+            // Per-step configuration errors (e.g., an entity with no SDK message filter). These fail
+            // the assembly result — and thus the command exit code — without aborting the remaining
+            // steps, mirroring how a thrown exception fails the whole assembly.
+            var stepErrors = new List<string>();
+
             // Deploy each type
             foreach (var typeConfig in assemblyConfig.Types)
             {
@@ -411,6 +416,26 @@ public static class DeployCommand
                         messageId.Value,
                         stepConfig.Entity,
                         stepConfig.SecondaryEntity);
+
+                    // A specified entity that resolves no SDK message filter is a configuration error
+                    // (typo, or unsupported message/entity combo) — the step can never be registered
+                    // against that entity. Creating it anyway would produce a GLOBAL step whose
+                    // read-back identity ("none") never matches this config identity, so every later
+                    // deploy would force-create yet another duplicate (#1332). Only an intentionally
+                    // global step (entity empty/"none") may proceed with a null filter.
+                    if (filterId == null &&
+                        (PluginStepIdentity.IsEntitySpecified(stepConfig.Entity) ||
+                         PluginStepIdentity.IsEntitySpecified(stepConfig.SecondaryEntity)))
+                    {
+                        var stepError = $"Step '{stepName}' was not deployed: " +
+                            PluginRegistrationService.DescribeMissingMessageFilter(
+                                stepConfig.Message, stepConfig.Entity, stepConfig.SecondaryEntity);
+                        stepErrors.Add(stepError);
+
+                        if (!globalOptions.IsJsonMode)
+                            Console.Error.WriteLine($"    [Error] {stepError}");
+                        continue;
+                    }
 
                     var matchedEnvStep = envForConfigStep.TryGetValue(stepConfig, out var env) ? env : null;
                     var isNew = matchedEnvStep is null;
@@ -518,6 +543,14 @@ public static class DeployCommand
                     if (!globalOptions.IsJsonMode)
                         Console.Error.WriteLine($"  [!] Warning: {warning}");
                 }
+            }
+
+            // Per-step configuration errors fail the assembly (and the command exit code) even though
+            // the remaining steps were still deployed.
+            if (stepErrors.Count > 0)
+            {
+                result.Success = false;
+                result.Error = string.Join("; ", stepErrors);
             }
         }
         catch (Exception ex)

--- a/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/DiffCommand.cs
@@ -256,15 +256,33 @@ public static class DiffCommand
             {
                 var typeConfig = match.TypeConfig!;
                 var stepConfig = match.Config!;
+                var missingName = PluginStepMatcher.ResolveConfigName(typeConfig, stepConfig);
                 drift.MissingSteps.Add(new StepDrift
                 {
                     TypeName = typeConfig.TypeName,
-                    StepName = PluginStepMatcher.ResolveConfigName(typeConfig, stepConfig),
+                    StepName = missingName,
                     Message = stepConfig.Message,
                     Entity = stepConfig.Entity,
                     Stage = stepConfig.Stage,
                     Mode = stepConfig.Mode
                 });
+
+                // Same lookup deploy performs before creating a step: a specified entity with no SDK
+                // message filter can never be deployed (#1332). Warn so "[+] Missing step" is not read
+                // as "deploy will create it".
+                if (PluginStepIdentity.IsEntitySpecified(stepConfig.Entity) ||
+                    PluginStepIdentity.IsEntitySpecified(stepConfig.SecondaryEntity))
+                {
+                    var messageId = await service.GetSdkMessageIdAsync(stepConfig.Message);
+                    if (messageId != null &&
+                        await service.GetSdkMessageFilterIdAsync(messageId.Value, stepConfig.Entity, stepConfig.SecondaryEntity) == null)
+                    {
+                        drift.Warnings.Add(
+                            $"Missing step '{missingName}' cannot be created by deploy: " +
+                            PluginRegistrationService.DescribeMissingMessageFilter(
+                                stepConfig.Message, stepConfig.Entity, stepConfig.SecondaryEntity));
+                    }
+                }
             }
             else if (match.IsOrphaned)
             {

--- a/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
+++ b/src/PPDS.Cli/Commands/Plugins/RegisterCommand.cs
@@ -538,6 +538,19 @@ public static class RegisterCommand
             // Get message filter ID
             var filterId = await registrationService.GetSdkMessageFilterIdAsync(messageId.Value, entity, null, cancellationToken);
 
+            // A specified entity with no SDK message filter is a configuration error (typo, or
+            // unsupported message/entity combo) — registering anyway would silently create a GLOBAL
+            // step that fires on every occurrence of the message (#1332). Only an intentionally
+            // global step (--entity none) may proceed with a null filter.
+            if (filterId == null && PluginStepIdentity.IsEntitySpecified(entity))
+            {
+                writer.WriteError(new StructuredError(
+                    ErrorCodes.Plugin.MessageFilterNotFound,
+                    PluginRegistrationService.DescribeMissingMessageFilter(message, entity),
+                    Target: entity));
+                return ExitCodes.NotFoundError;
+            }
+
             // Build step config
             var stepConfig = new PluginStepConfig
             {

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.PluginRegistration.cs
@@ -303,6 +303,18 @@ public partial class RpcMethodHandler
 
             var filterId = await registrationService.GetSdkMessageFilterIdAsync(messageId, entity, secondaryEntity, ct);
 
+            // A specified entity with no SDK message filter is a configuration error (typo, or
+            // unsupported message/entity combo) — registering anyway would silently create a GLOBAL
+            // step that fires on every occurrence of the message (#1332). Only an intentionally
+            // global step (entity "none") may proceed with a null filter.
+            if (filterId == null &&
+                (PluginStepIdentity.IsEntitySpecified(entity) || PluginStepIdentity.IsEntitySpecified(secondaryEntity)))
+            {
+                throw new RpcException(
+                    ErrorCodes.Plugin.MessageFilterNotFound,
+                    PluginRegistrationService.DescribeMissingMessageFilter(message, entity, secondaryEntity));
+            }
+
             var stepConfig = new PluginStepConfig
             {
                 Name = name ?? $"{message} of {entity}",

--- a/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
+++ b/src/PPDS.Cli/Infrastructure/Errors/ErrorCodes.cs
@@ -337,6 +337,9 @@ public static class ErrorCodes
         /// <summary>Specified user for impersonation was not found.</summary>
         public const string UserNotFound = "Plugin.UserNotFound";
 
+        /// <summary>No SDK message filter exists for the requested message/entity combination.</summary>
+        public const string MessageFilterNotFound = "Plugin.MessageFilterNotFound";
+
         /// <summary>Failed to enable or disable a plugin processing step.</summary>
         public const string SetStateFailed = "Plugin.SetStateFailed";
     }

--- a/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginRegistrationService.cs
@@ -951,6 +951,22 @@ public sealed class PluginRegistrationService : IPluginRegistrationService
         return results.Entities.FirstOrDefault()?.Id;
     }
 
+    /// <summary>
+    /// Formats the error for a message/entity combination that has no SDK message filter row —
+    /// i.e. <see cref="GetSdkMessageFilterIdAsync"/> returned null although an entity was specified.
+    /// Registering the step anyway would silently create a GLOBAL step (no filter) that fires on
+    /// every occurrence of the message. Shared by deploy/diff/register/RPC so the failure reads
+    /// identically on every surface.
+    /// </summary>
+    public static string DescribeMissingMessageFilter(string message, string primaryEntity, string? secondaryEntity = null)
+    {
+        var combination = PluginStepIdentity.IsEntitySpecified(secondaryEntity)
+            ? $"entity '{primaryEntity}' with secondary entity '{secondaryEntity}'"
+            : $"entity '{primaryEntity}'";
+        return $"No SDK message filter exists for message '{message}' on {combination}. " +
+               "Check the entity logical name; if the step is meant to be global, set entity to 'none'.";
+    }
+
     #endregion
 
     #region Create Operations

--- a/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
+++ b/src/PPDS.Cli/Plugins/Registration/PluginStepIdentity.cs
@@ -119,6 +119,14 @@ public readonly record struct PluginStepIdentity(
     }
 
     /// <summary>
+    /// True when the value names a real entity — i.e. it does not normalize to the
+    /// <see cref="NoEntity"/> sentinel (null, empty, whitespace, or "none" in any casing).
+    /// Callers use this to distinguish an intentionally global step (no entity, null filter is
+    /// legitimate) from a configured entity that failed to resolve an SDK message filter (error).
+    /// </summary>
+    public static bool IsEntitySpecified(string? entity) => NormalizeEntity(entity) != NoEntity;
+
+    /// <summary>
     /// Human-readable rendering for warnings and drift reporting, e.g.
     /// <c>myplugin.type: update of account (postoperation, synchronous)</c>. Components are shown in
     /// their normalized (lower-cased) form because that is what identity is compared on.

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DeployCommandTests.cs
@@ -463,4 +463,197 @@ public class DeployCommandTests : IDisposable
     }
 
     #endregion
+
+    #region Missing Message Filter Guard Tests (#1332)
+
+    // Bug (#1332): a configured entity that resolves no SDK message filter (typo like "acount") used
+    // to force-create an unfiltered GLOBAL step whose read-back identity ("none") never matches the
+    // config identity — so every deploy created another duplicate. The step must instead fail with a
+    // per-step error, be skipped, and fail the assembly result; other steps still deploy; repeated
+    // runs must not accumulate anything.
+    [Fact]
+    public async Task DeployAssemblyAsync_SpecifiedEntityWithNoMessageFilter_FailsStepAndNeverCreates()
+    {
+        var assemblyId = Guid.NewGuid();
+        var typeId = Guid.NewGuid();
+
+        var dummyAssembly = Path.Combine(Path.GetTempPath(), $"deploy-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(dummyAssembly, new byte[] { 0x4D, 0x5A });
+
+        try
+        {
+            // Stateful environment so a second deploy sees whatever the first one created.
+            var envSteps = new List<PluginStepInfo>();
+
+            var mock = new Mock<IPluginRegistrationService>();
+            mock.Setup(s => s.UpsertAssemblyAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(assemblyId);
+            mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+            mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => envSteps.ToList());
+            mock.Setup(s => s.UpsertPluginTypeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(typeId);
+            mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            // The valid entity resolves a filter; the typo'd entity does not.
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), "account", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), "acount", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid?)null);
+            mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginImageInfo>());
+            mock.Setup(s => s.UpsertStepAsync(
+                    It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<PluginStepConfig>(), It.IsAny<Guid>(),
+                    It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid _, string _, PluginStepConfig cfg, Guid _, Guid? _, string? _, StepIdentityResolution? res, CancellationToken _) =>
+                {
+                    if (res?.ExistingStepId is { } existingId)
+                        return existingId;
+
+                    var id = Guid.NewGuid();
+                    envSteps.Add(new PluginStepInfo
+                    {
+                        Id = id,
+                        Name = cfg.Name!,
+                        Message = cfg.Message,
+                        PrimaryEntity = cfg.Entity,
+                        Stage = cfg.Stage,
+                        Mode = cfg.Mode,
+                        ExecutionOrder = cfg.ExecutionOrder
+                    });
+                    return id;
+                });
+
+            PluginAssemblyConfig BuildConfig() => new()
+            {
+                Name = "MyPlugin",
+                Type = "Assembly",
+                Path = dummyAssembly,
+                Types =
+                {
+                    new PluginTypeConfig
+                    {
+                        TypeName = "MyPlugin.Handler",
+                        Steps =
+                        {
+                            new PluginStepConfig { Message = "Create", Entity = "acount", Stage = "PostOperation", Mode = "Synchronous" },
+                            new PluginStepConfig { Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous" }
+                        }
+                    }
+                }
+            };
+
+            var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+            // First deploy: the typo'd step fails, the valid step deploys.
+            var first = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, BuildConfig(), Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+
+            Assert.False(first.Success);
+            Assert.NotNull(first.Error);
+            Assert.Contains("acount", first.Error);
+            Assert.Contains("No SDK message filter", first.Error);
+            Assert.Contains("Create", first.Error);
+            Assert.Equal(1, first.StepsCreated);
+
+            // The typo'd step was never written; only the valid step was.
+            mock.Verify(s => s.UpsertStepAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(),
+                It.Is<PluginStepConfig>(c => c.Entity == "acount"),
+                It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<string?>(),
+                It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()), Times.Never);
+            Assert.Single(envSteps);
+
+            // Second deploy: still fails the same way — and accumulates nothing (the #1332 bug was one
+            // new active global step per run).
+            var second = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, BuildConfig(), Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+
+            Assert.False(second.Success);
+            Assert.Equal(0, second.StepsCreated);
+            Assert.Equal(1, second.StepsUpdated); // the valid step converges to an in-place update
+            Assert.Single(envSteps);
+        }
+        finally
+        {
+            File.Delete(dummyAssembly);
+        }
+    }
+
+    // Guard boundary (#1332): an intentionally global step — entity "none" (or empty) — legitimately
+    // resolves no filter and must keep deploying with a null filter id.
+    [Fact]
+    public async Task DeployAssemblyAsync_GlobalStepWithoutEntity_StillDeploysWithNullFilter()
+    {
+        var assemblyId = Guid.NewGuid();
+        var typeId = Guid.NewGuid();
+
+        var dummyAssembly = Path.Combine(Path.GetTempPath(), $"deploy-{Guid.NewGuid()}.dll");
+        File.WriteAllBytes(dummyAssembly, new byte[] { 0x4D, 0x5A });
+
+        try
+        {
+            var mock = new Mock<IPluginRegistrationService>();
+            mock.Setup(s => s.UpsertAssemblyAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(assemblyId);
+            mock.Setup(s => s.ListTypesForAssemblyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginTypeInfo> { new() { Id = typeId, TypeName = "MyPlugin.Handler" } });
+            mock.Setup(s => s.ListStepsForTypeAsync(It.IsAny<Guid>(), It.IsAny<PluginListOptions?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginStepInfo>());
+            mock.Setup(s => s.UpsertPluginTypeAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(typeId);
+            mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+            // Global messages have no filter row — the lookup returns null.
+            mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Guid?)null);
+            mock.Setup(s => s.ListImagesForStepAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<PluginImageInfo>());
+            mock.Setup(s => s.UpsertStepAsync(
+                    It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<PluginStepConfig>(), It.IsAny<Guid>(),
+                    It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+
+            var assemblyConfig = new PluginAssemblyConfig
+            {
+                Name = "MyPlugin",
+                Type = "Assembly",
+                Path = dummyAssembly,
+                Types =
+                {
+                    new PluginTypeConfig
+                    {
+                        TypeName = "MyPlugin.Handler",
+                        Steps =
+                        {
+                            new PluginStepConfig { Message = "Publish", Entity = "none", Stage = "PostOperation", Mode = "Synchronous" }
+                        }
+                    }
+                }
+            };
+
+            var globalOptions = new GlobalOptionValues { OutputFormat = OutputFormat.Json };
+
+            var result = await DeployCommand.DeployAssemblyAsync(
+                mock.Object, assemblyConfig, Path.GetTempPath(), null, clean: false, dryRun: false, globalOptions, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Null(result.Error);
+            Assert.Equal(1, result.StepsCreated);
+
+            // The step was written with a null filter id (a real global registration).
+            mock.Verify(s => s.UpsertStepAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(),
+                It.Is<PluginStepConfig>(c => c.Entity == "none"),
+                It.IsAny<Guid>(), It.Is<Guid?>(f => f == null), It.IsAny<string?>(),
+                It.IsAny<StepIdentityResolution?>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            File.Delete(dummyAssembly);
+        }
+    }
+
+    #endregion
 }

--- a/tests/PPDS.Cli.Tests/Commands/Plugins/DiffCommandTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Plugins/DiffCommandTests.cs
@@ -239,5 +239,51 @@ public class DiffCommandTests : IDisposable
         Assert.Equal("Old Display Name", change.Actual);
     }
 
+    // Bug (#1332): a missing step whose specified entity resolves no SDK message filter can never be
+    // created by deploy — diff must say so instead of presenting it as ordinary missing drift. An
+    // intentionally global step ("none") and a valid entity must not trigger the warning.
+    [Fact]
+    public async Task ComputeDriftAsync_MissingStepWithNoMessageFilter_WarnsItCannotBeCreated()
+    {
+        var typeId = Guid.NewGuid();
+
+        // Empty environment: every configured step is missing.
+        var mock = MockServiceWithSteps(Guid.NewGuid(), typeId, "MyPlugin.Handler", new List<PluginStepInfo>());
+        mock.Setup(s => s.GetSdkMessageIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), "account", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        mock.Setup(s => s.GetSdkMessageFilterIdAsync(It.IsAny<Guid>(), "acount", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        var config = new PluginAssemblyConfig
+        {
+            Name = "MyPlugin",
+            Types =
+            {
+                new PluginTypeConfig
+                {
+                    TypeName = "MyPlugin.Handler",
+                    Steps =
+                    {
+                        new PluginStepConfig { Message = "Create", Entity = "acount", Stage = "PostOperation", Mode = "Synchronous" },
+                        new PluginStepConfig { Message = "Update", Entity = "account", Stage = "PostOperation", Mode = "Synchronous" },
+                        new PluginStepConfig { Message = "Publish", Entity = "none", Stage = "PostOperation", Mode = "Synchronous" }
+                    }
+                }
+            }
+        };
+
+        var drift = await DiffCommand.ComputeDriftAsync(mock.Object, config);
+
+        // All three are missing, but only the typo'd entity warrants a warning: the valid entity is
+        // deployable and the global step legitimately has no filter.
+        Assert.Equal(3, drift.MissingSteps.Count);
+        var warning = Assert.Single(drift.Warnings);
+        Assert.Contains("cannot be created", warning);
+        Assert.Contains("acount", warning);
+        Assert.Contains("Create", warning);
+    }
+
     #endregion
 }

--- a/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
+++ b/tests/PPDS.Cli.Tests/Plugins/Registration/PluginStepIdentityTests.cs
@@ -163,6 +163,23 @@ public class PluginStepIdentityTests
         Assert.NotEqual(post, pre);
     }
 
+    // Guard boundary for #1332: "specified" means the value does not normalize to the NoEntity
+    // sentinel — only then is a null SDK message filter a configuration error.
+    [Theory]
+    [InlineData("account", true)]
+    [InlineData(" account ", true)]
+    [InlineData("acount", true)] // a typo is still "specified" — that is exactly the error case
+    [InlineData("none", false)]
+    [InlineData("NONE", false)]
+    [InlineData(" none ", false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData(null, false)]
+    public void IsEntitySpecified_DistinguishesRealEntitiesFromNoneSentinel(string? entity, bool expected)
+    {
+        Assert.Equal(expected, PluginStepIdentity.IsEntitySpecified(entity));
+    }
+
     [Fact]
     public void ToString_RendersReadableComponents()
     {


### PR DESCRIPTION
Guards the null SDK-message-filter case at every step-creation surface, distinguishing a configuration error (entity specified but no filter row) from an intentionally global step (entity empty/`none`).

**Bug (found during post-merge weekend review of #1302 / #1295):** a typo'd entity (e.g. `acount`) force-created an unfiltered **global** step; its read-back identity (`none`) never matched the config identity, so every subsequent `plugins deploy` classified the step as Missing and created another active duplicate — one per run, each firing on every occurrence of the message. Pre-#1302 name-matching was wrong-but-idempotent; the identity matcher made it non-convergent.

**Changes**
- `plugins deploy`: per-step `[Error]` on stderr (text) / error field in the JSON result; step skipped; assembly result fails → non-zero exit; remaining steps still deploy.
- `plugins diff`: warns that such a Missing step can never be created by deploy.
- `plugins register step` + RPC `plugins/registerStep`: fail with new `Plugin.MessageFilterNotFound` instead of silently registering a global step.
- Shared: `PluginStepIdentity.IsEntitySpecified` (reuses the `none` normalization) and `PluginRegistrationService.DescribeMissingMessageFilter` so the failure reads identically on every surface.
- Tests: DeployCommandTests (error path + intentionally-global step still deploys), DiffCommandTests, PluginStepIdentityTests.

No changelog entry by design: this amends the not-yet-released #1302 behavior; the backfilled entry (#1333) remains accurate.

Full .NET suite ran green via the repo pre-commit hook at commit time; CI on this PR is the authoritative gate.

Closes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin step registration now rejects entity combinations without a matching SDK message filter.
  * Deployment skips invalid steps, reports clear errors, and continues processing valid steps.
  * Drift detection warns when missing steps cannot be created due to an invalid entity configuration.
  * Global steps without an entity continue to deploy successfully.
  * Added consistent error reporting for missing message filters.

* **Tests**
  * Added coverage for deployment, registration, drift detection, global steps, and entity validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->