### PR TITLE
feat(ci): flag Cli releases missing the Extension bundled-CLI refresh (closes #1359)

### DIFF
--- a/.claude/skills/release/REFERENCE.md
+++ b/.claude/skills/release/REFERENCE.md
@@ -23,6 +23,23 @@ Channels:
 PPDS.Plugins is on its own lineage (it reached `1.0.0` ahead of the unified `1.x` line and is
 now `3.x`) — never regress its major to reconcile it with the other packages.
 
+### Cli ↔ Extension co-release rule
+
+**A `Cli-v*` release includes an `Extension-v*` bundled-CLI refresh in the same train.** The
+Extension bundles the CLI at publish time (`extension-publish.yml` → `npm run bundle:cli`), so
+marketplace users only pick up new CLI behavior when a *new* `Extension-v*` tag is cut. Whenever a
+release train ships a `Cli-v*` bump, cut an `Extension-v*` refresh that re-bundles it — even if the
+Extension's own source is unchanged (bump the Extension patch version to force a fresh vsix). Opt
+out **only** with a recorded reason (e.g. the CLI change cannot affect bundled behavior), noted in
+the release PR.
+
+This is the default that Cli-v1.3.0 + Mcp-v1.1.0 missed on 2026-07-14: no Extension release rode
+along, so marketplace users kept running ~1.2.0-era CLI behavior — including a bug 1.3.0 fixes. A
+mechanical backstop (`post-merge-release-check.yml` → `scripts/ci/check_extension_corelease.py`)
+files a `release:extension-corelease` issue whenever the latest stable `Cli-v*` tag postdates the
+latest `Extension-v*` tag, but the refresh belongs in the same train — treat the issue as a missed
+default, not the intended path.
+
 ## §2 - Signing matrix
 
 Which keys sign which surfaces:

--- a/.github/workflows/post-merge-release-check.yml
+++ b/.github/workflows/post-merge-release-check.yml
@@ -4,6 +4,15 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  # The co-release guard (extension-corelease-detection job below) compares the
+  # latest Cli-v* and Extension-v* tags. A tag push is not a pull_request event,
+  # so the pull_request trigger above can't see it — we extend the triggers
+  # minimally with a Cli-v* tag push so the guard fires exactly when a new CLI
+  # release lands. workflow_dispatch allows a manual re-check.
+  push:
+    tags:
+      - 'Cli-v*'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -147,3 +156,70 @@ jobs:
           - [ ] Close this issue
 
           > **Procedure:** Follow the [Patch Release Procedure](.claude/skills/release/SKILL.md#patch-release-procedure) in the \`/release\` skill."
+
+  extension-corelease-detection:
+    name: Detect missing Extension bundled-CLI refresh
+    runs-on: ubuntu-latest
+    # Fires on a Cli-v* tag push (and manual dispatch), never on the PR-close
+    # path above — the two jobs are mutually exclusive by event.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Check for existing open co-release issue
+        id: open-issue
+        run: |
+          # Idempotency: reuse the same label-based dedup as the cadence check so
+          # repeated runs never file a duplicate issue.
+          OPEN_COUNT=$(gh issue list --label "release:extension-corelease" --state open --json number | jq 'length')
+          echo "open_count=${OPEN_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate co-release guard
+        id: evaluate
+        run: |
+          HAS_OPEN=""
+          if [ "${{ steps.open-issue.outputs.open_count }}" -gt "0" ]; then
+            HAS_OPEN="--has-open-issue"
+          fi
+
+          RESULT=$(python scripts/ci/check_extension_corelease.py ${HAS_OPEN})
+          echo "Guard result: ${RESULT}"
+          echo "should_open=$(echo "${RESULT}" | jq -r '.should_open_issue')" >> "$GITHUB_OUTPUT"
+          echo "reason=$(echo "${RESULT}" | jq -r '.reason')" >> "$GITHUB_OUTPUT"
+
+      - name: File Extension refresh issue
+        if: steps.evaluate.outputs.should_open == 'true'
+        run: |
+          # Ensure the dedup label exists (this is a new label; --force upserts
+          # idempotently so the create below never fails on a missing label).
+          gh label create "release:extension-corelease" \
+            --color BFD4F2 \
+            --description "A Cli-v* release shipped without an Extension bundled-CLI refresh" \
+            --force
+
+          # Title/body derive only from the tag state, not the dedup flag, so we
+          # regenerate them here without --has-open-issue.
+          TITLE=$(python scripts/ci/check_extension_corelease.py --format title)
+          BODY=$(python scripts/ci/check_extension_corelease.py --format body)
+
+          gh issue create \
+            --title "${TITLE}" \
+            --body  "${BODY}" \
+            --label "release:extension-corelease"
+
+      - name: Log decision (no issue opened)
+        if: steps.evaluate.outputs.should_open != 'true'
+        run: |
+          echo "No Extension co-release issue opened. Reason: ${{ steps.evaluate.outputs.reason }}"

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -28,7 +28,11 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - 'CLAUDE.md'
-      - '.github/workflows/workflow-tests.yml'
+      # The suite asserts invariants of OTHER workflow files (e.g.
+      # tests/ci/test_post_merge_release_check.py), so a PR editing only a
+      # workflow must trigger it too — otherwise the violation merges green and
+      # the suite goes red later on an unrelated PR (issue #1359, Gap 1).
+      - '.github/workflows/**'
   push:
     branches:
       - main
@@ -37,7 +41,7 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - 'CLAUDE.md'
-      - '.github/workflows/workflow-tests.yml'
+      - '.github/workflows/**'
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/MERGE-POLICY.md
+++ b/docs/MERGE-POLICY.md
@@ -16,7 +16,7 @@ gh pr merge <num> --squash --delete-branch --auto
 
 Use auto-merge when **green CI is sufficient evidence to ship**. Specifically:
 
-- Dependabot tooling/test bumps (eslint, knip, vitest, esbuild, prettier, stylelint, typescript, @types/*, @playwright/test, @vscode/test-electron, `eslint-plugin-*`, `stylelint-config-*`, Microsoft.NET.Test.Sdk, Microsoft.CodeAnalysis.\*Analyzers, xunit + xunit.skippablefact, coverlet, Moq, FluentAssertions) — see `scripts/dependabot/classify.py` (`TOOLING_PACKAGES` / `TOOLING_PREFIXES`) for the authoritative allowlist
+- Dependabot tooling/test bumps — dev-time lint/test/build packages (e.g. eslint, knip, vitest, esbuild, `@types/*`, `@playwright/test`, Microsoft.NET.Test.Sdk). These names are **examples only**; the authoritative allowlist is `scripts/dependabot/classify.py` (`TOOLING_PACKAGES` / `TOOLING_PREFIXES`, matched via `is_tooling_package()`) — consult it rather than this list when classifying.
 - Dependabot patch-level bumps on non-critical paths
 - GitHub Actions group bumps
 - Lockfile-only changes

--- a/docs/MERGE-POLICY.md
+++ b/docs/MERGE-POLICY.md
@@ -16,7 +16,7 @@ gh pr merge <num> --squash --delete-branch --auto
 
 Use auto-merge when **green CI is sufficient evidence to ship**. Specifically:
 
-- Dependabot tooling/test bumps (eslint, knip, vitest, esbuild, @types/*, @playwright/test, Microsoft.NET.Test.Sdk)
+- Dependabot tooling/test bumps (eslint, knip, vitest, esbuild, prettier, stylelint, typescript, @types/*, @playwright/test, @vscode/test-electron, `eslint-plugin-*`, `stylelint-config-*`, Microsoft.NET.Test.Sdk, Microsoft.CodeAnalysis.\*Analyzers, xunit + xunit.skippablefact, coverlet, Moq, FluentAssertions) — see `scripts/dependabot/classify.py` (`TOOLING_PACKAGES` / `TOOLING_PREFIXES`) for the authoritative allowlist
 - Dependabot patch-level bumps on non-critical paths
 - GitHub Actions group bumps
 - Lockfile-only changes

--- a/scripts/ci/check_extension_corelease.py
+++ b/scripts/ci/check_extension_corelease.py
@@ -261,7 +261,17 @@ def collect_tags(prefix: str) -> list[TagWithDate]:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
+    if result.returncode != 0:
+        # A git failure must not masquerade as "no tags" (which would silently
+        # suppress the guard). Surface it on stderr and raise so the CI step
+        # fails loudly rather than filing/skipping an issue on bad data.
+        raise RuntimeError(
+            f"git for-each-ref for {prefix}-v* failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
     tags: list[TagWithDate] = []
     for line in result.stdout.splitlines():
         line = line.strip()
@@ -314,11 +324,21 @@ def main(argv: Optional[list[str]] = None) -> int:
         has_open_issue=args.has_open_issue,
     )
 
-    if args.format == "title":
-        # Only meaningful when a flag is warranted; callers gate on should_open_issue.
-        print(build_flag_message(result["cli_tag"], result["extension_tag"]))
-    elif args.format == "body":
-        print(build_issue_body(result["cli_tag"], result["extension_tag"]))
+    if args.format in ("title", "body"):
+        # title/body are only meaningful when a flag is warranted; the workflow
+        # gates these on should_open_issue == true. Guard the standalone case
+        # (no stable Cli tag) so we never emit a title/body naming a None tag.
+        if result["cli_tag"] is None:
+            print(
+                "no stable Cli-v* tag; nothing to flag "
+                f"(reason: {result['reason']})",
+                file=sys.stderr,
+            )
+            return 0
+        if args.format == "title":
+            print(build_flag_message(result["cli_tag"], result["extension_tag"]))
+        else:
+            print(build_issue_body(result["cli_tag"], result["extension_tag"]))
     else:
         print(json.dumps(result))
 

--- a/scripts/ci/check_extension_corelease.py
+++ b/scripts/ci/check_extension_corelease.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Co-release guard — flag a Cli-v* release that shipped without an Extension refresh.
+
+The VS Code Extension bundles the CLI at publish time (``extension-publish.yml``
+runs ``npm run bundle:cli``), so marketplace users only pick up new CLI behavior
+when a *new* ``Extension-v*`` tag is cut. If a ``Cli-v*`` release lands without a
+matching ``Extension-v*`` refresh in the same train, marketplace users keep
+running whatever CLI the last Extension release bundled — silently stale.
+
+This helper encapsulates the decision so the GitHub Actions workflow
+``post-merge-release-check.yml`` can call it and parse its JSON output, and so
+unit tests can exercise the logic without touching git, GitHub Actions, or the
+``gh`` CLI. It mirrors the shape of ``check_release_cadence.py``.
+
+Comparison model
+----------------
+Cli and Extension version *numbers* are independent lines (Cli ``1.3.0`` vs
+Extension ``1.4.1``), so "is the Extension stale?" cannot be answered by
+comparing version numbers. We compare **tag dates** instead: if the newest
+Extension tag was created *before* the newest stable Cli tag, the Extension has
+not been refreshed to bundle that CLI, and the refresh is missing.
+
+Which tags count
+----------------
+* Cli: only *stable* tags — anything with a ``-rc.`` or ``-beta.`` prerelease
+  suffix is ignored (a prerelease CLI never ships to marketplace users).
+* Extension: *all* ``Extension-v*`` tags count. Extension channels are encoded in
+  the minor version (odd minor = pre-release, even minor = stable) rather than a
+  suffix, and *either* channel bundles a fresh CLI — so we deliberately keep the
+  comparison simple and treat any newer Extension tag as a satisfied refresh.
+
+Public API
+----------
+is_stable_cli_tag(tag)      — False for -rc./-beta. suffixed Cli tags
+select_latest_stable_cli(tags) — newest stable Cli (name, date) or None
+select_latest_extension(tags)  — newest Extension (name, date) or None
+evaluate_corelease(...)     — pure decision function, returns a decision dict
+build_flag_message(...)     — the exact one-line flag string (also the issue title)
+build_issue_body(...)       — issue body Markdown
+main(argv=None)             — argparse entry point; reads git, prints JSON to stdout
+
+Exit codes
+----------
+Always 0 — the caller reads the JSON ``should_open_issue`` field to decide
+whether to file an issue, matching ``check_release_cadence.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Tag parsing / selection
+# ---------------------------------------------------------------------------
+
+# A (tag_name, tag_date) pair. Dates come from git ``creatordate`` and let us
+# answer "which release is newer?" across the two independent version lines.
+TagWithDate = tuple[str, datetime]
+
+
+def is_stable_cli_tag(tag: str) -> bool:
+    """Return True unless *tag* carries an -rc./-beta. prerelease suffix.
+
+    Mirrors the stable/prerelease distinction the rest of the release tooling
+    uses: ``Cli-v1.3.0`` is stable; ``Cli-v1.4.0-rc.1`` and ``Cli-v1.4.0-beta.2``
+    are not.
+    """
+    return "-rc." not in tag and "-beta." not in tag
+
+
+def _version_key(tag: str) -> tuple[int, ...]:
+    """Sort key from the numeric ``X.Y.Z`` core of a ``<Prefix>-vX.Y.Z`` tag.
+
+    The prerelease suffix (everything after the first ``-`` in the version) is
+    dropped for sorting; only stable tags are ranked against each other here.
+    Unparseable tags sort lowest so a malformed tag never wins selection.
+    """
+    _, _, version = tag.partition("-v")
+    core = version.split("-", 1)[0]  # strip any -rc./-beta. suffix
+    parts: list[int] = []
+    for piece in core.split("."):
+        if not piece.isdigit():
+            return (-1,)
+        parts.append(int(piece))
+    return tuple(parts) if parts else (-1,)
+
+
+def select_latest_stable_cli(tags: list[TagWithDate]) -> Optional[TagWithDate]:
+    """Return the highest-versioned *stable* Cli tag as (name, date), or None.
+
+    Prerelease Cli tags are excluded before ranking, so a newer ``-rc.`` tag can
+    never mask a missing refresh for the last stable release.
+    """
+    stable = [t for t in tags if is_stable_cli_tag(t[0])]
+    if not stable:
+        return None
+    return max(stable, key=lambda t: _version_key(t[0]))
+
+
+def select_latest_extension(tags: list[TagWithDate]) -> Optional[TagWithDate]:
+    """Return the highest-versioned Extension tag as (name, date), or None.
+
+    All Extension tags count regardless of channel (odd/even minor); either
+    channel bundles a fresh CLI.
+    """
+    if not tags:
+        return None
+    return max(tags, key=lambda t: _version_key(t[0]))
+
+
+# ---------------------------------------------------------------------------
+# Core decision logic
+# ---------------------------------------------------------------------------
+
+def evaluate_corelease(
+    *,
+    cli: Optional[TagWithDate],
+    extension: Optional[TagWithDate],
+    has_open_issue: bool,
+) -> dict:
+    """Decide whether an "Extension refresh missing" issue should be opened.
+
+    Parameters
+    ----------
+    cli:
+        The latest *stable* Cli tag as ``(name, date)``, or None if none exist.
+    extension:
+        The latest Extension tag as ``(name, date)``, or None if none exist.
+    has_open_issue:
+        True if an issue with the ``release:extension-corelease`` label is
+        already open — prevents duplicates on every run (idempotency).
+
+    Returns
+    -------
+    dict with keys:
+        should_open_issue  bool
+        reason             str  ("no stable cli tag" | "duplicate" |
+                                 "no extension tag" | "extension current" |
+                                 "extension stale")
+        cli_tag            str | None
+        extension_tag      str | None
+    """
+    cli_tag = cli[0] if cli else None
+    ext_tag = extension[0] if extension else None
+
+    if cli is None:
+        # Nothing has shipped a stable CLI yet — nothing to guard.
+        return {
+            "should_open_issue": False,
+            "reason": "no stable cli tag",
+            "cli_tag": None,
+            "extension_tag": ext_tag,
+        }
+
+    if has_open_issue:
+        return {
+            "should_open_issue": False,
+            "reason": "duplicate",
+            "cli_tag": cli_tag,
+            "extension_tag": ext_tag,
+        }
+
+    if extension is None:
+        # A stable CLI exists but the Extension has never been tagged — the
+        # bundled CLI can only be stale. Flag it.
+        return {
+            "should_open_issue": True,
+            "reason": "no extension tag",
+            "cli_tag": cli_tag,
+            "extension_tag": None,
+        }
+
+    # The refresh is satisfied when the newest Extension tag is at least as new
+    # as the newest stable Cli tag. ``>=`` keeps a same-train Extension release
+    # (tagged moments after the CLI) silent.
+    if extension[1] >= cli[1]:
+        return {
+            "should_open_issue": False,
+            "reason": "extension current",
+            "cli_tag": cli_tag,
+            "extension_tag": ext_tag,
+        }
+
+    return {
+        "should_open_issue": True,
+        "reason": "extension stale",
+        "cli_tag": cli_tag,
+        "extension_tag": ext_tag,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Issue formatting helpers
+# ---------------------------------------------------------------------------
+
+def build_flag_message(cli_tag: str, extension_tag: Optional[str]) -> str:
+    """Return the exact one-line flag string (also used as the issue title)."""
+    ext_display = extension_tag if extension_tag else "(none)"
+    return (
+        f"Extension bundled-CLI refresh missing for {cli_tag} "
+        f"(latest {ext_display} predates it)"
+    )
+
+
+def build_issue_body(cli_tag: str, extension_tag: Optional[str]) -> str:
+    """Return the GitHub issue body (Markdown) for a missing-refresh issue."""
+    ext_display = f"`{extension_tag}`" if extension_tag else "_none tagged yet_"
+    return f"""\
+## Extension Bundled-CLI Refresh Missing
+
+A `{cli_tag}` release has shipped, but the latest `Extension-v*` tag predates it. \
+The VS Code Extension bundles the CLI at publish time (`extension-publish.yml` → \
+`npm run bundle:cli`), so **marketplace users keep running the CLI bundled by the \
+last Extension release** until an `Extension-v*` refresh is cut.
+
+| Field | Value |
+|-------|-------|
+| Latest stable Cli tag | `{cli_tag}` |
+| Latest Extension tag | {ext_display} |
+
+**Default rule:** a `Cli-v*` release includes an `Extension-v*` bundled-CLI \
+refresh in the same train — opt-out only with a recorded reason.
+
+## Options for the Maintainer
+
+- **Cut the refresh** — run `/release` for an `Extension-v*` bundled-CLI refresh so \
+  marketplace users pick up `{cli_tag}`
+- **Opt out with a reason** — comment the reason on this issue and close it (e.g. \
+  the CLI change does not affect bundled behavior)
+
+## Checklist
+
+- [ ] Cut an `Extension-v*` refresh bundling `{cli_tag}`, **or** record an opt-out reason
+- [ ] Close this issue once actioned
+
+> **Procedure:** Follow the co-release rule in the [`/release` skill](.claude/skills/release/SKILL.md).
+"""
+
+
+# ---------------------------------------------------------------------------
+# git helpers (not exercised by unit tests — the pure functions above are)
+# ---------------------------------------------------------------------------
+
+def collect_tags(prefix: str) -> list[TagWithDate]:
+    """Collect ``(tag_name, creatordate)`` pairs for tags matching ``<prefix>-v*``.
+
+    Uses ``git for-each-ref`` so the creator date is available for the newness
+    comparison. Tags with an unparseable date are skipped.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "for-each-ref",
+            "--format=%(refname:short)%09%(creatordate:iso-strict)",
+            f"refs/tags/{prefix}-v*",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    tags: list[TagWithDate] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or "\t" not in line:
+            continue
+        name, _, date_str = line.partition("\t")
+        try:
+            when = datetime.fromisoformat(date_str.strip())
+        except ValueError:
+            continue
+        tags.append((name.strip(), when))
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate whether a Cli-v* release shipped without an Extension "
+            "bundled-CLI refresh. Reads git tags; outputs a JSON object to "
+            "stdout; always exits 0."
+        ),
+    )
+    parser.add_argument(
+        "--has-open-issue",
+        action="store_true",
+        default=False,
+        help="Pass this flag if an open release:extension-corelease issue exists.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "title", "body"],
+        default="json",
+        help=(
+            "Output format. 'json' (default) emits the evaluate_corelease result. "
+            "'title' emits the flag message. 'body' emits the issue body markdown."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    cli = select_latest_stable_cli(collect_tags("Cli"))
+    extension = select_latest_extension(collect_tags("Extension"))
+
+    result = evaluate_corelease(
+        cli=cli,
+        extension=extension,
+        has_open_issue=args.has_open_issue,
+    )
+
+    if args.format == "title":
+        # Only meaningful when a flag is warranted; callers gate on should_open_issue.
+        print(build_flag_message(result["cli_tag"], result["extension_tag"]))
+    elif args.format == "body":
+        print(build_issue_body(result["cli_tag"], result["extension_tag"]))
+    else:
+        print(json.dumps(result))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_extension_corelease_check.py
+++ b/tests/ci/test_extension_corelease_check.py
@@ -1,0 +1,271 @@
+"""Unit tests for scripts/ci/check_extension_corelease.py.
+
+Run with: python -m pytest tests/ci/test_extension_corelease_check.py -v
+
+Guards the co-release rule: a `Cli-v*` release includes an `Extension-v*`
+bundled-CLI refresh in the same train. Each test exercises the public functions
+directly — no source-code inspection, no string matching on implementation text —
+in the style of tests/ci/test_release_cadence_check.py.
+
+The three behaviors the task calls out:
+  (a) Cli tag newer than Extension tag  -> flagged with the exact message
+  (b) Extension tag current or newer    -> silent
+  (c) prerelease Cli tags ignored
+Plus dedup, no-tag edge cases, and the workflow trigger/wiring.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+import check_extension_corelease as cec  # noqa: E402
+
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "post-merge-release-check.yml"
+
+
+# Fixed reference instant; tags are dated relative to it (Date.now() is avoided).
+NOW = datetime(2026, 7, 14, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# (a) Cli tag newer than Extension tag -> flagged with the exact message
+# ---------------------------------------------------------------------------
+
+class TestCliNewerThanExtensionIsFlagged:
+    """A stable Cli tag dated after the latest Extension tag must be flagged."""
+
+    def test_flags_when_cli_newer(self):
+        cli = ("Cli-v1.3.0", NOW)
+        ext = ("Extension-v1.4.0", NOW - timedelta(days=30))
+
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=False)
+
+        assert result["should_open_issue"] is True
+        assert result["reason"] == "extension stale"
+        assert result["cli_tag"] == "Cli-v1.3.0"
+        assert result["extension_tag"] == "Extension-v1.4.0"
+
+    def test_flag_message_is_exact(self):
+        """The surfaced message must match the wording the task specifies."""
+        msg = cec.build_flag_message("Cli-v1.3.0", "Extension-v1.4.0")
+        assert msg == (
+            "Extension bundled-CLI refresh missing for Cli-v1.3.0 "
+            "(latest Extension-v1.4.0 predates it)"
+        )
+
+    def test_incident_scenario_end_to_end(self):
+        """The exact Cli-v1.3.0 / Extension-v1.4.0 incident: flag + message."""
+        cli = cec.select_latest_stable_cli([
+            ("Cli-v1.2.0", NOW - timedelta(days=90)),
+            ("Cli-v1.3.0", NOW),
+        ])
+        ext = cec.select_latest_extension([
+            ("Extension-v1.4.0", NOW - timedelta(days=20)),
+        ])
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=False)
+
+        assert result["should_open_issue"] is True
+        message = cec.build_flag_message(result["cli_tag"], result["extension_tag"])
+        assert message == (
+            "Extension bundled-CLI refresh missing for Cli-v1.3.0 "
+            "(latest Extension-v1.4.0 predates it)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Extension tag current or newer -> silent
+# ---------------------------------------------------------------------------
+
+class TestExtensionCurrentIsSilent:
+    """When the Extension tag is at least as new as the Cli tag, stay silent."""
+
+    def test_silent_when_extension_newer(self):
+        cli = ("Cli-v1.3.0", NOW - timedelta(days=5))
+        ext = ("Extension-v1.4.1", NOW)
+
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=False)
+
+        assert result["should_open_issue"] is False
+        assert result["reason"] == "extension current"
+
+    def test_silent_when_same_train_same_instant(self):
+        """Same-train Extension tagged at the same instant (>=) stays silent."""
+        cli = ("Cli-v1.3.0", NOW)
+        ext = ("Extension-v1.4.2", NOW)
+
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=False)
+
+        assert result["should_open_issue"] is False
+        assert result["reason"] == "extension current"
+
+
+# ---------------------------------------------------------------------------
+# (c) prerelease Cli tags ignored
+# ---------------------------------------------------------------------------
+
+class TestPrereleaseCliTagsIgnored:
+    """A newer -rc./-beta. Cli tag must not mask the last stable release."""
+
+    def test_is_stable_cli_tag_classification(self):
+        assert cec.is_stable_cli_tag("Cli-v1.3.0") is True
+        assert cec.is_stable_cli_tag("Cli-v1.4.0-rc.1") is False
+        assert cec.is_stable_cli_tag("Cli-v1.4.0-beta.2") is False
+
+    def test_prerelease_cli_excluded_from_selection(self):
+        """The newest -rc. tag is skipped; the last stable tag is selected."""
+        tags = [
+            ("Cli-v1.3.0", NOW - timedelta(days=10)),
+            ("Cli-v1.4.0-rc.1", NOW),  # newer, but prerelease
+        ]
+        selected = cec.select_latest_stable_cli(tags)
+        assert selected is not None
+        assert selected[0] == "Cli-v1.3.0"
+
+    def test_prerelease_cli_does_not_flag_when_stable_is_covered(self):
+        """
+        With a newer -rc. Cli tag but a stable Cli older than the Extension,
+        the guard stays silent — proving the prerelease is ignored. Were the
+        prerelease counted, the newer rc date would flag a stale Extension.
+        """
+        cli = cec.select_latest_stable_cli([
+            ("Cli-v1.3.0", NOW - timedelta(days=10)),
+            ("Cli-v1.4.0-rc.1", NOW),
+        ])
+        ext = cec.select_latest_extension([
+            ("Extension-v1.4.1", NOW - timedelta(days=2)),  # newer than stable Cli
+        ])
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=False)
+
+        assert result["should_open_issue"] is False
+        assert result["reason"] == "extension current"
+
+
+# ---------------------------------------------------------------------------
+# Dedup / idempotency
+# ---------------------------------------------------------------------------
+
+class TestNoDuplicateIssue:
+    def test_no_duplicate_when_issue_open(self):
+        cli = ("Cli-v1.3.0", NOW)
+        ext = ("Extension-v1.4.0", NOW - timedelta(days=30))
+
+        result = cec.evaluate_corelease(cli=cli, extension=ext, has_open_issue=True)
+
+        assert result["should_open_issue"] is False
+        assert result["reason"] == "duplicate"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: missing tags
+# ---------------------------------------------------------------------------
+
+class TestMissingTags:
+    def test_no_stable_cli_tag_is_silent(self):
+        result = cec.evaluate_corelease(
+            cli=None,
+            extension=("Extension-v1.4.0", NOW),
+            has_open_issue=False,
+        )
+        assert result["should_open_issue"] is False
+        assert result["reason"] == "no stable cli tag"
+
+    def test_no_extension_tag_flags(self):
+        cli = ("Cli-v1.3.0", NOW)
+        result = cec.evaluate_corelease(cli=cli, extension=None, has_open_issue=False)
+        assert result["should_open_issue"] is True
+        assert result["reason"] == "no extension tag"
+
+    def test_flag_message_handles_missing_extension(self):
+        msg = cec.build_flag_message("Cli-v1.3.0", None)
+        assert msg == (
+            "Extension bundled-CLI refresh missing for Cli-v1.3.0 "
+            "(latest (none) predates it)"
+        )
+
+    def test_select_latest_stable_cli_all_prerelease_returns_none(self):
+        selected = cec.select_latest_stable_cli([
+            ("Cli-v1.4.0-rc.1", NOW),
+            ("Cli-v1.4.0-beta.2", NOW - timedelta(days=1)),
+        ])
+        assert selected is None
+
+    def test_select_latest_extension_empty_returns_none(self):
+        assert cec.select_latest_extension([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Selection ranks by version, not list order
+# ---------------------------------------------------------------------------
+
+class TestSelectionRanksByVersion:
+    def test_latest_stable_cli_picks_highest_version(self):
+        tags = [
+            ("Cli-v1.3.0", NOW - timedelta(days=1)),
+            ("Cli-v1.10.0", NOW - timedelta(days=2)),  # highest version, out of order
+            ("Cli-v1.2.0", NOW),
+        ]
+        selected = cec.select_latest_stable_cli(tags)
+        assert selected[0] == "Cli-v1.10.0"
+
+    def test_latest_extension_picks_highest_version(self):
+        tags = [
+            ("Extension-v1.4.0", NOW),
+            ("Extension-v1.5.0", NOW - timedelta(days=3)),  # odd minor = pre-release channel
+        ]
+        selected = cec.select_latest_extension(tags)
+        assert selected[0] == "Extension-v1.5.0"
+
+
+# ---------------------------------------------------------------------------
+# Issue body formatting
+# ---------------------------------------------------------------------------
+
+class TestBuildIssueBody:
+    def test_body_mentions_tags_and_bundle(self):
+        body = cec.build_issue_body("Cli-v1.3.0", "Extension-v1.4.0")
+        assert "Cli-v1.3.0" in body
+        assert "Extension-v1.4.0" in body
+        assert "bundle:cli" in body
+
+    def test_body_mentions_opt_out(self):
+        body = cec.build_issue_body("Cli-v1.3.0", "Extension-v1.4.0")
+        assert "opt-out" in body.lower() or "opt out" in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# Workflow wiring — the guard is actually reachable from CI
+# ---------------------------------------------------------------------------
+
+class TestWorkflowWiring:
+    """The guard is worthless unless the workflow can see a Cli tag push."""
+
+    def _load_workflow(self) -> dict:
+        try:
+            import yaml  # type: ignore
+            with WORKFLOW_PATH.open(encoding="utf-8") as f:
+                return yaml.safe_load(f)
+        except ImportError:
+            pytest.skip("PyYAML not installed; cannot parse workflow YAML")
+
+    def test_workflow_triggers_on_cli_tag_push(self):
+        wf = self._load_workflow()
+        on = wf.get("on") or wf.get(True)  # some loaders parse `on` as True
+        push = on.get("push", {}) if isinstance(on, dict) else {}
+        tags = push.get("tags") or []
+        assert any("Cli-v" in str(t) for t in tags), (
+            f"Workflow must trigger on a Cli-v* tag push; got tags={tags!r}"
+        )
+
+    def test_corelease_job_files_issue_with_label(self):
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert "check_extension_corelease.py" in text, (
+            "Workflow must invoke the co-release guard script"
+        )
+        assert "release:extension-corelease" in text, (
+            "Workflow must file/dedup on the release:extension-corelease label"
+        )


### PR DESCRIPTION
## Incident

`Cli-v1.3.0` + `Mcp-v1.1.0` shipped 2026-07-14 **without an Extension release**. The VS Code Extension bundles the CLI at publish time (`extension-publish.yml` → `npm run bundle:cli`), so marketplace users kept running ~1.2.0-era CLI behavior — including a bug 1.3.0 fixes — because no `Extension-v*` refresh rode along to re-bundle the new CLI.

## The rule

**A `Cli-v*` release includes an `Extension-v*` bundled-CLI refresh in the same train — opt-out only with a recorded reason.** This PR is the *mechanical* backstop for that rule. The human-facing runbook paragraph is documented here too (see below) because the in-flight `release: Extension 1.4.1 (bundled CLI 1.3.0 refresh)` PR that was to carry it never landed.

## How the guard works

A new `extension-corelease-detection` job in `.github/workflows/post-merge-release-check.yml`:

- **Triggers** on a `Cli-v*` **tag push** (plus `workflow_dispatch` for a manual re-check). The existing job triggers on `pull_request: closed`, which can't see a tag push, so the triggers are extended minimally with `push.tags: ['Cli-v*']`. The two jobs are mutually exclusive by event (`github.event_name`), so neither cross-fires.
- **Compares** the latest **stable** `Cli-v*` tag against the latest `Extension-v*` tag via `scripts/ci/check_extension_corelease.py`. Because Cli and Extension version numbers are independent lines (Cli `1.3.0` vs Extension `1.4.1`), "is the Extension stale?" is answered by **tag date**, not version number: if the newest Extension tag was created *before* the newest stable Cli tag, the refresh is missing.
  - **Stable filter:** `-rc.`/`-beta.` suffixed Cli tags are excluded (a prerelease CLI never ships to marketplace users). Extension channels use the odd/even-minor convention, not suffixes, and *either* channel bundles a fresh CLI — so the comparison deliberately treats any newer Extension tag as a satisfied refresh (well-commented in the script).
- **Files** an issue titled exactly `Extension bundled-CLI refresh missing for Cli-vX.Y.Z (latest Extension-vA.B.C predates it)` through the workflow's existing `gh issue create` mechanism, with a release checklist.
- **Dedups** by reusing the cadence check's label pattern: it counts open `release:extension-corelease` issues first and passes `--has-open-issue`, so repeated runs never file a duplicate. The label is upserted idempotently (`gh label create --force`) since it's new to the repo.

## Guard the guard (Closes #1359)

- **`workflow-tests.yml` path filter** now includes `.github/workflows/**` (both `pull_request` and `push`). Previously a PR editing only a workflow never triggered the suite that asserts workflow invariants (including the new co-release tests) — the violation would merge green and surface as a misattributed red X on an unrelated PR. This was #1359 Gap 1.
- **`docs/MERGE-POLICY.md` tooling list** synced with `scripts/dependabot/classify.py`'s current `TOOLING_PACKAGES`/`TOOLING_PREFIXES` allowlist and pointed at the classifier as authoritative (it had drifted post-#1351). This was #1359 Gap 2.

## Tests

`tests/ci/test_extension_corelease_check.py` (20 tests), in the existing test file's style:

- **(a)** Cli tag newer than Extension → flagged, asserting the **exact** message.
- **(b)** Extension tag current or newer → silent (including same-instant same-train).
- **(c)** prerelease Cli tags ignored — a newer `-rc.` tag does not mask the last stable release.
- Plus dedup, missing-tag edge cases, version-rank selection, issue-body content, and workflow wiring (tag-push trigger + script/label presence).

Each fails without the change (the test module imports the new script; workflow-wiring tests assert the new trigger/label).

## Gates

- `python -m pytest tests/ scripts/ --import-mode=importlib -q` → **551 passed**.
- Both touched workflow YAMLs validated with `yaml.safe_load`.

## Sweep results

| Item | Disposition |
|---|---|
| 1.4.1 release PR / runbook paragraph | **Never landed** (no PR exists). Runbook paragraph added to `.claude/skills/release/REFERENCE.md` §1 — not `SKILL.md`, which is 626 lines and blocked by the 150-line-cap hook; the repo's two-file pattern puts runbook detail in REFERENCE.md. |
| #1359 Gap 1 (path filter) | Fixed |
| #1359 Gap 2 (MERGE-POLICY drift) | Fixed |

Closes #1359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automated co-release guard to detect when a new CLI stable release is missing the corresponding Extension bundled refresh, using tag timing and stable-only selection.
  - Creates a deduplicated follow-up issue with standardized messaging; stays quiet when the Extension refresh is current.

- **CI / Workflows**
  - Added a tag-push trigger so the guard runs on new matching CLI tags (with manual re-runs).
  - Broadened workflow regression coverage to run when any workflow definition changes.

- **Documentation**
  - Updated the release reference with the default co-release rule and opt-out requirements.
  - Expanded Dependabot auto-merge eligibility examples and pointed to the authoritative allowlist.

- **Tests**
  - Added unit tests covering detection, prerelease exclusion, idempotency, and issue/workflow wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->