### PR TITLE
fix(ext): bound DataTable virtual-scroll host so full lists render (#1365)

### DIFF
--- a/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { DataTable } from '../../../panels/webview/shared/data-table.js';
+
+/**
+ * Regression guard for the virtual-scroll "empty void" bug.
+ *
+ * DataTable virtualises rows and reads `scrollContainer.clientHeight` to decide the
+ * visible window. The inner `.data-table-scroll` is `flex:1; min-height:0`, so it only
+ * gets a real (bounded) height when its host is a flex column. If the host is a plain
+ * block, `.data-table-scroll` expands to the full content height, never scrolls, its
+ * scroll handler never fires, and only the initial row buffer renders — the rest of the
+ * list becomes an empty void. (Introduced with virtual scrolling in PR #651 /
+ * commit f809c0e0; shipped in every Extension release since v0.7.0.)
+ *
+ * The fix has two coupled halves — DataTable tags its host `.data-table-host`, and
+ * shared.css makes `.data-table-host` a flex column. Both must stay in place, so both
+ * are asserted here.
+ */
+describe('DataTable virtual-scroll host contract', () => {
+    it('tags its host element with .data-table-host', () => {
+        // Minimal container stub — the constructor only calls classList.add + addEventListener.
+        const classes = new Set<string>();
+        const container = {
+            classList: {
+                add: (c: string) => classes.add(c),
+                remove: (c: string) => classes.delete(c),
+                contains: (c: string) => classes.has(c),
+            },
+            addEventListener: () => { /* no-op */ },
+        };
+
+        new DataTable<{ id: string }>({
+            columns: [{ key: 'id', label: 'Id', render: (r) => r.id }],
+            getRowId: (r) => r.id,
+            container,
+        });
+
+        // The class the CSS below hangs off of must be applied to the host.
+        expect(classes.has('data-table-host')).toBe(true);
+    });
+
+    it('shared.css makes .data-table-host a bounded flex column', () => {
+        const css = readFileSync(
+            resolve(__dirname, '../../../panels/styles/shared.css'),
+            'utf-8',
+        );
+        const rule = css.match(/\.data-table-host\s*\{([^}]*)\}/);
+        expect(rule, '.data-table-host rule missing from shared.css').not.toBeNull();
+        const body = rule![1];
+        // Without a flex column + min-height:0, the inner .data-table-scroll cannot be bounded.
+        expect(body).toMatch(/display\s*:\s*flex/);
+        expect(body).toMatch(/flex-direction\s*:\s*column/);
+        expect(body).toMatch(/min-height\s*:\s*0/);
+    });
+});

--- a/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
@@ -47,12 +47,13 @@ describe('DataTable virtual-scroll host contract', () => {
             resolve(__dirname, '../../../panels/styles/shared.css'),
             'utf-8',
         );
-        const rule = css.match(/\.data-table-host\s*\{([^}]*)\}/);
+        // Tolerate grouped selectors and extra whitespace (e.g. `.data-table-host, .x {`).
+        const rule = css.match(/(?:^|[\s,])\.data-table-host\b[^{]*\{([^}]*)\}/);
         expect(rule, '.data-table-host rule missing from shared.css').not.toBeNull();
         const body = rule![1];
         // Without a flex column + min-height:0, the inner .data-table-scroll cannot be bounded.
-        expect(body).toMatch(/display\s*:\s*flex/);
-        expect(body).toMatch(/flex-direction\s*:\s*column/);
-        expect(body).toMatch(/min-height\s*:\s*0/);
+        expect(body).toMatch(/display\s*:\s*flex\b/);
+        expect(body).toMatch(/flex-direction\s*:\s*column\b/);
+        expect(body).toMatch(/min-height\s*:\s*0\b/);
     });
 });

--- a/src/PPDS.Extension/src/panels/styles/shared.css
+++ b/src/PPDS.Extension/src/panels/styles/shared.css
@@ -249,6 +249,18 @@ input, textarea, pre, code, .selectable, [contenteditable], .data-table td {
     color: var(--vscode-list-activeSelectionForeground);
 }
 
