### PR TITLE
fix(ci): run full tests/ Python suite on pull_request (closes #1353)

### DIFF
--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -1,28 +1,42 @@
-name: Workflow Tests
+name: Python Tests
 
-# Runs the Python regression tests that protect `.claude/` workflow
-# infrastructure — hook command paths, settings-json-guard, hook envelopes.
+# Runs the repository's pure-Python regression suite (`pytest tests/`) on any
+# change that could affect it. These tests guard `.claude/` workflow
+# infrastructure, CI helper scripts (`scripts/ci/`, `scripts/dependabot/`),
+# hook behavior, and skill/spec/CLAUDE.md content.
 #
-# Existed before this workflow: `tests/test_hook_paths.py` (added by PR #907)
-# asserted every hook in `.claude/settings.json` uses `$CLAUDE_PROJECT_DIR/`.
-# It was correct and would have failed on PR #973, which silently regressed
-# all 39 entries back to bare-relative paths — but nothing in CI invoked it.
-# This workflow closes that gap so the regression can't happen a third time.
+# History of the gap this closes — the same failure has now recurred twice:
+#   * `tests/test_hook_paths.py` (PR #907) asserted every hook in
+#     `.claude/settings.json` uses `$CLAUDE_PROJECT_DIR/`. It was correct and
+#     would have caught PR #973 silently regressing all 39 entries back to
+#     bare-relative paths — but nothing in CI invoked it. This workflow was
+#     created to run that file (plus `tests/test_hooks.py`).
+#   * `tests/scripts/dependabot/test_classify.py` guards `classify.py` — the
+#     module deciding which dependabot PRs auto-merge — yet no `pull_request`
+#     workflow ran it, so a regression could merge with green CI (found while
+#     shipping PR #1351; see issue #1353).
+#
+# Rather than enumerate individual files a third time, this workflow now runs
+# the ENTIRE `tests/` Python suite, so any future test file added under
+# `tests/` is covered automatically. (The .NET test projects under `tests/`
+# have no Python test files, so pytest simply skips them.)
 
 on:
   pull_request:
     paths:
+      - 'tests/**'
+      - 'scripts/**'
       - '.claude/**'
-      - 'tests/test_hook_paths.py'
-      - 'tests/test_hooks.py'
+      - 'CLAUDE.md'
       - '.github/workflows/workflow-tests.yml'
   push:
     branches:
       - main
     paths:
+      - 'tests/**'
+      - 'scripts/**'
       - '.claude/**'
-      - 'tests/test_hook_paths.py'
-      - 'tests/test_hooks.py'
+      - 'CLAUDE.md'
       - '.github/workflows/workflow-tests.yml'
   workflow_dispatch: {}
 
@@ -43,8 +57,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install pytest + pyyaml
+        run: pip install pytest pyyaml
 
-      - name: Run hook-path regression tests
-        run: pytest tests/test_hook_paths.py tests/test_hooks.py -v
+      - name: Run Python regression suite
+        run: python -m pytest tests/ -q


### PR DESCRIPTION
Closes #1353.

## Problem

No `pull_request`-triggered workflow ran the Python tests under `tests/scripts/`, so a regression to `scripts/dependabot/classify.py` — the module that decides which dependabot PRs auto-merge — could merge with **green CI**. Nothing ever executed `tests/scripts/dependabot/test_classify.py`.

`grep pytest .github/workflows/*.yml` showed pytest ran in only three workflows, none covering `tests/scripts/`:

| Workflow | Ran |
|----------|-----|
| `workflow-tests.yml` | `tests/test_hook_paths.py tests/test_hooks.py` only |
| `extension-publish.yml` / `marketplace-listing-gate.yml` | `tests/extension_listing/` |

Everything else in `pytest tests/` (505 tests) — `tests/scripts/`, `tests/ci/`, `tests/hooks/`, and most top-level `tests/test_*.py` — was never run on a PR.

This is the exact gap class documented in `workflow-tests.yml`'s own header: `tests/test_hook_paths.py` (PR #907) went uninvoked until PR #973 silently regressed all 39 hook entries. Enumerating two files closed it for those two files only.

## Fix

Broaden `workflow-tests.yml` to run the **entire** `tests/` Python suite (`python -m pytest tests/ -q`) on any change to `tests/**`, `scripts/**`, `.claude/**`, or `CLAUDE.md`. Any future test file added under `tests/` is now covered automatically, rather than requiring a third round of file enumeration.

- Installs `pyyaml` — the only third-party dependency (verified by an import scan of `tests/` + `scripts/`), needed by the `extension_listing` and yaml-parsing suites now in scope.
- Job id kept as `workflow-tests` to preserve the check context; display name updated to **Python Tests** to reflect the broadened scope.

## Verification

- `python -m pytest tests/ -q` → **505 passed** locally (Windows + Ubuntu-equivalent pure-Python suite).
- Confirmed no required status check keys on the `workflow-tests` context (required checks are `build-status` / `test-status`), so the display-name change is safe.
- The `.NET` test projects under `tests/` contain no Python test files, so pytest skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated validation to run the complete Python test suite.
  * Added required test dependencies for broader coverage.
* **Chores**
  * Updated workflow triggers so relevant test, script, configuration, and documentation changes automatically run CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->