### PR TITLE
fix(dependabot): classify dev-only lint/test tooling as auto-merge eligible

### DIFF
--- a/scripts/dependabot/classify.py
+++ b/scripts/dependabot/classify.py
@@ -64,9 +64,13 @@ TOOLING_PACKAGES = frozenset({
     "typescript-eslint",
     "@typescript-eslint/parser",
     "@typescript-eslint/eslint-plugin",
+    "@vscode/test-electron",
     "microsoft.net.test.sdk",
+    "microsoft.codeanalysis.analyzers",
+    "microsoft.codeanalysis.publicapianalyzers",
     "xunit",
     "xunit.runner.visualstudio",
+    "xunit.skippablefact",
     "coverlet.collector",
     "moq",
     "fluentassertions",
@@ -79,6 +83,8 @@ TOOLING_PACKAGES = frozenset({
 TOOLING_PREFIXES = (
     "@types/",
     "fakexrmeasy",
+    "eslint-plugin-",  # ESLint plugins — dev-only lint tooling by naming convention
+    "stylelint-config-",  # stylelint shareable configs — lint config by naming convention
 )
 
 # Paths that elevate any bump to at least Group B.

--- a/tests/scripts/dependabot/test_classify.py
+++ b/tests/scripts/dependabot/test_classify.py
@@ -201,6 +201,101 @@ class TestClassifyPR(unittest.TestCase):
         self.assertEqual(c.update_type, "minor")
         self.assertIn("tooling", c.reason)
 
+    def test_minor_eslint_plugin_import_x_is_group_a(self):
+        # eslint-plugin-import-x is a dev-only ESLint plugin (devDependencies in
+        # src/PPDS.Extension) — definitionally lint tooling, never runtime. Real
+        # case: PR #1342 (4.16.2 -> 4.17.1) misclassified as Group B "verify-
+        # then-merge for runtime change" (issue #1350). Covered by the
+        # "eslint-plugin-" prefix: ESLint resolves plugins by that naming
+        # convention, so any eslint-plugin-* package is lint tooling.
+        pr = make_pr(
+            number=1342,
+            title="deps(extension): Bump eslint-plugin-import-x from 4.16.2 to 4.17.1 in /src/PPDS.Extension",
+            labels=["dependencies"],
+            head_ref="dependabot/npm_and_yarn/src/PPDS.Extension/eslint-plugin-import-x-4.17.1",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
+    def test_minor_stylelint_config_standard_is_group_a(self):
+        # stylelint shareable configs are named stylelint-config-* by stylelint's
+        # resolution convention — pure lint configuration, dev-only (issue #1350).
+        pr = make_pr(
+            number=1343,
+            title="deps(extension): Bump stylelint-config-standard from 40.0.0 to 40.1.0 in /src/PPDS.Extension",
+            labels=["dependencies"],
+            head_ref="dependabot/npm_and_yarn/src/PPDS.Extension/stylelint-config-standard-40.1.0",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
+    def test_minor_vscode_test_electron_is_group_a(self):
+        # @vscode/test-electron downloads VS Code and runs extension tests —
+        # test-harness tooling only, never packaged into the VSIX (issue #1350).
+        pr = make_pr(
+            number=1344,
+            title="deps(extension): Bump @vscode/test-electron from 3.0.0 to 3.1.0 in /src/PPDS.Extension",
+            labels=["dependencies"],
+            head_ref="dependabot/npm_and_yarn/src/PPDS.Extension/vscode/test-electron-3.1.0",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
+    def test_minor_xunit_skippablefact_is_group_a(self):
+        # Xunit.SkippableFact is an xunit extension referenced only by test
+        # projects (tests/PPDS.Auth.IntegrationTests) — test tooling (issue #1350).
+        pr = make_pr(
+            number=1345,
+            title="deps: Bump Xunit.SkippableFact from 1.5.61 to 1.6.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Xunit.SkippableFact-1.6.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
+    def test_minor_codeanalysis_analyzers_is_group_a(self):
+        # Microsoft.CodeAnalysis.Analyzers is a compile-time analyzer consumed
+        # with PrivateAssets=all (src/PPDS.Analyzers) — a C# linter; it ships no
+        # runtime bytes, and a bad bump fails the build (CI-visible). Issue #1350.
+        pr = make_pr(
+            number=1346,
+            title="deps: Bump Microsoft.CodeAnalysis.Analyzers from 3.11.0 to 3.12.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Microsoft.CodeAnalysis.Analyzers-3.12.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
+    def test_minor_publicapi_analyzers_is_group_a(self):
+        # Microsoft.CodeAnalysis.PublicApiAnalyzers gates PublicAPI.*.txt at
+        # compile time, PrivateAssets=all — analyzer/linter tooling (issue #1350).
+        pr = make_pr(
+            number=1347,
+            title="deps: Bump Microsoft.CodeAnalysis.PublicApiAnalyzers from 3.11.0 to 3.12.0",
+            labels=["nuget", "dependencies"],
+            head_ref="dependabot/nuget/Microsoft.CodeAnalysis.PublicApiAnalyzers-3.12.0",
+            files=["Directory.Packages.props"],
+        )
+        c = classify.classify_pr(pr)
+        self.assertEqual(c.group, "A")
+        self.assertEqual(c.update_type, "minor")
+        self.assertIn("tooling", c.reason)
+
     def test_patch_nuget_test_sdk_is_group_a(self):
         pr = make_pr(
             number=824,
@@ -665,6 +760,22 @@ class TestClassifyPR(unittest.TestCase):
         )
         c = classify.classify_pr(pr)
         # Even though eslint is tooling, MAJOR is universal exclusion.
+        self.assertEqual(c.group, "C")
+        self.assertEqual(c.update_type, "major")
+        self.assertIn("major", c.reason)
+
+    def test_major_eslint_plugin_is_group_c(self):
+        # The "eslint-plugin-" tooling prefix must not swallow majors — the
+        # universal major exclusion outranks the tooling allowlist, exactly as
+        # it does for exact-name tooling entries like eslint itself.
+        pr = make_pr(
+            number=1348,
+            title="deps(extension): Bump eslint-plugin-import-x from 4.17.1 to 5.0.0 in /src/PPDS.Extension",
+            labels=["dependencies"],
+            head_ref="dependabot/npm_and_yarn/src/PPDS.Extension/eslint-plugin-import-x-5.0.0",
+            files=["src/PPDS.Extension/package.json", "src/PPDS.Extension/package-lock.json"],
+        )
+        c = classify.classify_pr(pr)
         self.assertEqual(c.group, "C")
         self.assertEqual(c.update_type, "major")
         self.assertIn("major", c.reason)


### PR DESCRIPTION
## The misclassification

Today's `/dependabot-triage` run (2026-07-14) classified **PR #1342** (`eslint-plugin-import-x` 4.16.2 -> 4.17.1, a dev-only ESLint plugin in `src/PPDS.Extension` devDependencies) as **Group B** — "minor bump — verify-then-merge for runtime change". ESLint plugins are definitionally dev-only lint tooling; per `docs/MERGE-POLICY.md` tooling bumps at patch/minor are Group A (green CI is sufficient evidence). #1342 was merged after human review, so nothing shipped wrong — this fixes future triage accuracy. Same family as the stylelint gap fixed in #1311.

## The fix

Follows #1311's pattern (`TOOLING_PACKAGES` entries) plus the existing `TOOLING_PREFIXES` mechanism for definitional naming conventions (the mechanism `@types/` already uses):

- **Prefixes:** `eslint-plugin-` (ESLint resolves plugins by this naming convention), `stylelint-config-` (stylelint shareable-config convention)
- **Exact names:** `@vscode/test-electron`, `xunit.skippablefact`, `microsoft.codeanalysis.analyzers`, `microsoft.codeanalysis.publicapianalyzers`

## Sweep results

Enumerated every devDependency in `src/PPDS.Extension/package.json` and every test/build-tooling package in `Directory.Packages.props`; simulated a minor bump against the classifier before/after.

### Added (misclassified as B, unambiguous dev-only tooling)

| Package | Ecosystem | Why unambiguous | Before -> After |
|---|---|---|---|
| `eslint-plugin-import-x` (via `eslint-plugin-` prefix) | npm | ESLint plugin naming convention = lint tooling; the #1342 case | B -> A |
| `stylelint-config-standard` (via `stylelint-config-` prefix) | npm | stylelint shareable-config convention = lint config | B -> A |
| `@vscode/test-electron` | npm | test harness (downloads VS Code, runs extension tests); never in the VSIX | B -> A |
| `Xunit.SkippableFact` | NuGet | xunit extension; referenced only by `tests/PPDS.Auth.IntegrationTests` | B -> A |
| `Microsoft.CodeAnalysis.Analyzers` | NuGet | compile-time analyzer, `PrivateAssets=all` (src/PPDS.Analyzers, `IsPackable=false`); breakage = build failure = red CI | B -> A |
| `Microsoft.CodeAnalysis.PublicApiAnalyzers` | NuGet | compile-time analyzer, `PrivateAssets=all` (src/PPDS.Auth); breakage = red CI | B -> A |

### Deliberately NOT allowlisted (stay Group B on minor)

| Package | Why left conservative |
|---|---|
| `@vscode/vsce` | Packaging tool whose output IS the shipped VSIX; `extension-publish.yml` runs only on tags/dispatch, so a bad bump is invisible to PR CI |
| `MinVer` | Stamps release versions on shipped artifacts; a mis-stamp passes green CI |
| `Microsoft.SourceLink.GitHub` | Embeds source-link metadata in shipped PDBs/packages; failure is green-CI-invisible |
| `Microsoft.CodeAnalysis.CSharp` / `.CSharp.Workspaces` | General-purpose compiler API libraries — dev-only in this repo today, but runtime-capable; a name-based allowlist can't see the usage graph |
| `Microsoft.NETFramework.ReferenceAssemblies.net462` | Build-asset-only but embedded into the shipped CLI binary for runtime assembly resolution in `plugins extract` (#1294) |
| `vscode-jsonrpc`, `monaco-editor`, `@vscode/webview-ui-toolkit` | Extension runtime dependencies |
| Terminal.Gui, StreamJsonRpc, System.\*, Microsoft.Extensions.\*, Microsoft.Identity.\*, Microsoft.PowerPlatform.\*, etc. | Runtime / auth-critical — hard exclusions |

Verified post-fix that all "stay B" rows still classify B and runtime deps are unchanged.

Observations (no code change): `TOOLING_PACKAGES` contains a stray `"fakeitem"` entry (likely a `FakeItEasy` typo; harmless — the repo has no such dependency). `System.IdentityModel.Tokens.Jwt` is not in `AUTH_CRITICAL_PACKAGES` — raising it would need the MERGE-POLICY drift markers updated too, so left for separate triage.

## Test evidence

One regression test per added entry in `tests/scripts/dependabot/test_classify.py` (following #1311's test style), plus a guard that the `eslint-plugin-` prefix doesn't swallow major bumps (universal Group-C exclusion).

- Pre-fix: all 6 new tests fail (`AssertionError: 'B' != 'A'`); 68 existing pass
- Post-fix: `python -m pytest tests/scripts/dependabot/ -q` -> **74 passed**
- Full gate: `python -m pytest tests/ scripts/ --import-mode=importlib -q` -> **531 passed**

Closes #1350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded recognition of development and testing tools during automated dependency update classification.
  * Additional linting, styling, testing, and code analysis packages can now qualify for eligible minor updates.

* **Bug Fixes**
  * Major updates continue to be excluded from automatic merge eligibility, including packages matching tooling naming conventions.

* **Tests**
  * Added coverage for the newly recognized tooling packages and major-update safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->