### PR TITLE
chore(deps): let PPDS.Auth follow the central Microsoft.Extensions.Logging pin

### DIFF
--- a/src/PPDS.Auth/PPDS.Auth.csproj
+++ b/src/PPDS.Auth/PPDS.Auth.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Azure.Identity" />
 
     <!-- MSAL for device code and token caching -->
-  <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" />
 


### PR DESCRIPTION
## Summary

Removes the `VersionOverride="10.0.5"` attribute from the `Microsoft.Extensions.Logging` PackageReference in `src/PPDS.Auth/PPDS.Auth.csproj` so the package follows the central pin in `Directory.Packages.props` (`10.0.9`). The PackageReference itself stays; the line's indentation is fixed to match its neighbors.

Closes #1330

## How the drift happened

- Dependabot rollup #583 (commit `b49902559`, "Bump the microsoft-extensions group with 10 updates") mechanically injected `VersionOverride="10.0.5"` into PPDS.Auth.csproj. At that moment it was **equal to the central pin** (Directory.Packages.props also said `10.0.5`), so it changed nothing — and it landed with broken indentation, under the "MSAL" comment, with no rationale anywhere.
- Every subsequent microsoft-extensions group bump only edited `Directory.Packages.props`, so central moved `10.0.5 -> 10.0.9` while the override silently froze PPDS.Auth's copy at `10.0.5`.
- Result: PPDS.Auth — which ships to NuGet — restored `Microsoft.Extensions.Logging 10.0.5` next to `Microsoft.Extensions.Logging.Abstractions 10.0.9` (the Abstractions reference has no override, so it followed central). That intra-family skew is the observable symptom.
- The sibling equal-to-central overrides were already removed by #1334; this was the only remaining `VersionOverride` in the repo, and the only one that actually differed from central.

## Before / after resolved versions

`dotnet list src/PPDS.Auth/PPDS.Auth.csproj package` (identical across net8.0 / net9.0 / net10.0):

| Package | Before | After |
|---|---|---|
| Microsoft.Extensions.Logging | 10.0.5 | **10.0.9** |
| Microsoft.Extensions.Logging.Abstractions | 10.0.9 | 10.0.9 |

## Verification

- `dotnet build PPDS.sln -v q` — 0 errors (PPDS.Auth promotes RS0016/RS0017 to errors; no `PublicAPI.*.txt` changes needed, API surface untouched)
- `dotnet test tests/PPDS.Auth.Tests --filter "Category!=Integration"` — 592 passed / 0 failed / 1 skipped on each of net8.0, net9.0, net10.0
- Pre-commit hook additionally ran the full .NET unit suite — all green

## CI note

This PR touches `src/PPDS.Auth/**`, so it path-triggers the **Credential Store Interop** workflow — 3-OS (windows / macos / ubuntu) credential-vault validation runs against the rebased Logging dependency in addition to the standard gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project configuration to use standard logging package version resolution.
  * No user-facing behavior or functionality changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->