### PR TITLE
chore(ci): have CodeRabbit review draft PRs (gate assumes review lands pre-flip)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# The draft-first PR gate (ADR 0041/0042) assumes automated review lands during the
+# draft phase, but CodeRabbit skips drafts by default — its comments landed post-triage
+# on #1345/#1347 (2026-07-13). With Gemini sunsetting 2026-07-17, review drafts.
+reviews:
+  auto_review:
+    drafts: true


### PR DESCRIPTION
## Why

The repo's draft-first PR gate (ADR 0041/0042: draft -> CI green + bot-comment triage -> ready flip) assumes **all automated review input lands during the draft phase**. CodeRabbit's default skips draft PRs and reviews only after the ready flip, so its comments land after triage has concluded.

- **Incident:** on #1345 and #1347 (2026-07-13), CodeRabbit's comments arrived post-flip and went untriaged until a human caught them.
- **Urgency:** Gemini code-assist sunsets **2026-07-17**, after which CodeRabbit is the only automated reviewer. Left at defaults, the draft-triage phase would review nothing at all.

Draft status in this repo is a process gate, not a WIP signal — agent PRs arrive complete — so draft reviews are reviews of finished code.

## What

Adds a minimal `.coderabbit.yaml` at repo root:

```yaml
reviews:
  auto_review:
    drafts: true
```

Nothing else is set or restated: `reviews.auto_review.enabled` and `reviews.auto_incremental_review` already default to `true` (verified against [docs.coderabbit.ai/reference/configuration](https://docs.coderabbit.ai/reference/configuration)). The `$schema` header URL is the one CodeRabbit's own docs cite (`https://coderabbit.ai/integrations/schema.v2.json`).

## Verification

- YAML parses: `python -c "import yaml; yaml.safe_load(open('.coderabbit.yaml'))"` -> OK.
- No prior `.coderabbit.yaml`/`.coderabbit.yml` existed at repo root (recent CodeRabbit runs reported "Configuration used: defaults").
- Activation: CodeRabbit reads the config from the PR head branch under review, so this PR itself should receive a draft-phase review; once merged to `main`, the setting applies repo-wide.

## Note

A possible one-sentence follow-up to `.claude/skills/pr/SKILL.md` (documenting that CodeRabbit now reviews during the draft phase) is pending a separate user decision and may be added to this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated code reviews are now enabled for draft pull requests.
  * Added configuration guidance describing draft review behavior and timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->