### PR TITLE
chore(release): stable train — Extension 1.6.0, Cli 1.4.0, Dataverse 1.3.0, Mcp 1.2.0

### DIFF
--- a/docs/qa/security-review-metadata-browser-1.6.0.md
+++ b/docs/qa/security-review-metadata-browser-1.6.0.md
@@ -1,0 +1,60 @@
+# Security Review — Metadata Browser round 2 (stable 1.6.0 train)
+
+- **Date:** 2026-07-15
+- **Reviewer:** Claude Opus 4.8 (security-review skill) + adversarial verification sub-agent
+- **Release train:** Extension 1.6.0 (stable), Cli 1.4.0, Dataverse 1.3.0, Mcp 1.2.0
+- **Scope (delta since last stable):** `git diff Extension-v1.4.1..origin/main` over
+  `src/PPDS.Cli`, `src/PPDS.Dataverse`, `src/PPDS.Mcp`, `src/PPDS.Extension`
+  (14 files, +718/-113). Covers PRs #1366 (scroll fix) lineage and #1373
+  (metadata browser round 2: Choices tab, wire fidelity, mark-don't-mask
+  auxiliaries, tab order).
+
+## Result: PASS — no HIGH or MEDIUM findings
+
+No concretely-exploitable vulnerability was identified at ≥8/10 confidence. The two
+plausible attack surfaces were traced and both hold up.
+
+## Surfaces examined
+
+### 1. Webview XSS — not exploitable
+
+The DataTable cell trust boundary is `td.innerHTML = col.render(item)`
+(`data-table.ts:335`), so column `render` functions must escape.
+
+- **New auxiliary Display Name render** (`metadata-browser-panel.ts`): emits
+  `'<span class="attr-aux-label">aux of ' + escapeHtml(a.attributeOf ?? '') + '</span>'`.
+  `attributeOf` passes through `escapeHtml` (`dom-utils.ts`, a correct entity encoder for
+  `& < > " '`); the `<span>`/class are static literals. Dataverse logical names (the
+  source of `attributeOf`) are constrained to `[a-z0-9_]`, so markup cannot be smuggled
+  in even before escaping. Closed.
+- **Rewritten properties panel** (`showAttributePropertiesPanel`): all ~40 pass-through
+  fields (incl. `formulaDefinition`, `externalName`, descriptions, dates) are written via
+  `textContent`, which cannot execute markup. Safer than the surrounding legacy code.
+- **`rowClassName`** (`data-table.ts`): concatenated into `tr.className` (not innerHTML);
+  the only caller returns the static literal `'attr-aux'` or `null`. No attribute injection.
+- **`toggleOptionValues` colSpan**: computed integer assigned to a numeric DOM property.
+
+### 2. Data exposure via widened RPC — not a new exposure
+
+The ~18 added `MetadataAttributeDto` fields are **entity schema metadata**, not row data.
+The daemon RPC is localhost (extension ↔ CLI daemon) for the same authenticated
+user/token. Every field is sourced from the standard `AttributeMetadata` the same caller
+can already retrieve directly (`ppds metadata attributes`, MCP, or a raw metadata request).
+No cross-tenant/cross-user content, no PII, no secrets. `formulaDefinition` is a
+calculated-column authoring artifact; audit fields are boolean flags, not audit records.
+The widening changes only which already-authorized metadata crosses an internal boundary.
+
+### 3. CLI / TUI — clean
+
+- `AttributesCommand.cs` `--exclude-auxiliary`: a `bool` driving `.Where(a => a.AttributeOf == null)`; the `aux:{AttributeOf}` flag is written to stdout as data (no shell/eval).
+- `MetadataExplorerScreen.cs`: `aux of {AttributeOf}` into a Terminal.Gui data cell (rendered, not interpreted).
+
+## Exclusions applied
+
+Per the review rubric: DoS/resource-exhaustion, on-disk secrets, rate limiting, outdated
+third-party libraries, and test-only files were out of scope. No findings were suppressed
+under these exclusions — none were identified in the first place.
+
+## Sign-off
+
+Delta is safe to ship to the stable channel. Gate satisfied for the 1.6.0 train.

