### PR TITLE
fix(ext,cli,mcp,tui): metadata browser round 2 — Choices tab, wire fidelity, mark-don't-mask auxiliaries, tab order

### DIFF
--- a/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
+++ b/src/PPDS.Cli/Commands/Metadata/AttributesCommand.cs
@@ -27,12 +27,20 @@ public static class AttributesCommand
             Description = "Filter by attribute type (e.g., 'Lookup', 'String', 'DateTime', 'Picklist')"
         };
 
+        // #1368 "mark, don't mask": auxiliaries are shown (and flagged) by default;
+        // exclusion is an explicit opt-in so scripts and humans both see the full schema.
+        var excludeAuxiliaryOption = new Option<bool>("--exclude-auxiliary")
+        {
+            Description = "Exclude auxiliary attributes (lookup name/yomi companions marked with AttributeOf)"
+        };
+
         var command = new Command("attributes", "List attributes for an entity")
         {
             entityArgument,
             MetadataCommandGroup.ProfileOption,
             MetadataCommandGroup.EnvironmentOption,
-            typeOption
+            typeOption,
+            excludeAuxiliaryOption
         };
 
         GlobalOptions.AddToCommand(command);
@@ -43,9 +51,10 @@ public static class AttributesCommand
             var profile = parseResult.GetValue(MetadataCommandGroup.ProfileOption);
             var environment = parseResult.GetValue(MetadataCommandGroup.EnvironmentOption);
             var type = parseResult.GetValue(typeOption);
+            var excludeAuxiliary = parseResult.GetValue(excludeAuxiliaryOption);
             var globalOptions = GlobalOptions.GetValues(parseResult);
 
-            return await ExecuteAsync(entity!, profile, environment, type, globalOptions, cancellationToken);
+            return await ExecuteAsync(entity!, profile, environment, type, excludeAuxiliary, globalOptions, cancellationToken);
         });
 
         return command;
@@ -56,6 +65,7 @@ public static class AttributesCommand
         string? profile,
         string? environment,
         string? type,
+        bool excludeAuxiliary,
         GlobalOptionValues globalOptions,
         CancellationToken cancellationToken)
     {
@@ -83,6 +93,11 @@ public static class AttributesCommand
 
             var attributes = await metadataService.GetAttributesAsync(entity, type, cancellationToken);
 
+            if (excludeAuxiliary)
+            {
+                attributes = attributes.Where(a => a.AttributeOf == null).ToList();
+            }
+
             if (globalOptions.IsJsonMode)
             {
                 writer.WriteSuccess(attributes);
@@ -102,6 +117,8 @@ public static class AttributesCommand
                     if (!attr.IsValidForCreate && !attr.IsValidForUpdate) flags.Add("readonly");
                     if (attr.RequiredLevel == "ApplicationRequired" || attr.RequiredLevel == "SystemRequired")
                         flags.Add("required");
+                    // #1368 "mark, don't mask": auxiliary companions are flagged, not hidden
+                    if (attr.AttributeOf != null) flags.Add($"aux:{attr.AttributeOf}");
 
                     var flagText = flags.Count > 0 ? string.Join(", ", flags) : "";
                     Console.WriteLine($"  {attr.LogicalName,-35} {attr.AttributeType,-20} {attr.DisplayName,-30} {flagText}");

--- a/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.Metadata.cs
+++ b/src/PPDS.Cli/Commands/Serve/Handlers/RpcMethodHandler.Metadata.cs
@@ -238,7 +238,8 @@ public partial class RpcMethodHandler
         };
     }
 
-    private static MetadataAttributeDto MapAttributeToRpc(AttributeMetadataDto a)
+    // Internal for tests: the wire contract must preserve every service-DTO field (#1369).
+    internal static MetadataAttributeDto MapAttributeToRpc(AttributeMetadataDto a)
     {
         return new MetadataAttributeDto
         {
@@ -264,7 +265,35 @@ public partial class RpcMethodHandler
             SourceType = a.SourceType,
             IsSecured = a.IsSecured,
             Description = a.Description,
-            AutoNumberFormat = a.AutoNumberFormat
+            AutoNumberFormat = a.AutoNumberFormat,
+            // Full-fidelity pass-through (#1369)
+            MetadataId = a.MetadataId,
+            IsManaged = a.IsManaged,
+            AttributeOf = a.AttributeOf,
+            IsLogical = a.IsLogical,
+            IsValidForCreate = a.IsValidForCreate,
+            IsValidForUpdate = a.IsValidForUpdate,
+            IsValidForRead = a.IsValidForRead,
+            IsValidForForm = a.IsValidForForm,
+            IsValidForGrid = a.IsValidForGrid,
+            IsValidForAdvancedFind = a.IsValidForAdvancedFind,
+            IsSearchable = a.IsSearchable,
+            IsFilterable = a.IsFilterable,
+            IsSortable = a.IsSortable,
+            IsRetrievable = a.IsRetrievable,
+            CanBeSecuredForRead = a.CanBeSecuredForRead,
+            CanBeSecuredForCreate = a.CanBeSecuredForCreate,
+            CanBeSecuredForUpdate = a.CanBeSecuredForUpdate,
+            IsAuditEnabled = a.IsAuditEnabled,
+            IsCustomizable = a.IsCustomizable,
+            IsRenameable = a.IsRenameable,
+            FormulaDefinition = a.FormulaDefinition,
+            IntroducedVersion = a.IntroducedVersion,
+            DeprecatedVersion = a.DeprecatedVersion,
+            ExternalName = a.ExternalName,
+            ColumnNumber = a.ColumnNumber,
+            CreatedOn = a.CreatedOn,
+            ModifiedOn = a.ModifiedOn
         };
     }
 
