### PR TITLE
release: Extension 1.4.1 (bundled CLI 1.3.0 refresh)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -221,6 +221,8 @@ Template: use PR #785 as reference (`gh pr view 785 --json body`).
 
 ### 8. Post-Merge: Push Tags
 
+> **Co-release rule:** A `Cli-v*` release includes an `Extension-v*` bundled-CLI refresh release in the same train — the vsix bundles the CLI at publish time (`extension-publish.yml` → `npm run bundle:cli`), so marketplace users only receive CLI changes via an extension release. Opt out only with a recorded reason in the release PR (e.g. the extension is mid-pre-release cycle).
+
 After the PR merges, pull main and push tags **individually** (see Gotcha 6):
 
 ```bash

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-14
+
+### Changed
+- **Bundled CLI updated to 1.3.0** — brings plugin-step functional-identity matching for deploy/diff/clean, a clear error instead of a silent global step when a configured entity has no SDK message filter (surfaced through the plugin panel's register/deploy flows), and working `plugins extract` from the extension's bundled single-file CLI (#1294, #1295, #1332).
+
 ## [1.4.0] - 2026-06-17
 
 ### Added
@@ -147,6 +152,7 @@ Complete ground-up rebuild of the extension. The new architecture uses a thin VS
 
 _Last stable release of the legacy architecture. See [archived repository](https://github.com/joshsmithxrm/power-platform-developer-suite/tree/archived) for full history._
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.1...HEAD
+[1.4.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.0...Extension-v1.4.1
 [1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...Extension-v1.4.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Extension-v1.2.0

--- a/src/PPDS.Extension/package-lock.json
+++ b/src/PPDS.Extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "power-platform-developer-suite",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "power-platform-developer-suite",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -2,7 +2,7 @@
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
   "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "JoshSmithXRM",
   "preview": false,
   "qna": false,


### PR DESCRIPTION
## Summary

Refreshes the **PPDS Extension** to **1.4.1** so the VS Code Marketplace vsix bundles **CLI 1.3.0** at publish time. This is a **bundled-CLI-only** release — extension source is unchanged since `Extension-v1.4.0` (only dev-dep bumps, which don't ship).

The vsix bundles the `ppds` CLI at publish time (`extension-publish.yml` → `npm run bundle:cli`), so marketplace users only receive CLI changes via an extension release. Until this ships, they still run a ~1.2.0-era CLI — including the broken single-file `plugins extract` that CLI 1.3.0 fixes.

## Versions

| Package | Previous | New | Channel |
|---|---|---|---|
| PPDS.Extension | 1.4.0 | **1.4.1** | stable (even minor) |

No other package is released. No extension-feature changes → patch bump only (no minor bump).

## What marketplace users receive (from bundled CLI 1.3.0)

- **Plugin-step functional-identity matching** for `deploy` / `diff` / `clean` (#1295)
- **A clear error instead of a silent global step** when a configured entity has no SDK message filter — surfaced through the plugin panel's register/deploy flows (#1332)
- **Working `plugins extract`** from the extension's bundled single-file CLI (#1294)

## Changes in this PR

- `src/PPDS.Extension/package.json` + `package-lock.json` — version `1.4.0` → `1.4.1`
- `src/PPDS.Extension/CHANGELOG.md` — new `## [1.4.1]` entry + compare-link refresh
- `.claude/skills/release/SKILL.md` — codifies the `Cli-v*` → `Extension-v*` bundled-CLI co-release rule (Step 8)

## Release flow after merge

1. Tag `Extension-v1.4.1` on the merge commit and push it individually.
2. `extension-publish.yml` auto-dispatches on the tag; channel inferred as **stable** (even minor).
3. Watch the 4-target matrix to completion: `win32-x64`, `linux-x64`, `darwin-x64`, `darwin-arm64` — a partial failure leaves the channel inconsistent.
4. Verify marketplace listing shows 1.4.1 on the stable channel.

## Test plan

- CI: marketplace-listing gate (pytest listing tests, triggered by the CHANGELOG touch) + pre-merge gate must be green.
- Post-merge: all 4 publish-matrix targets succeed; marketplace listing reflects 1.4.1 (stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the extension to include CLI version 1.3.0 and its latest plugin, deployment, diff, and cleanup improvements.
  - Improved the `plugins extract` workflow for more reliable operation.

- **Bug Fixes**
  - Addressed issues affecting plugin extraction and related command behavior.

- **Documentation**
  - Added release notes for extension version 1.4.1, including details of the bundled CLI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->