### PR TITLE
chore(release): PPDS.Cli 1.3.0 and PPDS.Mcp 1.1.0

### DIFF
--- a/docs/qa/security-review-cli-1.3.0-mcp-1.1.0.md
+++ b/docs/qa/security-review-cli-1.3.0-mcp-1.1.0.md
@@ -1,0 +1,73 @@
+# PPDS.Cli 1.3.0 / PPDS.Mcp 1.1.0 — Security Review
+
+**Date:** 2026-07-14
+**Reviewer:** Release-gate security review (agent-assisted, findings independently verified against source).
+**Scope:** Delta `abd0d57f5..HEAD` (everything since the last stable release `Cli-v1.2.0` / `Mcp-v1.0.1`, both tagged 2026-06-17) restricted to `src/PPDS.Cli/` and `src/PPDS.Mcp/`.
+**Method:** Full unified-diff review + read of the complete current source for every file-writing / path-handling / guardrail component, cross-checked with `git`. Focus areas: path traversal / zip-slip, arbitrary file deletion, new option path validation, secret logging, command injection, deserialization, MCP session-guardrail regression.
+
+**Why this artifact exists:** The `/release` skill's stable-release security-review gate (Rule 8) requires a `docs/qa/security-review-*.md` covering the delta since the last stable tag. The prior artifact (`security-review-v1.md`, 2026-04-20) predates this delta and does not cover it, so this review was produced specifically for the 1.3.0 / 1.1.0 boundary.
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 0 |
+| Low      | 1 |
+| Info     | 2 |
+
+**Verdict: SHIP.** No ship-blocker. The user-supplied-archive path has layered zip-slip protection, the net462 cache self-heal deletion is provably confined to a content-addressed, user-scoped path with no user-influenced traversal, and the plugin-registration changes strengthen rather than weaken existing guardrails. LOW-1 and the INFO items are non-blocking follow-ups.
+
+---
+
+## Focus-area results
+
+### 1. Path traversal / zip-slip — PASS
+User-supplied `.nupkg` (the only attacker-controllable archive) is extracted with `ZipFile.ExtractToDirectory(..., overwriteFiles: false)` (the .NET 8 built-in zip-slip mitigation) into a fresh per-invocation GUID temp directory, then **re-validated** by `AssertExtractedEntriesContained` (`NupkgExtractor.cs:163-197`): each entry is canonicalized via `Path.GetFullPath` and rejected unless it stays under the canonical destination (trailing-separator anchored, per-OS case comparison that only ever rejects). Verified directly in source.
+
+The embedded net462 reference-assembly zip (`AssemblyExtractor.cs:217-221`) is a build-time trusted resource compiled into the CLI (`PPDS.Cli.csproj` embeds `Resources.Net462ReferenceAssemblies.zip`), not attacker input.
+
+### 2. Arbitrary file deletion (net462 cache self-heal, #1326) — PASS
+`TryDeleteDirectory` (`AssemblyExtractor.cs:286-297`) deletes only `Directory.Exists(directory)` targets, and the only production callers pass `cacheDir` / `stagingDir`, both derived as `Path.Combine(baseDir, <content-hash|.staging-GUID>)`. `baseDir` in production is `Path.Combine(Path.GetTempPath(), $"ppds-{userScope}", "net462-ref")` where `userScope` is `Environment.UserName` filtered through `Path.GetInvalidFileNameChars()` (which includes path separators on both Windows and Unix, so no traversal is expressible). The cache key `hash` is a SHA-256 of the embedded resource — fixed per CLI build, never user-influenced. `--reference-dir` does **not** flow into the cache root. Verified in source (`AssemblyExtractor.cs:165-297`).
+
+### 3. `--reference-dir` new option — PASS
+Declared with `.AcceptExistingOnly()` and re-guarded with `Directory.Exists` before `Directory.GetFiles(dir, "*.dll")`. Values are used only to enumerate DLLs fed to the metadata resolver — no shell, no `Process.Start`, no command-string construction, no logging of the values, and no influence on the delete path above.
+
+### 4. Secret / credential logging — PASS
+New stderr/error lines emit only assembly file names, exception `.Message`, and plugin message/entity names. No tokens, secrets, connection strings, or credential-store values are logged. MCP `--version` / `serverInfo.version` emit only the version string.
+
+### 5. Command / argument injection — PASS
+No `Process.Start`, shell invocation, or command-string construction anywhere in the delta.
+
+### 6. Deserialization — PASS
+Plugin assemblies are inspected with `MetadataLoadContext` (metadata-only; never executes assembly code or static initializers) — the correct safe API for untrusted DLLs. Archives use `System.IO.Compression`; no `BinaryFormatter`.
+
+### 7. MCP session options / version reporting — PASS
+`McpSessionOptions.IsVersionRequested` (`McpSessionOptions.cs:51-56`) is a pure `args.Contains("--version")` check. `Program.cs:14-18` short-circuits to a version print + `return 0` **before** any host build and before `Parse` runs. It does not touch, weaken, or bypass the `--read-only` / `--allowed-env` allowlists — `Parse` (`McpSessionOptions.cs:62-86`) is unchanged and only runs on the normal startup path. Verified in source.
+
+### 8. Regression of existing guardrails — PASS (net positive)
+`UpsertStepAsync` still calls `_guard.EnsureCanMutate(...)` before any write. The new message-filter guard (#1345) is a security improvement: it refuses to silently register an unfiltered **global** step (which would fire on every occurrence of a message) when an entity was specified but no filter resolved. Identity-based GUID targeting (`PluginStepIdentity`, #1302) removes the prior "update an arbitrary same-named row" hazard.
+
+---
+
+## Findings
+
+### LOW-1 — Zip-slip re-validation runs after extraction, not before
+`src/PPDS.Cli/Plugins/Extraction/NupkgExtractor.cs` (`ExtractToDirectory` then `AssertExtractedEntriesContained`)
+The archive is written to disk first; the containment assertion inspects it only afterward. If the .NET 8 platform mitigation ever regressed, a traversal entry would already be written before the assertion threw. Impact is bounded — the primary .NET 8 mitigation is the real defense, and extraction targets a private per-invocation GUID temp dir — so this is defense-in-depth ordering, not a live vulnerability. Suggested fix: validate entry paths via `ZipFile.OpenRead` before extracting, so the guard is authoritative rather than post-hoc. **Non-blocking; track as backlog.**
+
+### INFO-1 — CSV formula injection is pre-existing and unchanged
+`src/PPDS.Cli/Infrastructure/Output/QueryResultFormatter.cs`
+The delta only changes zero-row behavior and gates `Csv` to a small set of commands; `EscapeCsvField` is unchanged. CSV values beginning with `= + - @` are not neutralized against spreadsheet formula injection — but this is pre-existing behavior outside the delta's material change. Worth a separate backlog item, not a release gate.
+
+### INFO-2 — `--reference-dir` DLL enumeration is trust-appropriate
+No action needed. The option widens only where the user's own extraction reads DLLs, at the user's own privilege; no privilege boundary is crossed.
+
+---
+
+## Follow-ups (non-blocking)
+- LOW-1: make the zip-slip guard pre-extraction authoritative in `NupkgExtractor`.
+- INFO-1: neutralize CSV formula-injection prefixes in `QueryResultFormatter.EscapeCsvField`.

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-14
+
 ### Added
 - **`--reference-dir` on `ppds plugins extract`** — repeatable option naming additional directories to search for a plugin's referenced assemblies when they live outside the input assembly's folder (#1294).
 
@@ -126,7 +128,8 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **`ppds flows get|url` accept GUID or unique name** — The `name` argument resolves by workflow ID (GUID) when provided, falling back to unique-name lookup ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Extension panel UX** — Unified panel navigation and filtering, 300 ms filter debouncing, and race-condition prevention across 8 VS Code panels ([#633](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/633)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.2.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.3.0...HEAD
+[1.3.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.2.0...Cli-v1.3.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...Cli-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0...Cli-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Cli-v1.0.0

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-14
+
 ### Added
 
 - **`ppds-mcp-server --version` prints the package version and exits** — previously the flag was documented in the README's bug-report instructions but unhandled: the server started normally and blocked silently waiting for MCP protocol messages on stdin. `--version` anywhere in the argument list now short-circuits startup, prints the MinVer-resolved version to stdout, and exits 0 ([#1273](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1273), [#1324](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1324)).
@@ -42,6 +44,7 @@ First stable release. Consolidates features developed across `1.0.0-beta.1` and 
 - **Structured MCP error responses** — All tool exceptions now surface `errorCode`, `userMessage`, and `context`, giving MCP clients machine-readable failure details ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Configurable log level** — `--log-level` flag and `PPDS_MCP_LOG_LEVEL` environment variable let operators adjust server verbosity without rebuilding ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.1...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.1.0...HEAD
+[1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.1...Mcp-v1.1.0
 [1.0.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0...Mcp-v1.0.1
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Mcp-v1.0.0


### PR DESCRIPTION
## Summary

Coordinated two-package release: **PPDS.Cli 1.3.0** and **PPDS.Mcp 1.1.0**.

This PR consolidates each package's `[Unreleased]` CHANGELOG entries into versioned
sections and adds the release-gate security review. No code changes — the released
code is already on `main` (verified green). Versions are MinVer tag-driven; no csproj
edits. Versions land via the `Cli-v1.3.0` and `Mcp-v1.1.0` tags pushed after merge.

Release window: `Cli-v1.2.0` / `Mcp-v1.0.1` (2026-06-17) → HEAD.

## Versions

| Package   | Previous (stable) | New     | Tag prefix |
|-----------|-------------------|---------|------------|
| PPDS.Cli  | 1.2.0             | 1.3.0   | `Cli-v`    |
| PPDS.Mcp  | 1.0.1             | 1.1.0   | `Mcp-v`    |

No other package has CHANGELOG deltas since its last tag (Auth/Dataverse/Migration/
Plugins/Query/Extension verified clean; dependency bumps excluded by repo convention).

## Highlights

**PPDS.Cli 1.3.0**
- Added: `--reference-dir` on `plugins extract` (search extra dirs for referenced assemblies).
- Changed: kebab-case top-level command names (`plugin-traces`, `environment-variables`,
  `connection-references`, `import-jobs`) with deprecated run-together aliases; `--output-format Csv`
  now fails clearly on commands that don't render CSV, and help/completions advertise only accepted values.
- Fixed: plugin-step matching by functional identity (survives duplicate step names); deploy/register
  refuse to silently create a global step when the entity resolves no message filter; cleaner invalid
  `--output-format` errors; single-file/self-contained `plugins extract` works (embedded net462 refs).

**PPDS.Mcp 1.1.0**
- Added: `ppds-mcp-server --version` short-circuits startup, prints the MinVer version, exits 0.
- Fixed: `serverInfo.version` in the MCP `initialize` handshake reports the real package version
  instead of the fixed `1.0.0.0` AssemblyVersion.

## Security review

`docs/qa/security-review-cli-1.3.0-mcp-1.1.0.md` — covers the delta since the last stable
tags. **Verdict: SHIP** (0 Critical/High/Medium; 1 Low + 2 Info, all non-blocking follow-ups).
Zip-slip containment, the net462 cache self-heal deletion path, and the MCP `--read-only`/
`--allowed-env` guardrails were each verified in source.

## Release flow after merge

Tags pushed individually (batch `--tags` does not trigger Actions):

```
git tag Cli-v1.3.0 <merge-sha>
git tag Mcp-v1.1.0 <merge-sha>
git push origin refs/tags/Cli-v1.3.0   # → publish-nuget.yml + release-cli.yml
sleep 3
git push origin refs/tags/Mcp-v1.1.0   # → publish-nuget.yml
```

- `Cli-v1.3.0` → NuGet tool `PPDS.Cli` + multi-platform CLI binaries + GitHub release.
- `Mcp-v1.1.0` → NuGet `PPDS.Mcp`.
- No unified `v*` tag: the two packages are on divergent versions (1.3.0 vs 1.1.0), so there is
  no single coordinated version to tag; docs-release is not triggered for this boundary.

## Test plan

- [x] Security-review gate satisfied (artifact covers `Cli-v1.2.0..HEAD` / `Mcp-v1.0.1..HEAD`).
- [x] CHANGELOG entries pre-verified accurate against real diffs (#1356).
- [x] Changes are markdown-only; released code already green on `main`.
- [ ] PR CI green (Build, Test, Integration, Credential Interop, CodeQL).
- [ ] Post-merge: NuGet listings for `PPDS.Cli` 1.3.0 and `PPDS.Mcp` 1.1.0; CLI GitHub release binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security review artifact covering the CLI 1.3.0 and MCP 1.1.0 boundary, including guardrail assessments, findings, and follow-up actions.
  * Documented the CLI 1.3.0 release and updated version comparison references.
  * Documented the MCP 1.1.0 release and updated version comparison references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->