@@ -652,6 +681,99 @@ public class MetadataAttributeDto
     [JsonPropertyName("autoNumberFormat")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AutoNumberFormat { get; set; }
+
+    // ── Full-fidelity pass-through of the service DTO (#1369) ──
+    // The RPC layer originally forwarded a curated subset; clients (Metadata
+    // Browser properties panel) need the complete attribute metadata.
+
+    [JsonPropertyName("metadataId")]
+    public Guid MetadataId { get; set; }
+
+    [JsonPropertyName("isManaged")]
+    public bool IsManaged { get; set; }
+
+    [JsonPropertyName("attributeOf")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AttributeOf { get; set; }
+
+    [JsonPropertyName("isLogical")]
+    public bool IsLogical { get; set; }
+
+    [JsonPropertyName("isValidForCreate")]
+    public bool IsValidForCreate { get; set; }
+
+    [JsonPropertyName("isValidForUpdate")]
+    public bool IsValidForUpdate { get; set; }
+
+    [JsonPropertyName("isValidForRead")]
+    public bool IsValidForRead { get; set; }
+
+    [JsonPropertyName("isValidForForm")]
+    public bool IsValidForForm { get; set; }
+
+    [JsonPropertyName("isValidForGrid")]
+    public bool IsValidForGrid { get; set; }
+
+    [JsonPropertyName("isValidForAdvancedFind")]
+    public bool IsValidForAdvancedFind { get; set; }
+
+    [JsonPropertyName("isSearchable")]
+    public bool IsSearchable { get; set; }
+
+    [JsonPropertyName("isFilterable")]
+    public bool IsFilterable { get; set; }
+
+    [JsonPropertyName("isSortable")]
+    public bool IsSortable { get; set; }
+
+    [JsonPropertyName("isRetrievable")]
+    public bool IsRetrievable { get; set; }
+
+    [JsonPropertyName("canBeSecuredForRead")]
+    public bool CanBeSecuredForRead { get; set; }
+
+    [JsonPropertyName("canBeSecuredForCreate")]
+    public bool CanBeSecuredForCreate { get; set; }
+
+    [JsonPropertyName("canBeSecuredForUpdate")]
+    public bool CanBeSecuredForUpdate { get; set; }
+
+    [JsonPropertyName("isAuditEnabled")]
+    public bool IsAuditEnabled { get; set; }
+
+    [JsonPropertyName("isCustomizable")]
+    public bool IsCustomizable { get; set; }
+
+    [JsonPropertyName("isRenameable")]
+    public bool IsRenameable { get; set; }
+
+    [JsonPropertyName("formulaDefinition")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FormulaDefinition { get; set; }
+
+    [JsonPropertyName("introducedVersion")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IntroducedVersion { get; set; }
+
+    [JsonPropertyName("deprecatedVersion")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DeprecatedVersion { get; set; }
+
+    [JsonPropertyName("externalName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExternalName { get; set; }
+
+    [JsonPropertyName("columnNumber")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ColumnNumber { get; set; }
+
+    [JsonPropertyName("createdOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? CreatedOn { get; set; }
+
+    [JsonPropertyName("modifiedOn")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? ModifiedOn { get; set; }
 }
 
 public class MetadataRelationshipDto

--- a/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
+++ b/src/PPDS.Cli/Tui/Screens/MetadataExplorerScreen.cs
@@ -1104,9 +1104,15 @@ internal sealed class MetadataExplorerScreen : TuiScreenBase
 
         foreach (var attr in _selectedEntity!.Attributes.OrderBy(a => a.LogicalName))
         {
+            // #1368 "mark, don't mask": auxiliary companions have no display name of
+            // their own \u2014 show what they extend instead of a blank cell.
+            var displayName = attr.AttributeOf != null && string.IsNullOrEmpty(attr.DisplayName)
+                ? $"aux of {attr.AttributeOf}"
+                : attr.DisplayName;
+
             dt.Rows.Add(
                 attr.LogicalName,
-                attr.DisplayName,
+                displayName,
                 attr.AttributeType,
                 attr.RequiredLevel ?? "\u2014",
                 attr.IsCustomAttribute ? "\u2713" : "\u2014",

--- a/src/PPDS.Dataverse/Metadata/DataverseMetadataQueryService.cs
+++ b/src/PPDS.Dataverse/Metadata/DataverseMetadataQueryService.cs
@@ -582,7 +582,16 @@ public class DataverseMetadataQueryService : IMetadataQueryService
             IsRetrievable = attr.IsRetrievable ?? false,
             AttributeOf = attr.AttributeOf,
             IsLogical = attr.IsLogical ?? false,
-            IntroducedVersion = attr.IntroducedVersion
+            IntroducedVersion = attr.IntroducedVersion,
+            DeprecatedVersion = attr.DeprecatedVersion,
+            IsAuditEnabled = attr.IsAuditEnabled?.Value ?? false,
+            IsCustomizable = attr.IsCustomizable?.Value ?? false,
+            IsRenameable = attr.IsRenameable?.Value ?? false,
+            IsValidForAdvancedFind = attr.IsValidForAdvancedFind?.Value ?? false,
+            ExternalName = attr.ExternalName,
+            ColumnNumber = attr.ColumnNumber,
+            CreatedOn = attr.CreatedOn,
+            ModifiedOn = attr.ModifiedOn
         };
     }
 

--- a/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
+++ b/src/PPDS.Dataverse/Metadata/Models/AttributeMetadataDto.cs
@@ -269,5 +269,59 @@ public sealed class AttributeMetadataDto
     [JsonPropertyName("introducedVersion")]
     public string? IntroducedVersion { get; init; }
 
+    /// <summary>
+    /// Gets the version when this attribute was deprecated.
+    /// </summary>
+    [JsonPropertyName("deprecatedVersion")]
+    public string? DeprecatedVersion { get; init; }
+
+    /// <summary>
+    /// Gets whether auditing is enabled for this attribute.
+    /// </summary>
+    [JsonPropertyName("isAuditEnabled")]
+    public bool IsAuditEnabled { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute is customizable.
+    /// </summary>
+    [JsonPropertyName("isCustomizable")]
+    public bool IsCustomizable { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute can be renamed.
+    /// </summary>
+    [JsonPropertyName("isRenameable")]
+    public bool IsRenameable { get; init; }
+
+    /// <summary>
+    /// Gets whether the attribute appears in Advanced Find.
+    /// </summary>
+    [JsonPropertyName("isValidForAdvancedFind")]
+    public bool IsValidForAdvancedFind { get; init; }
+
+    /// <summary>
+    /// Gets the external name for virtual entity providers.
+    /// </summary>
+    [JsonPropertyName("externalName")]
+    public string? ExternalName { get; init; }
+
+    /// <summary>
+    /// Gets the physical column number of the attribute.
+    /// </summary>
+    [JsonPropertyName("columnNumber")]
+    public int? ColumnNumber { get; init; }
+
+    /// <summary>
+    /// Gets when the attribute was created.
+    /// </summary>
+    [JsonPropertyName("createdOn")]
+    public DateTime? CreatedOn { get; init; }
+
+    /// <summary>
+    /// Gets when the attribute was last modified.
+    /// </summary>
+    [JsonPropertyName("modifiedOn")]
+    public DateTime? ModifiedOn { get; init; }
+
     #endregion
 }

--- a/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webview/data-table-host.test.ts
@@ -20,8 +20,8 @@ import { DataTable } from '../../../panels/webview/shared/data-table.js';
  * are asserted here.
  */
 describe('DataTable virtual-scroll host contract', () => {
-    it('tags its host element with .data-table-host', () => {
-        // Minimal container stub — the constructor only calls classList.add + addEventListener.
+    // Minimal container stub — the constructor only calls classList.add + addEventListener.
+    function fakeContainer(): { classes: Set<string>; container: unknown } {
         const classes = new Set<string>();
         const container = {
             classList: {
@@ -31,15 +31,35 @@ describe('DataTable virtual-scroll host contract', () => {
             },
             addEventListener: () => { /* no-op */ },
         };
+        return { classes, container };
+    }
+
+    it('tags its host element with .data-table-host', () => {
+        const { classes, container } = fakeContainer();
 
         new DataTable<{ id: string }>({
             columns: [{ key: 'id', label: 'Id', render: (r) => r.id }],
             getRowId: (r) => r.id,
-            container,
+            container: container as never,
         });
 
         // The class the CSS below hangs off of must be applied to the host.
         expect(classes.has('data-table-host')).toBe(true);
+    });
+
+    it('accepts virtualize:false and rowClassName (#1367/#1368 contract)', () => {
+        const { container } = fakeContainer();
+
+        // Compile-time + constructor-level lock: eager mode for short tables with
+        // expansion rows (#1367), and per-row marking for auxiliary items (#1368).
+        const table = new DataTable<{ id: string; aux: boolean }>({
+            columns: [{ key: 'id', label: 'Id', render: (r) => r.id }],
+            getRowId: (r) => r.id,
+            container: container as never,
+            virtualize: false,
+            rowClassName: (r) => r.aux ? 'attr-aux' : null,
+        });
+        expect(table).toBeInstanceOf(DataTable);
     });
 
     it('shared.css makes .data-table-host a bounded flex column', () => {

--- a/src/PPDS.Extension/src/__tests__/panels/webview/metadata-utils.test.ts
+++ b/src/PPDS.Extension/src/__tests__/panels/webview/metadata-utils.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+import { isAuxiliaryAttribute } from '../../../panels/webview/shared/metadata-utils.js';
+import type { MetadataAttributeDto } from '../../../types.js';
+
+/**
+ * #1368/#1369 contract tests.
+ *
+ * - isAuxiliaryAttribute: AttributeOf is the deterministic marker for auxiliary
+ *   attributes (lookup name/yomi companions), used to MARK rows (and power the
+ *   user-initiated hide toggle) per "mark, don't mask". Missing field (older
+ *   bundled CLI) must degrade to "real attribute" — pre-widening behavior.
+ * - The fully-populated literal locks the widened DTO shape at compile time: if a
+ *   full-fidelity field is dropped from types.ts, this file stops compiling.
+ */
+
+function makeAttr(overrides: Partial<MetadataAttributeDto> = {}): MetadataAttributeDto {
+    return {
+        logicalName: 'name',
+        displayName: 'Account Name',
+        schemaName: 'Name',
+        attributeType: 'String',
+        attributeTypeName: 'StringType',
+        isPrimaryId: false,
+        isPrimaryName: true,
+        isCustomAttribute: false,
+        requiredLevel: 'ApplicationRequired',
+        maxLength: 160,
+        minValue: null,
+        maxValue: null,
+        precision: null,
+        targets: null,
+        optionSetName: null,
+        isGlobalOptionSet: false,
+        options: null,
+        format: 'Text',
+        dateTimeBehavior: null,
+        sourceType: 0,
+        isSecured: false,
+        description: 'Type the company or business name.',
+        autoNumberFormat: null,
+        ...overrides,
+    };
+}
+
+describe('isAuxiliaryAttribute (#1368)', () => {
+    it('flags attributes carrying attributeOf', () => {
+        expect(isAuxiliaryAttribute(makeAttr({
+            logicalName: 'primarycontactidname',
+            displayName: null,
+            attributeOf: 'primarycontactid',
+        }))).toBe(true);
+    });
+
+    it('treats null attributeOf as a real attribute', () => {
+        expect(isAuxiliaryAttribute(makeAttr({ attributeOf: null }))).toBe(false);
+    });
+
+    it('treats a missing attributeOf field (older bundled CLI) as a real attribute', () => {
+        expect(isAuxiliaryAttribute(makeAttr())).toBe(false);
+    });
+
+    it('treats an empty-string attributeOf as a real attribute', () => {
+        expect(isAuxiliaryAttribute(makeAttr({ attributeOf: '' }))).toBe(false);
+    });
+});
+
+describe('MetadataAttributeDto full-fidelity shape (#1369)', () => {
+    it('accepts every widened wire field', () => {
+        // Required<> forces every optional field to be present — a compile-time
+        // exhaustiveness lock on the widened contract.
+        const full: Required<MetadataAttributeDto> = {
+            ...makeAttr(),
+            metadataId: '11111111-2222-3333-4444-555555555555',
+            isManaged: true,
+            attributeOf: 'primarycontactid',
+            isLogical: true,
+            isValidForCreate: true,
+            isValidForUpdate: false,
+            isValidForRead: true,
+            isValidForForm: true,
+            isValidForGrid: false,
+            isValidForAdvancedFind: true,
+            isSearchable: true,
+            isFilterable: true,
+            isSortable: true,
+            isRetrievable: true,
+            canBeSecuredForRead: true,
+            canBeSecuredForCreate: false,
+            canBeSecuredForUpdate: true,
+            isAuditEnabled: true,
+            isCustomizable: false,
+            isRenameable: true,
+            formulaDefinition: '<formula/>',
+            introducedVersion: '5.0.0.0',
+            deprecatedVersion: '9.0.0.0',
+            externalName: 'ext_name',
+            columnNumber: 42,
+            createdOn: '2024-01-02T03:04:05Z',
+            modifiedOn: '2025-06-07T08:09:10Z',
+        };
+        expect(full.attributeOf).toBe('primarycontactid');
+        expect(full.isAuditEnabled).toBe(true);
+    });
+});

--- a/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
+++ b/src/PPDS.Extension/src/panels/styles/metadata-browser-panel.css
@@ -189,10 +189,13 @@
     padding: 6px 8px;
     border-bottom: 1px solid var(--vscode-panel-border);
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 .tab-search-input {
-    width: 100%;
+    flex: 1;
     background: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
     border: 1px solid var(--vscode-input-border);
@@ -285,6 +288,17 @@
 .data-table-row.selected {
     background: var(--vscode-list-activeSelectionBackground);
     color: var(--vscode-list-activeSelectionForeground);
+}
+
+/* ── Auxiliary attributes (#1368: mark, don't mask) ────────────────────── */
+
+.data-table-row.attr-aux {
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+}
+
+.attr-aux-label {
+    opacity: 0.85;
 }
 
 /* Entity links in relationship tables */

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -48,9 +48,11 @@ let currentGlobalChoice: MetadataOptionSetDto | null = null;
 let activeTab = 'config';
 let hideSystem = false;
 let intersectHiddenCount = 0;
-// #1368 "mark, don't mask": auxiliary attributes (attributeOf != null) are SHOWN by
-// default and visually marked; this user-initiated toggle hides them for cleanliness.
-let hideAuxiliaryAttributes = false;
+// #1368: auxiliary attributes (attributeOf != null) are hidden by default because
+// they are dense API plumbing, but this is a *disclosed* reduction, not a silent one:
+// the toggle shows the hidden count and restores them in one click (same contract as
+// the "Include Intersect" entity filter). When shown they are visually marked.
+let hideAuxiliaryAttributes = true;
 
 // Per-tab search state
 const tabSearchTerms: Record<string, string> = {};
@@ -555,20 +557,25 @@ function renderAttributesTab(): void {
         renderAttributeTable(tabContent, currentEntity!.attributes);
     });
 
-    // #1368 "mark, don't mask": auxiliaries show by default; this hides them on request.
-    const auxToggle = document.createElement('label');
-    auxToggle.className = 'toolbar-checkbox';
-    const auxCheckbox = document.createElement('input');
-    auxCheckbox.type = 'checkbox';
-    auxCheckbox.checked = hideAuxiliaryAttributes;
-    auxCheckbox.addEventListener('change', () => {
-        hideAuxiliaryAttributes = auxCheckbox.checked;
-        renderAttributeTable(tabContent, currentEntity!.attributes);
-    });
-    auxToggle.appendChild(auxCheckbox);
-    auxToggle.appendChild(document.createTextNode(' Hide auxiliary'));
-    auxToggle.title = 'Hide auxiliary attributes (lookup name/yomi companions marked with AttributeOf)';
-    searchBar.appendChild(auxToggle);
+    // #1368: hidden by default, but disclosed — the label carries the hidden count so
+    // the reduction is visible, and one click restores them (the intersect-filter contract).
+    const auxCount = currentEntity.attributes.filter(isAuxiliaryAttribute).length;
+    if (auxCount > 0) {
+        const auxToggle = document.createElement('label');
+        auxToggle.className = 'toolbar-checkbox';
+        const auxCheckbox = document.createElement('input');
+        auxCheckbox.type = 'checkbox';
+        auxCheckbox.checked = hideAuxiliaryAttributes;
+        auxCheckbox.addEventListener('change', () => {
+            hideAuxiliaryAttributes = auxCheckbox.checked;
+            renderAttributeTable(tabContent, currentEntity!.attributes);
+        });
+        auxToggle.appendChild(auxCheckbox);
+        auxToggle.appendChild(document.createTextNode(` Hide auxiliary (${auxCount})`));
+        auxToggle.title = 'Auxiliary attributes are lookup name/yomi companions (marked with AttributeOf). '
+            + 'Hidden by default; uncheck to show them (marked in the list).';
+        searchBar.appendChild(auxToggle);
+    }
 
     tabContent.appendChild(searchBar);
 

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -609,7 +609,11 @@ function renderAttributeTable(container: HTMLElement, attrs: MetadataAttributeDt
                 render: (a) => isAuxiliaryAttribute(a) && !a.displayName
                     ? '<span class="attr-aux-label">aux of ' + escapeHtml(a.attributeOf ?? '') + '</span>'
                     : escapeHtml(a.displayName ?? '\u2014'),
-                sortValue: (a) => a.displayName ?? (isAuxiliaryAttribute(a) ? 'aux of ' + (a.attributeOf ?? '') : ''),
+                // Mirror render()'s branch exactly (empty-string displayName included)
+                // so the sort key matches what's shown.
+                sortValue: (a) => isAuxiliaryAttribute(a) && !a.displayName
+                    ? 'aux of ' + (a.attributeOf ?? '')
+                    : (a.displayName ?? ''),
             },
             { key: 'logicalName', label: 'Logical Name', render: (a) => escapeHtml(a.logicalName) },
             { key: 'attributeType', label: 'Type', render: (a) => escapeHtml(a.attributeType) },
@@ -740,7 +744,9 @@ function showAttributePropertiesPanel(attr: MetadataAttributeDto, container: HTM
             ['Targets', attr.targets && attr.targets.length > 0 ? attr.targets.join(', ') : null],
             ['Option Set Name', fmt(attr.optionSetName)],
             ['Is Global Option Set', attr.optionSetName ? fmt(attr.isGlobalOptionSet) : null],
-            ['Option Count', attr.options && attr.options.length > 0 ? String(attr.options.length) : null],
+            // Show an explicit 0 for a present-but-empty option set (real metadata);
+            // only omit when options is absent entirely (non-choice attribute).
+            ['Option Count', attr.options ? String(attr.options.length) : null],
         ]],
         ['System', [
             ['Metadata Id', fmt(attr.metadataId)],
@@ -1430,10 +1436,13 @@ function toggleOptionValues(
     tr.id = 'option-values-' + key;
     tr.className = 'option-values-row expanded';
     const td = document.createElement('td');
-    // Span exactly the real column count. Under table-layout:fixed an oversized
-    // colspan (the old 99) inflates the layout to that many columns, collapsing
-    // the real ones to slivers (#1367).
-    td.colSpan = Math.max(1, container.querySelectorAll('thead th').length);
+    // Span exactly the parent table's column count. Under table-layout:fixed an
+    // oversized colspan (the old 99) inflates the layout to that many columns,
+    // collapsing the real ones to slivers (#1367). Use the parent table's own
+    // <thead> only — a container-wide `thead th` query would also count headers
+    // from already-expanded option sub-tables and re-inflate the span.
+    const parentTable = selectedRow.closest('table');
+    td.colSpan = Math.max(1, parentTable?.tHead?.querySelectorAll('th').length ?? 1);
 
     if (options.length === 0) {
         td.textContent = 'No option values';

--- a/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
+++ b/src/PPDS.Extension/src/panels/webview/metadata-browser-panel.ts
@@ -18,6 +18,7 @@ import { assertNever } from './shared/assert-never.js';
 import { getVsCodeApi } from './shared/vscode-api.js';
 import { installErrorHandler } from './shared/error-handler.js';
 import { DataTable } from './shared/data-table.js';
+import { isAuxiliaryAttribute } from './shared/metadata-utils.js';
 
 const vscode = getVsCodeApi<MetadataBrowserPanelWebviewToHost>();
 installErrorHandler((msg) => vscode.postMessage(msg));
@@ -44,9 +45,12 @@ let selectedEntityName: string | null = null;
 let selectedChoiceName: string | null = null;
 let currentEntity: MetadataEntityDetailDto | null = null;
 let currentGlobalChoice: MetadataOptionSetDto | null = null;
-let activeTab = 'attributes';
+let activeTab = 'config';
 let hideSystem = false;
 let intersectHiddenCount = 0;
+// #1368 "mark, don't mask": auxiliary attributes (attributeOf != null) are SHOWN by
+// default and visually marked; this user-initiated toggle hides them for cleanliness.
+let hideAuxiliaryAttributes = false;
 
 // Per-tab search state
 const tabSearchTerms: Record<string, string> = {};
@@ -57,9 +61,10 @@ let choicesSectionCollapsed = false;
 
 type TabId = 'attributes' | 'config' | '1n' | 'n1' | 'nn' | 'keys' | 'privileges' | 'choices' | 'choice-detail';
 
+// #1370: Configuration first — it describes the entity itself; Attributes is a drill-down.
 const ENTITY_TAB_DEFS: { id: TabId; label: string }[] = [
-    { id: 'attributes', label: 'Attributes' },
     { id: 'config', label: 'Configuration' },
+    { id: 'attributes', label: 'Attributes' },
     { id: '1n', label: '1:N' },
     { id: 'n1', label: 'N:1' },
     { id: 'nn', label: 'N:N' },
@@ -549,15 +554,35 @@ function renderAttributesTab(): void {
     const searchBar = buildTabSearchBar('attributes', 'Search attributes...', () => {
         renderAttributeTable(tabContent, currentEntity!.attributes);
     });
+
+    // #1368 "mark, don't mask": auxiliaries show by default; this hides them on request.
+    const auxToggle = document.createElement('label');
+    auxToggle.className = 'toolbar-checkbox';
+    const auxCheckbox = document.createElement('input');
+    auxCheckbox.type = 'checkbox';
+    auxCheckbox.checked = hideAuxiliaryAttributes;
+    auxCheckbox.addEventListener('change', () => {
+        hideAuxiliaryAttributes = auxCheckbox.checked;
+        renderAttributeTable(tabContent, currentEntity!.attributes);
+    });
+    auxToggle.appendChild(auxCheckbox);
+    auxToggle.appendChild(document.createTextNode(' Hide auxiliary'));
+    auxToggle.title = 'Hide auxiliary attributes (lookup name/yomi companions marked with AttributeOf)';
+    searchBar.appendChild(auxToggle);
+
     tabContent.appendChild(searchBar);
 
     renderAttributeTable(tabContent, currentEntity.attributes);
 }
 
 function getFilteredAttributes(attrs: MetadataAttributeDto[]): MetadataAttributeDto[] {
+    let result = attrs;
+    if (hideAuxiliaryAttributes) {
+        result = result.filter(a => !isAuxiliaryAttribute(a));
+    }
     const term = (tabSearchTerms['attributes'] ?? '').toLowerCase().trim();
-    if (!term) return attrs;
-    return attrs.filter(a =>
+    if (!term) return result;
+    return result.filter(a =>
         (a.displayName ?? '').toLowerCase().includes(term) ||
         a.logicalName.toLowerCase().includes(term) ||
         a.attributeType.toLowerCase().includes(term)
@@ -577,8 +602,15 @@ function renderAttributeTable(container: HTMLElement, attrs: MetadataAttributeDt
     const table = new DataTable<MetadataAttributeDto>({
         container: wrapper,
         columns: [
-            // MB-10: displayName first
-            { key: 'displayName', label: 'Display Name', render: (a) => escapeHtml(a.displayName ?? '\u2014') },
+            // MB-10: displayName first. Auxiliary attributes have no display name of
+            // their own \u2014 show what they are instead of a blank cell (#1368).
+            {
+                key: 'displayName', label: 'Display Name',
+                render: (a) => isAuxiliaryAttribute(a) && !a.displayName
+                    ? '<span class="attr-aux-label">aux of ' + escapeHtml(a.attributeOf ?? '') + '</span>'
+                    : escapeHtml(a.displayName ?? '\u2014'),
+                sortValue: (a) => a.displayName ?? (isAuxiliaryAttribute(a) ? 'aux of ' + (a.attributeOf ?? '') : ''),
+            },
             { key: 'logicalName', label: 'Logical Name', render: (a) => escapeHtml(a.logicalName) },
             { key: 'attributeType', label: 'Type', render: (a) => escapeHtml(a.attributeType) },
             { key: 'requiredLevel', label: 'Required', render: (a) => escapeHtml(a.requiredLevel ?? '\u2014') },
@@ -592,6 +624,8 @@ function renderAttributeTable(container: HTMLElement, attrs: MetadataAttributeDt
         emptyMessage: 'No attributes',
         // MB-05: click to show properties panel
         onRowClick: (a) => showAttributePropertiesPanel(a, wrapper),
+        // #1368: mark auxiliary rows so they read as plumbing, not broken fields
+        rowClassName: (a) => isAuxiliaryAttribute(a) ? 'attr-aux' : null,
     });
     table.setItems(filtered);
 
@@ -635,80 +669,117 @@ function showAttributePropertiesPanel(attr: MetadataAttributeDto, container: HTM
     closeBtn.addEventListener('click', () => panel.remove());
     title.appendChild(closeBtn);
 
-    const props: [string, string | number | boolean | null][] = [
-        ['Display Name', attr.displayName],
-        ['Logical Name', attr.logicalName],
-        ['Schema Name', attr.schemaName],
-        ['Type', attr.attributeType],
-        ['Type Name', attr.attributeTypeName],
-        ['Required Level', attr.requiredLevel],
-        ['Is Custom', attr.isCustomAttribute ? 'Yes' : 'No'],
-        ['Is Secured', attr.isSecured ? 'Yes' : 'No'],
+    // #1369: render the complete attribute metadata, grouped for readability.
+    // Booleans render Yes/No including false (false is information); null/undefined
+    // rows are omitted (not applicable, or a bundled CLI older than the RPC widening).
+    const fmt = (v: string | number | boolean | null | undefined): string | null => {
+        if (v === null || v === undefined) return null;
+        if (typeof v === 'boolean') return v ? 'Yes' : 'No';
+        const s = String(v);
+        return s.length > 0 ? s : null;
+    };
+    const fmtDate = (v: string | null | undefined): string | null => {
+        if (!v) return null;
+        const d = new Date(v);
+        return isNaN(d.getTime()) ? v : d.toLocaleString();
+    };
+    const SOURCE_TYPE_LABELS: Record<number, string> = { 0: '0 (Simple)', 1: '1 (Calculated)', 2: '2 (Rollup)' };
+    const sourceType = attr.sourceType !== null && attr.sourceType !== undefined
+        ? (SOURCE_TYPE_LABELS[attr.sourceType] ?? String(attr.sourceType))
+        : null;
+
+    const sections: [string, [string, string | null][]][] = [
+        ['General', [
+            ['Display Name', fmt(attr.displayName)],
+            ['Logical Name', fmt(attr.logicalName)],
+            ['Schema Name', fmt(attr.schemaName)],
+            ['Attribute Of', fmt(attr.attributeOf)],
+            ['Type', fmt(attr.attributeType)],
+            ['Type Name', fmt(attr.attributeTypeName)],
+            ['Required Level', fmt(attr.requiredLevel)],
+            ['Source Type', sourceType],
+            ['Description', fmt(attr.description)],
+        ]],
+        ['Flags', [
+            ['Is Custom', fmt(attr.isCustomAttribute)],
+            ['Is Managed', fmt(attr.isManaged)],
+            ['Is Primary Id', fmt(attr.isPrimaryId)],
+            ['Is Primary Name', fmt(attr.isPrimaryName)],
+            ['Is Logical', fmt(attr.isLogical)],
+            ['Is Audit Enabled', fmt(attr.isAuditEnabled)],
+            ['Is Customizable', fmt(attr.isCustomizable)],
+            ['Is Renameable', fmt(attr.isRenameable)],
+        ]],
+        ['Behavior', [
+            ['Valid For Create', fmt(attr.isValidForCreate)],
+            ['Valid For Update', fmt(attr.isValidForUpdate)],
+            ['Valid For Read', fmt(attr.isValidForRead)],
+            ['Valid For Form', fmt(attr.isValidForForm)],
+            ['Valid For Grid', fmt(attr.isValidForGrid)],
+            ['Valid For Advanced Find', fmt(attr.isValidForAdvancedFind)],
+            ['Searchable', fmt(attr.isSearchable)],
+            ['Filterable', fmt(attr.isFilterable)],
+            ['Sortable', fmt(attr.isSortable)],
+            ['Retrievable', fmt(attr.isRetrievable)],
+        ]],
+        ['Security', [
+            ['Is Secured', fmt(attr.isSecured)],
+            ['Can Be Secured For Read', fmt(attr.canBeSecuredForRead)],
+            ['Can Be Secured For Create', fmt(attr.canBeSecuredForCreate)],
+            ['Can Be Secured For Update', fmt(attr.canBeSecuredForUpdate)],
+        ]],
+        ['Type Details', [
+            ['Max Length', fmt(attr.maxLength)],
+            ['Precision', fmt(attr.precision)],
+            ['Min Value', fmt(attr.minValue)],
+            ['Max Value', fmt(attr.maxValue)],
+            ['Format', fmt(attr.format)],
+            ['Date/Time Behavior', fmt(attr.dateTimeBehavior)],
+            ['Auto Number Format', fmt(attr.autoNumberFormat)],
+            ['Formula Definition', fmt(attr.formulaDefinition)],
+            ['Targets', attr.targets && attr.targets.length > 0 ? attr.targets.join(', ') : null],
+            ['Option Set Name', fmt(attr.optionSetName)],
+            ['Is Global Option Set', attr.optionSetName ? fmt(attr.isGlobalOptionSet) : null],
+            ['Option Count', attr.options && attr.options.length > 0 ? String(attr.options.length) : null],
+        ]],
+        ['System', [
+            ['Metadata Id', fmt(attr.metadataId)],
+            ['Column Number', fmt(attr.columnNumber)],
+            ['External Name', fmt(attr.externalName)],
+            ['Introduced Version', fmt(attr.introducedVersion)],
+            ['Deprecated Version', fmt(attr.deprecatedVersion)],
+            ['Created On', fmtDate(attr.createdOn)],
+            ['Modified On', fmtDate(attr.modifiedOn)],
+        ]],
     ];
 
-    // Type-specific properties (MB-32/33)
-    if (attr.maxLength !== null && attr.maxLength !== undefined) {
-        props.push(['Max Length', attr.maxLength]);
-    }
-    if (attr.precision !== null && attr.precision !== undefined) {
-        props.push(['Precision', attr.precision]);
-    }
-    if (attr.minValue !== null && attr.minValue !== undefined) {
-        props.push(['Min Value', attr.minValue]);
-    }
-    if (attr.maxValue !== null && attr.maxValue !== undefined) {
-        props.push(['Max Value', attr.maxValue]);
-    }
-    if (attr.format) {
-        props.push(['Format', attr.format]);
-    }
-    if (attr.dateTimeBehavior) {
-        props.push(['Date/Time Behavior', attr.dateTimeBehavior]);
-    }
-    if (attr.autoNumberFormat) {
-        props.push(['Auto Number Format', attr.autoNumberFormat]);
-    }
-    if (attr.sourceType !== null && attr.sourceType !== undefined) {
-        props.push(['Source Type', attr.sourceType]);
-    }
-    if (attr.description) {
-        props.push(['Description', attr.description]);
-    }
+    for (const [sectionTitle, rows] of sections) {
+        const visible = rows.filter((r): r is [string, string] => r[1] !== null);
+        if (visible.length === 0) continue;
 
-    // Lookup targets
-    if (attr.targets && attr.targets.length > 0) {
-        props.push(['Targets', attr.targets.join(', ')]);
+        const header = document.createElement('div');
+        header.className = 'prop-section-header';
+        header.textContent = sectionTitle;
+        panel.appendChild(header);
+
+        const table = document.createElement('table');
+        table.className = 'prop-panel-table';
+        for (const [label, value] of visible) {
+            const tr = document.createElement('tr');
+            const labelTd = document.createElement('td');
+            labelTd.className = 'prop-label';
+            labelTd.textContent = label;
+            tr.appendChild(labelTd);
+
+            const valueTd = document.createElement('td');
+            valueTd.className = 'prop-value';
+            valueTd.textContent = value;
+            tr.appendChild(valueTd);
+
+            table.appendChild(tr);
+        }
+        panel.appendChild(table);
     }
-
-    // Option set info
-    if (attr.optionSetName) {
-        props.push(['Option Set Name', attr.optionSetName]);
-        props.push(['Is Global Option Set', attr.isGlobalOptionSet ? 'Yes' : 'No']);
-    }
-    if (attr.options && attr.options.length > 0) {
-        props.push(['Option Count', attr.options.length]);
-    }
-
-    const table = document.createElement('table');
-    table.className = 'prop-panel-table';
-
-    for (const [label, value] of props) {
-        if (value === null || value === undefined) continue;
-        const tr = document.createElement('tr');
-        const labelTd = document.createElement('td');
-        labelTd.className = 'prop-label';
-        labelTd.textContent = label;
-        tr.appendChild(labelTd);
-
-        const valueTd = document.createElement('td');
-        valueTd.className = 'prop-value';
-        valueTd.textContent = String(value);
-        tr.appendChild(valueTd);
-
-        table.appendChild(tr);
-    }
-
-    panel.appendChild(table);
 
     // Show options table if present
     if (attr.options && attr.options.length > 0) {
@@ -1250,6 +1321,10 @@ function renderChoicesContent(container: HTMLElement): void {
     entityHeader.textContent = 'Entity Choices';
     entitySection.appendChild(entityHeader);
 
+    // Attach the section before populating its table: DataTable measures its
+    // viewport at setItems() time, and a detached container measures 0 (#1367).
+    wrapper.appendChild(entitySection);
+
     if (entityChoiceAttrs.length === 0) {
         const empty = document.createElement('div');
         empty.className = 'empty-state';
@@ -1271,11 +1346,12 @@ function renderChoicesContent(container: HTMLElement): void {
             defaultSortKey: 'logicalName',
             defaultSortDirection: 'asc',
             emptyMessage: 'No entity choices',
+            // Short list inside the tab's outer scroll page, and rows inject
+            // expansion sub-tables \u2014 both rule out virtualization (#1367).
+            virtualize: false,
         });
         table.setItems(entityChoiceAttrs);
     }
-
-    wrapper.appendChild(entitySection);
 
     // -- Global Option Sets section --
     const globalSection = document.createElement('div');
@@ -1285,6 +1361,9 @@ function renderChoicesContent(container: HTMLElement): void {
     globalHeader.className = 'choices-section-header';
     globalHeader.textContent = 'Global Option Sets';
     globalSection.appendChild(globalHeader);
+
+    // Attach before populating (see entity section note, #1367).
+    wrapper.appendChild(globalSection);
 
     if (globalOptionSets.length === 0) {
         const empty = document.createElement('div');
@@ -1324,11 +1403,10 @@ function renderChoicesContent(container: HTMLElement): void {
             defaultSortKey: 'name',
             defaultSortDirection: 'asc',
             emptyMessage: 'No global option sets',
+            virtualize: false,
         });
         globalTable.setItems(globalRows);
     }
-
-    wrapper.appendChild(globalSection);
 }
 
 /** Toggle visibility of option values sub-table for a choice row. */
@@ -1352,7 +1430,10 @@ function toggleOptionValues(
     tr.id = 'option-values-' + key;
     tr.className = 'option-values-row expanded';
     const td = document.createElement('td');
-    td.colSpan = 99;
+    // Span exactly the real column count. Under table-layout:fixed an oversized
+    // colspan (the old 99) inflates the layout to that many columns, collapsing
+    // the real ones to slivers (#1367).
+    td.colSpan = Math.max(1, container.querySelectorAll('thead th').length);
 
     if (options.length === 0) {
         td.textContent = 'No option values';
@@ -1589,7 +1670,7 @@ window.addEventListener('message', (event: MessageEvent<MetadataBrowserPanelHost
         case 'entityDetailLoaded':
             currentEntity = msg.entity;
             currentGlobalChoice = null;
-            activeTab = 'attributes';
+            activeTab = 'config';
             updateBreadcrumb();
             renderTabBar();
             renderTabContent();

--- a/src/PPDS.Extension/src/panels/webview/shared/data-table.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/data-table.ts
@@ -31,6 +31,15 @@ interface DataTableOptions<T> {
     rowHeight?: number;
     /** Number of buffer rows above and below the visible area (default: 20) */
     bufferRows?: number;
+    /**
+     * Virtualize rows (default: true). Set false to render every row eagerly —
+     * required for short tables that live inside an outer scrolling page (no bounded
+     * viewport of their own) and for tables that inject expansion rows, which
+     * virtualization would orphan on re-window.
+     */
+    virtualize?: boolean;
+    /** Optional extra CSS class for a row (e.g. to visually mark auxiliary items). */
+    rowClassName?: (item: T) => string | null;
 }
 
 /** Strip HTML tags to extract plain text (for tooltips and legacy sort). */
@@ -50,11 +59,14 @@ export class DataTable<T> {
     // Virtual scroll state
     private readonly rowHeight: number;
     private readonly bufferRows: number;
+    private readonly virtualize: boolean;
     private scrollContainer: HTMLElement | null = null;
     private spacer: HTMLElement | null = null;
     private tbody: HTMLElement | null = null;
-    private visibleStart = 0;
-    private visibleEnd = 0;
+    // -1 sentinel: "nothing rendered yet" — must not collide with a real 0..0 range,
+    // or single-row tables skip their initial render.
+    private visibleStart = -1;
+    private visibleEnd = -1;
     private scrollRafId = 0;
 
     constructor(opts: DataTableOptions<T>) {
@@ -73,6 +85,7 @@ export class DataTable<T> {
         this.sortDirection = opts.defaultSortDirection === 'asc' ? 'asc' : opts.defaultSortDirection === 'desc' ? 'desc' : 'none';
         this.rowHeight = opts.rowHeight ?? 28;
         this.bufferRows = opts.bufferRows ?? 20;
+        this.virtualize = opts.virtualize ?? true;
 
         // Keyboard: Enter on row (delegated, registered once)
         opts.container.addEventListener('keydown', (e) => {
@@ -179,18 +192,21 @@ export class DataTable<T> {
         this.tbody = tbody;
 
         // Initial render of visible rows
-        this.visibleStart = 0;
-        this.visibleEnd = 0;
+        this.visibleStart = -1;
+        this.visibleEnd = -1;
         this.updateVisibleRows();
 
-        // Scroll handler with requestAnimationFrame throttling
-        wrapper.addEventListener('scroll', () => {
-            if (this.scrollRafId) return;
-            this.scrollRafId = requestAnimationFrame(() => {
-                this.scrollRafId = 0;
-                this.updateVisibleRows();
+        // Scroll handler with requestAnimationFrame throttling.
+        // Non-virtualized tables render everything up front — no re-window needed.
+        if (this.virtualize) {
+            wrapper.addEventListener('scroll', () => {
+                if (this.scrollRafId) return;
+                this.scrollRafId = requestAnimationFrame(() => {
+                    this.scrollRafId = 0;
+                    this.updateVisibleRows();
+                });
             });
-        });
+        }
 
         // Sort click handlers (delegated on the table)
         table.addEventListener('click', (e) => {
@@ -247,22 +263,31 @@ export class DataTable<T> {
 
         const { columns } = this.opts;
         const totalRows = this.sortedItems.length;
-        const scrollTop = this.scrollContainer.scrollTop;
-        const clientHeight = this.scrollContainer.clientHeight;
 
-        // Account for thead height
-        const thead = this.scrollContainer.querySelector('thead');
-        const theadHeight = thead ? thead.offsetHeight : 0;
-        const adjustedScrollTop = Math.max(0, scrollTop - theadHeight);
+        let start: number;
+        let end: number;
+        if (this.virtualize) {
+            const scrollTop = this.scrollContainer.scrollTop;
+            const clientHeight = this.scrollContainer.clientHeight;
 
-        const firstVisible = Math.floor(adjustedScrollTop / this.rowHeight);
-        const lastVisible = Math.min(
-            totalRows - 1,
-            Math.ceil((adjustedScrollTop + clientHeight) / this.rowHeight)
-        );
+            // Account for thead height
+            const thead = this.scrollContainer.querySelector('thead');
+            const theadHeight = thead ? thead.offsetHeight : 0;
+            const adjustedScrollTop = Math.max(0, scrollTop - theadHeight);
 
-        const start = Math.max(0, firstVisible - this.bufferRows);
-        const end = Math.min(totalRows - 1, lastVisible + this.bufferRows);
+            const firstVisible = Math.floor(adjustedScrollTop / this.rowHeight);
+            const lastVisible = Math.min(
+                totalRows - 1,
+                Math.ceil((adjustedScrollTop + clientHeight) / this.rowHeight)
+            );
+
+            start = Math.max(0, firstVisible - this.bufferRows);
+            end = Math.min(totalRows - 1, lastVisible + this.bufferRows);
+        } else {
+            // Eager mode: every row, always.
+            start = 0;
+            end = totalRows - 1;
+        }
 
         // Skip if the range hasn't changed
         if (start === this.visibleStart && end === this.visibleEnd) return;
@@ -294,6 +319,8 @@ export class DataTable<T> {
             const id = this.opts.getRowId(item);
             const tr = document.createElement('tr');
             tr.className = 'data-table-row';
+            const extraClass = this.opts.rowClassName?.(item);
+            if (extraClass) tr.className += ' ' + extraClass;
             if (id === this.selectedId) tr.className += ' selected';
             tr.dataset['id'] = id;
             tr.tabIndex = 0;

--- a/src/PPDS.Extension/src/panels/webview/shared/metadata-utils.ts
+++ b/src/PPDS.Extension/src/panels/webview/shared/metadata-utils.ts
@@ -1,0 +1,12 @@
+import type { MetadataAttributeDto } from '../../../types.js';
+
+/**
+ * #1368: auxiliary attributes carry AttributeOf — the logical name of the attribute
+ * they extend (lookup `…idname`/`…yominame` companions, image/virtual pairs).
+ * Per "mark, don't mask" they are shown by default and visually marked; consumers
+ * may offer a user-initiated hide. Absent field (bundled CLI older than the RPC
+ * widening) ⇒ treated as a real attribute, matching pre-widening behavior.
+ */
+export function isAuxiliaryAttribute(a: MetadataAttributeDto): boolean {
+    return typeof a.attributeOf === 'string' && a.attributeOf.length > 0;
+}

--- a/src/PPDS.Extension/src/types.ts
+++ b/src/PPDS.Extension/src/types.ts
@@ -379,6 +379,36 @@ export interface MetadataAttributeDto {
     isSecured: boolean;
     description: string | null;
     autoNumberFormat: string | null;
+    // Full-fidelity fields (#1369) — optional: absent when talking to a bundled
+    // CLI older than the RPC widening; treat missing as "unknown", not false.
+    metadataId?: string;
+    isManaged?: boolean;
+    /** Logical name of the attribute this auxiliary attribute extends (#1368). Null/absent = a real attribute. */
+    attributeOf?: string | null;
+    isLogical?: boolean;
+    isValidForCreate?: boolean;
+    isValidForUpdate?: boolean;
+    isValidForRead?: boolean;
+    isValidForForm?: boolean;
+    isValidForGrid?: boolean;
+    isValidForAdvancedFind?: boolean;
+    isSearchable?: boolean;
+    isFilterable?: boolean;
+    isSortable?: boolean;
+    isRetrievable?: boolean;
+    canBeSecuredForRead?: boolean;
+    canBeSecuredForCreate?: boolean;
+    canBeSecuredForUpdate?: boolean;
+    isAuditEnabled?: boolean;
+    isCustomizable?: boolean;
+    isRenameable?: boolean;
+    formulaDefinition?: string | null;
+    introducedVersion?: string | null;
+    deprecatedVersion?: string | null;
+    externalName?: string | null;
+    columnNumber?: number | null;
+    createdOn?: string | null;
+    modifiedOn?: string | null;
 }
 
 export interface MetadataRelationshipDto {

--- a/src/PPDS.Mcp/Tools/MetadataEntityTool.cs
+++ b/src/PPDS.Mcp/Tools/MetadataEntityTool.cs
@@ -79,7 +79,8 @@ public sealed class MetadataEntityTool : McpToolBase
                     MinValue = a.MinValue,
                     MaxValue = a.MaxValue,
                     Precision = a.Precision,
-                    TargetEntities = a.Targets?.ToList()
+                    TargetEntities = a.Targets?.ToList(),
+                    AttributeOf = a.AttributeOf
                 }).OrderBy(a => a.LogicalName).ToList();
             }
 
@@ -317,6 +318,17 @@ public sealed class MetadataAttributeInfo
     [JsonPropertyName("targetEntities")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string>? TargetEntities { get; set; }
+
+    /// <summary>
+    /// Logical name of the attribute this auxiliary attribute extends (lookup
+    /// name/yomi companions). Null (omitted) for real attributes. Lets agents
+    /// distinguish schema plumbing deterministically — "mark, don't mask" (#1368).
+    /// This projection is deliberately lean for agent context budgets; the marker
+    /// field is included so nothing is silently indistinguishable.
+    /// </summary>
+    [JsonPropertyName("attributeOf")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AttributeOf { get; set; }
 }
 
 /// <summary>

--- a/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/MetadataAttributeRpcMappingTests.cs
+++ b/tests/PPDS.Cli.Tests/Commands/Serve/Handlers/MetadataAttributeRpcMappingTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using PPDS.Cli.Commands.Serve.Handlers;
+using PPDS.Dataverse.Metadata.Models;
+using Xunit;
+
+namespace PPDS.Cli.Tests.Commands.Serve.Handlers;
+
+/// <summary>
+/// Guards the attribute wire contract (#1369): the daemon RPC layer originally
+/// forwarded a curated subset of <see cref="AttributeMetadataDto"/> and silently
+/// dropped the rest (including AttributeOf, #1368). These tests pin full-fidelity
+/// pass-through so a field added to the service DTO cannot silently vanish at the
+/// RPC boundary again.
+/// </summary>
+[Trait("Category", "Unit")]
+public class MetadataAttributeRpcMappingTests
+{
+    private static AttributeMetadataDto CreateFullServiceDto() => new()
+    {
+        MetadataId = Guid.Parse("11111111-2222-3333-4444-555555555555"),
+        LogicalName = "primarycontactidname",
+        DisplayName = "Primary Contact Name",
+        SchemaName = "PrimaryContactIdName",
+        AttributeType = "String",
+        AttributeTypeName = "StringType",
+        IsCustomAttribute = false,
+        IsManaged = true,
+        IsPrimaryId = false,
+        IsPrimaryName = false,
+        RequiredLevel = "None",
+        IsValidForCreate = true,
+        IsValidForUpdate = false,
+        IsValidForRead = true,
+        IsSearchable = true,
+        IsFilterable = true,
+        IsSortable = true,
+        Description = "Auxiliary name column",
+        MaxLength = 160,
+        MinValue = 1m,
+        MaxValue = 100m,
+        Precision = 2,
+        Targets = ["contact"],
+        OptionSetName = "some_optionset",
+        IsGlobalOptionSet = true,
+        DateTimeBehavior = "UserLocal",
+        Format = "Text",
+        SourceType = 1,
+        IsSecured = true,
+        FormulaDefinition = "<formula/>",
+        AutoNumberFormat = "AUTO-{SEQNUM:4}",
+        IsValidForForm = true,
+        IsValidForGrid = false,
+        CanBeSecuredForRead = true,
+        CanBeSecuredForCreate = false,
+        CanBeSecuredForUpdate = true,
+        IsRetrievable = true,
+        AttributeOf = "primarycontactid",
+        IsLogical = true,
+        IntroducedVersion = "5.0.0.0",
+        DeprecatedVersion = "9.0.0.0",
+        IsAuditEnabled = true,
+        IsCustomizable = false,
+        IsRenameable = true,
+        IsValidForAdvancedFind = true,
+        ExternalName = "ext_name",
+        ColumnNumber = 42,
+        CreatedOn = new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+        ModifiedOn = new DateTime(2025, 6, 7, 8, 9, 10, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public void MapAttributeToRpc_PreservesFullFidelityFields()
+    {
+        var rpc = RpcMethodHandler.MapAttributeToRpc(CreateFullServiceDto());
+
+        // #1368: the deterministic auxiliary marker must cross the wire.
+        rpc.AttributeOf.Should().Be("primarycontactid");
+
+        // #1369: previously-dropped fields.
+        rpc.MetadataId.Should().Be(Guid.Parse("11111111-2222-3333-4444-555555555555"));
+        rpc.IsManaged.Should().BeTrue();
+        rpc.IsLogical.Should().BeTrue();
+        rpc.IsValidForCreate.Should().BeTrue();
+        rpc.IsValidForUpdate.Should().BeFalse();
+        rpc.IsValidForRead.Should().BeTrue();
+        rpc.IsValidForForm.Should().BeTrue();
+        rpc.IsValidForGrid.Should().BeFalse();
+        rpc.IsValidForAdvancedFind.Should().BeTrue();
+        rpc.IsSearchable.Should().BeTrue();
+        rpc.IsFilterable.Should().BeTrue();
+        rpc.IsSortable.Should().BeTrue();
+        rpc.IsRetrievable.Should().BeTrue();
+        rpc.CanBeSecuredForRead.Should().BeTrue();
+        rpc.CanBeSecuredForCreate.Should().BeFalse();
+        rpc.CanBeSecuredForUpdate.Should().BeTrue();
+        rpc.IsAuditEnabled.Should().BeTrue();
+        rpc.IsCustomizable.Should().BeFalse();
+        rpc.IsRenameable.Should().BeTrue();
+        rpc.FormulaDefinition.Should().Be("<formula/>");
+        rpc.IntroducedVersion.Should().Be("5.0.0.0");
+        rpc.DeprecatedVersion.Should().Be("9.0.0.0");
+        rpc.ExternalName.Should().Be("ext_name");
+        rpc.ColumnNumber.Should().Be(42);
+        rpc.CreatedOn.Should().Be(new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc));
+        rpc.ModifiedOn.Should().Be(new DateTime(2025, 6, 7, 8, 9, 10, DateTimeKind.Utc));
+
+        // Curated fields keep working.
+        rpc.LogicalName.Should().Be("primarycontactidname");
+        rpc.MaxLength.Should().Be(160);
+        rpc.IsSecured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RpcAttributeDto_CoversEveryServiceDtoProperty()
+    {
+        // Completeness guard: every public property on the service DTO must have a
+        // same-named counterpart on the RPC DTO. This is the exact drift that caused
+        // #1369 — the RPC layer narrowing the contract without anyone noticing.
+        var serviceProps = typeof(AttributeMetadataDto).GetProperties().Select(p => p.Name);
+        var rpcProps = typeof(MetadataAttributeDto).GetProperties().Select(p => p.Name).ToHashSet();
+
+        var missing = serviceProps.Where(name => !rpcProps.Contains(name)).ToList();
+
+        missing.Should().BeEmpty(
+            "the RPC MetadataAttributeDto must mirror every AttributeMetadataDto property; " +
+            "add the field to the RPC DTO and MapAttributeToRpc");
+    }
+}


### PR DESCRIPTION
Closes #1367, #1368, #1369, #1370.

Round 2 of the Metadata Browser fixes (follows #1366), driven by live verification feedback and a design discussion that produced the **"mark, don't mask"** visibility principle (codification + repo-wide audit tracked in #1372).

## 1. Choices tab layout (#1367)

Two pre-existing defects, both shipped in every release:
- Expanded option rows used `colSpan = 99`; under `table-layout: fixed` that inflates the layout to 99 columns → sliver columns, overlapping headers.
- Both section tables were populated **while detached** (`clientHeight = 0`) → only the initial ~21-row buffer rendered; the outer page scrolls so the inner scroll handler never fires (same class as #1365, different trigger — why #1366 didn't cover it).

Fix: new `virtualize: false` eager mode on the shared DataTable (required for short tables inside an outer scrolling page, and for injected expansion rows that re-windowing would orphan), real `colSpan`, attach-before-populate. **Bonus fix:** the initial visible-range sentinel (`0/0`) collided with a real `0..0` range — single-row tables rendered empty in *every* DataTable panel; sentinel is now `-1`.

## 2. Attribute wire fidelity (#1369)

The daemon RPC layer forwarded ~23 of the service layer's ~33 attribute fields and silently dropped the rest (born narrow in #616). Widened to full pass-through, plus 9 new service-DTO fields (`IsAuditEnabled`, `IsCustomizable`, `IsRenameable`, `IsValidForAdvancedFind`, `ExternalName`, `ColumnNumber`, `CreatedOn`, `ModifiedOn`, `DeprecatedVersion`).

The extension properties panel now renders the **complete grouped property set** (General / Flags / Behavior / Security / Type Details / System). Booleans render Yes/No including false; absent fields (older bundled CLI) are omitted gracefully.

**Contract guard:** a reflection completeness test pins the RPC DTO to the service DTO — a field added to the service can never silently vanish at the RPC boundary again.

## 3. Auxiliary attributes — mark, don't mask (#1368)

`AttributeOf` (the deterministic auxiliary marker) now crosses the wire. Auxiliaries are **shown by default** on every surface and *marked* instead of hidden:

| Surface | Marking | Optional hide |
|---|---|---|
| Extension | dimmed/italic row; blank Display Name cell renders `aux of <parent>`; properties panel shows Attribute Of | "Hide auxiliary" toggle (default off) |
| CLI `metadata attributes` | `aux:<parent>` in Flags column; `--json` carries `attributeOf` | `--exclude-auxiliary` opt-in |
| MCP `metadata_entity` | emits `attributeOf` (null-omitted → zero payload cost for real attributes) | agents filter themselves |
| TUI Metadata Explorer | `aux of <parent>` in Display Name column | — |

## 4. Tab order (#1370)

Configuration precedes Attributes and is the landing tab on entity select (entity-level info before the drill-down list).

## Verification

- .NET: full solution build clean; unit suites pass (PPDS.Cli.Tests 4425 ×3 TFMs incl. new mapping/completeness tests; PPDS.Dataverse.Tests 1070 ×3).
- Extension: typecheck (both configs), eslint (0 errors), stylelint, esbuild, vitest 477 passed (6 new contract tests: virtualize/rowClassName options, isAuxiliaryAttribute semantics incl. old-CLI degradation, Required<> DTO shape lock).
- TUI: unit tests pass in the CLI sweep. The E2E snapshot harness can't run in this sandbox (node-pty native install fails); fixtures contain no `AttributeOf` data so the display-only change cannot alter snapshots — CI is authoritative.
- Old-daemon tolerance: all new TS fields optional; missing ⇒ behavior identical to today.
- Live verification: dev VSIX with bundled branch CLI installed locally for product-owner walkthrough (money `_base` spot-check noted in #1368).

## Release coupling

Ships as a combined **Cli 1.4.0 + Extension 1.5.0 (bundled-CLI refresh)** release after product-owner verification — see #1363/#1364 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide auxiliary attributes in metadata views and CLI output, and auxiliary attributes are now clearly labeled.
  * Expanded attribute metadata surfaced end-to-end, including validation, search/sort/retrieve, security, audit/customization/rename, formula/versioning, and created/modified timestamps.
* **Bug Fixes**
  * Improved auxiliary attribute display in tables (including styling) and refined metadata UI rendering, ordering, and non-virtualized table behavior.
* **Tests**
  * Added regression and contract tests for auxiliary handling and full-fidelity metadata mapping across RPC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->