+/* DataTable host — the element a DataTable is mounted into.
+   Applied automatically by DataTable (see data-table.ts). Must be a bounded
+   flex column so the inner `.data-table-scroll` (flex:1; min-height:0) resolves
+   to a real height and becomes the scroll viewport. Without this, the scroll
+   wrapper grows to full content height, never fires its scroll handler, and
+   virtual scrolling only ever renders the initial row buffer (empty void below). */
+.data-table-host {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
 /* Virtual scroll container */
 .data-table-scroll {
     overflow: auto;

--- a/src/PPDS.Extension/src/panels/webview/shared/data-table.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/data-table.ts
@@ -59,6 +59,15 @@ export class DataTable<T> {
 
     constructor(opts: DataTableOptions<T>) {
         this.opts = opts;
+
+        // Virtual scrolling requires the inner `.data-table-scroll` (flex:1; min-height:0)
+        // to be height-bounded by a flex-column host. Tag the container so it becomes the
+        // scroll viewport regardless of how the panel lays it out. Without this, when the
+        // container is not itself a flex column, `.data-table-scroll` expands to full content
+        // height, never scrolls, and only the initial row buffer renders — leaving the rest of
+        // the list as an empty void. See shared.css `.data-table-host`.
+        opts.container.classList.add('data-table-host');
+
         this.sortKey = opts.defaultSortKey ?? opts.columns[0]?.key ?? '';
         // Map legacy 'desc'/'asc' default to our three-state (for backward compat, default 'desc' means active desc)
         this.sortDirection = opts.defaultSortDirection === 'asc' ? 'asc' : opts.defaultSortDirection === 'desc' ? 'desc' : 'none';


### PR DESCRIPTION
Fixes #1365.

## Problem

The shared webview `DataTable` virtual-scroll rendered only the initial ~22-row buffer and then an **empty void** for the rest of the list. It broke the **Metadata Browser** and 4 other panels (Import Jobs, Environment Variables, Connection References, Web Resources). Plugin Traces was unaffected — and that's the clue.

## Root cause

`updateVisibleRows()` sizes the visible window from `.data-table-scroll`'s `clientHeight` and re-renders on that element's `scroll` event. `.data-table-scroll` is `flex:1; min-height:0`, so it is only height-bounded when its **host is a flex column**.

- Plugin Traces mounts the table into `.table-pane` (`display:flex; flex-direction:column`) → works.
- Every other panel mounts into a plain block (`.content`, `.attr-table-wrapper`, …) → `.data-table-scroll` expands to full content height (`clientHeight === scrollHeight`), never scrolls internally, its scroll handler never fires, and only the init buffer renders. The bottom spacer still reserves the full height, so the scrollbar scrolls into blank space.

Introduced with virtual scrolling in f809c0e0 (#651, 2026-03-23); shipped in **every** Extension release since `v0.7.0`.

## Fix

`DataTable` now tags its host element `.data-table-host` (in the constructor), and `shared.css` defines `.data-table-host` as a bounded flex column (`display:flex; flex-direction:column; min-height:0`). This makes the inner `.data-table-scroll` the bounded scroll viewport for **every** consumer, current and future — the same shape Plugin Traces already relied on. No per-panel changes required.

## Verification

Confirmed in a faithful browser repro (real layout engine, verbatim virtual-scroll logic + panel CSS, 200-row list):

| | inner `clientHeight` | inner `scrollHeight` | rows rendered |
|---|---|---|---|
| before | 5553 | 5553 (equal → never scrolls) | 23 (stuck) |
| after | 562 | 5473 | 47 (windowed correctly) |

- New regression test (`data-table-host.test.ts`) locks both halves of the fix: the class is applied to the host, and `shared.css` keeps `.data-table-host` a flex column.
- `data-table-host` verified present in every built panel bundle (JS + CSS).

## Gates

- `typecheck:all` ✅  · `compile` (esbuild) ✅  · `lint` ✅ (0 errors)  · `lint:css` ✅  · `vitest run` ✅ (471 passed)

## Notes / follow-up

The Metadata Browser **Choices** tab mounts sub-tables into unbounded plain-`div` hosts; those lists are short (the buffer covers them), so this change leaves them no worse. A non-virtualized render for that tab would be a small follow-up if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DataTable layout so virtual scrolling uses a correctly bounded scroll viewport.
  * Added DataTable host styling to ensure the inner scroll region sizes properly within panel layouts.

* **Tests**
  * Added a regression test verifying DataTable applies the host CSS class and that the corresponding shared CSS rule enables the expected flex/height behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->