--- a/docs/qa/security-review-metadata-browser-1.6.0.md
+++ b/docs/qa/security-review-metadata-browser-1.6.0.md
@@ -3,11 +3,12 @@
 - **Date:** 2026-07-15
 - **Reviewer:** Claude Opus 4.8 (security-review skill) + adversarial verification sub-agent
 - **Release train:** Extension 1.6.0 (stable), Cli 1.4.0, Dataverse 1.3.0, Mcp 1.2.0
-- **Scope (delta since last stable):** `git diff Extension-v1.4.1..origin/main` over
+- **Scope (immutable reviewed delta):** `git diff 85e1328ff..3534a06f3` over
   `src/PPDS.Cli`, `src/PPDS.Dataverse`, `src/PPDS.Mcp`, `src/PPDS.Extension`
-  (14 files, +718/-113). Covers PRs #1366 (scroll fix) lineage and #1373
-  (metadata browser round 2: Choices tab, wire fidelity, mark-don't-mask
-  auxiliaries, tab order).
+  (14 files, +718/-113), where `85e1328ff` = tag `Extension-v1.4.1` (last stable)
+  and `3534a06f3` = the round-2 merge on `main` (#1373) that this review signs off.
+  Covers PR #1366 (scroll fix) lineage and #1373 (metadata browser round 2:
+  Choices tab, wire fidelity, mark-don't-mask auxiliaries, tab order).
 
 ## Result: PASS — no HIGH or MEDIUM findings
 

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-15
+
+### Added
+- **`ppds metadata attributes --exclude-auxiliary`** — opt-in filter that omits auxiliary attributes (lookup name/yomi companions carrying `AttributeOf`). Auxiliaries are shown by default and flagged `aux:<parent>` in the Flags column; `--json` output now carries the `attributeOf` field so scripts can filter deterministically (#1368).
+
+### Changed
+- **Metadata attribute daemon RPC returns the full attribute contract** — the `metadata/entityDetail` RPC previously forwarded a curated ~23-field subset of the service attribute metadata and dropped the rest. It now passes through the complete set (identity, CRUD/form/grid validity, searchable/filterable/sortable, security-capability flags, audit/customizable/renameable flags, `attributeOf`, `formulaDefinition`, `columnNumber`, `externalName`, introduced/deprecated versions, created/modified timestamps), enabling the extension's full attribute properties panel. Additive and backward compatible; a reflection test pins the RPC contract to the service DTO to prevent silent narrowing (#1369).
+
 ## [1.3.0] - 2026-07-14
 
 ### Added
@@ -129,6 +137,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **Extension panel UX** — Unified panel navigation and filtering, 300 ms filter debouncing, and race-condition prevention across 8 VS Code panels ([#633](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/633)).
 
 [Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.3.0...HEAD
+[1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.3.0...Cli-v1.4.0
 [1.3.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.2.0...Cli-v1.3.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...Cli-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.0.0...Cli-v1.1.0

--- a/src/PPDS.Cli/CHANGELOG.md
+++ b/src/PPDS.Cli/CHANGELOG.md
@@ -136,7 +136,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **`ppds flows get|url` accept GUID or unique name** — The `name` argument resolves by workflow ID (GUID) when provided, falling back to unique-name lookup ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Extension panel UX** — Unified panel navigation and filtering, 300 ms filter debouncing, and race-condition prevention across 8 VS Code panels ([#633](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/633)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.3.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.4.0...HEAD
 [1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.3.0...Cli-v1.4.0
 [1.3.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.2.0...Cli-v1.3.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Cli-v1.1.0...Cli-v1.2.0

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-15
+
+### Added
+
+- **Enriched attribute metadata on `AttributeMetadataDto`** — added `DeprecatedVersion`, `IsAuditEnabled`, `IsCustomizable`, `IsRenameable`, `IsValidForAdvancedFind`, `ExternalName`, `ColumnNumber`, `CreatedOn`, and `ModifiedOn`, mapped from the SDK `AttributeMetadata`. Combined with the already-captured `AttributeOf`, this gives consumers the full attribute picture (including the deterministic auxiliary-attribute marker) rather than a curated subset ([#1369](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1369), [#1368](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1368)).
+
 ## [1.2.0] - 2026-06-17
 
 ### Added
@@ -61,6 +67,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **Pool-managed concurrency** — Batch parallelism is capped at pool capacity via pool-queue blocking at `GetClientAsync()`, preventing oversubscription during throttling.
 
 [Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.2.0...HEAD
+[1.3.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.2.0...Dataverse-v1.3.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.1.0...Dataverse-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0...Dataverse-v1.1.0
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Dataverse-v1.0.0

--- a/src/PPDS.Dataverse/CHANGELOG.md
+++ b/src/PPDS.Dataverse/CHANGELOG.md
@@ -66,7 +66,7 @@ First stable release. Consolidates features developed across the `1.0.0-beta.1` 
 - **Default `AcquireTimeout` of 120 s** — Connection acquisition from the pool waits up to 120 s, accommodating queuing on the DOP semaphore during large imports.
 - **Pool-managed concurrency** — Batch parallelism is capped at pool capacity via pool-queue blocking at `GetClientAsync()`, preventing oversubscription during throttling.
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.2.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.3.0...HEAD
 [1.3.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.2.0...Dataverse-v1.3.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.1.0...Dataverse-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Dataverse-v1.0.0...Dataverse-v1.1.0

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -169,7 +169,7 @@ Complete ground-up rebuild of the extension. The new architecture uses a thin VS
 
 _Last stable release of the legacy architecture. See [archived repository](https://github.com/joshsmithxrm/power-platform-developer-suite/tree/archived) for full history._
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.1...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.6.0...HEAD
 [1.6.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.1...Extension-v1.6.0
 [1.4.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.0...Extension-v1.4.1
 [1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...Extension-v1.4.0

--- a/src/PPDS.Extension/CHANGELOG.md
+++ b/src/PPDS.Extension/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-15
+
+Stable-channel release (even minor per odd/even convention; 1.5.x is the pre-release channel).
+
+### Fixed
+- **Metadata Browser and 4 other panels rendered only the first ~22 rows, then an empty void** — the shared `DataTable` virtual scroll sized its window from an inner wrapper that was never height-bounded, so it never scrolled and only the initial buffer rendered. The wrapper is now a bounded flex-column host, so long lists (attributes, import jobs, environment variables, connection references, web resources) render and scroll fully (#1365, #1366).
+- **Metadata Browser Choices tab** — expanding a choice row no longer collapses the table columns into unreadable slivers (an over-wide colspan under `table-layout:fixed`), and every entity choice / global option set now renders instead of stopping after ~21 rows (tables were populated while detached from the DOM) (#1367).
+- **Single-row tables rendered empty** in every DataTable panel due to an initial visible-range sentinel colliding with a real single-row range (#1367).
+
+### Added
+- **Full attribute metadata in the properties panel** — clicking an attribute now shows the complete, grouped property set (General / Flags / Behavior / Security / Type Details / System) instead of a curated dozen; booleans display for both true and false. Backed by a widened daemon attribute contract (bundled CLI 1.4.0) (#1369).
+- **Auxiliary attributes are identified and managed** — lookup name/yomi companion attributes (which carry `AttributeOf`) are hidden by default with a disclosed **"Hide auxiliary (N)"** toggle that restores them in one click; when shown they are visually marked and labelled `aux of <parent>` instead of appearing as broken blank-name fields (#1368).
+
+### Changed
+- **Metadata Browser tab order** — Configuration now precedes Attributes and is the landing tab when selecting an entity (entity-level detail before the attribute drill-down) (#1370).
+- **Bundled CLI updated to 1.4.0** — carries the full-fidelity attribute metadata contract and the `attributeOf` marker that power the properties panel and auxiliary handling above (#1369).
+
 ## [1.4.1] - 2026-07-14
 
 ### Changed
@@ -153,6 +170,7 @@ Complete ground-up rebuild of the extension. The new architecture uses a thin VS
 _Last stable release of the legacy architecture. See [archived repository](https://github.com/joshsmithxrm/power-platform-developer-suite/tree/archived) for full history._
 
 [Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.1...HEAD
+[1.6.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.1...Extension-v1.6.0
 [1.4.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.4.0...Extension-v1.4.1
 [1.4.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Extension-v1.2.0...Extension-v1.4.0
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Extension-v1.2.0

--- a/src/PPDS.Extension/package-lock.json
+++ b/src/PPDS.Extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "power-platform-developer-suite",
-  "version": "1.4.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "power-platform-developer-suite",
-      "version": "1.4.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/src/PPDS.Extension/package.json
+++ b/src/PPDS.Extension/package.json
@@ -2,7 +2,7 @@
   "name": "power-platform-developer-suite",
   "displayName": "Power Platform Developer Suite",
   "description": "Power Platform and Dataverse developer suite for VS Code — SQL/FetchXML notebooks, plugin registration, metadata browsing, bundled ppds CLI, and an MCP server for AI agents.",
-  "version": "1.4.1",
+  "version": "1.6.0",
   "publisher": "JoshSmithXRM",
   "preview": false,
   "qna": false,

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-15
+
+### Added
+
+- **`metadata_entity` attributes now include `attributeOf`** — each returned attribute carries the logical name of the attribute it extends when it is an auxiliary (lookup name/yomi) companion, and omits the field for real attributes. This lets agents deterministically distinguish schema plumbing from real, queryable columns without display-name heuristics ([#1368](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/1368)).
+
 ## [1.1.0] - 2026-07-14
 
 ### Added
@@ -45,6 +51,7 @@ First stable release. Consolidates features developed across `1.0.0-beta.1` and 
 - **Configurable log level** — `--log-level` flag and `PPDS_MCP_LOG_LEVEL` environment variable let operators adjust server verbosity without rebuilding ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 
 [Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.1.0...HEAD
+[1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.1.0...Mcp-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.1...Mcp-v1.1.0
 [1.0.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0...Mcp-v1.0.1
 [1.0.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/releases/tag/Mcp-v1.0.0

--- a/src/PPDS.Mcp/CHANGELOG.md
+++ b/src/PPDS.Mcp/CHANGELOG.md
@@ -50,7 +50,7 @@ First stable release. Consolidates features developed across `1.0.0-beta.1` and 
 - **Structured MCP error responses** — All tool exceptions now surface `errorCode`, `userMessage`, and `context`, giving MCP clients machine-readable failure details ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 - **Configurable log level** — `--log-level` flag and `PPDS_MCP_LOG_LEVEL` environment variable let operators adjust server verbosity without rebuilding ([#868](https://github.com/joshsmithxrm/power-platform-developer-suite/issues/868)).
 
-[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.1.0...HEAD
+[Unreleased]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.2.0...HEAD
 [1.2.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.1.0...Mcp-v1.2.0
 [1.1.0]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.1...Mcp-v1.1.0
 [1.0.1]: https://github.com/joshsmithxrm/power-platform-developer-suite/compare/Mcp-v1.0.0...Mcp-v1.0.1


### PR DESCRIPTION
Stable release train shipping the Metadata Browser fixes (and their multi-surface backing) to the **stable channel** for all users. The scroll-void bug (#1365/#1366) had shipped broken in every release; none of these fixes were in a released version until now.

## Versions

| Package | Previous | New | Bump | Notes |
|---|---|---|---|---|
| **PPDS.Extension** | 1.4.1 | **1.6.0** | minor | Stable channel (even minor). 1.5.x is the pre-release channel — skipped. Bundled CLI refreshed to 1.4.0. |
| **PPDS.Cli** | 1.3.0 | **1.4.0** | minor | Widened attribute RPC + `--exclude-auxiliary`. Additive/back-compat. |
| **PPDS.Dataverse** | 1.2.0 | **1.3.0** | minor | Enriched `AttributeMetadataDto`. |
| **PPDS.Mcp** | 1.1.0 | **1.2.0** | minor | `attributeOf` on `metadata_entity`. |

**Deferred** (not this train): Auth/Migration (dependency bumps only), Plugins/Query (docs only) → routine release.

## Highlights

- **Extension** — long lists render fully (scroll-void fix across 5 panels); Choices tab no longer collapses on expand; full grouped attribute properties panel; auxiliary attributes hidden-by-default with a disclosed "Hide auxiliary (N)" toggle and `aux of <parent>` marking; Configuration-first tab order.
- **Cli** — `metadata attributes` flags auxiliaries (`aux:<parent>`) and gains `--exclude-auxiliary`; `--json` carries `attributeOf`; daemon attribute RPC now full-fidelity (reflection test pins the contract).
- **Dataverse** — `AttributeMetadataDto` gains audit/customizable/renameable/advanced-find flags, `ExternalName`, `ColumnNumber`, created/modified/deprecated versions.
- **Mcp** — agents can deterministically distinguish auxiliary attributes via `attributeOf`.

## Security review (stable gate)

`docs/qa/security-review-metadata-browser-1.6.0.md` — covers the delta `Extension-v1.4.1..HEAD` across the 4 packages. **Result: PASS**, no HIGH/MEDIUM findings. Webview XSS surface closed (`escapeHtml` on the one new `innerHTML` write; properties panel uses `textContent`); the widened RPC forwards only schema metadata the same authenticated user can already retrieve.

## Test plan

**Before merge:** full CI on this branch (build, unit ×3 TFMs, extension, tui-e2e, integration). Code is byte-identical to already-green `main` + CHANGELOG/version/doc changes only.

**After merge — tag-push sequence** (per-package tags trigger publishes; unified `v1.6.0` triggers docs; individual pushes with delay per Gotcha 6):
```
Cli-v1.4.0  Mcp-v1.2.0  Dataverse-v1.3.0  Extension-v1.6.0   (+ unified v1.6.0)
```
- `publish-nuget.yml` → PPDS.Cli / PPDS.Mcp / PPDS.Dataverse on NuGet.org
- `release-cli.yml` → Cli multi-platform binaries + GitHub release
- `extension-publish.yml` (auto on `Extension-v1.6.0`, even minor → **stable** channel) → VS Marketplace
- `docs-release.yml` (on `v1.6.0`) → reference docs PR

**After publish:** verify NuGet listings, GitHub release binaries, Marketplace shows 1.6.0 on the stable channel, smoke-install the CLI tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer attribute metadata, including `attributeOf` relationships for auxiliary attributes.
  * Added a CLI flag to exclude auxiliary attributes; `--json` output now includes the `attributeOf` field for deterministic filtering.
  * Enhanced the properties panel to show full grouped attribute metadata (including true/false booleans) and a default-hidden auxiliary toggle (“Hide auxiliary (N)”).
  * Updated Metadata Browser tab order (Configuration before Attributes).

* **Bug Fixes**
  * Improved DataTable rendering for virtual scrolling and Metadata Browser “Choices” expansion.
  * Fixed empty states in single-row table displays.

* **Documentation**
  * Added/updated 1.6.0 release notes and a security review document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->