### PR TITLE
fix(cli): align --output-format help/completions with Csv validation; serialize console-capture tests (#1336)

### DIFF
--- a/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
+++ b/src/PPDS.Cli/Infrastructure/GlobalOptions.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Completions;
 using System.CommandLine.Parsing;
 using PPDS.Cli.Commands;
 
@@ -67,16 +68,24 @@ public static class GlobalOptions
     /// <summary>
     /// Creates an --output-format option with a clean parse error for invalid values (#1076)
     /// and, unless <paramref name="supportsCsv"/> is set, a validator rejecting CSV (#1078).
+    /// Help usage label and shell completions advertise only the instance's valid set (#1336).
     /// </summary>
     /// <param name="supportsCsv">Whether the owning command implements CSV rendering.</param>
     /// <param name="shortAlias">Short alias — "-f" everywhere except data load, where -f belongs to --file.</param>
     public static Option<OutputFormat> CreateOutputFormatOption(bool supportsCsv = false, string shortAlias = "-f")
     {
-        var validValues = supportsCsv ? "Text, Json, Csv" : "Text, Json";
+        string[] validValueNames = supportsCsv
+            ? [nameof(Commands.OutputFormat.Text), nameof(Commands.OutputFormat.Json), nameof(Commands.OutputFormat.Csv)]
+            : [nameof(Commands.OutputFormat.Text), nameof(Commands.OutputFormat.Json)];
+        var validValues = string.Join(", ", validValueNames);
 
         var option = new Option<OutputFormat>("--output-format", shortAlias)
         {
             Description = "Output format",
+            // Without an explicit HelpName, System.CommandLine derives the usage label from the
+            // enum type and advertises <Csv|Json|Text> even where the validator below rejects
+            // Csv (#1336). Pin the label to this instance's actual valid set instead.
+            HelpName = string.Join("|", validValueNames),
             DefaultValueFactory = _ => Commands.OutputFormat.Text,
             CustomParser = result =>
             {
@@ -96,6 +105,11 @@ public static class GlobalOptions
                 return Commands.OutputFormat.Text;
             }
         };
+
+        // Replace the enum-derived completion source (Csv|Json|Text) so shell completions offer
+        // only the values this instance accepts (#1336).
+        option.CompletionSources.Clear();
+        option.CompletionSources.Add(_ => validValueNames.Select(name => new CompletionItem(name)));
 
         if (!supportsCsv)
         {

--- a/tests/PPDS.Cli.Tests/Commands/Metadata/MetadataDeprecationTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Metadata/MetadataDeprecationTests.cs
@@ -5,6 +5,7 @@ using PPDS.Cli.Commands.Metadata.Attribute;
 using PPDS.Cli.Commands.Metadata.Choice;
 using PPDS.Cli.Commands.Metadata.Column;
 using PPDS.Cli.Commands.Metadata.Table;
+using PPDS.Cli.Tests.TestHelpers;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Commands.Metadata;
@@ -13,8 +14,11 @@ namespace PPDS.Cli.Tests.Commands.Metadata;
 /// Covers AC-41 (deprecated noun warns to stderr with canonical name),
 /// AC-42 (stdout clean — warning goes to stderr, not stdout),
 /// AC-43 (shared execute path — deprecated commands delegate to canonical execute methods).
+/// In the console-capture collection because <see cref="DeprecationWarning"/> writes directly to
+/// the console, so these tests swap the process-global <see cref="Console.Out"/>/<see cref="Console.Error"/>.
 /// </summary>
 [Trait("Category", "Unit")]
+[Collection(nameof(ConsoleCaptureCollection))]
 public class DeprecationWarningTests
 {
     [Fact]

--- a/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/GlobalOptionsOutputFormatTests.cs
@@ -8,6 +8,7 @@ using PPDS.Cli.Commands.Schema;
 using PPDS.Cli.Commands.Solutions;
 using PPDS.Cli.Infrastructure;
 using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Tests.TestHelpers;
 using PPDS.Dataverse.Query;
 using Xunit;
 
@@ -15,10 +16,14 @@ namespace PPDS.Cli.Tests.Infrastructure;
 
 /// <summary>
 /// Covers #1076 (invalid --output-format values produce a clean error instead of leaking
-/// the CLR enum type name) and #1078 (--output-format Csv is rejected on commands without
-/// CSV rendering and still accepted on the four commands that implement it).
+/// the CLR enum type name), #1078 (--output-format Csv is rejected on commands without
+/// CSV rendering and still accepted on the four commands that implement it), and #1336
+/// (help usage label and completions advertise only the values each instance accepts).
+/// In the console-capture collection because <see cref="CaptureStdout"/> swaps the
+/// process-global <see cref="Console.Out"/>.
 /// </summary>
 [Trait("Category", "Unit")]
+[Collection(nameof(ConsoleCaptureCollection))]
 public class GlobalOptionsOutputFormatTests
 {
     private static string JoinedErrors(ParseResult result) =>
@@ -248,6 +253,60 @@ public class GlobalOptionsOutputFormatTests
 
         Assert.Empty(result.Errors);
         Assert.Equal(OutputFormat.Text, GlobalOptions.GetValues(result).OutputFormat);
+    }
+
+    // ---- #1336: help + completions advertise only the values each instance accepts ----
+
+    [Fact]
+    public void Help_OnCsvRejectingCommand_DoesNotAdvertiseCsv()
+    {
+        var help = RenderHelp(SolutionsCommandGroup.Create(), "solutions list --help");
+
+        Assert.Contains("--output-format <Text|Json>", help);
+        Assert.DoesNotContain("Csv", help);
+    }
+
+    [Fact]
+    public void Help_OnCsvCapableCommand_AdvertisesCsv()
+    {
+        var help = RenderHelp(QueryCommandGroup.Create(), "query sql --help");
+
+        Assert.Contains("--output-format <Text|Json|Csv>", help);
+    }
+
+    [Fact]
+    public void Completions_OnCsvRejectingCommand_OmitCsv()
+    {
+        const string commandLine = "list --output-format ";
+        var completions = SolutionsCommandGroup.Create().Parse(commandLine).GetCompletions(commandLine.Length);
+
+        Assert.Equal(new[] { "Json", "Text" }, completions.Select(c => c.Label));
+    }
+
+    [Fact]
+    public void Completions_OnCsvCapableCommand_IncludeCsv()
+    {
+        const string commandLine = "sql --output-format ";
+        var completions = QueryCommandGroup.Create().Parse(commandLine).GetCompletions(commandLine.Length);
+
+        Assert.Equal(new[] { "Csv", "Json", "Text" }, completions.Select(c => c.Label));
+    }
+
+    /// <summary>
+    /// Renders --help for a command in-process. The command group is mounted on a
+    /// <see cref="RootCommand"/> because --help is the root's recursive <c>HelpOption</c>
+    /// (mirroring Program.cs); standalone command groups have no help option.
+    /// </summary>
+    private static string RenderHelp(Command commandGroup, string commandLine)
+    {
+        var root = new RootCommand();
+        root.Subcommands.Add(commandGroup);
+
+        using var output = new StringWriter();
+        var exitCode = root.Parse(commandLine).Invoke(new InvocationConfiguration { Output = output });
+
+        Assert.Equal(0, exitCode);
+        return output.ToString();
     }
 
     // ---- CSV emission still works for the shared query formatter ----

--- a/tests/PPDS.Cli.Tests/Infrastructure/Output/TextOutputWriterTests.cs
+++ b/tests/PPDS.Cli.Tests/Infrastructure/Output/TextOutputWriterTests.cs
@@ -1,9 +1,15 @@
 using PPDS.Cli.Infrastructure.Errors;
 using PPDS.Cli.Infrastructure.Output;
+using PPDS.Cli.Tests.TestHelpers;
 using Xunit;
 
 namespace PPDS.Cli.Tests.Infrastructure.Output;
 
+/// <summary>
+/// In the console-capture collection because <see cref="TextOutputWriter"/> writes directly to
+/// the console, so these tests swap the process-global <see cref="Console.Out"/>/<see cref="Console.Error"/>.
+/// </summary>
+[Collection(nameof(ConsoleCaptureCollection))]
 public class TextOutputWriterTests
 {
     [Fact]

--- a/tests/PPDS.Cli.Tests/TestHelpers/ConsoleCaptureCollection.cs
+++ b/tests/PPDS.Cli.Tests/TestHelpers/ConsoleCaptureCollection.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace PPDS.Cli.Tests.TestHelpers;
+
+/// <summary>
+/// Serializes tests that swap the process-global console writers via
+/// <see cref="System.Console.SetOut(System.IO.TextWriter)"/> / <see cref="System.Console.SetError(System.IO.TextWriter)"/>.
+/// Without this, xUnit runs test classes in parallel by default and concurrent swaps race:
+/// one class restores the original writer while another is still capturing, so output lands in
+/// the wrong <see cref="System.IO.StringWriter"/> (observed flaky on
+/// <c>FetchCommand_WriteCsvOutput_EmptyResult_EmitsHeaderNotZeroBytes</c>, #1336; same hazard
+/// documented on <c>CommandAliasDeprecation.WarnIfDeprecatedAliasUsed</c>). Tag every class that
+/// calls <c>Console.SetOut</c>/<c>Console.SetError</c> with
+/// <c>[Collection(nameof(ConsoleCaptureCollection))]</c> — or better, where the code under test
+/// accepts an injectable <see cref="System.IO.TextWriter"/>, assert on an isolated writer instead
+/// of swapping the console at all (see <c>CommandAliasDeprecationTests</c>).
+/// </summary>
+[CollectionDefinition(nameof(ConsoleCaptureCollection), DisableParallelization = true)]
+public class ConsoleCaptureCollection
+{
+}


### PR DESCRIPTION
Closes #1336

Two follow-ups to #1303 (which closed #1076/#1078), found during post-merge weekend review of #1303. No CHANGELOG entries: this amends unreleased #1303 behavior.

## A) Help + completions now advertise only the values each `--output-format` instance accepts

`GlobalOptions.CreateOutputFormatOption` added a `CustomParser` and a Csv-rejecting validator in #1303, but System.CommandLine 2.0.9 still derived help usage labels and shell completions from the enum type — so `solutions list --help` promised `<Csv|Json|Text>` while `-f Csv` errored with `Valid values: Text, Json.`

Verified against the installed 2.0.9 package (decompiled): the default `HelpBuilder` prefers `Option.HelpName` for the usage label, otherwise joins `GetCompletions()` labels; completions come from `CompletionSources`, which is lazily seeded with `Enum.GetNames` for enum-typed options. Fix uses each knob for its purpose, both derived from one `validValueNames` array per instance:

- `HelpName` pins the usage label to `<Text|Json>` (or `<Text|Json|Csv>` when `supportsCsv`), matching the parse-error message order.
- `CompletionSources` is cleared and replaced with the same values, so tab completion stops offering `Csv` where it is rejected.

All `--output-format` instances flow through this factory (shared statics + the `env`/`auth`/`data` local instances), so one fix covers every command.

New tests render `--help` in-process (`ParseResult.Invoke` with `InvocationConfiguration.Output` pointed at a `StringWriter`, command group mounted on a `RootCommand` mirroring `Program.cs`) and assert the rejecting variant contains `<Text|Json>` and no `Csv` anywhere, while the CSV-capable variant contains `<Text|Json|Csv>`; completion tests assert the exact label sets via `ParseResult.GetCompletions`.

## B) Console-capture tests serialized into one non-parallel collection

`GlobalOptionsOutputFormatTests.CaptureStdout` (added in #1303) swaps the process-global `Console.Out`; under xUnit cross-class parallelization this races (observed: `FetchCommand_WriteCsvOutput_EmptyResult_EmitsHeaderNotZeroBytes` failed on net8.0 in a full local run, passed on rerun/isolation/other TFMs — the failure family already documented on `CommandAliasDeprecation.WarnIfDeprecatedAliasUsed`).

Survey of `Console.SetOut`/`Console.SetError` swaps in `tests/PPDS.Cli.Tests` found three classes; none of the production code under test (`QueryResultFormatter.WriteCsvOutput`, `FetchCommand.WriteCsvOutput`, `TextOutputWriter`, `DeprecationWarning.Write`) accepts an injectable `TextWriter`, so the injected-writer strategy used by `CommandAliasDeprecationTests` would require production API changes. Instead all three join a new `ConsoleCaptureCollection` (`[CollectionDefinition(..., DisableParallelization = true)]`, same pattern as the existing `CurrentDirectoryMutatingCollection`):

| Test class | Strategy | Why |
| --- | --- | --- |
| `GlobalOptionsOutputFormatTests` | collection | `WriteCsvOutput` writes straight to `Console.Out` (stdout is the CSV data channel) |
| `TextOutputWriterTests` | collection | `TextOutputWriter` is console-coupled by design (color/redirection checks on `Console.Out`/`Error`) |
| `DeprecationWarningTests` (in `MetadataDeprecationTests.cs`) | collection | `DeprecationWarning.Write` writes straight to `Console.Error`; only this class in the file swaps writers |

## Test evidence

`dotnet build PPDS.sln -v q`: 0 errors (no new warnings in touched files).

`dotnet test tests/PPDS.Cli.Tests --filter "Category!=Integration" -v q --no-build`, run twice back-to-back for flake confidence:

- Run 1: net8.0 4408/4408 passed, net9.0 4408/4408 passed, net10.0 4408/4408 passed — 0 failed, 0 skipped
- Run 2: net8.0 4408/4408 passed, net9.0 4408/4408 passed, net10.0 4408/4408 passed — 0 failed, 0 skipped

(The pre-commit hook additionally ran the full .NET unit sweep across all test projects: green.)

## Noted, not fixed (context in #1336)

Numeric enum tokens still parse (`--output-format 1` binds to `Json`) — pre-existing quirk, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--output-format` help text and shell completions to show only values supported by each command.
  * Commands that support CSV now advertise it, while others restrict options to Text and JSON.

* **Tests**
  * Added coverage confirming output-format help and completion behavior.
  * Improved reliability for tests that capture console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->